### PR TITLE
feat: convert agent files to universal reference documents for standalone skills

### DIFF
--- a/.claude/PRPs/plans/completed/agent-to-reference-conversion.plan.md
+++ b/.claude/PRPs/plans/completed/agent-to-reference-conversion.plan.md
@@ -1,0 +1,496 @@
+# Feature: Agent-to-Reference Conversion
+
+## Summary
+
+Convert the 3 Claude Code agent files (`codebase-analyzer.md`, `scope-detector.md`, `file-evaluator.md`) into universal reference documents that standalone skills can consume inline. The conversion strips Claude Code-specific frontmatter, reframes agent persona declarations as follow-these-instructions directives, adds tool-agnostic execution notes, and preserves 100% of analysis logic (process steps, lookup tables, detection patterns, output format templates, self-verification checklists). The converted files are distributed as independent copies to the 4 standalone skill `references/` directories, totaling 8 new files.
+
+## User Story
+
+As a developer using any Agent Skills-compliant tool (not just Claude Code),
+I want standalone skills to have the same analysis quality as plugin skills,
+So that I get equally accurate CLAUDE.md/AGENTS.md output regardless of which tool I use.
+
+## Problem Statement
+
+Standalone skills currently use minimal inline bash commands for codebase analysis (e.g., `ls package.json 2>/dev/null`, `cat package.json | grep -A 30 '"scripts"'`). They rely on the executing model's general knowledge for analysis logic — leading to inconsistent detection of package managers, tech stacks, scope boundaries, and file quality issues. Plugin skills solve this by delegating to agents with structured detection patterns, but the Claude Code Task tool is not available in other Agent Skills-compliant tools.
+
+## Solution Statement
+
+Author 3 converted reference documents from the 3 agent source files, applying the 4 PRD conversion rules. Distribute copies to the standalone skills that need them. The converted files preserve the exact same lookup tables, detection patterns, output formats, and self-verification checklists as the original agents — just reframed as instructions that any model can follow inline.
+
+## Metadata
+
+| Field            | Value                                                |
+| ---------------- | ---------------------------------------------------- |
+| Type             | ENHANCEMENT                                          |
+| Complexity       | LOW-MEDIUM                                           |
+| Systems Affected | `skills/init-agents/`, `skills/init-claude/`, `skills/improve-agents/`, `skills/improve-claude/` |
+| Dependencies     | None (Phase 1 and 2 are complete; Phase 3 has no external deps) |
+| Estimated Tasks  | 7                                                    |
+
+---
+
+## UX Design
+
+### Before State
+
+```
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║                              BEFORE STATE                                   ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                             ║
+║   ┌───────────────────┐         ┌─────────────────────┐                     ║
+║   │ Standalone Skill  │ ──────► │  Inline bash cmds   │                     ║
+║   │  (e.g. Copilot)   │         │  (10 lines of ls/   │                     ║
+║   │                   │         │   cat/grep)          │                     ║
+║   └───────────────────┘         └──────────┬──────────┘                     ║
+║                                            │                                ║
+║                                            ▼                                ║
+║                                 ┌─────────────────────┐                     ║
+║                                 │  Model's general    │                     ║
+║                                 │  knowledge fills    │                     ║
+║                                 │  the gaps           │                     ║
+║                                 └──────────┬──────────┘                     ║
+║                                            │                                ║
+║                                            ▼                                ║
+║                                 ┌─────────────────────┐                     ║
+║                                 │  Inconsistent       │                     ║
+║                                 │  analysis results   │                     ║
+║                                 └─────────────────────┘                     ║
+║                                                                             ║
+║   PAIN_POINT: No detection tables, no structured output format,             ║
+║   no self-verification — quality depends on model's training data           ║
+║                                                                             ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+```
+
+### After State
+
+```
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║                               AFTER STATE                                   ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                             ║
+║   ┌───────────────────┐         ┌─────────────────────┐                     ║
+║   │ Standalone Skill  │ ──────► │  SKILL.md Phase N   │                     ║
+║   │  (any tool)       │         │  "Read references/  │                     ║
+║   │                   │         │   codebase-analyzer  │                     ║
+║   └───────────────────┘         │   .md"               │                     ║
+║                                 └──────────┬──────────┘                     ║
+║                                            │                                ║
+║                                            ▼                                ║
+║                                 ┌─────────────────────┐                     ║
+║                                 │  Converted ref doc  │                     ║
+║                                 │  with lookup tables,│                     ║
+║                                 │  detection patterns,│                     ║
+║                                 │  output format,     │                     ║
+║                                 │  self-verification  │                     ║
+║                                 └──────────┬──────────┘                     ║
+║                                            │                                ║
+║                                            ▼                                ║
+║                                 ┌─────────────────────┐                     ║
+║                                 │  Consistent,        │                     ║
+║                                 │  structured results │                     ║
+║                                 │  (same as plugin)   │                     ║
+║                                 └─────────────────────┘                     ║
+║                                                                             ║
+║   VALUE_ADD: Same detection logic as plugin agents, works on any tool       ║
+║                                                                             ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+```
+
+### Interaction Changes
+
+| Location | Before | After | User Impact |
+|----------|--------|-------|-------------|
+| `skills/*/SKILL.md` Phase 1-2 | Inline bash + model knowledge | `Read references/X.md` + structured inline analysis | Consistent analysis quality across all tools |
+| `skills/*/references/` | Only Phase 1 docs (4-6 files) | Phase 1 docs + 2 converted agent refs per skill | Complete reference set for every analysis phase |
+
+---
+
+## Mandatory Reading
+
+**CRITICAL: Implementation agent MUST read these files before starting any task:**
+
+| Priority | File | Lines | Why Read This |
+|----------|------|-------|---------------|
+| P0 | `plugins/agents-initializer/agents/codebase-analyzer.md` | 1-122 | SOURCE to convert — understand full structure |
+| P0 | `plugins/agents-initializer/agents/scope-detector.md` | 1-121 | SOURCE to convert — understand full structure |
+| P0 | `plugins/agents-initializer/agents/file-evaluator.md` | 1-151 | SOURCE to convert — understand full structure |
+| P1 | `skills/improve-agents/references/evaluation-criteria.md` | 1-135 | MIRROR this reference file format exactly |
+| P1 | `skills/init-agents/references/context-optimization.md` | 1-121 | MIRROR this reference file format exactly |
+| P2 | `.claude/PRPs/prds/skill-directory-evolution.prd.md` | 257-266 | Conversion rules (4 transformations) |
+| P2 | `.claude/rules/standalone-skills.md` | 1-10 | Rule: standalone skills must not reference agents by name |
+
+---
+
+## Patterns to Mirror
+
+**REFERENCE_FILE_HEADER:**
+
+```markdown
+// SOURCE: skills/improve-agents/references/evaluation-criteria.md:1-6
+// COPY THIS PATTERN:
+# Evaluation Criteria
+
+Scoring rubric for assessing existing AGENTS.md and CLAUDE.md files before improvement.
+Used by IMPROVE skills only. Source: file-evaluator.md, research-llm-context-optimization.md
+
+---
+```
+
+**REFERENCE_FILE_SECTION_ENDING:**
+
+```markdown
+// SOURCE: skills/improve-agents/references/evaluation-criteria.md:33
+// COPY THIS PATTERN:
+*Source: file-evaluator.md lines 30-41*
+```
+
+**REFERENCE_FILE_SECTION_DIVIDERS:**
+
+```markdown
+// SOURCE: skills/init-agents/references/context-optimization.md (throughout)
+// COPY THIS PATTERN:
+---
+```
+
+Each major section is separated by a `---` horizontal rule.
+
+**CONVERTED_REFRAMING (from PRD):**
+
+```markdown
+// SOURCE: .claude/PRPs/prds/skill-directory-evolution.prd.md:263
+// APPLY THIS TRANSFORMATION:
+// BEFORE (agent persona): "You are a codebase analysis specialist."
+// AFTER (instruction):    "Follow these codebase analysis instructions."
+```
+
+**TOOL_AGNOSTIC_NOTES (from PRD):**
+
+```markdown
+// SOURCE: .claude/PRPs/prds/skill-directory-evolution.prd.md:264
+// APPLY THIS TRANSFORMATION:
+// BEFORE (Claude Code): "Use Read, Grep, Glob, Bash"
+// AFTER (universal):    "Use your environment's file reading and search capabilities"
+```
+
+---
+
+## Files to Change
+
+| File | Action | Justification |
+| ---- | ------ | ------------- |
+| `skills/init-agents/references/codebase-analyzer.md` | CREATE | Converted ref for codebase analysis phase |
+| `skills/init-agents/references/scope-detector.md` | CREATE | Converted ref for scope detection phase |
+| `skills/init-claude/references/codebase-analyzer.md` | CREATE | Converted ref for codebase analysis phase |
+| `skills/init-claude/references/scope-detector.md` | CREATE | Converted ref for scope detection phase |
+| `skills/improve-agents/references/codebase-analyzer.md` | CREATE | Converted ref for codebase comparison phase |
+| `skills/improve-agents/references/file-evaluator.md` | CREATE | Converted ref for file evaluation phase |
+| `skills/improve-claude/references/codebase-analyzer.md` | CREATE | Converted ref for codebase comparison phase |
+| `skills/improve-claude/references/file-evaluator.md` | CREATE | Converted ref for file evaluation phase |
+
+---
+
+## NOT Building (Scope Limits)
+
+- **Not modifying original agent files** — `plugins/agents-initializer/agents/*.md` remain unchanged; converted copies are independent
+- **Not modifying SKILL.md files** — Phase 4 (plugin) and Phase 5 (standalone) will update SKILL.md to reference these files
+- **Not modifying plugin skill references** — plugin skills don't need converted agent refs; they delegate to live agents
+- **Not creating new reference content** — all content comes from existing agent files; no new analysis logic invented
+- **Not updating rules files** — Phase 6 handles `.claude/rules/` updates
+
+---
+
+## Step-by-Step Tasks
+
+Execute in order. Each task is atomic and independently verifiable.
+
+### Task 1: CONVERT `codebase-analyzer.md` to reference format
+
+- **ACTION**: Author a universal reference document from the plugin agent file
+- **SOURCE**: `plugins/agents-initializer/agents/codebase-analyzer.md` (122 lines)
+- **OUTPUT**: Write to a temporary master copy (e.g., `/tmp/refs/codebase-analyzer.md`)
+- **TRANSFORMATION RULES** (apply all 4 from PRD lines 257-266):
+  1. **Strip frontmatter**: Remove lines 1-7 (the YAML block with `name`, `description`, `tools`, `model`, `maxTurns`)
+  2. **Preserve all analysis logic**: Keep lines 9-122 intact — process steps (22-82), output format (83-113), self-verification (115-122)
+  3. **Reframe persona as instruction**: Change line 11 from "You are a codebase analysis specialist. Analyze the project at the current working directory and return a structured summary..." to "Follow these codebase analysis instructions. Analyze the project at the current working directory and return a structured summary..."
+  4. **Add tool-agnostic execution note**: Add a note after the title section: "Use your environment's file reading and search capabilities to examine the project."
+- **ADD REFERENCE FILE HEADER** (mirror `evaluation-criteria.md:1-6`):
+
+  ```markdown
+  # Codebase Analysis Instructions
+
+  Structured process for detecting project tech stack, tooling, and non-standard patterns.
+  Used by INIT and IMPROVE skills for codebase analysis. Source: agents/codebase-analyzer.md
+
+  ---
+  ```
+
+- **ADD SOURCE CITATIONS**: At the end of major sections, add `*Source: agents/codebase-analyzer.md lines X-Y*`
+- **VERIFY LINE COUNT**: Must be ≤ 200 lines (expected ~120 lines — original is 122 minus 7 frontmatter + ~5 header/notes)
+- **VALIDATE**: `wc -l /tmp/refs/codebase-analyzer.md` — must be ≤ 200
+
+### Task 2: CONVERT `scope-detector.md` to reference format
+
+- **ACTION**: Author a universal reference document from the plugin agent file
+- **SOURCE**: `plugins/agents-initializer/agents/scope-detector.md` (121 lines)
+- **OUTPUT**: Write to a temporary master copy (e.g., `/tmp/refs/scope-detector.md`)
+- **TRANSFORMATION RULES** (apply all 4):
+  1. **Strip frontmatter**: Remove lines 1-7
+  2. **Preserve all analysis logic**: Keep lines 9-121 intact — criteria table (20-39), process steps (41-76), output format (77-112), self-verification (113-121)
+  3. **Reframe persona**: Change line 11 from "You are a scope detection specialist. Identify distinct contexts..." to "Follow these scope detection instructions. Identify distinct contexts..."
+  4. **Add tool-agnostic note**: "Use your environment's file reading and search capabilities to examine the project."
+- **ADD REFERENCE FILE HEADER** (mirror convention):
+
+  ```markdown
+  # Scope Detection Instructions
+
+  Structured process for identifying distinct project contexts that need separate configuration files.
+  Used by INIT skills for scope detection. Source: agents/scope-detector.md
+
+  ---
+  ```
+
+- **ADD SOURCE CITATIONS**: At end of major sections
+- **VERIFY LINE COUNT**: Must be ≤ 200 lines (expected ~119 lines)
+- **VALIDATE**: `wc -l /tmp/refs/scope-detector.md` — must be ≤ 200
+
+### Task 3: CONVERT `file-evaluator.md` to reference format
+
+- **ACTION**: Author a universal reference document from the plugin agent file
+- **SOURCE**: `plugins/agents-initializer/agents/file-evaluator.md` (151 lines)
+- **OUTPUT**: Write to a temporary master copy (e.g., `/tmp/refs/file-evaluator.md`)
+- **TRANSFORMATION RULES** (apply all 4):
+  1. **Strip frontmatter**: Remove lines 1-7
+  2. **Preserve all analysis logic**: Keep lines 9-151 intact — quality criteria (20-59), process (61-88), output format (89-141), self-verification (143-151)
+  3. **Reframe persona**: Change line 11 from "You are a configuration file quality specialist. Analyze existing AGENTS.md or CLAUDE.md files..." to "Follow these file evaluation instructions. Analyze existing AGENTS.md or CLAUDE.md files..."
+  4. **Add tool-agnostic note**: "Use your environment's file reading and search capabilities to examine the project."
+- **ADD REFERENCE FILE HEADER** (mirror convention):
+
+  ```markdown
+  # File Evaluation Instructions
+
+  Structured process for evaluating existing AGENTS.md/CLAUDE.md files against evidence-based quality criteria.
+  Used by IMPROVE skills for current state analysis. Source: agents/file-evaluator.md
+
+  ---
+  ```
+
+- **ADD SOURCE CITATIONS**: At end of major sections
+- **VERIFY LINE COUNT**: Must be ≤ 200 lines (expected ~149 lines — original is 151 minus 7 frontmatter + ~5 header/notes)
+- **GOTCHA**: This is the largest agent file (151 lines). Monitor line count carefully — if conversion exceeds 200 lines, consolidate the header to fewer lines.
+- **VALIDATE**: `wc -l /tmp/refs/file-evaluator.md` — must be ≤ 200
+
+### Task 4: DISTRIBUTE `codebase-analyzer.md` to 4 standalone skills
+
+- **ACTION**: Copy the master converted file to the 4 standalone skills that need it
+- **SOURCE**: `/tmp/refs/codebase-analyzer.md` (master copy from Task 1)
+- **TARGETS** (all 4 standalone skills use codebase-analyzer):
+
+  ```
+  skills/init-agents/references/codebase-analyzer.md
+  skills/init-claude/references/codebase-analyzer.md
+  skills/improve-agents/references/codebase-analyzer.md
+  skills/improve-claude/references/codebase-analyzer.md
+  ```
+
+- **METHOD**: `cp /tmp/refs/codebase-analyzer.md` to each target path
+- **VERIFY**: All 4 copies are byte-identical: `md5sum skills/*/references/codebase-analyzer.md`
+- **VALIDATE**: 4 files exist, all identical checksums
+
+### Task 5: DISTRIBUTE `scope-detector.md` to 2 standalone skills
+
+- **ACTION**: Copy the master converted file to the 2 standalone init skills
+- **SOURCE**: `/tmp/refs/scope-detector.md` (master copy from Task 2)
+- **TARGETS** (only init skills use scope-detector):
+
+  ```
+  skills/init-agents/references/scope-detector.md
+  skills/init-claude/references/scope-detector.md
+  ```
+
+- **METHOD**: `cp /tmp/refs/scope-detector.md` to each target path
+- **VERIFY**: Both copies are byte-identical: `md5sum skills/init-*/references/scope-detector.md`
+- **VALIDATE**: 2 files exist, identical checksums
+
+### Task 6: DISTRIBUTE `file-evaluator.md` to 2 standalone skills
+
+- **ACTION**: Copy the master converted file to the 2 standalone improve skills
+- **SOURCE**: `/tmp/refs/file-evaluator.md` (master copy from Task 3)
+- **TARGETS** (only improve skills use file-evaluator):
+
+  ```
+  skills/improve-agents/references/file-evaluator.md
+  skills/improve-claude/references/file-evaluator.md
+  ```
+
+- **METHOD**: `cp /tmp/refs/file-evaluator.md` to each target path
+- **VERIFY**: Both copies are byte-identical: `md5sum skills/improve-*/references/file-evaluator.md`
+- **VALIDATE**: 2 files exist, identical checksums
+
+### Task 7: VALIDATE all 8 files — completeness and correctness
+
+- **ACTION**: Run comprehensive validation across all 8 distributed files
+- **CHECKS**:
+  1. **File existence**: All 8 target paths exist
+  2. **Line count**: All files ≤ 200 lines (`wc -l skills/*/references/{codebase-analyzer,scope-detector,file-evaluator}.md 2>/dev/null`)
+  3. **Identity verification**: Copies match their master — `md5sum` groups show identical hashes within each group
+  4. **No frontmatter**: No file starts with `---` YAML block — `head -1 skills/*/references/{codebase-analyzer,scope-detector,file-evaluator}.md 2>/dev/null` should show `# Title` not `---`
+  5. **No Claude Code syntax**: `grep -l "tools: Read" skills/*/references/{codebase-analyzer,scope-detector,file-evaluator}.md 2>/dev/null` should return zero matches
+  6. **No agent persona**: `grep -l "You are a" skills/*/references/{codebase-analyzer,scope-detector,file-evaluator}.md 2>/dev/null` should return zero matches
+  7. **Logic preservation**: Each converted file contains its key lookup tables — spot-check:
+     - `codebase-analyzer.md` contains "pnpm-lock.yaml" (package manager table)
+     - `scope-detector.md` contains "Different tech stack" (scope criteria table)
+     - `file-evaluator.md` contains "Bloat Indicators" (quality criteria section)
+  8. **Distribution correctness**: Count files per skill directory:
+     - `skills/init-agents/references/`: should have 6 files (4 Phase 1 + codebase-analyzer + scope-detector)
+     - `skills/init-claude/references/`: should have 7 files (5 Phase 1 + codebase-analyzer + scope-detector)
+     - `skills/improve-agents/references/`: should have 7 files (5 Phase 1 + codebase-analyzer + file-evaluator)
+     - `skills/improve-claude/references/`: should have 8 files (6 Phase 1 + codebase-analyzer + file-evaluator)
+- **VALIDATE**: All 8 checks pass
+
+---
+
+## Testing Strategy
+
+### Validation Tests
+
+| Check | Command | Expected Result |
+| ----- | ------- | --------------- |
+| File existence | `ls skills/*/references/{codebase-analyzer,scope-detector,file-evaluator}.md 2>/dev/null \| wc -l` | 8 |
+| Line count | `wc -l skills/*/references/{codebase-analyzer,scope-detector,file-evaluator}.md 2>/dev/null` | All ≤ 200 |
+| No frontmatter | `grep -c "^---$" skills/*/references/codebase-analyzer.md 2>/dev/null` | 0 per file (section dividers use `---` in the body — check only lines 1-2) |
+| No Claude Code syntax | `grep -rl "tools: Read\|model: sonnet\|maxTurns:" skills/*/references/ 2>/dev/null` | Empty (no matches) |
+| No agent persona | `grep -rl "^You are a" skills/*/references/{codebase-analyzer,scope-detector,file-evaluator}.md 2>/dev/null` | Empty |
+| Identity (codebase-analyzer) | `md5sum skills/*/references/codebase-analyzer.md` | 4 identical hashes |
+| Identity (scope-detector) | `md5sum skills/init-*/references/scope-detector.md` | 2 identical hashes |
+| Identity (file-evaluator) | `md5sum skills/improve-*/references/file-evaluator.md` | 2 identical hashes |
+| Logic preservation | `grep -l "pnpm-lock.yaml" skills/*/references/codebase-analyzer.md \| wc -l` | 4 |
+| Logic preservation | `grep -l "Different tech stack" skills/init-*/references/scope-detector.md \| wc -l` | 2 |
+| Logic preservation | `grep -l "Bloat Indicators" skills/improve-*/references/file-evaluator.md \| wc -l` | 2 |
+
+### Edge Cases Checklist
+
+- [ ] `file-evaluator.md` stays under 200 lines after conversion (it's the largest at 151 source lines)
+- [ ] No `---` on line 1 (which would be YAML frontmatter, not a section divider)
+- [ ] Horizontal rule `---` section dividers inside the body are preserved (they're part of the reference format)
+- [ ] Source citations reference `agents/codebase-analyzer.md` etc. (not `plugins/agents-initializer/agents/...`)
+- [ ] Content is reframed but not rewritten — lookup tables must be character-identical to originals
+
+---
+
+## Validation Commands
+
+### Level 1: FILE_EXISTENCE
+
+```bash
+ls skills/init-agents/references/codebase-analyzer.md \
+   skills/init-agents/references/scope-detector.md \
+   skills/init-claude/references/codebase-analyzer.md \
+   skills/init-claude/references/scope-detector.md \
+   skills/improve-agents/references/codebase-analyzer.md \
+   skills/improve-agents/references/file-evaluator.md \
+   skills/improve-claude/references/codebase-analyzer.md \
+   skills/improve-claude/references/file-evaluator.md
+```
+
+**EXPECT**: All 8 files listed, exit 0
+
+### Level 2: LINE_COUNTS
+
+```bash
+wc -l skills/*/references/codebase-analyzer.md skills/init-*/references/scope-detector.md skills/improve-*/references/file-evaluator.md
+```
+
+**EXPECT**: All files ≤ 200 lines
+
+### Level 3: CONTENT_INTEGRITY
+
+```bash
+# No Claude Code frontmatter fields
+grep -rn "^name:\|^tools:\|^model:\|^maxTurns:" skills/*/references/codebase-analyzer.md skills/init-*/references/scope-detector.md skills/improve-*/references/file-evaluator.md
+
+# No agent persona declarations
+grep -rn "^You are a" skills/*/references/codebase-analyzer.md skills/init-*/references/scope-detector.md skills/improve-*/references/file-evaluator.md
+```
+
+**EXPECT**: Both commands return zero matches (exit 1)
+
+### Level 4: COPY_IDENTITY
+
+```bash
+md5sum skills/*/references/codebase-analyzer.md
+md5sum skills/init-*/references/scope-detector.md
+md5sum skills/improve-*/references/file-evaluator.md
+```
+
+**EXPECT**: Each group shows identical hashes
+
+### Level 5: LOGIC_PRESERVATION
+
+```bash
+# Spot-check key content from each agent's analysis logic
+grep -c "pnpm-lock.yaml" skills/init-agents/references/codebase-analyzer.md
+grep -c "Different tech stack" skills/init-agents/references/scope-detector.md
+grep -c "Bloat Indicators" skills/improve-agents/references/file-evaluator.md
+```
+
+**EXPECT**: Each returns 1 (content preserved)
+
+### Level 6: DISTRIBUTION_COUNT
+
+```bash
+ls skills/init-agents/references/ | wc -l
+ls skills/init-claude/references/ | wc -l
+ls skills/improve-agents/references/ | wc -l
+ls skills/improve-claude/references/ | wc -l
+```
+
+**EXPECT**: 6, 7, 7, 8 (Phase 1 files + Phase 3 converted files)
+
+---
+
+## Acceptance Criteria
+
+- [ ] All 8 converted reference files exist in correct locations
+- [ ] All files ≤ 200 lines
+- [ ] No Claude Code-specific frontmatter in any converted file
+- [ ] No agent persona declarations ("You are a...")
+- [ ] Tool-agnostic execution note present in each file
+- [ ] 100% of analysis logic preserved (lookup tables, detection patterns, output format templates, self-verification checklists are character-identical to source agents)
+- [ ] Copies within each group are byte-identical (verified by md5sum)
+- [ ] Reference file header follows established convention (title + description + source + `---`)
+- [ ] Source citations present at end of major sections
+
+---
+
+## Completion Checklist
+
+- [ ] Tasks 1-3 completed: 3 master converted files authored
+- [ ] Tasks 4-6 completed: 8 copies distributed to correct skill directories
+- [ ] Task 7 completed: All 6 validation levels pass
+- [ ] All acceptance criteria met
+- [ ] PRD phase status updated to `in-progress`
+
+---
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| ---- | ---------- | ------ | ---------- |
+| `file-evaluator.md` exceeds 200 lines after conversion | LOW | MEDIUM | Source is 151 lines; minus 7 frontmatter + ~5 header = ~149 lines. Well under limit. If needed, make header more compact. |
+| Conversion accidentally modifies lookup table content | LOW | HIGH | Verification step checks for key strings (`pnpm-lock.yaml`, `Different tech stack`, `Bloat Indicators`). Full diff review at Task 7. |
+| Converted files not recognized by standalone SKILL.md | NONE (Phase 3) | N/A | SKILL.md updates happen in Phase 5, not Phase 3. Converted files just need to exist and be well-formed. |
+| Section dividers (`---`) confused with YAML frontmatter | LOW | LOW | Validate that line 1 is `# Title`, not `---`. Body `---` dividers are expected per reference file convention. |
+
+---
+
+## Notes
+
+- **Original agent files are NOT modified** — they remain in `plugins/agents-initializer/agents/` for plugin skills to delegate to
+- **Converted copies are independent** — they can evolve separately from the original agents per PRD line 266
+- **Phase 1 (complete)** already created `references/` directories and populated them with shared reference files — Phase 3 adds to those directories, not creates them
+- **Phase 2 (complete)** created asset templates — the converted reference output format templates must produce output compatible with those asset templates
+- **Phase 4 and 5** (downstream) will update SKILL.md files to reference these converted files — until then, the converted files exist but are not yet consumed
+- The `.claude/rules/standalone-skills.md` rule says "Never reference `codebase-analyzer`, `scope-detector`, or `file-evaluator` agents" — the converted reference files are instructions, not agent references, and the rule applies to SKILL.md files, not reference files (the rule is path-scoped to `skills/*/SKILL.md`)

--- a/.claude/PRPs/prds/skill-directory-evolution.prd.md
+++ b/.claude/PRPs/prds/skill-directory-evolution.prd.md
@@ -359,7 +359,7 @@ The `.claude/rules/` files enforce that when a shared reference is updated, all 
 |---|-------|-------------|--------|----------|---------|----------|
 | 1 | Reference content creation | Create all `references/` files derived from `docs/` research documents | in-progress | - | - | `.claude/PRPs/plans/reference-content-creation.plan.md` |
 | 2 | Asset templates creation | Create all `assets/templates/` files for consistent output generation | complete | with 1 | - | `.claude/PRPs/plans/asset-templates-creation.plan.md` |
-| 3 | Agent-to-reference conversion | Convert 3 agent files to universal reference docs for standalone skills | pending | with 1 | - | - |
+| 3 | Agent-to-reference conversion | Convert 3 agent files to universal reference docs for standalone skills | complete | with 1 | - | `.claude/PRPs/plans/agent-to-reference-conversion.plan.md` |
 | 4 | Plugin skills evolution | Rewrite 4 plugin SKILL.md files to use `references/` and `assets/`, add self-validation loop | pending | - | 1, 2 | - |
 | 5 | Standalone skills evolution | Rewrite 4 standalone SKILL.md files to use `references/` (including converted agents) and `assets/`, add self-validation loop | pending | - | 1, 2, 3 | - |
 | 6 | Rules and conventions update | Update `.claude/rules/`, `CLAUDE.md` files, and `plugin.json` to enforce new directory conventions | pending | - | 4, 5 | - |

--- a/.claude/PRPs/reports/agent-to-reference-conversion-report.md
+++ b/.claude/PRPs/reports/agent-to-reference-conversion-report.md
@@ -1,0 +1,96 @@
+# Implementation Report
+
+**Plan**: `.claude/PRPs/plans/agent-to-reference-conversion.plan.md`
+**Branch**: `feature/agent-to-reference-conversion`
+**Date**: 2026-03-23
+**Status**: COMPLETE
+
+---
+
+## Summary
+
+Converted 3 Claude Code agent files (`codebase-analyzer.md`, `scope-detector.md`, `file-evaluator.md`) into universal reference documents and distributed them to 8 target locations across 4 standalone skill directories. Each converted file strips Claude Code-specific frontmatter, reframes agent persona declarations as follow-these-instructions directives, adds a tool-agnostic execution note, and preserves 100% of analysis logic.
+
+---
+
+## Assessment vs Reality
+
+| Metric | Predicted | Actual | Reasoning |
+|--------|-----------|--------|-----------|
+| Complexity | LOW-MEDIUM | LOW | Straightforward text transformation with clear rules; no code changes required |
+| Confidence | HIGH | HIGH | Root cause and approach were correct; all 4 conversion rules applied cleanly |
+
+No deviations from the plan.
+
+---
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 1 | CONVERT codebase-analyzer.md | `/tmp/refs/codebase-analyzer.md` (131 lines) | ✅ |
+| 2 | CONVERT scope-detector.md | `/tmp/refs/scope-detector.md` (135 lines) | ✅ |
+| 3 | CONVERT file-evaluator.md | `/tmp/refs/file-evaluator.md` (165 lines) | ✅ |
+| 4 | DISTRIBUTE codebase-analyzer.md × 4 | `skills/*/references/codebase-analyzer.md` | ✅ |
+| 5 | DISTRIBUTE scope-detector.md × 2 | `skills/init-*/references/scope-detector.md` | ✅ |
+| 6 | DISTRIBUTE file-evaluator.md × 2 | `skills/improve-*/references/file-evaluator.md` | ✅ |
+| 7 | VALIDATE all 8 files | All 6 levels pass | ✅ |
+
+---
+
+## Validation Results
+
+| Check | Result | Details |
+|-------|--------|---------|
+| File existence | ✅ | All 8 files present |
+| Line counts | ✅ | 131, 135, 165 lines — all ≤ 200 |
+| No frontmatter fields | ✅ | Zero matches for `name:`, `tools:`, `model:`, `maxTurns:` |
+| No agent persona | ✅ | Zero matches for `^You are a` |
+| Copy identity (codebase-analyzer) | ✅ | 4 identical md5 hashes |
+| Copy identity (scope-detector) | ✅ | 2 identical md5 hashes |
+| Copy identity (file-evaluator) | ✅ | 2 identical md5 hashes |
+| Logic preservation (pnpm-lock.yaml) | ✅ | 1 match per codebase-analyzer copy |
+| Logic preservation (Different tech stack) | ✅ | 1 match per scope-detector copy |
+| Logic preservation (Bloat Indicators) | ✅ | 1 match per file-evaluator copy |
+| Distribution count | ✅ | 6, 7, 7, 8 files per skill directory |
+
+---
+
+## Files Changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `skills/init-agents/references/codebase-analyzer.md` | CREATE | +131 |
+| `skills/init-agents/references/scope-detector.md` | CREATE | +135 |
+| `skills/init-claude/references/codebase-analyzer.md` | CREATE | +131 |
+| `skills/init-claude/references/scope-detector.md` | CREATE | +135 |
+| `skills/improve-agents/references/codebase-analyzer.md` | CREATE | +131 |
+| `skills/improve-agents/references/file-evaluator.md` | CREATE | +165 |
+| `skills/improve-claude/references/codebase-analyzer.md` | CREATE | +131 |
+| `skills/improve-claude/references/file-evaluator.md` | CREATE | +165 |
+
+---
+
+## Deviations from Plan
+
+None.
+
+---
+
+## Issues Encountered
+
+None.
+
+---
+
+## Tests Written
+
+No code tests applicable — validation performed via filesystem checks (existence, line counts, md5sum, grep) as specified in plan.
+
+---
+
+## Next Steps
+
+- [ ] Review implementation
+- [ ] Create PR: `gh pr create` or `/prp-core:prp-pr`
+- [ ] Continue with Phase 4 (plugin SKILL.md updates) and Phase 5 (standalone SKILL.md updates) to reference these converted files

--- a/skills/improve-agents/references/codebase-analyzer.md
+++ b/skills/improve-agents/references/codebase-analyzer.md
@@ -1,0 +1,131 @@
+# Codebase Analysis Instructions
+
+Structured process for detecting project tech stack, tooling, and non-standard patterns.
+Used by INIT and IMPROVE skills for codebase analysis. Source: agents/codebase-analyzer.md
+
+---
+
+Follow these codebase analysis instructions. Analyze the project at the current working directory and return a structured summary of its technical characteristics. Focus on facts that would cause mistakes if an AI coding agent didn't know them.
+
+Use your environment's file reading and search capabilities to examine the project.
+
+## Constraints
+
+- Do not generate codebase overviews or directory listings — research shows these don't help agents navigate
+- Do not document obvious conventions the model already knows (e.g., standard JavaScript patterns)
+- Only report non-standard, non-obvious, or project-specific information
+- Shorter output is better — omit sections with nothing non-standard to report
+
+## Process
+
+### 1. Project Detection
+
+Search for configuration files to determine the project type:
+
+```
+Look for: package.json, Cargo.toml, go.mod, pyproject.toml, setup.py, requirements.txt,
+pom.xml, build.gradle, Gemfile, composer.json, mix.exs, CMakeLists.txt, Makefile,
+*.csproj, *.sln, deno.json, bun.lockb
+```
+
+### 2. Package Manager Detection
+
+Identify the package manager by checking for lock files:
+
+| Lock File | Package Manager |
+|-----------|----------------|
+| `pnpm-lock.yaml` | pnpm |
+| `yarn.lock` | yarn |
+| `package-lock.json` | npm |
+| `bun.lockb` | bun |
+| `Cargo.lock` | cargo |
+| `go.sum` | go modules |
+| `poetry.lock` | poetry |
+| `uv.lock` | uv |
+| `Pipfile.lock` | pipenv |
+| `Gemfile.lock` | bundler |
+| `composer.lock` | composer |
+
+Only report if non-default (e.g., pnpm instead of npm for JS projects).
+
+### 3. Build/Test/Lint Commands
+
+Extract commands from configuration files:
+
+- **package.json**: Read `scripts` section for build, test, lint, typecheck, dev commands
+- **Makefile**: Read target names
+- **pyproject.toml**: Read `[tool.pytest]`, `[tool.ruff]`, `[scripts]` sections
+- **Cargo.toml**: Check for workspace configuration
+
+Only report non-standard commands. Don't report `npm test` if that's the standard.
+
+### 4. Tech Stack Detection
+
+Identify key frameworks and tools by checking dependencies:
+
+- Frameworks: React, Next.js, Vue, Angular, Express, FastAPI, Django, Rails, etc.
+- Databases: Check for ORM configs (Prisma, TypeORM, SQLAlchemy, etc.)
+- Testing: Jest, Vitest, pytest, Go test, RSpec, etc.
+- Linting: ESLint, Prettier, Ruff, clippy, etc.
+- CI/CD: Check `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`
+
+### 5. Non-Standard Patterns
+
+Look for anything unusual that would trip up an agent:
+
+- Custom build scripts or tooling
+- Monorepo tools (Turborepo, Nx, Lerna, etc.)
+- Code generation (protobuf, GraphQL codegen, etc.)
+- Environment setup requirements (.env files, Docker, etc.)
+- Repository-specific tools mentioned in existing documentation
+
+*Source: agents/codebase-analyzer.md lines 22-82*
+
+---
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## Codebase Analysis Results
+
+### Project Type
+- Language: [primary language]
+- Framework: [if applicable]
+- Type: [application | library | monorepo | CLI tool | API | etc.]
+
+### Tooling (non-standard only)
+- Package manager: [only if non-default]
+- Build: `[command]`
+- Test: `[command]`
+- Lint: `[command]`
+- Typecheck: `[command]`
+- Dev server: `[command]`
+
+### Tech Stack
+- [Only list items that are non-obvious from the language/framework]
+
+### Non-Standard Patterns
+- [List anything unusual that would cause agent mistakes]
+
+### Domain Concepts
+- [Key domain terms that differ from common usage, if any]
+```
+
+If a section has nothing non-standard to report, omit it entirely. Shorter is better.
+
+*Source: agents/codebase-analyzer.md lines 83-113*
+
+---
+
+## Self-Verification
+
+Before returning results, verify:
+
+1. Every reported item is genuinely non-standard — would an experienced developer consider this worth noting?
+2. No directory listings or file structure descriptions crept in
+3. Output follows the exact format specified above
+4. Sections with no findings are omitted, not left empty
+
+*Source: agents/codebase-analyzer.md lines 115-122*

--- a/skills/improve-agents/references/file-evaluator.md
+++ b/skills/improve-agents/references/file-evaluator.md
@@ -1,0 +1,165 @@
+# File Evaluation Instructions
+
+Structured process for evaluating existing AGENTS.md/CLAUDE.md files against evidence-based quality criteria.
+Used by IMPROVE skills for current state analysis. Source: agents/file-evaluator.md
+
+---
+
+Follow these file evaluation instructions. Analyze existing AGENTS.md or CLAUDE.md files in the project at the current working directory and assess their quality against evidence-based criteria. Identify specific problems with evidence so an improvement skill can act on them.
+
+Use your environment's file reading and search capabilities to examine the project.
+
+## Constraints
+
+- Do not modify any files — only analyze and report
+- Do not suggest improvements — only identify problems with evidence
+- Be specific: cite exact line numbers and content for each issue found
+- Score objectively against the criteria below
+
+## Quality Criteria (from Research)
+
+### Hard Limits
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
+| Instruction count | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions" |
+| No contradictions | 0 conflicts | Anthropic: "Claude may pick one arbitrarily" |
+
+### Bloat Indicators
+
+Each of these wastes tokens without improving agent performance:
+
+| Indicator | Why It's Bloat | Source |
+|-----------|---------------|--------|
+| Directory/file structure listings | "Not effective at providing repository overview" | Evaluating AGENTS.md (ETH Zurich) |
+| Standard language conventions | Agent already knows these from training | Anthropic Best Practices |
+| Vague instructions ("write clean code") | Not actionable, wastes attention budget | a-guide-to-agents.md |
+| Codebase overview paragraphs | Increases steps without improving navigation | Evaluating AGENTS.md |
+| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it correctly, delete it" |
+| Duplicated information across files | Wastes tokens on every request | Context engineering research |
+
+### Staleness Indicators
+
+| Indicator | How to Detect |
+|-----------|---------------|
+| Referenced file paths that don't exist | Check if each `path/to/file` in the content actually exists |
+| Documented commands that fail | Try running documented build/test commands |
+| Package references to uninstalled deps | Check if mentioned packages are in manifest files |
+| Outdated framework version references | Compare mentioned versions with actual versions |
+
+### Progressive Disclosure Assessment
+
+| Question | Good | Bad |
+|----------|------|-----|
+| Does root file stay focused on essentials? | One-sentence desc + tooling + pointers | Inlines everything |
+| Are domain topics in separate files? | Testing in TESTING.md, build in BUILD.md | All in one file |
+| Do subdirectory files exist for distinct scopes? | packages/api/CLAUDE.md for API-specific rules | Everything in root |
+| Are pointers provided to detailed docs? | "See docs/TESTING.md" | No cross-references |
+
+*Source: agents/file-evaluator.md lines 20-59*
+
+---
+
+## Process
+
+### 1. Find All Configuration Files
+
+Search for:
+
+- `AGENTS.md` files at any depth
+- `CLAUDE.md` files at any depth
+- `.claude/rules/*.md` files (Claude Code path-scoped rules)
+- `.claude/CLAUDE.md` (project-level Claude Code config)
+
+### 2. Per-File Analysis
+
+For each file found:
+
+1. Count metrics: lines, sections (markdown headers), bullet points, code blocks
+2. Scan for bloat indicators: check each line against the bloat indicators table
+3. Check for staleness: verify referenced paths exist, commands work
+4. Identify contradictions: compare instructions across all files for conflicts
+5. Assess progressive disclosure: is content at the right scope level?
+6. Check instruction specificity: are instructions specific and verifiable?
+
+### 3. Cross-File Analysis
+
+- Are there contradictions between root and subdirectory files?
+- Is information duplicated across multiple files?
+- Are there scopes with distinct tooling that lack their own file?
+- Is the root file overloaded with scope-specific information?
+
+*Source: agents/file-evaluator.md lines 61-88*
+
+---
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## File Evaluation Results
+
+### Files Found
+| File | Lines | Sections | Status |
+|------|-------|----------|--------|
+| `./CLAUDE.md` | 342 | 15 | ⚠️ Over limit |
+| `./packages/api/CLAUDE.md` | 28 | 3 | ✅ Good |
+
+### Per-File Issues
+
+#### `./CLAUDE.md` (342 lines — OVER 200 LINE LIMIT)
+
+**Bloat Issues:**
+- Lines 45-78: Directory structure listing (research shows these don't help agents)
+- Lines 102-115: Standard TypeScript conventions (agent already knows these)
+- Line 134: "Write clean, maintainable code" (too vague to be actionable)
+
+**Staleness Issues:**
+- Line 23: References `src/auth/handlers.ts` — file does not exist
+- Line 89: Documents `npm run build:legacy` — command not in package.json
+
+**Contradiction Issues:**
+- Line 12: "Use 4-space indentation" conflicts with `.prettierrc` setting of 2 spaces
+
+**Progressive Disclosure Issues:**
+- Lines 150-200: Testing conventions should be in separate `docs/TESTING.md`
+- Lines 201-250: API design patterns should be in `packages/api/CLAUDE.md`
+
+**Specificity Issues:**
+- Line 67: "Follow best practices for error handling" — not actionable
+
+### Cross-File Issues
+- [List any cross-file contradictions or duplications]
+
+### Missing Scopes
+- `packages/web/` — Has distinct React tech stack, no config file
+- `scripts/` — Has custom tooling, no config file
+
+### Quality Score
+| Dimension | Score (1-10) | Notes |
+|-----------|-------------|-------|
+| Conciseness | 3 | 342 lines, 70%+ over limit |
+| Accuracy | 6 | 2 stale references found |
+| Specificity | 5 | Mix of specific and vague instructions |
+| Progressive Disclosure | 4 | Most content inlined in root |
+| Consistency | 7 | 1 contradiction found |
+| **Overall** | **4** | Needs significant refactoring |
+```
+
+*Source: agents/file-evaluator.md lines 89-141*
+
+---
+
+## Self-Verification
+
+Before returning results, verify:
+
+1. Every reported issue includes a specific line number or line range
+2. Bloat classifications match the criteria table — no false positives
+3. Staleness claims are verified (paths checked, commands checked)
+4. The quality score reflects the actual severity of issues found
+5. No improvement suggestions crept in — report only identifies problems
+
+*Source: agents/file-evaluator.md lines 143-151*

--- a/skills/improve-claude/references/codebase-analyzer.md
+++ b/skills/improve-claude/references/codebase-analyzer.md
@@ -1,0 +1,131 @@
+# Codebase Analysis Instructions
+
+Structured process for detecting project tech stack, tooling, and non-standard patterns.
+Used by INIT and IMPROVE skills for codebase analysis. Source: agents/codebase-analyzer.md
+
+---
+
+Follow these codebase analysis instructions. Analyze the project at the current working directory and return a structured summary of its technical characteristics. Focus on facts that would cause mistakes if an AI coding agent didn't know them.
+
+Use your environment's file reading and search capabilities to examine the project.
+
+## Constraints
+
+- Do not generate codebase overviews or directory listings — research shows these don't help agents navigate
+- Do not document obvious conventions the model already knows (e.g., standard JavaScript patterns)
+- Only report non-standard, non-obvious, or project-specific information
+- Shorter output is better — omit sections with nothing non-standard to report
+
+## Process
+
+### 1. Project Detection
+
+Search for configuration files to determine the project type:
+
+```
+Look for: package.json, Cargo.toml, go.mod, pyproject.toml, setup.py, requirements.txt,
+pom.xml, build.gradle, Gemfile, composer.json, mix.exs, CMakeLists.txt, Makefile,
+*.csproj, *.sln, deno.json, bun.lockb
+```
+
+### 2. Package Manager Detection
+
+Identify the package manager by checking for lock files:
+
+| Lock File | Package Manager |
+|-----------|----------------|
+| `pnpm-lock.yaml` | pnpm |
+| `yarn.lock` | yarn |
+| `package-lock.json` | npm |
+| `bun.lockb` | bun |
+| `Cargo.lock` | cargo |
+| `go.sum` | go modules |
+| `poetry.lock` | poetry |
+| `uv.lock` | uv |
+| `Pipfile.lock` | pipenv |
+| `Gemfile.lock` | bundler |
+| `composer.lock` | composer |
+
+Only report if non-default (e.g., pnpm instead of npm for JS projects).
+
+### 3. Build/Test/Lint Commands
+
+Extract commands from configuration files:
+
+- **package.json**: Read `scripts` section for build, test, lint, typecheck, dev commands
+- **Makefile**: Read target names
+- **pyproject.toml**: Read `[tool.pytest]`, `[tool.ruff]`, `[scripts]` sections
+- **Cargo.toml**: Check for workspace configuration
+
+Only report non-standard commands. Don't report `npm test` if that's the standard.
+
+### 4. Tech Stack Detection
+
+Identify key frameworks and tools by checking dependencies:
+
+- Frameworks: React, Next.js, Vue, Angular, Express, FastAPI, Django, Rails, etc.
+- Databases: Check for ORM configs (Prisma, TypeORM, SQLAlchemy, etc.)
+- Testing: Jest, Vitest, pytest, Go test, RSpec, etc.
+- Linting: ESLint, Prettier, Ruff, clippy, etc.
+- CI/CD: Check `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`
+
+### 5. Non-Standard Patterns
+
+Look for anything unusual that would trip up an agent:
+
+- Custom build scripts or tooling
+- Monorepo tools (Turborepo, Nx, Lerna, etc.)
+- Code generation (protobuf, GraphQL codegen, etc.)
+- Environment setup requirements (.env files, Docker, etc.)
+- Repository-specific tools mentioned in existing documentation
+
+*Source: agents/codebase-analyzer.md lines 22-82*
+
+---
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## Codebase Analysis Results
+
+### Project Type
+- Language: [primary language]
+- Framework: [if applicable]
+- Type: [application | library | monorepo | CLI tool | API | etc.]
+
+### Tooling (non-standard only)
+- Package manager: [only if non-default]
+- Build: `[command]`
+- Test: `[command]`
+- Lint: `[command]`
+- Typecheck: `[command]`
+- Dev server: `[command]`
+
+### Tech Stack
+- [Only list items that are non-obvious from the language/framework]
+
+### Non-Standard Patterns
+- [List anything unusual that would cause agent mistakes]
+
+### Domain Concepts
+- [Key domain terms that differ from common usage, if any]
+```
+
+If a section has nothing non-standard to report, omit it entirely. Shorter is better.
+
+*Source: agents/codebase-analyzer.md lines 83-113*
+
+---
+
+## Self-Verification
+
+Before returning results, verify:
+
+1. Every reported item is genuinely non-standard — would an experienced developer consider this worth noting?
+2. No directory listings or file structure descriptions crept in
+3. Output follows the exact format specified above
+4. Sections with no findings are omitted, not left empty
+
+*Source: agents/codebase-analyzer.md lines 115-122*

--- a/skills/improve-claude/references/file-evaluator.md
+++ b/skills/improve-claude/references/file-evaluator.md
@@ -1,0 +1,165 @@
+# File Evaluation Instructions
+
+Structured process for evaluating existing AGENTS.md/CLAUDE.md files against evidence-based quality criteria.
+Used by IMPROVE skills for current state analysis. Source: agents/file-evaluator.md
+
+---
+
+Follow these file evaluation instructions. Analyze existing AGENTS.md or CLAUDE.md files in the project at the current working directory and assess their quality against evidence-based criteria. Identify specific problems with evidence so an improvement skill can act on them.
+
+Use your environment's file reading and search capabilities to examine the project.
+
+## Constraints
+
+- Do not modify any files — only analyze and report
+- Do not suggest improvements — only identify problems with evidence
+- Be specific: cite exact line numbers and content for each issue found
+- Score objectively against the criteria below
+
+## Quality Criteria (from Research)
+
+### Hard Limits
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
+| Instruction count | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions" |
+| No contradictions | 0 conflicts | Anthropic: "Claude may pick one arbitrarily" |
+
+### Bloat Indicators
+
+Each of these wastes tokens without improving agent performance:
+
+| Indicator | Why It's Bloat | Source |
+|-----------|---------------|--------|
+| Directory/file structure listings | "Not effective at providing repository overview" | Evaluating AGENTS.md (ETH Zurich) |
+| Standard language conventions | Agent already knows these from training | Anthropic Best Practices |
+| Vague instructions ("write clean code") | Not actionable, wastes attention budget | a-guide-to-agents.md |
+| Codebase overview paragraphs | Increases steps without improving navigation | Evaluating AGENTS.md |
+| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it correctly, delete it" |
+| Duplicated information across files | Wastes tokens on every request | Context engineering research |
+
+### Staleness Indicators
+
+| Indicator | How to Detect |
+|-----------|---------------|
+| Referenced file paths that don't exist | Check if each `path/to/file` in the content actually exists |
+| Documented commands that fail | Try running documented build/test commands |
+| Package references to uninstalled deps | Check if mentioned packages are in manifest files |
+| Outdated framework version references | Compare mentioned versions with actual versions |
+
+### Progressive Disclosure Assessment
+
+| Question | Good | Bad |
+|----------|------|-----|
+| Does root file stay focused on essentials? | One-sentence desc + tooling + pointers | Inlines everything |
+| Are domain topics in separate files? | Testing in TESTING.md, build in BUILD.md | All in one file |
+| Do subdirectory files exist for distinct scopes? | packages/api/CLAUDE.md for API-specific rules | Everything in root |
+| Are pointers provided to detailed docs? | "See docs/TESTING.md" | No cross-references |
+
+*Source: agents/file-evaluator.md lines 20-59*
+
+---
+
+## Process
+
+### 1. Find All Configuration Files
+
+Search for:
+
+- `AGENTS.md` files at any depth
+- `CLAUDE.md` files at any depth
+- `.claude/rules/*.md` files (Claude Code path-scoped rules)
+- `.claude/CLAUDE.md` (project-level Claude Code config)
+
+### 2. Per-File Analysis
+
+For each file found:
+
+1. Count metrics: lines, sections (markdown headers), bullet points, code blocks
+2. Scan for bloat indicators: check each line against the bloat indicators table
+3. Check for staleness: verify referenced paths exist, commands work
+4. Identify contradictions: compare instructions across all files for conflicts
+5. Assess progressive disclosure: is content at the right scope level?
+6. Check instruction specificity: are instructions specific and verifiable?
+
+### 3. Cross-File Analysis
+
+- Are there contradictions between root and subdirectory files?
+- Is information duplicated across multiple files?
+- Are there scopes with distinct tooling that lack their own file?
+- Is the root file overloaded with scope-specific information?
+
+*Source: agents/file-evaluator.md lines 61-88*
+
+---
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## File Evaluation Results
+
+### Files Found
+| File | Lines | Sections | Status |
+|------|-------|----------|--------|
+| `./CLAUDE.md` | 342 | 15 | ⚠️ Over limit |
+| `./packages/api/CLAUDE.md` | 28 | 3 | ✅ Good |
+
+### Per-File Issues
+
+#### `./CLAUDE.md` (342 lines — OVER 200 LINE LIMIT)
+
+**Bloat Issues:**
+- Lines 45-78: Directory structure listing (research shows these don't help agents)
+- Lines 102-115: Standard TypeScript conventions (agent already knows these)
+- Line 134: "Write clean, maintainable code" (too vague to be actionable)
+
+**Staleness Issues:**
+- Line 23: References `src/auth/handlers.ts` — file does not exist
+- Line 89: Documents `npm run build:legacy` — command not in package.json
+
+**Contradiction Issues:**
+- Line 12: "Use 4-space indentation" conflicts with `.prettierrc` setting of 2 spaces
+
+**Progressive Disclosure Issues:**
+- Lines 150-200: Testing conventions should be in separate `docs/TESTING.md`
+- Lines 201-250: API design patterns should be in `packages/api/CLAUDE.md`
+
+**Specificity Issues:**
+- Line 67: "Follow best practices for error handling" — not actionable
+
+### Cross-File Issues
+- [List any cross-file contradictions or duplications]
+
+### Missing Scopes
+- `packages/web/` — Has distinct React tech stack, no config file
+- `scripts/` — Has custom tooling, no config file
+
+### Quality Score
+| Dimension | Score (1-10) | Notes |
+|-----------|-------------|-------|
+| Conciseness | 3 | 342 lines, 70%+ over limit |
+| Accuracy | 6 | 2 stale references found |
+| Specificity | 5 | Mix of specific and vague instructions |
+| Progressive Disclosure | 4 | Most content inlined in root |
+| Consistency | 7 | 1 contradiction found |
+| **Overall** | **4** | Needs significant refactoring |
+```
+
+*Source: agents/file-evaluator.md lines 89-141*
+
+---
+
+## Self-Verification
+
+Before returning results, verify:
+
+1. Every reported issue includes a specific line number or line range
+2. Bloat classifications match the criteria table — no false positives
+3. Staleness claims are verified (paths checked, commands checked)
+4. The quality score reflects the actual severity of issues found
+5. No improvement suggestions crept in — report only identifies problems
+
+*Source: agents/file-evaluator.md lines 143-151*

--- a/skills/init-agents/references/codebase-analyzer.md
+++ b/skills/init-agents/references/codebase-analyzer.md
@@ -1,0 +1,131 @@
+# Codebase Analysis Instructions
+
+Structured process for detecting project tech stack, tooling, and non-standard patterns.
+Used by INIT and IMPROVE skills for codebase analysis. Source: agents/codebase-analyzer.md
+
+---
+
+Follow these codebase analysis instructions. Analyze the project at the current working directory and return a structured summary of its technical characteristics. Focus on facts that would cause mistakes if an AI coding agent didn't know them.
+
+Use your environment's file reading and search capabilities to examine the project.
+
+## Constraints
+
+- Do not generate codebase overviews or directory listings — research shows these don't help agents navigate
+- Do not document obvious conventions the model already knows (e.g., standard JavaScript patterns)
+- Only report non-standard, non-obvious, or project-specific information
+- Shorter output is better — omit sections with nothing non-standard to report
+
+## Process
+
+### 1. Project Detection
+
+Search for configuration files to determine the project type:
+
+```
+Look for: package.json, Cargo.toml, go.mod, pyproject.toml, setup.py, requirements.txt,
+pom.xml, build.gradle, Gemfile, composer.json, mix.exs, CMakeLists.txt, Makefile,
+*.csproj, *.sln, deno.json, bun.lockb
+```
+
+### 2. Package Manager Detection
+
+Identify the package manager by checking for lock files:
+
+| Lock File | Package Manager |
+|-----------|----------------|
+| `pnpm-lock.yaml` | pnpm |
+| `yarn.lock` | yarn |
+| `package-lock.json` | npm |
+| `bun.lockb` | bun |
+| `Cargo.lock` | cargo |
+| `go.sum` | go modules |
+| `poetry.lock` | poetry |
+| `uv.lock` | uv |
+| `Pipfile.lock` | pipenv |
+| `Gemfile.lock` | bundler |
+| `composer.lock` | composer |
+
+Only report if non-default (e.g., pnpm instead of npm for JS projects).
+
+### 3. Build/Test/Lint Commands
+
+Extract commands from configuration files:
+
+- **package.json**: Read `scripts` section for build, test, lint, typecheck, dev commands
+- **Makefile**: Read target names
+- **pyproject.toml**: Read `[tool.pytest]`, `[tool.ruff]`, `[scripts]` sections
+- **Cargo.toml**: Check for workspace configuration
+
+Only report non-standard commands. Don't report `npm test` if that's the standard.
+
+### 4. Tech Stack Detection
+
+Identify key frameworks and tools by checking dependencies:
+
+- Frameworks: React, Next.js, Vue, Angular, Express, FastAPI, Django, Rails, etc.
+- Databases: Check for ORM configs (Prisma, TypeORM, SQLAlchemy, etc.)
+- Testing: Jest, Vitest, pytest, Go test, RSpec, etc.
+- Linting: ESLint, Prettier, Ruff, clippy, etc.
+- CI/CD: Check `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`
+
+### 5. Non-Standard Patterns
+
+Look for anything unusual that would trip up an agent:
+
+- Custom build scripts or tooling
+- Monorepo tools (Turborepo, Nx, Lerna, etc.)
+- Code generation (protobuf, GraphQL codegen, etc.)
+- Environment setup requirements (.env files, Docker, etc.)
+- Repository-specific tools mentioned in existing documentation
+
+*Source: agents/codebase-analyzer.md lines 22-82*
+
+---
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## Codebase Analysis Results
+
+### Project Type
+- Language: [primary language]
+- Framework: [if applicable]
+- Type: [application | library | monorepo | CLI tool | API | etc.]
+
+### Tooling (non-standard only)
+- Package manager: [only if non-default]
+- Build: `[command]`
+- Test: `[command]`
+- Lint: `[command]`
+- Typecheck: `[command]`
+- Dev server: `[command]`
+
+### Tech Stack
+- [Only list items that are non-obvious from the language/framework]
+
+### Non-Standard Patterns
+- [List anything unusual that would cause agent mistakes]
+
+### Domain Concepts
+- [Key domain terms that differ from common usage, if any]
+```
+
+If a section has nothing non-standard to report, omit it entirely. Shorter is better.
+
+*Source: agents/codebase-analyzer.md lines 83-113*
+
+---
+
+## Self-Verification
+
+Before returning results, verify:
+
+1. Every reported item is genuinely non-standard — would an experienced developer consider this worth noting?
+2. No directory listings or file structure descriptions crept in
+3. Output follows the exact format specified above
+4. Sections with no findings are omitted, not left empty
+
+*Source: agents/codebase-analyzer.md lines 115-122*

--- a/skills/init-agents/references/scope-detector.md
+++ b/skills/init-agents/references/scope-detector.md
@@ -1,0 +1,135 @@
+# Scope Detection Instructions
+
+Structured process for identifying distinct project contexts that need separate configuration files.
+Used by INIT skills for scope detection. Source: agents/scope-detector.md
+
+---
+
+Follow these scope detection instructions. Identify distinct contexts within the project at the current working directory that would benefit from their own configuration file (AGENTS.md or CLAUDE.md). Each scope represents an area where an agent needs different guidance than the root-level instructions.
+
+Use your environment's file reading and search capabilities to examine the project.
+
+## Constraints
+
+- Do not create a scope for every directory — only for truly distinct contexts
+- A scope needs its own file only if it has different tooling, conventions, or domain knowledge from the root
+- Single-package projects may have zero additional scopes (root file is sufficient)
+- Aim for the minimum number of scopes that captures meaningful differences
+
+## When a Directory Deserves Its Own Scope
+
+A directory is a distinct scope if ANY of these are true:
+
+| Criterion | Example |
+|-----------|---------|
+| Different tech stack | Frontend (React) vs Backend (Express) in a monorepo |
+| Different build/test commands | `packages/api` uses `jest`, `packages/web` uses `vitest` |
+| Different language | Go service alongside a TypeScript frontend |
+| Different deployment target | Lambda functions vs Docker containers |
+| Independent package with own dependencies | Monorepo package with own `package.json` |
+| Distinct domain with specialized conventions | Database migration scripts with specific ordering rules |
+| Unique constraints on a shared package | Zero-dependency rule, dual exports, conditional imports, `server-only` marker |
+| Security-sensitive data handling | Package that handles encryption, PII, or cross-schema access control |
+
+A directory is NOT a distinct scope if:
+
+- It merely organizes code within the same tech stack
+- Its conventions are identical to the root
+- It has no independent tooling or commands
+- It is a simple utility directory with no unique constraints
+
+## Process
+
+### 1. Check for Monorepo Structure
+
+Look for:
+
+- `workspaces` field in root `package.json`
+- `pnpm-workspace.yaml`
+- `lerna.json`
+- `nx.json` or `project.json` files
+- `turbo.json`
+- `Cargo.toml` with `[workspace]`
+- `go.work`
+- Multiple `package.json` / `Cargo.toml` / `go.mod` files
+
+### 2. Identify Package Boundaries
+
+For each potential package/service:
+
+- Read its manifest file (package.json, Cargo.toml, etc.)
+- Check if it has its own build/test commands
+- Determine its primary tech stack
+- Note any unique dependencies or tooling
+
+### 3. Identify Domain Boundaries
+
+Beyond packages, check for distinct domains:
+
+- `scripts/` or `tools/` directories with their own execution environment
+- `docs/` directories that may need documentation-specific guidance
+- Infrastructure code (`terraform/`, `kubernetes/`, `docker/`) with different tooling
+- Database-related directories (`migrations/`, `seeds/`) with ordering or naming conventions
+
+### 4. Determine Scope-Specific Content
+
+For each identified scope, determine what makes it different:
+
+- What unique commands does this scope have?
+- What conventions apply here but not elsewhere?
+- What tech-specific knowledge would an agent need?
+
+*Source: agents/scope-detector.md lines 41-76*
+
+---
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## Scope Detection Results
+
+### Project Structure
+- Type: [single-package | monorepo | multi-service | hybrid]
+- Monorepo tool: [if applicable]
+
+### Detected Scopes
+
+#### Scope: [relative/path]
+- Purpose: [one sentence]
+- Tech: [primary technology if different from root]
+- Commands: [scope-specific commands, if any]
+- Key conventions: [only if different from root]
+- Needs own config file: [yes/no with brief reason]
+
+#### Scope: [relative/path]
+...
+
+### Recommended File Tree
+- `./AGENTS.md` (root) — [one-line description of what goes here]
+- `[path]/AGENTS.md` — [one-line description, only for scopes marked "yes"]
+...
+
+### Domain Files Recommended
+- `docs/TESTING.md` — [only if non-standard testing patterns detected]
+- `docs/BUILD.md` — [only if non-standard build pipeline detected]
+...
+```
+
+If the project is a simple single-package project, report zero additional scopes — the root file is sufficient.
+
+*Source: agents/scope-detector.md lines 77-112*
+
+---
+
+## Self-Verification
+
+Before returning results, verify:
+
+1. Every recommended scope has genuinely different tooling or conventions from root
+2. No scopes were created just for organizational directories
+3. The recommended file count is the minimum necessary
+4. Simple projects correctly return zero additional scopes
+
+*Source: agents/scope-detector.md lines 113-121*

--- a/skills/init-claude/references/codebase-analyzer.md
+++ b/skills/init-claude/references/codebase-analyzer.md
@@ -1,0 +1,131 @@
+# Codebase Analysis Instructions
+
+Structured process for detecting project tech stack, tooling, and non-standard patterns.
+Used by INIT and IMPROVE skills for codebase analysis. Source: agents/codebase-analyzer.md
+
+---
+
+Follow these codebase analysis instructions. Analyze the project at the current working directory and return a structured summary of its technical characteristics. Focus on facts that would cause mistakes if an AI coding agent didn't know them.
+
+Use your environment's file reading and search capabilities to examine the project.
+
+## Constraints
+
+- Do not generate codebase overviews or directory listings — research shows these don't help agents navigate
+- Do not document obvious conventions the model already knows (e.g., standard JavaScript patterns)
+- Only report non-standard, non-obvious, or project-specific information
+- Shorter output is better — omit sections with nothing non-standard to report
+
+## Process
+
+### 1. Project Detection
+
+Search for configuration files to determine the project type:
+
+```
+Look for: package.json, Cargo.toml, go.mod, pyproject.toml, setup.py, requirements.txt,
+pom.xml, build.gradle, Gemfile, composer.json, mix.exs, CMakeLists.txt, Makefile,
+*.csproj, *.sln, deno.json, bun.lockb
+```
+
+### 2. Package Manager Detection
+
+Identify the package manager by checking for lock files:
+
+| Lock File | Package Manager |
+|-----------|----------------|
+| `pnpm-lock.yaml` | pnpm |
+| `yarn.lock` | yarn |
+| `package-lock.json` | npm |
+| `bun.lockb` | bun |
+| `Cargo.lock` | cargo |
+| `go.sum` | go modules |
+| `poetry.lock` | poetry |
+| `uv.lock` | uv |
+| `Pipfile.lock` | pipenv |
+| `Gemfile.lock` | bundler |
+| `composer.lock` | composer |
+
+Only report if non-default (e.g., pnpm instead of npm for JS projects).
+
+### 3. Build/Test/Lint Commands
+
+Extract commands from configuration files:
+
+- **package.json**: Read `scripts` section for build, test, lint, typecheck, dev commands
+- **Makefile**: Read target names
+- **pyproject.toml**: Read `[tool.pytest]`, `[tool.ruff]`, `[scripts]` sections
+- **Cargo.toml**: Check for workspace configuration
+
+Only report non-standard commands. Don't report `npm test` if that's the standard.
+
+### 4. Tech Stack Detection
+
+Identify key frameworks and tools by checking dependencies:
+
+- Frameworks: React, Next.js, Vue, Angular, Express, FastAPI, Django, Rails, etc.
+- Databases: Check for ORM configs (Prisma, TypeORM, SQLAlchemy, etc.)
+- Testing: Jest, Vitest, pytest, Go test, RSpec, etc.
+- Linting: ESLint, Prettier, Ruff, clippy, etc.
+- CI/CD: Check `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`
+
+### 5. Non-Standard Patterns
+
+Look for anything unusual that would trip up an agent:
+
+- Custom build scripts or tooling
+- Monorepo tools (Turborepo, Nx, Lerna, etc.)
+- Code generation (protobuf, GraphQL codegen, etc.)
+- Environment setup requirements (.env files, Docker, etc.)
+- Repository-specific tools mentioned in existing documentation
+
+*Source: agents/codebase-analyzer.md lines 22-82*
+
+---
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## Codebase Analysis Results
+
+### Project Type
+- Language: [primary language]
+- Framework: [if applicable]
+- Type: [application | library | monorepo | CLI tool | API | etc.]
+
+### Tooling (non-standard only)
+- Package manager: [only if non-default]
+- Build: `[command]`
+- Test: `[command]`
+- Lint: `[command]`
+- Typecheck: `[command]`
+- Dev server: `[command]`
+
+### Tech Stack
+- [Only list items that are non-obvious from the language/framework]
+
+### Non-Standard Patterns
+- [List anything unusual that would cause agent mistakes]
+
+### Domain Concepts
+- [Key domain terms that differ from common usage, if any]
+```
+
+If a section has nothing non-standard to report, omit it entirely. Shorter is better.
+
+*Source: agents/codebase-analyzer.md lines 83-113*
+
+---
+
+## Self-Verification
+
+Before returning results, verify:
+
+1. Every reported item is genuinely non-standard — would an experienced developer consider this worth noting?
+2. No directory listings or file structure descriptions crept in
+3. Output follows the exact format specified above
+4. Sections with no findings are omitted, not left empty
+
+*Source: agents/codebase-analyzer.md lines 115-122*

--- a/skills/init-claude/references/scope-detector.md
+++ b/skills/init-claude/references/scope-detector.md
@@ -1,0 +1,135 @@
+# Scope Detection Instructions
+
+Structured process for identifying distinct project contexts that need separate configuration files.
+Used by INIT skills for scope detection. Source: agents/scope-detector.md
+
+---
+
+Follow these scope detection instructions. Identify distinct contexts within the project at the current working directory that would benefit from their own configuration file (AGENTS.md or CLAUDE.md). Each scope represents an area where an agent needs different guidance than the root-level instructions.
+
+Use your environment's file reading and search capabilities to examine the project.
+
+## Constraints
+
+- Do not create a scope for every directory — only for truly distinct contexts
+- A scope needs its own file only if it has different tooling, conventions, or domain knowledge from the root
+- Single-package projects may have zero additional scopes (root file is sufficient)
+- Aim for the minimum number of scopes that captures meaningful differences
+
+## When a Directory Deserves Its Own Scope
+
+A directory is a distinct scope if ANY of these are true:
+
+| Criterion | Example |
+|-----------|---------|
+| Different tech stack | Frontend (React) vs Backend (Express) in a monorepo |
+| Different build/test commands | `packages/api` uses `jest`, `packages/web` uses `vitest` |
+| Different language | Go service alongside a TypeScript frontend |
+| Different deployment target | Lambda functions vs Docker containers |
+| Independent package with own dependencies | Monorepo package with own `package.json` |
+| Distinct domain with specialized conventions | Database migration scripts with specific ordering rules |
+| Unique constraints on a shared package | Zero-dependency rule, dual exports, conditional imports, `server-only` marker |
+| Security-sensitive data handling | Package that handles encryption, PII, or cross-schema access control |
+
+A directory is NOT a distinct scope if:
+
+- It merely organizes code within the same tech stack
+- Its conventions are identical to the root
+- It has no independent tooling or commands
+- It is a simple utility directory with no unique constraints
+
+## Process
+
+### 1. Check for Monorepo Structure
+
+Look for:
+
+- `workspaces` field in root `package.json`
+- `pnpm-workspace.yaml`
+- `lerna.json`
+- `nx.json` or `project.json` files
+- `turbo.json`
+- `Cargo.toml` with `[workspace]`
+- `go.work`
+- Multiple `package.json` / `Cargo.toml` / `go.mod` files
+
+### 2. Identify Package Boundaries
+
+For each potential package/service:
+
+- Read its manifest file (package.json, Cargo.toml, etc.)
+- Check if it has its own build/test commands
+- Determine its primary tech stack
+- Note any unique dependencies or tooling
+
+### 3. Identify Domain Boundaries
+
+Beyond packages, check for distinct domains:
+
+- `scripts/` or `tools/` directories with their own execution environment
+- `docs/` directories that may need documentation-specific guidance
+- Infrastructure code (`terraform/`, `kubernetes/`, `docker/`) with different tooling
+- Database-related directories (`migrations/`, `seeds/`) with ordering or naming conventions
+
+### 4. Determine Scope-Specific Content
+
+For each identified scope, determine what makes it different:
+
+- What unique commands does this scope have?
+- What conventions apply here but not elsewhere?
+- What tech-specific knowledge would an agent need?
+
+*Source: agents/scope-detector.md lines 41-76*
+
+---
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## Scope Detection Results
+
+### Project Structure
+- Type: [single-package | monorepo | multi-service | hybrid]
+- Monorepo tool: [if applicable]
+
+### Detected Scopes
+
+#### Scope: [relative/path]
+- Purpose: [one sentence]
+- Tech: [primary technology if different from root]
+- Commands: [scope-specific commands, if any]
+- Key conventions: [only if different from root]
+- Needs own config file: [yes/no with brief reason]
+
+#### Scope: [relative/path]
+...
+
+### Recommended File Tree
+- `./AGENTS.md` (root) — [one-line description of what goes here]
+- `[path]/AGENTS.md` — [one-line description, only for scopes marked "yes"]
+...
+
+### Domain Files Recommended
+- `docs/TESTING.md` — [only if non-standard testing patterns detected]
+- `docs/BUILD.md` — [only if non-standard build pipeline detected]
+...
+```
+
+If the project is a simple single-package project, report zero additional scopes — the root file is sufficient.
+
+*Source: agents/scope-detector.md lines 77-112*
+
+---
+
+## Self-Verification
+
+Before returning results, verify:
+
+1. Every recommended scope has genuinely different tooling or conventions from root
+2. No scopes were created just for organizational directories
+3. The recommended file count is the minimum necessary
+4. Simple projects correctly return zero additional scopes
+
+*Source: agents/scope-detector.md lines 113-121*


### PR DESCRIPTION
## Summary

Converted 3 Claude Code agent files (codebase-analyzer, scope-detector, file-evaluator) into universal reference documents that standalone skills can consume inline, achieving feature parity across all Agent Skills-compliant tools.

## Changes

- **feat**: Convert agent files to universal reference documents for standalone skills
  - Strip Claude Code-specific frontmatter (name, tools, model, maxTurns)
  - Preserve 100% of analysis logic (process steps, lookup tables, detection patterns, output format templates, self-verification checklists)
  - Reframe agent persona declarations as follow-these-instructions directives
  - Add tool-agnostic execution notes instead of Claude Code tool references
  - Distribute 8 converted references to skill directories (init-agents, init-claude, improve-agents, improve-claude)
  - Mark PRD Phase 3 complete and archive implementation plan

## Files Changed

11 files changed, +1717 lines

<details>
<summary>File list</summary>

- .claude/PRPs/plans/completed/agent-to-reference-conversion.plan.md (archived plan)
- .claude/PRPs/prds/skill-directory-evolution.prd.md (phase status update)
- .claude/PRPs/reports/agent-to-reference-conversion-report.md (implementation report)
- skills/improve-agents/references/codebase-analyzer.md
- skills/improve-agents/references/file-evaluator.md
- skills/improve-claude/references/codebase-analyzer.md
- skills/improve-claude/references/file-evaluator.md
- skills/init-agents/references/codebase-analyzer.md
- skills/init-agents/references/scope-detector.md
- skills/init-claude/references/codebase-analyzer.md
- skills/init-claude/references/scope-detector.md

</details>

## Validation

All 8 converted reference files pass 6-level validation:
- ✅ File existence (all 8 present)
- ✅ Line counts (131, 135, 165 lines — all ≤ 200)
- ✅ No Claude Code frontmatter
- ✅ No agent persona declarations
- ✅ Byte-identical copies within groups (verified via md5sum)
- ✅ Logic preservation (key strings present in all copies)

## Related Issues

None

## Notes

- Original agent files in plugins/agents-initializer/agents/ remain unchanged
- Converted copies are independent and can evolve separately
- Phase 4 and 5 (SKILL.md updates) will reference these converted files
- Implementation report: .claude/PRPs/reports/agent-to-reference-conversion-report.md