### PR TITLE
fix(refs): address Copilot CR feedback from PR #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ agent-engineering-toolkit/
 │   ├── cursor/                          # Cursor IDE specific docs
 │   ├── general-llm/                     # General LLM/agent research & guides
 │   ├── shared/                          # Cross-tool standards (Agent Skills)
-│   ├── analysis/                        # Deep extraction analysis (Portuguese)
+│   ├── analysis/                        # Deep extraction analysis
 │   └── plans/                           # Project design documents
 ├── README.md
 └── LICENSE

--- a/docs/analysis/analysis-claude-hook-reference-doc.md
+++ b/docs/analysis/analysis-claude-hook-reference-doc.md
@@ -399,7 +399,7 @@ echo "$SUMMARY" >> ~/.claude/projects/my-project/compaction-history.log
 | Structured output with JSON | All hook↔Claude communication uses structured JSON |
 | Tool use patterns | `PreToolUse`/`PostToolUse` control exactly how tools are used |
 
-### 7.4 a-guide-to-agents.md / a-guide-to-agents.md
+### 7.4 a-guide-to-agents.md (merged guide)
 
 | Guide Principle | Hooks as Implementation |
 |-----------------|------------------------|

--- a/docs/analysis/analysis-skill-authoring-best-practices.md
+++ b/docs/analysis/analysis-skill-authoring-best-practices.md
@@ -525,7 +525,7 @@ that might inform this task (previous decisions, preferences, constraints).
 | Think step by step | Workflows with sequential checklists |
 | Give Claude a role | Description implicitly defines the role |
 
-### 7.4 a-guide-to-agents.md / a-guide-to-agents.md
+### 7.4 a-guide-to-agents.md (merged guide)
 
 | Guide Principle | Skill Authoring Equivalent |
 |-----------------|----------------------------|

--- a/docs/general-llm/research-context-engineering-comprehensive.md
+++ b/docs/general-llm/research-context-engineering-comprehensive.md
@@ -1,6 +1,6 @@
 # LLM Context Engineering: Comprehensive Research Synthesis
 
-**Date**: July 2025
+**Date**: April 2026
 **Scope**: Context rot, context poisoning, attention budget, whitespace & formatting, multilingual performance (English vs Portuguese), prompt compression, RAG quality — synthesized from 50+ academic papers and official documentation (2022–2026).
 
 ---
@@ -245,4 +245,4 @@ This synthesis is split into focused files for efficient context loading:
 
 ---
 
-*Report generated: July 2025. This hub contains the Executive Summary, cross-cutting recommendations, and Full Citation List. Detailed research content is split into scoped files: [Context Rot & Management](research-context-rot-and-management.md) (Parts 1–8), [Whitespace & Formatting](research-whitespace-and-formatting.md) (Part 9), [Multilingual Performance](research-multilingual-performance.md) (Parts 10–11), [Agent Workflows & Patterns](research-agent-workflows-and-patterns.md) (Section 13). Synthesized from 55+ sources including peer-reviewed papers from NeurIPS, ACL, EMNLP, EACL, TACL, NAACL, AACL, ICLR, ICML, BRACIS, official documentation from Anthropic, Google Research, Microsoft Research, Chroma, and practitioner workflows.*
+*Report generated: April 2026. This hub contains the Executive Summary, cross-cutting recommendations, and Full Citation List. Detailed research content is split into scoped files: [Context Rot & Management](research-context-rot-and-management.md) (Parts 1–8), [Whitespace & Formatting](research-whitespace-and-formatting.md) (Part 9), [Multilingual Performance](research-multilingual-performance.md) (Parts 10–11), [Agent Workflows & Patterns](research-agent-workflows-and-patterns.md) (Section 13). Synthesized from 55+ sources including peer-reviewed papers from NeurIPS, ACL, EMNLP, EACL, TACL, NAACL, AACL, ICLR, ICML, BRACIS, official documentation from Anthropic, Google Research, Microsoft Research, Chroma, and practitioner workflows.*

--- a/docs/general-llm/research-whitespace-and-formatting.md
+++ b/docs/general-llm/research-whitespace-and-formatting.md
@@ -26,7 +26,7 @@ Modern LLMs use **Byte-Pair Encoding (BPE)** tokenizers. BPE handles whitespace 
 | `" hello"` (space + word) | 1 | Space merges with word |
 | `"    hello"` (indent + word) | 2 | 4-space indent = only 1 extra token |
 
-**Sources**: OpenAI tiktoken; Karpathy's tokenization lecture (2024); o200k_base experimental verification
+**Sources**: [OpenAI tiktoken](https://github.com/openai/tiktoken); [Karpathy — "Let's build the GPT Tokenizer" lecture (2024)](https://www.youtube.com/watch?v=zduSFxRajkE); o200k_base tokenizer experimental verification
 
 **Critical insight**: Spaces merge with following words. `"The cat sat"` → 3 tokens: `['The', ' cat', ' sat']`. Whitespace is nearly free.
 

--- a/docs/plans/2026-03-22-agents-initializer-plugin-design.md
+++ b/docs/plans/2026-03-22-agents-initializer-plugin-design.md
@@ -34,7 +34,7 @@ The plugin uses **subagent-driven development**: subagents (running on Claude So
 | Anthropic Engineering (Context Engineering) | "Context is a finite resource with diminishing marginal returns" | Minimal token footprint per scope |
 | Anthropic Engineering (Context Engineering) | Progressive disclosure via subdirectory CLAUDE.md, path-scoped rules, skills | Generate hierarchical file trees, not flat files |
 | Lost in the Middle (TACL 2023) | Information in the middle of long contexts gets lost | Keep files short; critical instructions at start |
-| a-guide-to-agents.md / a-guide-to-agents.md | Progressive disclosure patterns, monorepo support, domain files | Generate BUILD.md, TESTING.md, etc. as separate files |
+| a-guide-to-agents.md | Progressive disclosure patterns, monorepo support, domain files | Generate BUILD.md, TESTING.md, etc. as separate files |
 
 ## Architecture
 
@@ -271,8 +271,7 @@ agent-engineering-toolkit/
 ├── README.md                    # Full documentation
 ├── LICENSE
 └── docs/
-    ├── a-guide-to-agents.md     # Reference: AGENTS.md guide
-    ├── a-guide-to-agents.md     # Reference: CLAUDE.md guide
+    ├── a-guide-to-agents.md     # Reference: AGENTS.md + CLAUDE.md guide (merged)
     ├── Evaluating-AGENTS-paper.pdf  # Research paper
     ├── research-context-engineering-comprehensive.md  # Context optimization research
     ├── research-claude-code-skills-format.md  # Skills/plugin format research

--- a/docs/plans/2026-03-22-agents-initializer-plugin-design.md
+++ b/docs/plans/2026-03-22-agents-initializer-plugin-design.md
@@ -271,10 +271,16 @@ agent-engineering-toolkit/
 ├── README.md                    # Full documentation
 ├── LICENSE
 └── docs/
-    ├── a-guide-to-agents.md     # Reference: AGENTS.md + CLAUDE.md guide (merged)
-    ├── Evaluating-AGENTS-paper.pdf  # Research paper
-    ├── research-context-engineering-comprehensive.md  # Context optimization research
-    ├── research-claude-code-skills-format.md  # Skills/plugin format research
+    ├── general-llm/
+    │   ├── a-guide-to-agents.md                        # Reference: AGENTS.md + CLAUDE.md guide (merged)
+    │   ├── Evaluating-AGENTS-paper.pdf                 # Research paper
+    │   └── research-context-engineering-comprehensive.md  # Context optimization research (hub)
+    ├── claude-code/
+    │   └── skills/
+    │       └── research-claude-code-skills-format.md   # Skills/plugin format research
+    ├── analysis/                                        # Deep-dive analysis extractions
+    ├── cursor/                                          # Cursor IDE docs
+    ├── shared/                                          # Cross-tool standards
     └── plans/
         └── 2026-03-22-agents-initializer-plugin-design.md  # This document
 ```

--- a/plugins/agents-initializer/skills/improve-agents/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,7 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
+Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -44,7 +44,7 @@ Generate root files with **only** these elements:
 4. **Progressive disclosure pointers** — links to domain files, not inline content
 
 > "Consider this the absolute minimum... That's honestly it. Everything else should go elsewhere."
-> — a-guide-to-agents.md / a-guide-to-agents.md
+> — a-guide-to-agents.md
 
 ---
 

--- a/plugins/agents-initializer/skills/improve-claude/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/progressive-disclosure-guide.md
@@ -1,7 +1,7 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
+Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -44,7 +44,7 @@ Generate root files with **only** these elements:
 4. **Progressive disclosure pointers** — links to domain files, not inline content
 
 > "Consider this the absolute minimum... That's honestly it. Everything else should go elsewhere."
-> — a-guide-to-agents.md / a-guide-to-agents.md
+> — a-guide-to-agents.md
 
 ---
 

--- a/plugins/agents-initializer/skills/init-agents/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/init-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,7 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
+Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -44,7 +44,7 @@ Generate root files with **only** these elements:
 4. **Progressive disclosure pointers** — links to domain files, not inline content
 
 > "Consider this the absolute minimum... That's honestly it. Everything else should go elsewhere."
-> — a-guide-to-agents.md / a-guide-to-agents.md
+> — a-guide-to-agents.md
 
 ---
 

--- a/plugins/agents-initializer/skills/init-claude/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/init-claude/references/progressive-disclosure-guide.md
@@ -1,7 +1,7 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
+Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -44,7 +44,7 @@ Generate root files with **only** these elements:
 4. **Progressive disclosure pointers** — links to domain files, not inline content
 
 > "Consider this the absolute minimum... That's honestly it. Everything else should go elsewhere."
-> — a-guide-to-agents.md / a-guide-to-agents.md
+> — a-guide-to-agents.md
 
 ---
 

--- a/skills/improve-agents/references/progressive-disclosure-guide.md
+++ b/skills/improve-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,7 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
+Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -44,7 +44,7 @@ Generate root files with **only** these elements:
 4. **Progressive disclosure pointers** — links to domain files, not inline content
 
 > "Consider this the absolute minimum... That's honestly it. Everything else should go elsewhere."
-> — a-guide-to-agents.md / a-guide-to-agents.md
+> — a-guide-to-agents.md
 
 ---
 

--- a/skills/improve-claude/references/progressive-disclosure-guide.md
+++ b/skills/improve-claude/references/progressive-disclosure-guide.md
@@ -1,7 +1,7 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
+Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -44,7 +44,7 @@ Generate root files with **only** these elements:
 4. **Progressive disclosure pointers** — links to domain files, not inline content
 
 > "Consider this the absolute minimum... That's honestly it. Everything else should go elsewhere."
-> — a-guide-to-agents.md / a-guide-to-agents.md
+> — a-guide-to-agents.md
 
 ---
 

--- a/skills/init-agents/references/progressive-disclosure-guide.md
+++ b/skills/init-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,7 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
+Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -44,7 +44,7 @@ Generate root files with **only** these elements:
 4. **Progressive disclosure pointers** — links to domain files, not inline content
 
 > "Consider this the absolute minimum... That's honestly it. Everything else should go elsewhere."
-> — a-guide-to-agents.md / a-guide-to-agents.md
+> — a-guide-to-agents.md
 
 ---
 

--- a/skills/init-claude/references/progressive-disclosure-guide.md
+++ b/skills/init-claude/references/progressive-disclosure-guide.md
@@ -1,7 +1,7 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
+Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -44,7 +44,7 @@ Generate root files with **only** these elements:
 4. **Progressive disclosure pointers** — links to domain files, not inline content
 
 > "Consider this the absolute minimum... That's honestly it. Everything else should go elsewhere."
-> — a-guide-to-agents.md / a-guide-to-agents.md
+> — a-guide-to-agents.md
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses all 13 inline review comments raised by Copilot code review on PR #33 (docs: context engineering research, docs reorganization, and context exclusions).

## Changes

- **8 `progressive-disclosure-guide.md` copies** (both plugin and standalone distributions) — removed duplicate `a-guide-to-agents.md` entry in Sources line and quote attribution block, a sed artifact from the `a-guide-to-claude.md → a-guide-to-agents.md` rename
- **`docs/analysis/analysis-claude-hook-reference-doc.md`** — deduplicated section 7.4 header
- **`docs/analysis/analysis-skill-authoring-best-practices.md`** — deduplicated section 7.4 header
- **`docs/general-llm/research-context-engineering-comprehensive.md`** — corrected date from "July 2025" to "April 2026" in header and footer; coverage window is 2022–2026, not a single 2025 month
- **`docs/general-llm/research-whitespace-and-formatting.md`** — added URLs for tiktoken GitHub repo and Karpathy "Let's build the GPT Tokenizer" YouTube lecture
- **`docs/plans/2026-03-22-agents-initializer-plugin-design.md`** — removed duplicate `a-guide-to-agents.md` from evidence table row and structure diagram
- **`README.md`** — removed stale "(Portuguese)" label from `docs/analysis/` (all 16 files were translated to English in PR #33)

## Files Changed

14 files changed

<details>
<summary>File list</summary>

```
README.md
docs/analysis/analysis-claude-hook-reference-doc.md
docs/analysis/analysis-skill-authoring-best-practices.md
docs/general-llm/research-context-engineering-comprehensive.md
docs/general-llm/research-whitespace-and-formatting.md
docs/plans/2026-03-22-agents-initializer-plugin-design.md
plugins/agents-initializer/skills/improve-agents/references/progressive-disclosure-guide.md
plugins/agents-initializer/skills/improve-claude/references/progressive-disclosure-guide.md
plugins/agents-initializer/skills/init-agents/references/progressive-disclosure-guide.md
plugins/agents-initializer/skills/init-claude/references/progressive-disclosure-guide.md
skills/improve-agents/references/progressive-disclosure-guide.md
skills/improve-claude/references/progressive-disclosure-guide.md
skills/init-agents/references/progressive-disclosure-guide.md
skills/init-claude/references/progressive-disclosure-guide.md
```

</details>

## Testing

- [ ] All duplicate entries removed (verified via grep)
- [ ] Date consistency confirmed in comprehensive research hub
- [ ] Source URLs verified accessible
- [ ] No information lost — purely cosmetic/correctness fixes

## Related Issues

Closes feedback from PR #33 Copilot code review