### PR TITLE
feat(cursor-initializer): Cursor IDE plugin — AGENTS.md and .cursor/rules/ generation

### DIFF
--- a/.claude/PRPs/CLAUDE.md
+++ b/.claude/PRPs/CLAUDE.md
@@ -1,6 +1,6 @@
 - Every time a file `*.prd.md` is created, a detailed GitHub issue related to it must be created with follow-up checks. The created issue must be attached in the created prd file.
 - Every time a file `*.prd.md` is edited (content or progress), the related issue must be updated.
-- Always before initializing an implementation file `*.plan.md`, a GitHub sub-issue (of `*.prd.md` parent) related to it must be created with follow-up checks. The created sub-issue must be attached in the created plan file.
+- Always before initializing an implementation file `*.plan.md`, a GitHub sub-issue (of `*.prd.md` parent - or a issue of no parent prd exists) related to it must be created with follow-up checks. The created sub-issue and parent issue must be attached in the created plan file.
 - Always after finishing an implementation file `*.plan.md` the following steps must be executed:  
   - Execute skill `/prp-core:prp-commit` following Git Conventions
   - Push branch to origin

--- a/.claude/PRPs/CLAUDE.md
+++ b/.claude/PRPs/CLAUDE.md
@@ -1,6 +1,6 @@
 - Every time a file `*.prd.md` is created, a detailed GitHub issue related to it must be created with follow-up checks. The created issue must be attached in the created prd file.
 - Every time a file `*.prd.md` is edited (content or progress), the related issue must be updated.
-- Always before initializing an implementation file `*.plan.md`, a GitHub sub-issue (of `*.prd.md` parent - or a issue of no parent prd exists) related to it must be created with follow-up checks. The created sub-issue and parent issue must be attached in the created plan file.
+- Always before initializing an implementation file `*.plan.md`, a GitHub sub-issue (of `*.prd.md` parent, or an issue if no parent PRD exists) related to it must be created with follow-up checks. The created sub-issue and parent issue must be attached in the created plan file.
 - Always after finishing an implementation file `*.plan.md` the following steps must be executed:  
   - Execute skill `/prp-core:prp-commit` following Git Conventions
   - Push branch to origin

--- a/.claude/PRPs/tests/scenarios/improve-reasonable-file.md
+++ b/.claude/PRPs/tests/scenarios/improve-reasonable-file.md
@@ -1,7 +1,7 @@
 # Test Scenario: Improve — Decent Existing Configuration
 
 **Scenario ID**: S4
-**Skills Under Test**: `improve-agents` (plugin + standalone), `improve-claude` (plugin + standalone)
+**Skills Under Test**: `improve-agents` (plugin + standalone), `improve-claude` (plugin + standalone), `improve-cursor` (plugin)
 **Phase**: GREEN (Tasks M5–M8)
 **Input Fixtures**: `reasonable-agents-md.md`, `reasonable-claude-md.md`
 
@@ -69,6 +69,29 @@ The skill should make targeted improvements without restructuring the whole file
 | Over-specification | Removed (tools enforce this) |
 | Everything else | Preserved exactly as-is |
 
+### improve-cursor (reasonable fixture)
+
+Use `reasonable-agents-md.md` as the existing root file and add a small existing rule such as:
+
+```md
+---
+description: API route conventions
+alwaysApply: true
+---
+
+- Route handlers belong under `src/routes/`
+- Prefer zod for request validation
+```
+
+The skill should make targeted improvements without over-reacting:
+
+| Action | Expected |
+|--------|----------|
+| Existing AGENTS.md | Improved only if genuinely needed |
+| Existing Cursor rule | Kept small and valid; activation mode tightened only if justified |
+| Good content | Preserved exactly as-is |
+| Overall structure | Remains lightweight; no unnecessary file explosion |
+
 ---
 
 ## Pass Criteria
@@ -81,6 +104,8 @@ The skill should make targeted improvements without restructuring the whole file
 | Root file stays concise | Still 15–40 lines after improvement | `wc -l` |
 | Planted issues addressed | All 2–3 issues resolved | Manual checklist |
 | No over-modification | Non-issue sections unchanged | Diff review |
+| Cursor rule remains valid | Frontmatter limited to `description`, `alwaysApply`, `globs` | Manual review |
+| Cursor activation stays proportionate | No gratuitous `alwaysApply: true` retention | Manual review |
 
 ### Scoring (5-dimension rubric)
 
@@ -121,5 +146,6 @@ Watch for:
 - Skills that over-apply changes (rewriting sections that were fine)
 - Skills that miss the subtle issues (only catch obvious violations)
 - Skills that introduce new issues while fixing existing ones
+- `improve-cursor` suggesting a large rules hierarchy for a project that already has a decent minimal setup
 
 **Expected loop behavior**: Loop may not need to iterate if the skill is well-calibrated. Excessive looping on a reasonable file suggests the evaluation criteria are too aggressive.

--- a/.claude/PRPs/tests/scenarios/init-preflight-redirect.md
+++ b/.claude/PRPs/tests/scenarios/init-preflight-redirect.md
@@ -1,7 +1,7 @@
 # Test Scenario: Init — Preflight Redirect When Files Exist
 
 **Scenario ID**: S5
-**Skills Under Test**: `init-agents` (plugin + standalone), `init-claude` (plugin + standalone)
+**Skills Under Test**: `init-agents` (plugin + standalone), `init-claude` (plugin + standalone), `init-cursor` (plugin)
 **Phase**: GREEN (Tasks R1–R4)
 
 ---
@@ -20,6 +20,7 @@ Use the S4 reasonable fixtures as the pre-existing files:
 
 - `reasonable-agents-md.md` → copy as `AGENTS.md` in test project
 - `reasonable-claude-md.md` → copy as `CLAUDE.md` in test project
+- Create `.cursor/rules/existing-rule.mdc` with any valid minimal rule for the Cursor variant
 
 ---
 
@@ -45,6 +46,16 @@ Use the S4 reasonable fixtures as the pre-existing files:
 | Phase 1 execution | Does NOT execute init Phase 1 |
 | Improve flow | Follows complete improve-claude process |
 
+### init-cursor (plugin)
+
+| Step | Expected |
+|------|----------|
+| Preflight check | Detects existing `AGENTS.md` and/or `.cursor/rules/*` |
+| User notification | Emits the Cursor-specific redirect message from `init-cursor` |
+| Redirect | Invokes `improve-cursor` skill |
+| Phase 1 execution | Does NOT execute init Phase 1 |
+| Improve flow | Follows complete improve-cursor process |
+
 ---
 
 ## Pass Criteria
@@ -57,6 +68,7 @@ Use the S4 reasonable fixtures as the pre-existing files:
 | STOP enforced | Init phases 1-5 NOT executed | No init template, no scope detection |
 | Improve flow completes | Improve skill runs to completion | Verify improve output generated |
 | Original file preserved | No overwrite of existing file | Diff before/after |
+| Cursor rules preserved | Existing `.cursor/rules/*` not overwritten during redirect | Diff before/after |
 
 ---
 

--- a/.claude/PRPs/tests/scenarios/init-simple-project.md
+++ b/.claude/PRPs/tests/scenarios/init-simple-project.md
@@ -1,7 +1,7 @@
 # Test Scenario: Init — Simple Single-Scope Project
 
 **Scenario ID**: S1
-**Skills Under Test**: `init-agents` (plugin + standalone), `init-claude` (plugin + standalone)
+**Skills Under Test**: `init-agents` (plugin + standalone), `init-claude` (plugin + standalone), `init-cursor` (plugin)
 **Phase**: GREEN (Tasks I1–I4)
 
 ---
@@ -102,6 +102,19 @@ Root CLAUDE.md should contain:
 - Non-obvious build commands or flags
 - Critical constraints (e.g., must maintain mypy strict compliance)
 
+### init-cursor
+
+| File | Expected Lines | Key Constraints |
+|------|---------------|-----------------|
+| `AGENTS.md` (root) | 15–40 | Same minimal root constraints as `init-agents` |
+| `.cursor/rules/*.mdc` | 0 or small focused set | Only generated if truly justified; must use valid Cursor frontmatter |
+
+`init-cursor` should:
+
+- Generate the same minimal root `AGENTS.md` quality bar as `init-agents`
+- Prefer **zero** `.cursor/rules/*.mdc` files for this simple single-scope project unless the analysis finds a truly non-obvious file-pattern rule
+- If any `.mdc` file is generated, keep it focused and validate frontmatter with only `description`, `alwaysApply`, and `globs`
+
 ---
 
 ## Pass Criteria
@@ -115,6 +128,9 @@ Root CLAUDE.md should contain:
 | No generic advice | 0 "write clean", "readable code" phrases | Manual review |
 | No default commands documented | pytest, ruff, mypy not in "run X to do Y" form | Manual review |
 | Non-standard config captured | line-length 120, strict mypy, --cov=src | Manual review |
+| Cursor root file stays minimal | Same 15–40 line target as `init-agents` | `wc -l AGENTS.md` |
+| Cursor rules remain restrained | 0 unnecessary `.cursor/rules/*.mdc` files | Manual review |
+| Cursor frontmatter valid | Only `description`, `alwaysApply`, `globs` | Manual review |
 
 ---
 

--- a/.claude/rules/cursor-agent-files.md
+++ b/.claude/rules/cursor-agent-files.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "plugins/cursor-initializer/agents/*.md"
+---
+# Cursor Agent File Conventions
+
+- YAML frontmatter required: `name`, `description`, `model`, `readonly`
+- `model: inherit` — Cursor agents inherit model from parent context
+- `readonly: true` — analysis agents MUST NOT write; Cursor uses boolean, not tool whitelists
+- Do NOT use `tools:` or `maxTurns:` — these are Claude Code specific
+- Prompt must request structured output format
+- Agents cannot spawn other agents

--- a/.claude/rules/cursor-agent-files.md
+++ b/.claude/rules/cursor-agent-files.md
@@ -9,4 +9,4 @@ paths:
 - `readonly: true` — analysis agents MUST NOT write; Cursor uses boolean, not tool whitelists
 - Do NOT use `tools:` or `maxTurns:` — these are Claude Code specific
 - Prompt must request structured output format
-- Agents cannot spawn other agents
+- Agents MUST NOT spawn other agents

--- a/.claude/rules/cursor-plugin-skills.md
+++ b/.claude/rules/cursor-plugin-skills.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - "plugins/cursor-initializer/skills/*/SKILL.md"
+---
+# Cursor Plugin Skill Conventions
+
+- Analysis phases MUST delegate to named agents: `codebase-analyzer`, `scope-detector`, `file-evaluator`
+- Never add inline bash analysis here — subagent delegation keeps the orchestrator context clean
+- Reference agents by registered name (e.g., "Delegate to the `codebase-analyzer` agent with this task:")
+- `references/` directory MUST exist alongside SKILL.md and contain evidence-based guidance files
+- `assets/templates/` directory MUST exist alongside SKILL.md and contain output templates
+- Self-validation phase MUST read `references/validation-criteria.md` and loop until all checks pass
+- Reference files must be one level deep from SKILL.md — no nested `references/references/` paths
+- Conditional reference loading pattern: "read X only if project uses Y"
+- init-cursor generates AGENTS.md + `.cursor/rules/*.mdc` files; improve-cursor handles AGENTS.md only when target project uses it
+- Subagent definitions use `readonly: true`, NOT `tools:` whitelists or `maxTurns:`
+- .mdc frontmatter allows ONLY: `description` (string), `alwaysApply` (boolean), `globs` (string|array)
+- Never use `paths:` in .mdc frontmatter — that is Claude Code specific
+- SKILL.md `name` field: ≤64 chars, lowercase letters/numbers/hyphens only, no XML tags
+- SKILL.md `description` field: non-empty, ≤1024 chars, third person, no XML tags
+- SKILL.md body: under 500 lines

--- a/.claude/rules/cursor-plugin-skills.md
+++ b/.claude/rules/cursor-plugin-skills.md
@@ -9,6 +9,7 @@ paths:
 - Reference agents by registered name (e.g., "Delegate to the `codebase-analyzer` agent with this task:")
 - `references/` directory MUST exist alongside SKILL.md and contain evidence-based guidance files
 - `assets/templates/` directory MUST exist alongside SKILL.md and contain output templates
+- Bundled files in Cursor SKILL.md files MUST be referenced with relative paths from the skill root (`references/...`, `assets/templates/...`), not `${CLAUDE_SKILL_DIR}`
 - Self-validation phase MUST read `references/validation-criteria.md` and loop until all checks pass
 - Reference files must be one level deep from SKILL.md — no nested `references/references/` paths
 - Conditional reference loading pattern: "read X only if project uses Y"

--- a/.claude/rules/reference-files.md
+++ b/.claude/rules/reference-files.md
@@ -11,6 +11,6 @@ paths:
 - Maximum 200 lines per reference file
 - Content must be framed as "read as instructions" — not as executable scripts
 - Each file must have a clear source attribution (e.g., `Source: docs/research-*.md`)
-- Shared references (same filename across skills/distributions) must have identical content
-- When updating a shared reference, update ALL copies across all distributions
+- Identical-content parity applies only to explicitly shared references and same-platform copies
+- Platform-specific references may reuse filenames when their content is intentionally platform-native
 - No nested references — reference files must not import or reference other reference files

--- a/.claude/rules/reference-files.md
+++ b/.claude/rules/reference-files.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - "plugins/agents-initializer/skills/*/references/*.md"
+  - "plugins/cursor-initializer/skills/*/references/*.md"
   - "plugins/agent-customizer/skills/*/references/*.md"
   - "skills/*/references/*.md"
 ---
@@ -11,5 +12,5 @@ paths:
 - Content must be framed as "read as instructions" — not as executable scripts
 - Each file must have a clear source attribution (e.g., `Source: docs/research-*.md`)
 - Shared references (same filename across skills/distributions) must have identical content
-- When updating a shared reference, update ALL copies across both distributions
+- When updating a shared reference, update ALL copies across all distributions
 - No nested references — reference files must not import or reference other reference files

--- a/.claude/rules/standalone-skills.md
+++ b/.claude/rules/standalone-skills.md
@@ -15,7 +15,7 @@ paths:
 - Self-validation phase MUST read `references/validation-criteria.md` and loop until all checks pass
 - Reference files must be one level deep from SKILL.md — no nested `references/references/` paths
 - Each skill bundles its own copies of shared references — no symlinks, no cross-directory references
-- When a shared reference is updated, update ALL copies across both distributions in sync
+- When an intentionally shared reference is updated, update all intended copies in sync
 - Standalone improve skills MUST suggest only skills and path-scoped rules as migration targets — NEVER hooks or subagents (these require Claude Code plugin architecture)
 - When shared references mention hooks or subagents, standalone SKILL.md MUST instruct to substitute with the closest available mechanism (rule or skill)
 - SKILL.md `name` field: ≤64 chars, lowercase letters/numbers/hyphens only, no XML tags

--- a/.claude/skills/quality-gate/agents/parity-checker.md
+++ b/.claude/skills/quality-gate/agents/parity-checker.md
@@ -1,6 +1,6 @@
 ---
 name: parity-checker
-description: "Verifies that shared reference files and templates are identical across all copies in both plugin and standalone distributions of the agents-initializer project."
+description: "Verifies that intentionally shared reference files and templates stay identical across their intended copies in the agents-initializer project."
 tools: Read, Grep, Glob, Bash
 model: sonnet
 maxTurns: 15
@@ -8,11 +8,11 @@ maxTurns: 15
 
 # Parity Checker
 
-You are a cross-distribution consistency auditor for the agents-initializer project. Verify that all shared files (same filename appearing in multiple skills or distributions) have identical content. Use `md5sum` to compare files efficiently.
+You are a cross-distribution consistency auditor for the agents-initializer project. Verify that intentionally shared files remain identical across their intended copies. Do not treat platform-specific files that merely reuse the same filename as parity failures. Use `md5sum` to compare files efficiently.
 
-**Rule source:** `.claude/rules/reference-files.md` — "Shared references (same filename across skills/distributions) must have identical content"
+**Rule source:** `.claude/rules/reference-files.md` — "Identical-content parity applies only to explicitly shared references and same-platform copies"
 
-**Rule source:** `.claude/rules/standalone-skills.md` — "Each skill bundles its own copies of shared references — no symlinks, no cross-directory references. When a shared reference is updated, update ALL copies across both distributions in sync"
+**Rule source:** `.claude/rules/standalone-skills.md` — "Each skill bundles its own copies of shared references — no symlinks, no cross-directory references. When an intentionally shared reference is updated, update all intended copies in sync"
 
 ---
 
@@ -20,7 +20,7 @@ You are a cross-distribution consistency auditor for the agents-initializer proj
 
 ### 1. Shared Reference Files
 
-These files appear in multiple skills. All copies must be byte-for-byte identical.
+These files are intentionally shared across skills. All intended copies must be byte-for-byte identical.
 
 **Present in ALL 8 skills (4 plugin + 4 standalone):**
 

--- a/.claude/skills/quality-gate/agents/parity-checker.md
+++ b/.claude/skills/quality-gate/agents/parity-checker.md
@@ -61,6 +61,18 @@ md5sum plugins/agents-initializer/skills/improve-claude/references/claude-rules-
        skills/init-claude/references/claude-rules-system.md
 ```
 
+**Present in cursor skills only (2 copies: plugin init + improve):**
+
+```bash
+md5sum plugins/cursor-initializer/skills/*/references/context-optimization.md
+
+md5sum plugins/cursor-initializer/skills/*/references/validation-criteria.md
+
+md5sum plugins/cursor-initializer/skills/*/references/what-not-to-include.md
+
+md5sum plugins/cursor-initializer/skills/*/references/progressive-disclosure-guide.md
+```
+
 **Present in standalone init skills (2 copies, no plugin counterpart):**
 
 ```bash
@@ -112,6 +124,15 @@ md5sum plugins/agents-initializer/skills/improve-claude/assets/templates/root-cl
 # domain-doc: all 8 skills
 md5sum plugins/agents-initializer/skills/*/assets/templates/domain-doc.md \
        skills/*/assets/templates/domain-doc.md
+
+# cursor templates: init vs improve
+md5sum plugins/cursor-initializer/skills/*/assets/templates/root-agents-md.md
+
+md5sum plugins/cursor-initializer/skills/*/assets/templates/scoped-agents-md.md
+
+md5sum plugins/cursor-initializer/skills/*/assets/templates/domain-doc.md
+
+md5sum plugins/cursor-initializer/skills/*/assets/templates/cursor-rule.mdc
 ```
 
 ---
@@ -143,12 +164,20 @@ Return exactly this structure:
 | automation-migration-guide.md (4 copies) | 4 | [MATCH/MISMATCH] | |
 | evaluation-criteria.md (4 copies) | 4 | [MATCH/MISMATCH] | |
 | claude-rules-system.md (4 copies) | 4 | [MATCH/MISMATCH] | |
+| cursor context-optimization.md (2 copies) | 2 | [MATCH/MISMATCH] | |
+| cursor validation-criteria.md (2 copies) | 2 | [MATCH/MISMATCH] | |
+| cursor what-not-to-include.md (2 copies) | 2 | [MATCH/MISMATCH] | |
+| cursor progressive-disclosure-guide.md (2 copies) | 2 | [MATCH/MISMATCH] | |
 | scope-detector.md (2 copies) | 2 | [MATCH/MISMATCH] | |
 | codebase-analyzer.md (4 copies) | 4 | [MATCH/MISMATCH] | |
 | file-evaluator.md (2 copies) | 2 | [MATCH/MISMATCH] | |
 | root-agents-md.md templates | 4 | [MATCH/MISMATCH] | |
 | root-claude-md.md templates | 4 | [MATCH/MISMATCH] | |
 | domain-doc.md templates | 8 | [MATCH/MISMATCH] | |
+| cursor root-agents-md.md templates | 2 | [MATCH/MISMATCH] | |
+| cursor scoped-agents-md.md templates | 2 | [MATCH/MISMATCH] | |
+| cursor domain-doc.md templates | 2 | [MATCH/MISMATCH] | |
+| cursor-rule.mdc templates | 2 | [MATCH/MISMATCH] | |
 
 ### Divergences Found
 [If none: "✅ No divergences — all shared files are identical across distributions."]

--- a/.claude/skills/update-review-instructions/references/scope-registry.md
+++ b/.claude/skills/update-review-instructions/references/scope-registry.md
@@ -6,13 +6,13 @@ Maps project scopes to their `applyTo` patterns, convention sources, and instruc
 
 | Scope ID | Instruction File | applyTo Pattern | Convention Sources |
 |----------|-----------------|-----------------|-------------------|
-| skill-files | `skill-files.instructions.md` | `**/skills/*/SKILL.md` | `.claude/rules/plugin-skills.md`, `.claude/rules/standalone-skills.md`, DESIGN-GUIDELINES.md §7 |
+| skill-files | `skill-files.instructions.md` | `**/skills/*/SKILL.md` | `.claude/rules/plugin-skills.md`, `.claude/rules/cursor-plugin-skills.md`, `.claude/rules/standalone-skills.md`, DESIGN-GUIDELINES.md §7 |
 | reference-files | `reference-files.instructions.md` | `**/references/**/*.md` | `.claude/rules/reference-files.md`, DESIGN-GUIDELINES.md §2 |
-| agent-definitions | `agent-definitions.instructions.md` | `**/agents/**/*.md` | `.claude/rules/agent-files.md`, DESIGN-GUIDELINES.md §6 |
-| template-files | `template-files.instructions.md` | `**/assets/templates/**/*.md` | DESIGN-GUIDELINES.md §15 |
+| agent-definitions | `agent-definitions.instructions.md` | `**/agents/**/*.md` | `.claude/rules/agent-files.md`, `.claude/rules/cursor-agent-files.md`, DESIGN-GUIDELINES.md §6 |
+| template-files | `template-files.instructions.md` | `**/assets/templates/**/*.md,**/assets/templates/**/*.mdc` | DESIGN-GUIDELINES.md §15 |
 | rules | `rules.instructions.md` | `.claude/rules/**/*.md` | DESIGN-GUIDELINES.md §1, §10 |
 | documentation | `documentation.instructions.md` | `docs/**/*.md` | DESIGN-GUIDELINES.md §5, Research Foundation section |
-| plugin-config | `plugin-config.instructions.md` | `**/.claude-plugin,**/CLAUDE.md,DESIGN-GUIDELINES.md` | DESIGN-GUIDELINES.md §1-§4, plugins/agents-initializer/CLAUDE.md |
+| plugin-config | `plugin-config.instructions.md` | `**/.claude-plugin,**/.cursor-plugin,**/CLAUDE.md,DESIGN-GUIDELINES.md` | DESIGN-GUIDELINES.md §1-§4, plugins/*/CLAUDE.md |
 
 ## Adding New Scopes
 
@@ -30,5 +30,6 @@ Review these areas periodically for potential new scopes:
 - `.claude/PRPs/` — PRP artifacts (plans, PRDs, reports, tests)
 - `.claude/hooks/` — Hook configuration files (if hooks are added)
 - `.claude/settings*.json` — Settings files
+- `.cursor/rules/` — Generated Cursor rules (output of cursor-initializer skills)
 - `plugins/agent-customizer/` — When agent-customizer skills are implemented
 - Root config files — `README.md`, `LICENSE`, `.gitignore`, `next-steps.md`

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "agent-engineering-toolkit",
+  "owner": {
+    "name": "rodrigorjsf"
+  },
+  "metadata": {
+    "description": "Multi-plugin marketplace for evidence-based Cursor artifact engineering. Provides plugins for configuration initialization (AGENTS.md, .cursor/rules/) based on academic research and Cursor best practices.",
+    "version": "1.0.0",
+    "pluginRoot": "plugins"
+  },
+  "plugins": [
+    {
+      "name": "cursor-initializer",
+      "source": "cursor-initializer",
+      "description": "Generate and optimize minimal, scoped AGENTS.md and .cursor/rules/*.mdc configuration files based on academic research and Cursor best practices. Uses subagent-driven analysis for context-efficient file generation."
+    }
+  ]
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Project: agent-engineering-toolkit
 
-Multi-plugin marketplace for evidence-based agent artifact engineering. Three distributions (Claude Code plugin, Cursor IDE plugin, and standalone) ship identical skill names with different analysis mechanisms.
+Multi-plugin marketplace for evidence-based agent artifact engineering. Three distributions (Claude Code plugin, Cursor IDE plugin, and standalone) ship aligned capabilities with platform-specific skill names and analysis mechanisms.
 
 ## Architecture
 
@@ -14,7 +14,7 @@ Multi-plugin marketplace for evidence-based agent artifact engineering. Three di
 ## Critical Conventions
 
 - Shared references are copied (not symlinked) into each skill directory — each skill is self-contained
-- When updating a shared reference, update ALL copies across all distributions in sync
+- When updating an intentionally shared reference, update all copies of that shared reference in sync
 - No generated file exceeds 200 lines; root files target 15-40 lines; scope files target 10-30 lines
 - Every instruction must pass: "Would removing this cause the agent to make mistakes?" If not, cut it
 - Plugin skills delegate to named agents; standalone skills use inline bash — never mix these patterns

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,11 @@
 # Project: agent-engineering-toolkit
 
-Multi-plugin Claude Code marketplace for evidence-based agent artifact engineering. Two distributions (plugin and standalone) ship identical skill names with different analysis mechanisms.
+Multi-plugin marketplace for evidence-based agent artifact engineering. Three distributions (Claude Code plugin, Cursor IDE plugin, and standalone) ship identical skill names with different analysis mechanisms.
 
 ## Architecture
 
-- `plugins/agents-initializer/skills/` — Plugin distribution: delegates analysis to subagents (codebase-analyzer, scope-detector, file-evaluator)
+- `plugins/agents-initializer/skills/` — Claude Code plugin: delegates analysis to subagents (codebase-analyzer, scope-detector, file-evaluator)
+- `plugins/cursor-initializer/skills/` — Cursor IDE plugin: delegates analysis to subagents (Cursor-native format: readonly, model inherit)
 - `skills/` — Standalone distribution: all analysis inline, no agent delegation, works with any AI tool
 - Each skill contains: `SKILL.md` (entry point), `references/` (evidence-based guidance), `assets/templates/` (output templates)
 - `.claude/rules/` — Path-scoped conventions enforced automatically
@@ -13,11 +14,12 @@ Multi-plugin Claude Code marketplace for evidence-based agent artifact engineeri
 ## Critical Conventions
 
 - Shared references are copied (not symlinked) into each skill directory — each skill is self-contained
-- When updating a shared reference, update ALL copies across both distributions in sync
+- When updating a shared reference, update ALL copies across all distributions in sync
 - No generated file exceeds 200 lines; root files target 15-40 lines; scope files target 10-30 lines
 - Every instruction must pass: "Would removing this cause the agent to make mistakes?" If not, cut it
 - Plugin skills delegate to named agents; standalone skills use inline bash — never mix these patterns
-- Agent definitions require: model sonnet, read-only tools only, maxTurns 15-20, structured output
+- Claude Code agent definitions: model sonnet, read-only tools only, maxTurns 15-20, structured output
+- Cursor agent definitions: model inherit, readonly true — no tools/maxTurns fields
 - SKILL.md name ≤64 chars, description ≤1024 chars, body <500 lines
 
 ## Git Conventions

--- a/.github/instructions/agent-definitions.instructions.md
+++ b/.github/instructions/agent-definitions.instructions.md
@@ -6,25 +6,31 @@ applyTo: "**/agents/**/*.md"
 
 ## YAML Frontmatter (Required)
 
-Every agent file must have YAML frontmatter with these fields:
-- `name`: agent identifier
-- `description`: what the agent does
-- `tools`: list of allowed tools
-- `model`: model to use
-- `maxTurns`: maximum execution turns
+Every agent file must have YAML frontmatter. Required fields depend on the plugin:
+
+**Claude Code agents** (`plugins/agents-initializer/agents/`):
+- `name`, `description`, `tools`, `model`, `maxTurns`
+
+**Cursor agents** (`plugins/cursor-initializer/agents/`):
+- `name`, `description`, `model`, `readonly`
 
 ## Mandatory Constraints
 
-- `model` MUST be `sonnet` — never haiku (too weak for analysis) or opus (too costly)
-- `tools` MUST be restricted to read-only: `Read`, `Grep`, `Glob`, `Bash` — no write tools
+**Claude Code agents:**
+- `model` MUST be `sonnet` — never haiku or opus
+- `tools` MUST be restricted to read-only: `Read`, `Grep`, `Glob`, `Bash`
 - `maxTurns`: 15 for codebase/scope agents; 20 for evaluator agents
-- Prompt MUST request structured output format (tables, lists, or labeled sections)
+
+**Cursor agents:**
+- `model` MUST be `inherit` — inherits from parent context
+- `readonly` MUST be `true` — analysis agents must not write
+- Must NOT have `tools` or `maxTurns` fields (Claude-specific)
 
 ## Isolation Rules
 
-- Agents cannot spawn other agents (Task tool is unavailable in agent context)
-- Agents receive only their system prompt plus basic environment — not parent conversation
-- Agent instructions must be self-contained with complete context for the task
+- Agents cannot spawn other agents (Task tool unavailable in agent context)
+- Agents receive only their system prompt plus basic environment
+- Agent instructions must be self-contained with complete context
 
 ## Output Quality
 
@@ -34,9 +40,8 @@ Every agent file must have YAML frontmatter with these fields:
 
 ## Common Issues to Flag
 
-- Model set to anything other than sonnet
-- Write tools (Edit, Create, Write) in the tools list
+- Claude agents: model not `sonnet`, write tools in list, maxTurns outside 15-20
+- Cursor agents: `tools`/`maxTurns` present, model not `inherit`, missing `readonly: true`
+- Cross-contamination: Claude frontmatter fields in Cursor agents or vice versa
 - Missing structured output specification in the prompt
-- maxTurns outside the 15-20 range
 - References to spawning other agents or using Task tool
-- Missing YAML frontmatter fields

--- a/.github/instructions/agent-definitions.instructions.md
+++ b/.github/instructions/agent-definitions.instructions.md
@@ -28,7 +28,7 @@ Every agent file must have YAML frontmatter. Required fields depend on the plugi
 
 ## Isolation Rules
 
-- Agents cannot spawn other agents (Task tool unavailable in agent context)
+- Cursor agents MAY support nested launches, but this project's Cursor agents MUST NOT spawn other agents
 - Agents receive only their system prompt plus basic environment
 - Agent instructions must be self-contained with complete context
 

--- a/.github/instructions/plugin-config.instructions.md
+++ b/.github/instructions/plugin-config.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/.claude-plugin,**/CLAUDE.md,DESIGN-GUIDELINES.md"
+applyTo: "**/.claude-plugin,**/.cursor-plugin,**/CLAUDE.md,DESIGN-GUIDELINES.md"
 ---
 
 # Plugin Configuration Review Guidelines
@@ -17,20 +17,26 @@ applyTo: "**/.claude-plugin,**/CLAUDE.md,DESIGN-GUIDELINES.md"
 - Every token in CLAUDE.md loads on every request — minimize always-loaded content
 - Apply the test: "Would removing this cause the agent to make mistakes?" If not, cut it
 
-## .claude-plugin Files
+## Plugin Manifests
 
-- Must follow the official Claude Code plugin specification
-- `source` field must point to the correct plugin directory
+- `.claude-plugin/plugin.json` — Claude Code plugin specification
+- `.cursor-plugin/plugin.json` — Cursor IDE plugin specification
+- Both must have `name` field; `source` field must point to correct plugin directory
 
 ## DESIGN-GUIDELINES.md
 
 - Every guideline must have: Source citation, "In practice" section, "Implemented in" traceability
 - Guidelines must map to specific artifacts in the project
 - New guidelines require evidence from published research or official documentation
-- Self-Application Record section must stay current with actual changes made
 
 ## Progressive Disclosure Compliance
 
-- Root files must not contain domain-specific rules (those go in scope files or `.claude/rules/`)
+- Root files must not contain domain-specific rules (those go in scope files)
 - Content should be organized by loading tier: always-loaded → on-demand → invoked
-- Flag any content in root CLAUDE.md that only applies to specific file patterns
+- Flag content in root CLAUDE.md that only applies to specific file patterns
+
+## Common Issues to Flag
+
+- CLAUDE.md over 40 lines at root or 30 lines in plugins
+- Missing source citations in DESIGN-GUIDELINES.md
+- Cursor plugin manifests with Claude-specific fields or vice versa

--- a/.github/instructions/plugin-config.instructions.md
+++ b/.github/instructions/plugin-config.instructions.md
@@ -20,8 +20,8 @@ applyTo: "**/.claude-plugin,**/.cursor-plugin,**/CLAUDE.md,DESIGN-GUIDELINES.md"
 ## Plugin Manifests
 
 - `.claude-plugin/plugin.json` — Claude Code plugin specification
-- `.cursor-plugin/plugin.json` — Cursor IDE plugin specification
-- Both must have `name` field; `source` field must point to correct plugin directory
+- `.cursor-plugin/plugin.json` — Cursor IDE plugin specification (per-plugin manifest; only `name` field required)
+- Both per-plugin manifests must have a `name` field; the `source` field is marketplace-manifest-only (`.cursor-plugin/marketplace.json`, `.claude-plugin/marketplace.json`) — do not require `source` in per-plugin manifests
 
 ## DESIGN-GUIDELINES.md
 

--- a/.github/instructions/reference-files.instructions.md
+++ b/.github/instructions/reference-files.instructions.md
@@ -18,9 +18,9 @@ applyTo: "**/references/**/*.md"
 
 ## Cross-Distribution Parity
 
-- Shared references (same filename used across `plugins/*/skills/*/references/` and `skills/*/references/`) MUST have identical content
-- When reviewing a change to a shared reference, verify the same change is applied to ALL copies
-- Flag any divergence between copies of the same reference file
+- Explicitly shared references MUST have identical content across their intended copies
+- Platform-specific references may reuse filenames when the target artifact system differs
+- When reviewing a change to an intentionally shared reference, verify the same change is applied to all intended copies
 
 ## Information Density
 

--- a/.github/instructions/skill-files.instructions.md
+++ b/.github/instructions/skill-files.instructions.md
@@ -32,8 +32,15 @@ Check the file path to determine distribution:
 **Standalone skills** (`skills/*/SKILL.md`):
 - ALL analysis must be inline — explicit bash commands for each step
 - Must NEVER reference agent names or use Task tool delegation
-- Must suggest ONLY skills and path-scoped rules as migration targets (never hooks or subagents)
-- When shared references mention hooks/subagents, SKILL.md must instruct to substitute with rule or skill
+- Must suggest ONLY skills and path-scoped rules as migration targets
+
+## Platform-Specific Output (Critical)
+
+- `init-claude`/`improve-claude` skills → generate `.claude/rules/` and `CLAUDE.md`
+- `init-cursor`/`improve-cursor` skills → generate `.cursor/rules/*.mdc` and AGENTS.md
+- `init-agents`/`improve-agents` skills → generate only AGENTS.md (portable)
+- Flag Claude artifacts (`.claude/rules/`, `CLAUDE.md`, `paths:`) in cursor skills
+- Flag Cursor artifacts (`.cursor/rules/`, `.mdc`, `globs:`) in claude skills
 
 ## Common Issues to Flag
 
@@ -41,4 +48,5 @@ Check the file path to determine distribution:
 - Missing self-validation phase
 - References to files outside the skill's own directory
 - Phase instructions that are vague rather than actionable
+- Cross-platform contamination (Claude references in Cursor skills or vice versa)
 - Name or description exceeding character limits

--- a/.github/instructions/skill-files.instructions.md
+++ b/.github/instructions/skill-files.instructions.md
@@ -17,7 +17,7 @@ Flag any SKILL.md missing frontmatter or violating these constraints.
 - Body must be under 500 lines total
 - Must define a clear phase-based workflow (Phase 1, Phase 2, etc.)
 - Must include a self-validation phase that reads `references/validation-criteria.md`
-- Reference files must be loaded conditionally using `${CLAUDE_SKILL_DIR}/references/` path
+- Reference files must be loaded conditionally using the platform-appropriate skill-root path convention
 - Sibling directories `references/` and `assets/templates/` must exist alongside SKILL.md
 
 ## Plugin vs Standalone Pattern (Critical)
@@ -28,11 +28,14 @@ Check the file path to determine distribution:
 - Analysis phases MUST delegate to named agents: `codebase-analyzer`, `scope-detector`, `file-evaluator`
 - Never contain inline bash analysis commands
 - May suggest all 4 migration mechanisms: hooks, rules, skills, subagents
+- Cursor plugin skills must reference bundled files with relative paths from the skill root (`references/...`, `assets/templates/...`)
+- Claude-targeted plugin skills may use `${CLAUDE_SKILL_DIR}` for bundled file references
 
 **Standalone skills** (`skills/*/SKILL.md`):
 - ALL analysis must be inline — explicit bash commands for each step
 - Must NEVER reference agent names or use Task tool delegation
 - Must suggest ONLY skills and path-scoped rules as migration targets
+- Follow the skill runtime's supported bundled-file path convention consistently within the file
 
 ## Platform-Specific Output (Critical)
 

--- a/.github/instructions/template-files.instructions.md
+++ b/.github/instructions/template-files.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/assets/templates/**/*.md"
+applyTo: "**/assets/templates/**/*.md,**/assets/templates/**/*.mdc"
 ---
 
 # Template File Review Guidelines
@@ -22,13 +22,19 @@ Templates should use HTML comment blocks for metadata:
 - Templates define the exact structure of generated output files
 - HTML comments guide the generating agent on what to include/exclude
 - Templates must demonstrate progressive disclosure patterns (where to split content)
-- Source attribution comments (`<!-- Migrated from [source-file]:lines [N-M] -->`) must be present in migration templates
+
+## .mdc Template Requirements
+
+- `.mdc` templates (Cursor rules) must use ONLY valid frontmatter: `description`, `alwaysApply`, `globs`
+- Never include `paths:` in .mdc templates (that is Claude Code specific)
+- Must demonstrate the 4 activation modes: Always, Auto-attached, Agent-requested, Manual
 
 ## Distribution Awareness
 
 - `hook-config.md` template must exist ONLY in plugin improve skill directories — never in standalone
 - Standalone templates must never reference hooks or subagents
 - Init skill templates do NOT include migration-specific templates
+- `cursor-rule.mdc` templates belong in cursor-initializer skills only, not agents-initializer
 
 ## Common Issues to Flag
 
@@ -37,3 +43,4 @@ Templates should use HTML comment blocks for metadata:
 - Hook-related templates in standalone skill directories
 - Migration templates in init skill directories
 - Templates that would generate files exceeding 200 lines
+- `paths:` frontmatter in .mdc templates (Claude leak)

--- a/.github/instructions/template-files.instructions.md
+++ b/.github/instructions/template-files.instructions.md
@@ -10,6 +10,7 @@ Templates should use HTML comment blocks for metadata:
 - `<!-- TEMPLATE: ... -->` for placement, naming, line targets, and embedded rules
 - `<!-- CONDITIONAL: ... -->` for optional sections included only when applicable
 - `<!-- MIGRATION: ... -->` blocks apply only in improve (not init) context
+- Migration templates that preserve source material must require a provenance comment like `<!-- Migrated from [source-file]:lines [N-M] -->`
 
 ## Placeholder Conventions
 
@@ -42,5 +43,6 @@ Templates should use HTML comment blocks for metadata:
 - Missing HTML comment metadata
 - Hook-related templates in standalone skill directories
 - Migration templates in init skill directories
+- Migration templates missing provenance attribution comments
 - Templates that would generate files exceeding 200 lines
 - `paths:` frontmatter in .mdc templates (Claude leak)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,13 +2,93 @@
 
 <!-- Describe what this PR does and why. Reference the PRD or design document when applicable. -->
 
-## Type of Change
+<!--
+BEFORE SUBMITTING: Read every word of this template. PRs that leave
+sections blank, contain multiple unrelated changes, or show no evidence
+of human involvement will be closed without review.
+-->
 
-- [ ] `feat` — new skill, agent, reference, or template
-- [ ] `fix` — bug fix in existing artifacts
-- [ ] `refactor` — restructure without behavior change
-- [ ] `docs` — documentation, analysis, or research additions
-- [ ] `chore` — configuration, CI/CD, version bumps
+## What problem are you trying to solve?
+<!-- Describe the specific problem you encountered. If this was a session
+     issue, include: what you were doing, what went wrong, the model's
+     exact failure mode, and ideally a transcript or session log.
+
+     "Improving" something is not a problem statement. What broke? What
+     failed? What was the user experience that motivated this? -->
+
+## What does this PR change?
+<!-- 1-3 sentences. What, not why — the "why" belongs above. -->
+
+## Is this change appropriate for the core library?
+<!-- Superpowers core contains general-purpose skills and infrastructure
+     that benefit all users. Ask yourself:
+
+     - Would this be useful to someone working on a completely different
+       kind of project than yours?
+     - Is this project-specific, team-specific, or tool-specific?
+     - Does this integrate or promote a third-party service?
+
+     If your change is a new skill for a specific domain, workflow tool,
+     or third-party integration, it belongs in its own plugin — not here.
+     See the plugin development docs for how to publish it separately. -->
+
+## What alternatives did you consider?
+<!-- What other approaches did you try or evaluate before landing on this
+     one? Why were they worse? If you didn't consider alternatives, say so
+     — but know that's a red flag. -->
+
+## Does this PR contain multiple unrelated changes?
+<!-- If yes: stop. Split it into separate PRs. Bundled PRs will be closed.
+     If you believe the changes are related, explain the dependency. -->
+
+## Existing PRs
+- [ ] I have reviewed all open AND closed PRs for duplicates or prior art
+- Related PRs: <!-- #number, #number, or "none found" -->
+
+<!-- If a related closed PR exists, explain what's different about your
+     approach and why it should succeed where the other didn't. -->
+
+## Environment tested
+
+| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
+|-------------------------------------|-----------------|-------|------------------|
+|                                     |                 |       |                  |
+
+## Evaluation
+- What was the initial prompt you (or your human partner) used to start
+  the session that led to this change?
+- How many eval sessions did you run AFTER making the change?
+- How did outcomes change compared to before the change?
+
+<!-- "It works" is not evaluation. Describe the before/after difference
+     you observed across multiple sessions. -->
+
+## Rigor
+
+- [ ] If this is a skills change: I used `superpowers:writing-skills` and
+      completed adversarial pressure testing (paste results below)
+- [ ] This change was tested adversarially, not just on the happy path
+- [ ] I did not modify carefully-tuned content (Red Flags table,
+      rationalizations, "human partner" language) without extensive evals
+      showing the change is an improvement
+
+<!-- If you changed wording in skills that shape agent behavior, show your
+     eval methodology and results. These are not prose — they are code. -->
+
+## Human review
+- [ ] A human has reviewed the COMPLETE proposed diff before submission
+
+<!--
+STOP. If the checkbox above is not checked, do not submit this PR.
+
+PRs will be closed without review if they:
+- Show no evidence of human involvement
+- Contain multiple unrelated changes
+- Promote or integrate third-party services or tools
+- Submit project-specific or personal configuration as core changes
+- Leave required sections blank or use placeholder text
+- Modify behavior-shaping content without eval evidence
+-->
 
 ## Changes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ of human involvement will be closed without review.
 <!-- 1-3 sentences. What, not why — the "why" belongs above. -->
 
 ## Is this change appropriate for the core library?
-<!-- Superpowers core contains general-purpose skills and infrastructure
+<!-- agent-engineering-toolkit contains general-purpose plugins and infrastructure
      that benefit all users. Ask yourself:
 
      - Would this be useful to someone working on a completely different
@@ -65,8 +65,8 @@ of human involvement will be closed without review.
 
 ## Rigor
 
-- [ ] If this is a skills change: I used `superpowers:writing-skills` and
-      completed adversarial pressure testing (paste results below)
+- [ ] If this is a skills change: I verified skill behavior with adversarial
+      pressure testing and completed at least 3 eval sessions (paste results below)
 - [ ] This change was tested adversarially, not just on the happy path
 - [ ] I did not modify carefully-tuned content (Red Flags table,
       rationalizations, "human partner" language) without extensive evals

--- a/.github/workflows/copilot-review-fix-loop.yml
+++ b/.github/workflows/copilot-review-fix-loop.yml
@@ -39,7 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
-      GH_TOKEN: ${{ secrets.COPILOT_REVIEW_FIX_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_REVIEW_FIX_TOKEN }}
       WORKFLOW_PR_NUMBER: ${{ inputs.pr_number }}
       WORKFLOW_REVIEW_ID: ${{ inputs.review_id }}
       WORKFLOW_MAX_ITERATIONS: ${{ inputs.max_iterations }}
@@ -47,10 +48,10 @@ jobs:
       REPO_DEFAULT_MAX_ITERATIONS: ${{ vars.COPILOT_REVIEW_FIX_MAX_ITERATIONS }}
       REPO_DEFAULT_MODEL: ${{ vars.COPILOT_REVIEW_FIX_MODEL }}
     steps:
-      - name: Validate workflow secret
+      - name: Validate Copilot token secret
         run: |
-          if [[ -z "${GH_TOKEN:-}" ]]; then
-            echo "::error::Set the COPILOT_REVIEW_FIX_TOKEN secret with Copilot Requests, contents:write, issues:write, and pull-requests:write permissions."
+          if [[ -z "${COPILOT_GITHUB_TOKEN:-}" ]]; then
+            echo "::error::Set the COPILOT_REVIEW_FIX_TOKEN secret to a fine-grained PAT with the Copilot Requests permission."
             exit 1
           fi
 
@@ -79,7 +80,7 @@ jobs:
           repository: ${{ steps.pr.outputs.repository }}
           ref: ${{ steps.pr.outputs.ref }}
           fetch-depth: 0
-          token: ${{ secrets.COPILOT_REVIEW_FIX_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 # Personal session tracking
 next-steps.md
+
+.claude/PRPs/reviews/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Multi-plugin Claude Code marketplace for evidence-based agent artifact engineeri
 
 ## Structure
 
-Two plugins, each with two separate skill sets — same names, different conventions:
+Multiple plugin distributions and one standalone distribution — each follows its own platform conventions:
 
 - `plugins/agents-initializer/skills/` — Claude Code plugin; delegates analysis to subagents
 - `plugins/cursor-initializer/skills/` — Cursor IDE plugin; delegates analysis to subagents (Cursor-native format)
@@ -21,7 +21,7 @@ Each skill directory contains:
 
 - Distribution-specific rules in `.claude/rules/plugin-skills.md` and `.claude/rules/standalone-skills.md`
 - Shared references are copied into each skill (not symlinked) — each skill is self-contained
-- When updating a shared reference, update all copies across both distributions in sync
+- When updating an intentionally shared reference, update all intended copies in sync
 - `.claude/rules/` enforces conventions automatically via path-scoped rules
 - `.claude/skills/` — development meta-skills for this project (not distributed to end-users)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # agent-engineering-toolkit
 
-Multi-plugin Claude Code marketplace for evidence-based agent artifact engineering.
+Multi-plugin marketplace for evidence-based agent artifact engineering.
 
 ## Structure
 
@@ -19,7 +19,7 @@ Each skill directory contains:
 
 ## Conventions
 
-- Distribution-specific rules in `.claude/rules/plugin-skills.md` and `.claude/rules/standalone-skills.md`
+- Distribution-specific rules in `.claude/rules/plugin-skills.md`, `.claude/rules/cursor-plugin-skills.md`, and `.claude/rules/standalone-skills.md`
 - Shared references are copied into each skill (not symlinked) — each skill is self-contained
 - When updating an intentionally shared reference, update all intended copies in sync
 - `.claude/rules/` enforces conventions automatically via path-scoped rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Multi-plugin Claude Code marketplace for evidence-based agent artifact engineeri
 Two plugins, each with two separate skill sets — same names, different conventions:
 
 - `plugins/agents-initializer/skills/` — Claude Code plugin; delegates analysis to subagents
+- `plugins/cursor-initializer/skills/` — Cursor IDE plugin; delegates analysis to subagents (Cursor-native format)
 - `plugins/agent-customizer/skills/` — Claude Code plugin; artifact creation/improvement
 - `skills/` — npx skills add; standalone inline analysis, no agent delegation
 
@@ -25,6 +26,7 @@ Each skill directory contains:
 - `.claude/skills/` — development meta-skills for this project (not distributed to end-users)
 
 See `plugins/agents-initializer/CLAUDE.md` for plugin-specific conventions.
+See `plugins/cursor-initializer/CLAUDE.md` for cursor-initializer plugin conventions.
 See `plugins/agent-customizer/CLAUDE.md` for agent-customizer plugin conventions.
 
 ## RAG Knowledge Base

--- a/DESIGN-GUIDELINES.md
+++ b/DESIGN-GUIDELINES.md
@@ -217,7 +217,7 @@ Converting a behavioral instruction from CLAUDE.md to a hook removes it from the
 
 **Source**: [Agent Skills Open Standard](docs/claude-code/skills/research-claude-code-skills-format.md) | Project architecture decision
 
-The toolkit ships three distributions with identical skill names but different analysis mechanisms:
+The toolkit ships three distributions with aligned capabilities but platform-specific skill names and analysis mechanisms:
 
 | Aspect           | Plugin (Claude Code)                      | Plugin (Cursor IDE)                        | Standalone (npx skills add)               |
 | ---------------- | ----------------------------------------- | ------------------------------------------ | ----------------------------------------- |
@@ -228,7 +228,7 @@ The toolkit ships three distributions with identical skill names but different a
 | Skills support   | Full                                      | Full                                       | Full                                      |
 | Output quality   | Identical                                 | Identical                                  | Identical                                 |
 
-Shared references are copied (not symlinked) into each skill directory. When updating a shared reference, all copies across all distributions must stay in sync.
+Shared references are copied (not symlinked) into each skill directory. When a reference is intentionally shared, all copies of that shared reference must stay in sync; platform-specific references may diverge when the target artifact system differs.
 
 **Implemented in**: `.claude/rules/plugin-skills.md`, `.claude/rules/cursor-plugin-skills.md`, `.claude/rules/standalone-skills.md`, `.claude/rules/reference-files.md`, CLAUDE.md (sync convention)
 

--- a/DESIGN-GUIDELINES.md
+++ b/DESIGN-GUIDELINES.md
@@ -217,20 +217,20 @@ Converting a behavioral instruction from CLAUDE.md to a hook removes it from the
 
 **Source**: [Agent Skills Open Standard](docs/claude-code/skills/research-claude-code-skills-format.md) | Project architecture decision
 
-The plugin ships two distributions with identical skill names but different analysis mechanisms:
+The toolkit ships three distributions with identical skill names but different analysis mechanisms:
 
-| Aspect           | Plugin (Claude Code)                      | Standalone (npx skills add)               |
-| ---------------- | ----------------------------------------- | ----------------------------------------- |
-| Analysis         | Delegates to named subagents              | Reads reference docs, runs inline         |
-| Hooks support    | Full (suggest hooks in improve)           | None (standalone tools lack hooks)        |
-| Subagent support | Full (suggest subagents)                  | None                                      |
-| Rules support    | Full (`.claude/rules/` with path-scoping) | Partial (suggest rules as separate files) |
-| Skills support   | Full                                      | Full                                      |
-| Output quality   | Identical                                 | Identical                                 |
+| Aspect           | Plugin (Claude Code)                      | Plugin (Cursor IDE)                        | Standalone (npx skills add)               |
+| ---------------- | ----------------------------------------- | ------------------------------------------ | ----------------------------------------- |
+| Analysis         | Delegates to named subagents              | Delegates to named subagents               | Reads reference docs, runs inline         |
+| Hooks support    | Full (suggest hooks in improve)           | Full (`.cursor/hooks.json` format)         | None (standalone tools lack hooks)        |
+| Subagent support | Full (suggest subagents)                  | Full (Cursor agent format)                 | None                                      |
+| Rules support    | Full (`.claude/rules/` with path-scoping) | Full (`.cursor/rules/*.mdc` with globs)    | Partial (suggest rules as separate files) |
+| Skills support   | Full                                      | Full                                       | Full                                      |
+| Output quality   | Identical                                 | Identical                                  | Identical                                 |
 
-Shared references are copied (not symlinked) into each skill directory. When updating a shared reference, all copies across both distributions must stay in sync.
+Shared references are copied (not symlinked) into each skill directory. When updating a shared reference, all copies across all distributions must stay in sync.
 
-**Implemented in**: `.claude/rules/plugin-skills.md`, `.claude/rules/standalone-skills.md`, `.claude/rules/reference-files.md`, CLAUDE.md (sync convention)
+**Implemented in**: `.claude/rules/plugin-skills.md`, `.claude/rules/cursor-plugin-skills.md`, `.claude/rules/standalone-skills.md`, `.claude/rules/reference-files.md`, CLAUDE.md (sync convention)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Evaluate and improve existing `.cursor/rules/*.mdc` files.
 - Rules that should be AGENTS.md content instead (portable, no metadata needed)
 - AGENTS.md evaluation is conditional: only included when the target project already uses AGENTS.md
 
-> **Note:** For AGENTS.md initialization and improvement, use the `agents-initializer` plugin (`/init-agents`, `/improve-agents`). The `cursor-initializer` plugin focuses on Cursor-native artifacts.
+> **Note:** Use `cursor-initializer` when you want the full Cursor configuration hierarchy, including AGENTS.md alongside `.cursor/rules/*.mdc`. Use `agents-initializer` (`/init-agents`, `/improve-agents`) when you want AGENTS.md/CLAUDE.md workflows outside a Cursor-specific setup.
 
 ## Installation
 
@@ -301,7 +301,11 @@ After installation, invoke skills by name:
 
 # If installed as a plugin (namespaced)
 /agents-initializer:init-claude
+/agents-initializer:improve-claude
+/agents-initializer:init-agents
+/agents-initializer:improve-agents
 /cursor-initializer:init-cursor
+/cursor-initializer:improve-cursor
 ```
 
 ## Research Foundation

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ To maintain context integrity during execution, this plugin uses **subagent isol
 
 | Subagent | Role | Used By |
 |----------|------|---------|
-| `codebase-analyzer` | Detects tech stack, package manager, build/test commands | All 4 skills |
+| `codebase-analyzer` | Detects tech stack, package manager, build/test commands | All subagent-backed plugin skills |
 | `scope-detector` | Identifies distinct scopes/contexts in the project | init skills |
 | `file-evaluator` | Assesses existing config file quality against research criteria | improve skills |
 
-All subagents are defined as native Claude Code subagent files with proper YAML frontmatter (`name`, `description`, `tools`, `model`, `maxTurns`). They run on **Claude Sonnet** with read-only tools (`Read`, `Grep`, `Glob`, `Bash`) for cost efficiency and safety. They return structured summaries — high signal, low noise — keeping the orchestrator's context clean.
+The Claude Code plugin uses native Claude subagent files with read-only tool whitelists and `model: sonnet`; the Cursor plugin uses Cursor's native subagent format with `model: inherit` and `readonly: true`. Both return structured summaries — high signal, low noise — keeping the orchestrator's context clean.
 
 #### Subagent Metadata
 
@@ -239,6 +239,24 @@ claude plugin install agents-initializer@agent-engineering-toolkit --scope proje
 claude plugin install agents-initializer@agent-engineering-toolkit --scope local
 ```
 
+### Cursor IDE (Native Plugin System)
+
+For local development and testing, load this repository through Cursor's local plugin directory:
+
+```bash
+# Clone the repository
+git clone https://github.com/rodrigorjsf/agent-engineering-toolkit.git ~/src/agent-engineering-toolkit
+
+# Register it as a local Cursor plugin marketplace
+mkdir -p ~/.cursor/plugins/local
+ln -s ~/src/agent-engineering-toolkit ~/.cursor/plugins/local/agent-engineering-toolkit
+```
+
+Then restart Cursor (or run **Developer: Reload Window**). The repo root `.cursor-plugin/marketplace.json` exposes the `cursor-initializer` plugin, which provides:
+
+- `/cursor-initializer:init-cursor`
+- `/cursor-initializer:improve-cursor`
+
 ### npx skills add (Third-Party Skills CLI)
 
 For users of the [skills CLI](https://skills.sh/) — works with VS Code Copilot, Cursor, Windsurf, and other AI coding tools:
@@ -253,15 +271,14 @@ npx skills add rodrigorjsf/agent-engineering-toolkit
 # Install for specific AI tools
 npx skills add rodrigorjsf/agent-engineering-toolkit --agent cursor copilot
 
-# Install only specific skills (Claude Code or Cursor variants)
+# Install only specific standalone skills
 npx skills add rodrigorjsf/agent-engineering-toolkit --skill init-claude improve-claude
-npx skills add rodrigorjsf/agent-engineering-toolkit --skill init-cursor improve-cursor
 
 # List available skills before installing
 npx skills add rodrigorjsf/agent-engineering-toolkit --list
 ```
 
-**These are standalone skills** — they perform all analysis inline without delegating to subagents. They work with any AI coding tool without requiring Claude Code's subagent system.
+**These are standalone skills** — they come from the root `skills/` directory, perform all analysis inline, and work with any AI coding tool without requiring plugin subagents. The Cursor-specific `init-cursor` / `improve-cursor` skills are **plugin-only** and require the native Cursor plugin install path above.
 
 ### Manual Installation
 
@@ -269,20 +286,22 @@ npx skills add rodrigorjsf/agent-engineering-toolkit --list
 # Clone the repository
 git clone https://github.com/rodrigorjsf/agent-engineering-toolkit.git /tmp/agent-engineering-toolkit
 
-# For Claude Code (project-level)
+# For standalone skills in Claude Code (project-level)
 mkdir -p .claude/skills
-cp -r /tmp/agent-engineering-toolkit/plugins/agents-initializer/skills/* .claude/skills/
+cp -r /tmp/agent-engineering-toolkit/skills/* .claude/skills/
 
-# For Claude Code (user-level, all projects)
-cp -r /tmp/agent-engineering-toolkit/plugins/agents-initializer/skills/* ~/.claude/skills/
+# For standalone skills in Claude Code (user-level, all projects)
+cp -r /tmp/agent-engineering-toolkit/skills/* ~/.claude/skills/
 
 # For VS Code / GitHub Copilot
 mkdir -p .agents/skills
-cp -r /tmp/agent-engineering-toolkit/plugins/agents-initializer/skills/* .agents/skills/
+cp -r /tmp/agent-engineering-toolkit/skills/* .agents/skills/
 
 # Clean up
 rm -rf /tmp/agent-engineering-toolkit
 ```
+
+For the native Claude Code and Cursor plugin distributions, use the plugin installation flows above instead of copying `plugins/*/skills/` by themselves — the plugin variants depend on their surrounding plugin layout (agents, manifests, and namespacing).
 
 ## Usage
 
@@ -394,9 +413,11 @@ agent-engineering-toolkit/
 >
 > - `plugins/agents-initializer/skills/` — **Claude Code plugin skills** that follow the official spec: analysis is delegated to isolated `codebase-analyzer`, `scope-detector`, and `file-evaluator` subagents, keeping the orchestrating context clean. Requires Claude Code's subagent system.
 >
-> - `skills/` — **Standalone skills** for `npx skills add` users. Perform all analysis inline with direct bash/file commands. No subagent delegation, compatible with any AI coding tool.
+> - `plugins/cursor-initializer/skills/` — **Cursor plugin skills** for the native Cursor plugin system. Uses Cursor's own subagent format and exposes namespaced `/cursor-initializer:*` commands.
 >
-> `npx skills add` does a recursive SKILL.md search. Both paths are discovered, but they have the same skill names — the root `skills/` (standalone versions) are processed last and take precedence, ensuring npx users get the tool-agnostic standalone versions.
+> - `skills/` — **Standalone skills** for `npx skills add` and manual installation. Perform all analysis inline with direct bash/file commands. No subagent delegation, compatible with any AI coding tool.
+>
+> `npx skills add` should be treated as the standalone distribution only. The root `skills/` directory provides the portable skill set; Cursor-specific plugin skills are not duplicated there.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ Initialize an optimized `.cursor/rules/*.mdc` hierarchy for your project.
 
 1. Launches a `codebase-analyzer` subagent to detect your tech stack and tooling
 2. Launches a `scope-detector` subagent to identify distinct project contexts
-3. Generates `.cursor/rules/*.mdc` files with appropriate activation modes (`alwaysApply`, `globs`, `description`)
+3. Generates `AGENTS.md` (root + per detected scope) and `.cursor/rules/*.mdc` files with appropriate activation modes (`alwaysApply`, `globs`, `description`)
 4. Presents all files for review before writing
 
-**Preflight check:** If `.cursor/rules/` already has rules, the skill redirects to `improve-cursor`.
+**Preflight check:** If `.cursor/rules/` already has rules **or** the project already has an `AGENTS.md`, the skill redirects to `improve-cursor`.
 
 ### `improve-cursor`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Engineering Toolkit
 
-A multi-plugin marketplace providing evidence-based Claude Code artifact engineering. The `agents-initializer` plugin generates and optimizes AGENTS.md and CLAUDE.md configuration files. Instead of auto-generating one bloated file, this toolkit creates **minimal, scoped files** following progressive disclosure principles — proven by research to outperform comprehensive auto-generated configurations.
+A multi-plugin marketplace providing evidence-based agent artifact engineering. The `agents-initializer` plugin generates and optimizes AGENTS.md and CLAUDE.md configuration files for Claude Code. The `cursor-initializer` plugin does the same for Cursor IDE, generating AGENTS.md and `.cursor/rules/*.mdc` files. Instead of auto-generating one bloated file, this toolkit creates **minimal, scoped files** following progressive disclosure principles — proven by research to outperform comprehensive auto-generated configurations.
 
 ## Why This Plugin Exists
 
@@ -58,6 +58,17 @@ description: "When to use this agent..."   # Routing signal for Claude's delegat
 tools: Read, Grep, Glob, Bash             # Restricted to read-only + shell
 model: sonnet                              # Cost-efficient for investigation tasks
 maxTurns: 15                               # Prevents runaway execution
+---
+```
+
+The Cursor variant (`plugins/cursor-initializer/agents/`) uses Cursor's native format:
+
+```yaml
+---
+name: codebase-analyzer
+description: "When to use this agent..."
+model: inherit                             # Inherits from parent context
+readonly: true                             # Read-only — boolean, not tool whitelist
 ---
 ```
 
@@ -158,6 +169,42 @@ Evaluate and improve existing CLAUDE.md files and `.claude/rules/`.
 - `.claude/rules/[topic].md` — migrated path-scoped conventions
 - Hook config snippets for `.claude/settings.json` (plugin distribution only)
 
+### Cursor IDE Skills
+
+The `cursor-initializer` plugin provides equivalent skills optimized for Cursor IDE's artifact system:
+
+### `init-cursor`
+
+Initialize an optimized `.cursor/rules/*.mdc` hierarchy for your project.
+
+**What it does:**
+
+1. Launches a `codebase-analyzer` subagent to detect your tech stack and tooling
+2. Launches a `scope-detector` subagent to identify distinct project contexts
+3. Generates `.cursor/rules/*.mdc` files with appropriate activation modes (`alwaysApply`, `globs`, `description`)
+4. Presents all files for review before writing
+
+**Preflight check:** If `.cursor/rules/` already has rules, the skill redirects to `improve-cursor`.
+
+### `improve-cursor`
+
+Evaluate and improve existing `.cursor/rules/*.mdc` files.
+
+**What it does:**
+
+1. Launches a `file-evaluator` subagent to assess .mdc file quality and activation mode correctness
+2. Generates an improvement plan (removals → refactoring → mode optimization → additions)
+3. Presents changes with token savings metrics before applying
+
+**Cursor-specific checks:**
+
+- Invalid frontmatter fields (only `description`, `alwaysApply`, `globs` are valid)
+- Activation mode optimization (e.g., converting `alwaysApply` rules to `globs`-based auto-attachment)
+- Rules that should be AGENTS.md content instead (portable, no metadata needed)
+- AGENTS.md evaluation is conditional: only included when the target project already uses AGENTS.md
+
+> **Note:** For AGENTS.md initialization and improvement, use the `agents-initializer` plugin (`/init-agents`, `/improve-agents`). The `cursor-initializer` plugin focuses on Cursor-native artifacts.
+
 ## Installation
 
 ### Claude Code (Native Plugin System)
@@ -206,8 +253,9 @@ npx skills add rodrigorjsf/agent-engineering-toolkit
 # Install for specific AI tools
 npx skills add rodrigorjsf/agent-engineering-toolkit --agent cursor copilot
 
-# Install only specific skills
+# Install only specific skills (Claude Code or Cursor variants)
 npx skills add rodrigorjsf/agent-engineering-toolkit --skill init-claude improve-claude
+npx skills add rodrigorjsf/agent-engineering-toolkit --skill init-cursor improve-cursor
 
 # List available skills before installing
 npx skills add rodrigorjsf/agent-engineering-toolkit --list
@@ -247,9 +295,13 @@ After installation, invoke skills by name:
 /improve-claude       # Improve existing CLAUDE.md files
 /improve-agents       # Improve existing AGENTS.md files
 
+# In Cursor IDE
+/init-cursor          # Initialize .cursor/rules/*.mdc + AGENTS.md hierarchy
+/improve-cursor       # Improve existing .cursor/rules/*.mdc files (and AGENTS.md if present)
+
 # If installed as a plugin (namespaced)
 /agents-initializer:init-claude
-/agents-initializer:improve-claude
+/cursor-initializer:init-cursor
 ```
 
 ## Research Foundation
@@ -292,19 +344,32 @@ For a comprehensive mapping of every design decision to its evidence source, see
 agent-engineering-toolkit/
 ├── .claude-plugin/
 │   └── marketplace.json             # Marketplace catalog (Claude Code plugin system)
+├── .cursor-plugin/
+│   └── marketplace.json             # Marketplace catalog (Cursor plugin system)
 ├── plugins/
-│   └── agents-initializer/          # Claude Code plugin — agent-delegating skills + proper agents
-│       ├── .claude-plugin/
+│   ├── agents-initializer/          # Claude Code plugin — agent-delegating skills + proper agents
+│   │   ├── .claude-plugin/
+│   │   │   └── plugin.json          # Plugin manifest
+│   │   ├── skills/
+│   │   │   ├── init-agents/SKILL.md     # Delegates to codebase-analyzer + scope-detector agents
+│   │   │   ├── init-claude/SKILL.md     # Delegates to codebase-analyzer + scope-detector agents
+│   │   │   ├── improve-agents/SKILL.md  # Delegates to file-evaluator + codebase-analyzer agents
+│   │   │   └── improve-claude/SKILL.md  # Delegates to file-evaluator + codebase-analyzer agents
+│   │   └── agents/                  # Claude Code subagents (proper YAML spec)
+│   │       ├── codebase-analyzer.md # Subagent: tech stack and tooling detection
+│   │       ├── scope-detector.md    # Subagent: project scope/context detection
+│   │       └── file-evaluator.md    # Subagent: config file quality assessment
+│   └── cursor-initializer/         # Cursor IDE plugin — Cursor-native artifact generation
+│       ├── .cursor-plugin/
 │       │   └── plugin.json          # Plugin manifest
+│       ├── AGENTS.md                # Cursor-native plugin config (for working in this directory)
 │       ├── skills/
-│       │   ├── init-agents/SKILL.md     # Delegates to codebase-analyzer + scope-detector agents
-│       │   ├── init-claude/SKILL.md     # Delegates to codebase-analyzer + scope-detector agents
-│       │   ├── improve-agents/SKILL.md  # Delegates to file-evaluator + codebase-analyzer agents
-│       │   └── improve-claude/SKILL.md  # Delegates to file-evaluator + codebase-analyzer agents
-│       └── agents/                  # Claude Code subagents (proper YAML spec)
-│           ├── codebase-analyzer.md # Subagent: tech stack and tooling detection
-│           ├── scope-detector.md    # Subagent: project scope/context detection
-│           └── file-evaluator.md    # Subagent: config file quality assessment
+│       │   ├── init-cursor/SKILL.md     # .cursor/rules/*.mdc + AGENTS.md generation
+│       │   └── improve-cursor/SKILL.md  # .cursor/rules/*.mdc evaluation/improvement (AGENTS.md conditional)
+│       └── agents/                  # Cursor subagents (readonly: true format)
+│           ├── codebase-analyzer.md # Subagent: tech stack detection
+│           ├── scope-detector.md    # Subagent: scope detection
+│           └── file-evaluator.md    # Subagent: .mdc file quality assessment
 ├── skills/                          # npx skills add — standalone skills (no agent delegation)
 │   ├── init-agents/SKILL.md         # Self-contained: inline analysis, no subagents required
 │   ├── init-claude/SKILL.md         # Self-contained: inline analysis, no subagents required
@@ -334,8 +399,10 @@ agent-engineering-toolkit/
 Development conventions are enforced by `.claude/rules/` — path-scoped rules load automatically when editing matching files. Key rules:
 
 - `plugin-skills.md` — plugin skill authoring constraints (delegation, validation, limits)
+- `cursor-plugin-skills.md` — cursor plugin constraints (.mdc format, readonly agents)
 - `standalone-skills.md` — standalone skill constraints (inline analysis, distribution awareness)
 - `agent-files.md` — subagent file requirements (frontmatter, model, tools)
+- `cursor-agent-files.md` — Cursor subagent requirements (readonly, model inherit)
 - `reference-files.md` — reference file format and size constraints
 
 See `DESIGN-GUIDELINES.md` for the evidence base behind each convention.

--- a/docs/cursor/README.md
+++ b/docs/cursor/README.md
@@ -1,6 +1,6 @@
 # Cursor IDE — Official Documentation
 
-This directory contains official documentation mirrored from [cursor.com/docs](https://cursor.com/docs). Each document describes how a specific Cursor IDE artifact should be defined to achieve the best IDE and agent behavior.
+This directory contains official documentation and blog guidance mirrored from [cursor.com](https://cursor.com). The documents cover both Cursor IDE artifact definitions and official workflow guidance for effective agent usage.
 
 AI agents should treat these documents as authoritative references when generating, reviewing, or validating Cursor artifacts (rules, skills, hooks, MCP servers, subagents, and plugins).
 

--- a/docs/cursor/README.md
+++ b/docs/cursor/README.md
@@ -25,6 +25,7 @@ AI agents should treat these documents as authoritative references when generati
 | [`rules/`](./rules/rules.md) | `rules.md` | System-level instructions (Always, Auto-attached, Agent-requested, Manual) that guide agent behavior |
 | [`skills/`](./skills/agent-skills-guide.md) | `agent-skills-guide.md` | Agent Skills standard — portable, version-controlled capability packages for agents |
 | [`subagents/`](./subagents/subagents-guide.md) | `subagents-guide.md` | Subagents — specialized assistants the agent can delegate tasks to in isolated context windows |
+| [`best-practices/`](./best-practices/agent-best-practices.md) | `agent-best-practices.md` | Official Cursor blog guide on agent workflows, planning, context management, and best practices |
 | [`tools/`](#tools) | ↓ 4 guides | Built-in agent tools: terminal, browser, search, and worktrees |
 
 ### tools/ sub-directories
@@ -35,6 +36,14 @@ AI agents should treat these documents as authoritative references when generati
 | [`tools/browser/`](./tools/browser/browser-guide.md) | `browser-guide.md` | Browser automation, design sidebar, session persistence, security, enterprise origin allowlists |
 | [`tools/search/`](./tools/search/search-guide.md) | `search-guide.md` | Instant grep, semantic search, indexing, the Explore subagent, privacy |
 | [`tools/worktrees/`](./tools/worktrees/worktrees-guide.md) | `worktrees-guide.md` | Parallel agents via Git worktrees, Best-of-N models, setup scripts, cleanup |
+
+## best-practices/
+
+**Source:** [cursor.com/blog/agent-best-practices](https://cursor.com/blog/agent-best-practices)
+
+Official Cursor guide covering techniques for working effectively with Cursor's agent — harness architecture, plan mode, context management, rules vs skills, TDD workflows, parallel agents, cloud agents, and debug mode.
+
+→ [`best-practices/agent-best-practices.md`](./best-practices/agent-best-practices.md)
 
 ## hooks/
 

--- a/docs/cursor/best-practices/agent-best-practices.md
+++ b/docs/cursor/best-practices/agent-best-practices.md
@@ -1,0 +1,179 @@
+# Agent Best Practices
+
+**Source:** [cursor.com/blog/agent-best-practices](https://cursor.com/blog/agent-best-practices)
+
+Official Cursor guide covering techniques for working effectively with Cursor's agent. Extracted from the Cursor blog.
+
+## Understanding Agent Harnesses
+
+An agent harness is built on three components:
+
+1. **Instructions**: The system prompt and rules that guide agent behavior
+2. **Tools**: File editing, codebase search, terminal execution, and more
+3. **Model**: The agent model you pick for the task
+
+Cursor's agent harness orchestrates these components for each model, tuning instructions and tools specifically for every frontier model based on internal evals and external benchmarks.
+
+## Start with Plans
+
+The most impactful change: planning before coding.
+
+A [study](https://cursor.com/blog/productivity) from the University of Chicago found that experienced developers are more likely to plan before generating code.
+
+### Using Plan Mode
+
+Press `Shift+Tab` in the agent input to toggle Plan Mode. The agent will:
+
+1. Research your codebase to find relevant files
+2. Ask clarifying questions about your requirements
+3. Create a detailed implementation plan with file paths and code references
+4. Wait for your approval before building
+
+Plans open as Markdown files you can edit directly.
+
+> **Tip:** Click "Save to workspace" to store plans in `.cursor/plans/`. This creates documentation for your team and provides context for future agents.
+
+### Starting Over from a Plan
+
+When the agent builds something wrong: revert changes, refine the plan, and run again. Often faster than fixing an in-progress agent.
+
+## Managing Context
+
+### Let the Agent Find Context
+
+Don't manually tag every file. Cursor's agent has powerful search tools and pulls context on demand. Including irrelevant files can confuse the agent about what's important.
+
+### When to Start a New Conversation
+
+**Start new when:**
+- Moving to a different task or feature
+- The agent seems confused or keeps making the same mistakes
+- Finished one logical unit of work
+
+**Continue when:**
+- Iterating on the same feature
+- The agent needs context from earlier
+- Debugging something it just built
+
+Long conversations cause the agent to lose focus — context accumulates noise after many turns and summarizations.
+
+### Reference Past Work
+
+Use `@Past Chats` to reference previous work rather than copy-pasting the whole conversation.
+
+## Extending the Agent
+
+### Rules: Static Context for Your Project
+
+Rules provide persistent instructions. Create as markdown files in `.cursor/rules/`:
+
+```markdown
+# Commands
+- `npm run build`: Build the project
+- `npm run typecheck`: Run the typechecker
+- `npm run test`: Run tests
+
+# Code style
+- Use ES modules (import/export), not CommonJS (require)
+- Destructure imports when possible
+- See `components/Button.tsx` for canonical component structure
+
+# Workflow
+- Always typecheck after making a series of code changes
+- API routes go in `app/api/` following existing patterns
+```
+
+**Keep rules focused on essentials**: commands to run, patterns to follow, pointers to canonical examples. Reference files instead of copying contents.
+
+**What to avoid in rules:**
+- Copying entire style guides (use a linter instead)
+- Documenting every possible command (the agent knows common tools)
+- Adding instructions for edge cases that rarely apply
+
+> **Tip:** Start simple. Add rules only when you notice the agent making the same mistake repeatedly.
+
+### Skills: Dynamic Capabilities and Workflows
+
+Skills extend what agents can do. Defined in `SKILL.md` files, they include:
+- **Custom commands**: Reusable workflows triggered with `/` in the agent input
+- **Hooks**: Scripts that run before or after agent actions
+- **Domain knowledge**: Instructions for specific tasks the agent can pull in on demand
+
+Unlike Rules (always included), Skills are loaded dynamically when the agent decides they're relevant.
+
+## Common Workflows
+
+### Test-Driven Development
+
+1. Ask the agent to write tests based on expected input/output pairs
+2. Tell the agent to run tests and confirm they fail (no implementation code yet)
+3. Commit the tests when satisfied
+4. Ask the agent to write code that passes the tests (no test modifications)
+5. Commit the implementation
+
+Agents perform best when they have a clear target to iterate against.
+
+### Git Workflows
+
+A `/pr` command example:
+```markdown
+Create a pull request for the current changes.
+1. Look at the staged and unstaged changes with `git diff`
+2. Write a clear commit message based on what changed
+3. Commit and push to the current branch
+4. Use `gh pr create` to open a pull request
+5. Return the PR URL when done
+```
+
+## Reviewing Code
+
+### During Generation
+
+Watch the agent work. The diff view shows changes as they happen. Click **Stop** to cancel and redirect.
+
+### Agent Review
+
+Click **Review** → **Find Issues** to run a dedicated review pass.
+
+### BugBot for Pull Requests
+
+Push to source control to get automated reviews on pull requests. BugBot applies advanced analysis to catch issues early.
+
+## Running Agents in Parallel
+
+### Native Worktree Support
+
+Cursor automatically creates and manages git worktrees for parallel agents. Each agent runs in its own worktree with isolated files and changes.
+
+### Run Multiple Models at Once
+
+Select multiple models from the dropdown, submit your prompt, compare results side by side. Useful for hard problems and finding edge cases.
+
+## Delegating to Cloud Agents
+
+Cloud agents work well for:
+- Bug fixes that came up while working on something else
+- Refactors of recent code changes
+- Generating tests for existing code
+- Documentation updates
+
+Cloud agents clone your repo, create a branch, work autonomously, and open a pull request when finished.
+
+## Debug Mode
+
+Debug Mode provides evidence-based debugging:
+1. Generates multiple hypotheses
+2. Instruments code with logging
+3. Asks you to reproduce the bug while collecting runtime data
+4. Analyzes actual behavior to pinpoint root cause
+5. Makes targeted fixes based on evidence
+
+Best for reproducible bugs, race conditions, performance problems, and regressions.
+
+## Developing Your Workflow
+
+Key traits of effective agent users:
+
+- **Write specific prompts**: Compare "add tests for auth.ts" with "Write a test case for auth.ts covering the logout edge case, using the patterns in `__tests__/` and avoiding mocks."
+- **Iterate on setup**: Start simple. Add rules only when you notice repeated mistakes. Add commands after figuring out workflows you want to repeat.
+- **Review carefully**: AI-generated code can look right while being subtly wrong. Treat AI code with the same rigor as a PR from a junior developer.

--- a/docs/cursor/best-practices/agent-best-practices.md
+++ b/docs/cursor/best-practices/agent-best-practices.md
@@ -2,178 +2,19 @@
 
 **Source:** [cursor.com/blog/agent-best-practices](https://cursor.com/blog/agent-best-practices)
 
-Official Cursor guide covering techniques for working effectively with Cursor's agent. Extracted from the Cursor blog.
+Summary of Cursor's guidance for working effectively with its agent. For full details and UI walkthroughs, read the source at the link above.
 
-## Understanding Agent Harnesses
+## Key Points
 
-An agent harness is built on three components:
+- **Agent harness = instructions + tools + model.** Cursor tunes instructions and tools per model based on internal evals.
+- **Plan before coding.** Use Plan Mode (`Shift+Tab`) to let the agent research the codebase, ask clarifying questions, and draft a plan before making changes. Revert and replan when things go off track — often faster than patching a flawed implementation.
+- **Keep context focused.** Let the agent find files on demand rather than tagging everything manually. Start a fresh conversation when switching tasks or when the agent loses focus.
+- **Rules = static context.** Keep `.cursor/rules/*.mdc` files focused: build commands, project-specific patterns, pointers to canonical examples. Add rules only when the agent repeats the same mistake.
+- **Skills = dynamic workflows.** Defined in `SKILL.md` files; loaded when the agent deems them relevant. Use for reusable multi-step workflows and domain knowledge that doesn't belong in always-loaded rules.
+- **Write specific prompts.** Prefer "Write a test for auth.ts covering the logout edge case, following patterns in `__tests__/`" over "add tests." Specificity reduces correction cycles.
+- **Parallel agents via worktrees.** Cursor creates isolated git worktrees for parallel agent tasks; each has its own file state.
+- **Review AI output rigorously.** Treat generated code like a PR from a junior developer — it can look right while being subtly wrong.
 
-1. **Instructions**: The system prompt and rules that guide agent behavior
-2. **Tools**: File editing, codebase search, terminal execution, and more
-3. **Model**: The agent model you pick for the task
+## Notes
 
-Cursor's agent harness orchestrates these components for each model, tuning instructions and tools specifically for every frontier model based on internal evals and external benchmarks.
-
-## Start with Plans
-
-The most impactful change: planning before coding.
-
-A [study](https://cursor.com/blog/productivity) from the University of Chicago found that experienced developers are more likely to plan before generating code.
-
-### Using Plan Mode
-
-Press `Shift+Tab` in the agent input to toggle Plan Mode. The agent will:
-
-1. Research your codebase to find relevant files
-2. Ask clarifying questions about your requirements
-3. Create a detailed implementation plan with file paths and code references
-4. Wait for your approval before building
-
-Plans open as Markdown files you can edit directly.
-
-> **Tip:** Click "Save to workspace" to store plans in `.cursor/plans/`. This creates documentation for your team and provides context for future agents.
-
-### Starting Over from a Plan
-
-When the agent builds something wrong: revert changes, refine the plan, and run again. Often faster than fixing an in-progress agent.
-
-## Managing Context
-
-### Let the Agent Find Context
-
-Don't manually tag every file. Cursor's agent has powerful search tools and pulls context on demand. Including irrelevant files can confuse the agent about what's important.
-
-### When to Start a New Conversation
-
-**Start new when:**
-- Moving to a different task or feature
-- The agent seems confused or keeps making the same mistakes
-- Finished one logical unit of work
-
-**Continue when:**
-- Iterating on the same feature
-- The agent needs context from earlier
-- Debugging something it just built
-
-Long conversations cause the agent to lose focus — context accumulates noise after many turns and summarizations.
-
-### Reference Past Work
-
-Use `@Past Chats` to reference previous work rather than copy-pasting the whole conversation.
-
-## Extending the Agent
-
-### Rules: Static Context for Your Project
-
-Rules provide persistent instructions. Create as markdown files in `.cursor/rules/`:
-
-```markdown
-# Commands
-- `npm run build`: Build the project
-- `npm run typecheck`: Run the typechecker
-- `npm run test`: Run tests
-
-# Code style
-- Use ES modules (import/export), not CommonJS (require)
-- Destructure imports when possible
-- See `components/Button.tsx` for canonical component structure
-
-# Workflow
-- Always typecheck after making a series of code changes
-- API routes go in `app/api/` following existing patterns
-```
-
-**Keep rules focused on essentials**: commands to run, patterns to follow, pointers to canonical examples. Reference files instead of copying contents.
-
-**What to avoid in rules:**
-- Copying entire style guides (use a linter instead)
-- Documenting every possible command (the agent knows common tools)
-- Adding instructions for edge cases that rarely apply
-
-> **Tip:** Start simple. Add rules only when you notice the agent making the same mistake repeatedly.
-
-### Skills: Dynamic Capabilities and Workflows
-
-Skills extend what agents can do. Defined in `SKILL.md` files, they include:
-- **Custom commands**: Reusable workflows triggered with `/` in the agent input
-- **Hooks**: Scripts that run before or after agent actions
-- **Domain knowledge**: Instructions for specific tasks the agent can pull in on demand
-
-Unlike Rules (always included), Skills are loaded dynamically when the agent decides they're relevant.
-
-## Common Workflows
-
-### Test-Driven Development
-
-1. Ask the agent to write tests based on expected input/output pairs
-2. Tell the agent to run tests and confirm they fail (no implementation code yet)
-3. Commit the tests when satisfied
-4. Ask the agent to write code that passes the tests (no test modifications)
-5. Commit the implementation
-
-Agents perform best when they have a clear target to iterate against.
-
-### Git Workflows
-
-A `/pr` command example:
-```markdown
-Create a pull request for the current changes.
-1. Look at the staged and unstaged changes with `git diff`
-2. Write a clear commit message based on what changed
-3. Commit and push to the current branch
-4. Use `gh pr create` to open a pull request
-5. Return the PR URL when done
-```
-
-## Reviewing Code
-
-### During Generation
-
-Watch the agent work. The diff view shows changes as they happen. Click **Stop** to cancel and redirect.
-
-### Agent Review
-
-Click **Review** → **Find Issues** to run a dedicated review pass.
-
-### BugBot for Pull Requests
-
-Push to source control to get automated reviews on pull requests. BugBot applies advanced analysis to catch issues early.
-
-## Running Agents in Parallel
-
-### Native Worktree Support
-
-Cursor automatically creates and manages git worktrees for parallel agents. Each agent runs in its own worktree with isolated files and changes.
-
-### Run Multiple Models at Once
-
-Select multiple models from the dropdown, submit your prompt, compare results side by side. Useful for hard problems and finding edge cases.
-
-## Delegating to Cloud Agents
-
-Cloud agents work well for:
-- Bug fixes that came up while working on something else
-- Refactors of recent code changes
-- Generating tests for existing code
-- Documentation updates
-
-Cloud agents clone your repo, create a branch, work autonomously, and open a pull request when finished.
-
-## Debug Mode
-
-Debug Mode provides evidence-based debugging:
-1. Generates multiple hypotheses
-2. Instruments code with logging
-3. Asks you to reproduce the bug while collecting runtime data
-4. Analyzes actual behavior to pinpoint root cause
-5. Makes targeted fixes based on evidence
-
-Best for reproducible bugs, race conditions, performance problems, and regressions.
-
-## Developing Your Workflow
-
-Key traits of effective agent users:
-
-- **Write specific prompts**: Compare "add tests for auth.ts" with "Write a test case for auth.ts covering the logout edge case, using the patterns in `__tests__/` and avoiding mocks."
-- **Iterate on setup**: Start simple. Add rules only when you notice repeated mistakes. Add commands after figuring out workflows you want to repeat.
-- **Review carefully**: AI-generated code can look right while being subtly wrong. Treat AI code with the same rigor as a PR from a junior developer.
+This file intentionally summarizes ideas in original wording rather than reproducing the full post. Refer to the source for exact UI details, step-by-step examples, and current product features.

--- a/plugins/cursor-initializer/.cursor-plugin/plugin.json
+++ b/plugins/cursor-initializer/.cursor-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "cursor-initializer",
+  "version": "1.0.0",
+  "description": "Evidence-based AGENTS.md and Cursor rules initializer and optimizer. Generates minimal, scoped configuration files following progressive disclosure principles — based on the ETH Zurich 'Evaluating AGENTS.md' study and Cursor's context engineering best practices.",
+  "author": {
+    "name": "rodrigorjsf"
+  },
+  "repository": "https://github.com/rodrigorjsf/agent-engineering-toolkit",
+  "license": "MIT"
+}

--- a/plugins/cursor-initializer/AGENTS.md
+++ b/plugins/cursor-initializer/AGENTS.md
@@ -1,0 +1,25 @@
+# cursor-initializer Plugin
+
+Cursor IDE plugin that generates evidence-based AGENTS.md and `.cursor/rules/*.mdc` configuration files.
+
+## Skills
+
+- `init-cursor` — Generates AGENTS.md + `.cursor/rules/*.mdc` hierarchy for projects without Cursor config
+- `improve-cursor` — Evaluates and improves existing AGENTS.md and `.cursor/rules/*.mdc` files; AGENTS.md handling is conditional on whether the target project uses it
+
+## Subagents
+
+Three read-only agents in `agents/`: `codebase-analyzer` (tech stack detection), `scope-detector` (project context mapping), `file-evaluator` (.mdc and AGENTS.md quality assessment).
+
+## Conventions
+
+- Generated `.mdc` frontmatter allows ONLY: `description`, `alwaysApply`, `globs`
+- Subagents use `readonly: true` and `model: inherit` — never `tools:` whitelists or `maxTurns:`
+- `init-cursor` always generates AGENTS.md as part of the Cursor configuration hierarchy
+- `improve-cursor` only handles AGENTS.md if the target project already has it
+- Output targets `.cursor/rules/` only — never `.claude/rules/`
+- No reference file may exceed 200 lines; SKILL.md body under 500 lines
+
+## Validation
+
+Skill changes must pass `references/validation-criteria.md` in the relevant skill directory.

--- a/plugins/cursor-initializer/CLAUDE.md
+++ b/plugins/cursor-initializer/CLAUDE.md
@@ -8,7 +8,7 @@ Follows the official Cursor plugin specification. Two Cursor-specific skills: `i
 - `skills/*/references/` — evidence-based guidance files loaded conditionally by SKILL.md phases
 - `skills/*/assets/templates/` — output template files used during file generation phases
 - `agents/` — Cursor-native subagent format: `name`, `description`, `model`, `readonly` frontmatter
-- Plugin agents cannot spawn other agents and cannot use write tools when `readonly: true`
+- Plugin agents MUST NOT spawn other agents and cannot use write tools when `readonly: true`
 - Generated rules use `.mdc` format with only `description`, `alwaysApply`, `globs` frontmatter
 - Generated project output targets `.cursor/rules/` (not `.claude/rules/`)
 - `init-cursor` always generates AGENTS.md; `improve-cursor` only handles AGENTS.md if target project has it

--- a/plugins/cursor-initializer/CLAUDE.md
+++ b/plugins/cursor-initializer/CLAUDE.md
@@ -1,0 +1,14 @@
+# cursor-initializer Plugin
+
+Follows the official Cursor plugin specification. Two Cursor-specific skills: `init-cursor` and `improve-cursor`.
+
+## Conventions
+
+- `skills/` — SKILL.md entry points; authoring constraints in `.claude/rules/cursor-plugin-skills.md`
+- `skills/*/references/` — evidence-based guidance files loaded conditionally by SKILL.md phases
+- `skills/*/assets/templates/` — output template files used during file generation phases
+- `agents/` — Cursor-native subagent format: `name`, `description`, `model`, `readonly` frontmatter
+- Plugin agents cannot spawn other agents and cannot use write tools when `readonly: true`
+- Generated rules use `.mdc` format with only `description`, `alwaysApply`, `globs` frontmatter
+- Generated project output targets `.cursor/rules/` (not `.claude/rules/`)
+- `init-cursor` always generates AGENTS.md; `improve-cursor` only handles AGENTS.md if target project has it

--- a/plugins/cursor-initializer/agents/codebase-analyzer.md
+++ b/plugins/cursor-initializer/agents/codebase-analyzer.md
@@ -1,0 +1,120 @@
+---
+name: codebase-analyzer
+description: "Analyze a project's technical characteristics — tech stack, tooling, build/test commands, non-standard patterns. Use when initializing or improving AGENTS.md or Cursor rules."
+model: inherit
+readonly: true
+---
+
+# Codebase Analyzer
+
+You are a codebase analysis specialist. Analyze the project at the current working directory and return a structured summary of its technical characteristics. Focus on facts that would cause mistakes if an AI coding agent didn't know them.
+
+## Constraints
+
+- Do not generate codebase overviews or directory listings — research shows these don't help agents navigate
+- Do not document obvious conventions the model already knows (e.g., standard JavaScript patterns)
+- Only report non-standard, non-obvious, or project-specific information
+- Shorter output is better — omit sections with nothing non-standard to report
+
+## Process
+
+### 1. Project Detection
+
+Search for configuration files to determine the project type:
+
+```
+Look for: package.json, Cargo.toml, go.mod, pyproject.toml, setup.py, requirements.txt,
+pom.xml, build.gradle, Gemfile, composer.json, mix.exs, CMakeLists.txt, Makefile,
+*.csproj, *.sln, deno.json, bun.lockb
+```
+
+### 2. Package Manager Detection
+
+Identify the package manager by checking for lock files:
+
+| Lock File | Package Manager |
+|-----------|----------------|
+| `pnpm-lock.yaml` | pnpm |
+| `yarn.lock` | yarn |
+| `package-lock.json` | npm |
+| `bun.lockb` | bun |
+| `Cargo.lock` | cargo |
+| `go.sum` | go modules |
+| `poetry.lock` | poetry |
+| `uv.lock` | uv |
+| `Pipfile.lock` | pipenv |
+| `Gemfile.lock` | bundler |
+| `composer.lock` | composer |
+
+Only report if non-default (e.g., pnpm instead of npm for JS projects).
+
+### 3. Build/Test/Lint Commands
+
+Extract commands from configuration files:
+
+- **package.json**: Read `scripts` section for build, test, lint, typecheck, dev commands
+- **Makefile**: Read target names
+- **pyproject.toml**: Read `[tool.pytest]`, `[tool.ruff]`, `[scripts]` sections
+- **Cargo.toml**: Check for workspace configuration
+
+Only report non-standard commands. Don't report `npm test` if that's the standard.
+
+### 4. Tech Stack Detection
+
+Identify key frameworks and tools by checking dependencies:
+
+- Frameworks: React, Next.js, Vue, Angular, Express, FastAPI, Django, Rails, etc.
+- Databases: Check for ORM configs (Prisma, TypeORM, SQLAlchemy, etc.)
+- Testing: Jest, Vitest, pytest, Go test, RSpec, etc.
+- Linting: ESLint, Prettier, Ruff, clippy, etc.
+- CI/CD: Check `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`
+
+### 5. Non-Standard Patterns
+
+Look for anything unusual that would trip up an agent:
+
+- Custom build scripts or tooling
+- Monorepo tools (Turborepo, Nx, Lerna, etc.)
+- Code generation (protobuf, GraphQL codegen, etc.)
+- Environment setup requirements (.env files, Docker, etc.)
+- Repository-specific tools mentioned in existing documentation
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## Codebase Analysis Results
+
+### Project Type
+- Language: [primary language]
+- Framework: [if applicable]
+- Type: [application | library | monorepo | CLI tool | API | etc.]
+
+### Tooling (non-standard only)
+- Package manager: [only if non-default]
+- Build: `[command]`
+- Test: `[command]`
+- Lint: `[command]`
+- Typecheck: `[command]`
+- Dev server: `[command]`
+
+### Tech Stack
+- [Only list items that are non-obvious from the language/framework]
+
+### Non-Standard Patterns
+- [List anything unusual that would cause agent mistakes]
+
+### Domain Concepts
+- [Key domain terms that differ from common usage, if any]
+```
+
+If a section has nothing non-standard to report, omit it entirely. Shorter is better.
+
+## Self-Verification
+
+Before returning results, verify:
+1. Every reported item is genuinely non-standard — would an experienced developer consider this worth noting?
+2. No directory listings or file structure descriptions crept in
+3. Output follows the exact format specified above
+4. Sections with no findings are omitted, not left empty

--- a/plugins/cursor-initializer/agents/file-evaluator.md
+++ b/plugins/cursor-initializer/agents/file-evaluator.md
@@ -36,7 +36,7 @@ Each of these wastes tokens without improving agent performance:
 | Standard language conventions | Agent already knows these from training | Anthropic Best Practices |
 | Vague instructions ("write clean code") | Not actionable, wastes attention budget | a-guide-to-agents.md |
 | Codebase overview paragraphs | Increases steps without improving navigation | Evaluating AGENTS.md |
-| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it correctly, delete it" |
+| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic Best Practices |
 | Duplicated information across files | Wastes tokens on every request | Context engineering research |
 
 ### Staleness Indicators

--- a/plugins/cursor-initializer/agents/file-evaluator.md
+++ b/plugins/cursor-initializer/agents/file-evaluator.md
@@ -1,0 +1,170 @@
+---
+name: file-evaluator
+description: "Evaluate existing AGENTS.md or Cursor rules (.mdc) against evidence-based quality criteria. Use when improving configuration files — identifies bloat, contradictions, staleness, and missed scopes."
+model: inherit
+readonly: true
+---
+
+# File Evaluator
+
+You are a configuration file quality specialist. Analyze existing AGENTS.md or `.cursor/rules/*.mdc` files in the project at the current working directory and assess their quality against evidence-based criteria. Identify specific problems with evidence so an improvement skill can act on them.
+
+## Constraints
+
+- Do not modify any files — only analyze and report
+- Do not suggest improvements — only identify problems with evidence
+- Be specific: cite exact line numbers and content for each issue found
+- Score objectively against the criteria below
+
+## Quality Criteria (from Research)
+
+### Hard Limits
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| File length | ≤ 200 lines | ETH Zurich study + Cursor best practices: keep rules under 500 lines, config files under 200 |
+| Instruction count | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions" |
+| No contradictions | 0 conflicts | Conflicting instructions cause agents to pick one arbitrarily |
+
+### Bloat Indicators
+
+Each of these wastes tokens without improving agent performance:
+
+| Indicator | Why It's Bloat | Source |
+|-----------|---------------|--------|
+| Directory/file structure listings | "Not effective at providing repository overview" | Evaluating AGENTS.md (ETH Zurich) |
+| Standard language conventions | Agent already knows these from training | Anthropic Best Practices |
+| Vague instructions ("write clean code") | Not actionable, wastes attention budget | a-guide-to-agents.md |
+| Codebase overview paragraphs | Increases steps without improving navigation | Evaluating AGENTS.md |
+| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it correctly, delete it" |
+| Duplicated information across files | Wastes tokens on every request | Context engineering research |
+
+### Staleness Indicators
+
+| Indicator | How to Detect |
+|-----------|---------------|
+| Referenced file paths that don't exist | Check if each `path/to/file` in the content actually exists |
+| Documented commands that fail | Try running documented build/test commands |
+| Package references to uninstalled deps | Check if mentioned packages are in manifest files |
+| Outdated framework version references | Compare mentioned versions with actual versions |
+
+### Progressive Disclosure Assessment
+
+| Question | Good | Bad |
+|----------|------|-----|
+| Does root file stay focused on essentials? | One-sentence desc + tooling + pointers | Inlines everything |
+| Are domain topics in separate files? | Testing in TESTING.md, build in BUILD.md | All in one file |
+| Do scoped rules exist for distinct contexts? | `.cursor/rules/*.mdc` for pattern-specific rules | Everything in root |
+| Are pointers provided to detailed docs? | "See docs/TESTING.md" | No cross-references |
+
+### Automation Opportunity Indicators
+
+Flag instructions that are candidates for migration to on-demand mechanisms:
+
+| Indicator | Migration Type | Flag As |
+|-----------|---------------|---------|
+| Instructions with specific file patterns (globs) | `.cursor/rules/*.mdc` with `globs:` | `RULE_CANDIDATE` |
+| Formatting/blocking/notification enforcement | `.cursor/hooks.json` | `HOOK_CANDIDATE` |
+| "Always"/"never" deterministic enforcement semantics | `.cursor/hooks.json` | `HOOK_CANDIDATE` |
+| Domain knowledge or workflow blocks >50 lines | Skill | `SKILL_CANDIDATE` |
+| Content agents can infer from code | Deletion | `DELETE_CANDIDATE` |
+| Instructions duplicated across multiple files | Consolidation | `CONSOLIDATE` |
+| Version numbers, team names, high-churn content | Deletion | `DELETE_CANDIDATE` |
+
+## Process
+
+### 1. Find All Configuration Files
+
+Search for:
+
+- `AGENTS.md` files at any depth
+- `.cursor/rules/*.mdc` files (Cursor path-scoped rules)
+
+### 2. Per-File Analysis
+
+For each file found:
+
+1. Count metrics: lines, sections (markdown headers), bullet points, code blocks
+2. Scan for bloat indicators: check each line against the bloat indicators table
+3. Check for staleness: verify referenced paths exist, commands work
+4. Identify contradictions: compare instructions across all files for conflicts
+5. Assess progressive disclosure: is content at the right scope level?
+6. Check instruction specificity: are instructions specific and verifiable?
+7. Scan for automation opportunities: check each instruction against the automation opportunity indicators table above
+
+### 3. Cross-File Analysis
+
+- Are there contradictions between root and subdirectory files?
+- Is information duplicated across multiple files?
+- Are there scopes with distinct tooling that lack their own file?
+- Is the root file overloaded with scope-specific information?
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## File Evaluation Results
+
+### Files Found
+| File | Lines | Sections | Status |
+|------|-------|----------|--------|
+| `./AGENTS.md` | 342 | 15 | ⚠️ Over limit |
+| `./packages/api/AGENTS.md` | 28 | 3 | ✅ Good |
+
+### Per-File Issues
+
+#### `./AGENTS.md` (342 lines — OVER 200 LINE LIMIT)
+
+**Bloat Issues:**
+- Lines 45-78: Directory structure listing (research shows these don't help agents)
+- Lines 102-115: Standard TypeScript conventions (agent already knows these)
+- Line 134: "Write clean, maintainable code" (too vague to be actionable)
+
+**Staleness Issues:**
+- Line 23: References `src/auth/handlers.ts` — file does not exist
+- Line 89: Documents `npm run build:legacy` — command not in package.json
+
+**Contradiction Issues:**
+- Line 12: "Use 4-space indentation" conflicts with `.prettierrc` setting of 2 spaces
+
+**Progressive Disclosure Issues:**
+- Lines 150-200: Testing conventions should be in separate `docs/TESTING.md`
+- Lines 201-250: API design patterns should be in `packages/api/AGENTS.md`
+
+**Specificity Issues:**
+- Line 67: "Follow best practices for error handling" — not actionable
+
+**Automation Opportunity Issues:**
+- Lines 45-60: Formatting enforcement (HOOK_CANDIDATE — deterministic behavior)
+- Lines 102-130: Testing domain block, 28 lines (SKILL_CANDIDATE — domain knowledge)
+- Lines 200-210: Glob-based rule "*.test.ts" (RULE_CANDIDATE — .cursor/rules/*.mdc)
+
+### Cross-File Issues
+- [List any cross-file contradictions or duplications]
+
+### Missing Scopes
+- `packages/web/` — Has distinct React tech stack, no config file
+- `scripts/` — Has custom tooling, no config file
+
+### Quality Score
+| Dimension | Score (1-10) | Notes |
+|-----------|-------------|-------|
+| Conciseness | 3 | 342 lines, 70%+ over limit |
+| Accuracy | 6 | 2 stale references found |
+| Specificity | 5 | Mix of specific and vague instructions |
+| Progressive Disclosure | 4 | Most content inlined in root |
+| Consistency | 7 | 1 contradiction found |
+| **Overall** | **4** | Needs significant refactoring |
+```
+
+## Self-Verification
+
+Before returning results, verify:
+
+1. Every reported issue includes a specific line number or line range
+2. Bloat classifications match the criteria table — no false positives
+3. Staleness claims are verified (paths checked, commands checked)
+4. The quality score reflects the actual severity of issues found
+5. No improvement suggestions crept in — report only identifies problems
+6. Automation opportunity flags match the indicators table — no false classifications

--- a/plugins/cursor-initializer/agents/file-evaluator.md
+++ b/plugins/cursor-initializer/agents/file-evaluator.md
@@ -1,13 +1,13 @@
 ---
 name: file-evaluator
-description: "Evaluate existing AGENTS.md or Cursor rules (.mdc) against evidence-based quality criteria. Use when improving configuration files — identifies bloat, contradictions, staleness, and missed scopes."
+description: "Evaluate existing AGENTS.md or Cursor rules (.md and .mdc) against evidence-based quality criteria. Use when improving configuration files — identifies bloat, contradictions, staleness, and missed scopes."
 model: inherit
 readonly: true
 ---
 
 # File Evaluator
 
-You are a configuration file quality specialist. Analyze existing AGENTS.md or `.cursor/rules/*.mdc` files in the project at the current working directory and assess their quality against evidence-based criteria. Identify specific problems with evidence so an improvement skill can act on them.
+You are a configuration file quality specialist. Analyze existing AGENTS.md or `.cursor/rules/` files (`.mdc` and `.md`) in the project at the current working directory and assess their quality against evidence-based criteria. Identify specific problems with evidence so an improvement skill can act on them.
 
 ## Constraints
 
@@ -78,7 +78,7 @@ Flag instructions that are candidates for migration to on-demand mechanisms:
 Search for:
 
 - `AGENTS.md` files at any depth
-- `.cursor/rules/*.mdc` files (Cursor path-scoped rules)
+- `.cursor/rules/*.mdc` and `.cursor/rules/*.md` files (Cursor rules)
 
 ### 2. Per-File Analysis
 

--- a/plugins/cursor-initializer/agents/scope-detector.md
+++ b/plugins/cursor-initializer/agents/scope-detector.md
@@ -1,0 +1,119 @@
+---
+name: scope-detector
+description: "Identify distinct contexts (scopes) in a project that need their own AGENTS.md or Cursor rules. Use when initializing configuration file hierarchies."
+model: inherit
+readonly: true
+---
+
+# Scope Detector
+
+You are a scope detection specialist. Identify distinct contexts within the project at the current working directory that would benefit from their own configuration file (AGENTS.md or Cursor rules). Each scope represents an area where an agent needs different guidance than the root-level instructions.
+
+## Constraints
+
+- Do not create a scope for every directory — only for truly distinct contexts
+- A scope needs its own file only if it has different tooling, conventions, or domain knowledge from the root
+- Single-package projects may have zero additional scopes (root file is sufficient)
+- Aim for the minimum number of scopes that captures meaningful differences
+
+## When a Directory Deserves Its Own Scope
+
+A directory is a distinct scope if ANY of these are true:
+
+| Criterion | Example |
+|-----------|---------|
+| Different tech stack | Frontend (React) vs Backend (Express) in a monorepo |
+| Different build/test commands | `packages/api` uses `jest`, `packages/web` uses `vitest` |
+| Different language | Go service alongside a TypeScript frontend |
+| Different deployment target | Lambda functions vs Docker containers |
+| Independent package with own dependencies | Monorepo package with own `package.json` |
+| Distinct domain with specialized conventions | Database migration scripts with specific ordering rules |
+| Unique constraints on a shared package | Zero-dependency rule, dual exports, conditional imports, `server-only` marker |
+| Security-sensitive data handling | Package that handles encryption, PII, or cross-schema access control |
+
+A directory is NOT a distinct scope if:
+- It merely organizes code within the same tech stack
+- Its conventions are identical to the root
+- It has no independent tooling or commands
+- It is a simple utility directory with no unique constraints
+
+## Process
+
+### 1. Check for Monorepo Structure
+
+Look for:
+- `workspaces` field in root `package.json`
+- `pnpm-workspace.yaml`
+- `lerna.json`
+- `nx.json` or `project.json` files
+- `turbo.json`
+- `Cargo.toml` with `[workspace]`
+- `go.work`
+- Multiple `package.json` / `Cargo.toml` / `go.mod` files
+
+### 2. Identify Package Boundaries
+
+For each potential package/service:
+- Read its manifest file (package.json, Cargo.toml, etc.)
+- Check if it has its own build/test commands
+- Determine its primary tech stack
+- Note any unique dependencies or tooling
+
+### 3. Identify Domain Boundaries
+
+Beyond packages, check for distinct domains:
+- `scripts/` or `tools/` directories with their own execution environment
+- `docs/` directories that may need documentation-specific guidance
+- Infrastructure code (`terraform/`, `kubernetes/`, `docker/`) with different tooling
+- Database-related directories (`migrations/`, `seeds/`) with ordering or naming conventions
+
+### 4. Determine Scope-Specific Content
+
+For each identified scope, determine what makes it different:
+- What unique commands does this scope have?
+- What conventions apply here but not elsewhere?
+- What tech-specific knowledge would an agent need?
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## Scope Detection Results
+
+### Project Structure
+- Type: [single-package | monorepo | multi-service | hybrid]
+- Monorepo tool: [if applicable]
+
+### Detected Scopes
+
+#### Scope: [relative/path]
+- Purpose: [one sentence]
+- Tech: [primary technology if different from root]
+- Commands: [scope-specific commands, if any]
+- Key conventions: [only if different from root]
+- Needs own config file: [yes/no with brief reason]
+
+#### Scope: [relative/path]
+...
+
+### Recommended File Tree
+- `./AGENTS.md` (root) — [one-line description of what goes here]
+- `[path]/AGENTS.md` — [one-line description, only for scopes marked "yes"]
+...
+
+### Domain Files Recommended
+- `docs/TESTING.md` — [only if non-standard testing patterns detected]
+- `docs/BUILD.md` — [only if non-standard build pipeline detected]
+...
+```
+
+If the project is a simple single-package project, report zero additional scopes — the root file is sufficient.
+
+## Self-Verification
+
+Before returning results, verify:
+1. Every recommended scope has genuinely different tooling or conventions from root
+2. No scopes were created just for organizational directories
+3. The recommended file count is the minimum necessary
+4. Simple projects correctly return zero additional scopes

--- a/plugins/cursor-initializer/skills/improve-cursor/SKILL.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/SKILL.md
@@ -64,10 +64,10 @@ Build the `file-evaluator` task dynamically based on what was found:
 >
 > Return a structured assessment with specific line numbers and content for each issue.
 
-**If `has_agents_md` (with or without rules):** Delegate to the `file-evaluator` agent with this task:
+**If `has_agents_md` and `has_rules`:** Delegate to the `file-evaluator` agent with this task:
 
-> Evaluate all AGENTS.md files [if has_rules: and all `.cursor/rules/` files (.mdc and .md)] in the project at the current working directory. Check for:
->
+> Evaluate all AGENTS.md files and all `.cursor/rules/` files (.mdc and .md) in the project at the current working directory. Check for:
+> 
 > 1. Files over 200 lines
 > 2. Bloat indicators (directory listings, obvious conventions, vague instructions)
 > 3. Stale references (file paths that don't exist, commands that aren't in package.json)
@@ -77,6 +77,20 @@ Build the `file-evaluator` task dynamically based on what was found:
 > 7. Rules with `alwaysApply: true` that should use globs or description instead (wasting tokens on every request)
 > 8. Content in root AGENTS.md that only applies to specific file patterns (should be in `.cursor/rules/*.mdc` with globs)
 > 9. Invalid .mdc frontmatter (only `description`, `alwaysApply`, `globs` are valid)
+>
+> Return a structured assessment with specific line numbers and content for each issue.
+
+**If `has_agents_md` and not `has_rules`:** Delegate to the `file-evaluator` agent with this task:
+
+> Evaluate all AGENTS.md files in the project at the current working directory. Check for:
+>
+> 1. Files over 200 lines
+> 2. Bloat indicators (directory listings, obvious conventions, vague instructions)
+> 3. Stale references (file paths that don't exist, commands that aren't in package.json)
+> 4. Contradictions between AGENTS.md files
+> 5. Progressive disclosure opportunities (content that should be in separate files)
+> 6. Missing scope-specific files
+> 7. Content in root AGENTS.md that only applies to specific file patterns (should be in `.cursor/rules/*.mdc` with globs)
 >
 > Return a structured assessment with specific line numbers and content for each issue.
 

--- a/plugins/cursor-initializer/skills/improve-cursor/SKILL.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: improve-cursor
+description: "Evaluates and improves existing Cursor rules (.cursor/rules/) and AGENTS.md files in projects. Identifies bloat, contradictions, stale references, and missing scopes — then applies progressive disclosure refactoring using Cursor's full configuration system."
+---
+
+# Improve Cursor Rules
+
+Evaluate existing `.cursor/rules/*.mdc` files and AGENTS.md against evidence-based quality criteria and apply improvements to optimize context usage, reduce token waste, and improve Cursor agent performance.
+
+## Why This Matters
+
+The ETH Zurich study found that **unnecessary requirements in context files make tasks harder**. Every always-loaded rule consumes tokens on every request. Bloated or poorly-scoped rules cause agents to:
+
+- Spend more steps exploring (cost +20%)
+- Follow irrelevant instructions that distract from the actual task
+- Lose important instructions in the noise ("lost in the middle" effect)
+
+Cursor's rule system offers powerful activation modes — but only if rules are properly scoped. An `alwaysApply: true` rule with content that should be auto-attached by globs wastes tokens on every conversation where those files aren't relevant.
+
+## Hard Rules
+
+<RULES>
+- **ALWAYS** evaluate before modifying — never change files without analysis
+- **ALWAYS** present changes to the user before applying them
+- **NEVER** add content without removing more (net reduction is the goal)
+- **NEVER** exceed 200 lines per file after improvements
+- **PRESERVE** all genuinely useful instructions — only remove waste
+- **SPLIT** bloated files using Cursor's full hierarchy (subdirectory AGENTS.md, `.cursor/rules/*.mdc`, domain files)
+- **VERIFY** that file path references in content still point to existing files
+- **CONVERT** always-loaded rules to auto-attached (`globs`) or agent-requested (`description`) when they only apply to specific contexts
+- **MAXIMIZE** on-demand loading — minimize always-loaded content
+- **ROOT TARGET: 15-40 lines** — root AGENTS.md should contain ONLY: one-sentence description, non-standard tooling commands, import boundaries (if any), and pointers to scope files. Move everything else to on-demand locations.
+- `.mdc` frontmatter: ONLY `description`, `alwaysApply`, `globs` — no other fields
+</RULES>
+
+## Process
+
+### Preflight Check
+
+Check whether the project has:
+- A `.cursor/rules/` directory containing `.mdc` or `.md` files — record as **has_rules**
+- An `AGENTS.md` file in the current working directory — record as **has_agents_md**
+
+**If neither exists:** Inform the user: "No Cursor configuration found. Run `init-cursor` to generate an optimized hierarchy from scratch." **STOP.**
+
+Proceed to Phase 1 with `has_rules` and `has_agents_md` flags set.
+
+### Phase 1: Current State Analysis
+
+Read `${CLAUDE_SKILL_DIR}/references/evaluation-criteria.md` for the scoring rubric and bloat/staleness indicators.
+
+Build the `file-evaluator` task dynamically based on what was found:
+
+**If `has_rules` only (no AGENTS.md):** Delegate to the `file-evaluator` agent with this task:
+
+> Evaluate all `.cursor/rules/` files (.mdc and .md) in the project at the current working directory. Check for:
+>
+> 1. Files over 200 lines
+> 2. Bloat indicators (directory listings, obvious conventions, vague instructions)
+> 3. Stale references (file paths that don't exist, commands that aren't in package.json)
+> 4. Progressive disclosure opportunities (content that should be in separate files or auto-attached rules)
+> 5. Rules with `alwaysApply: true` that should use globs or description instead (wasting tokens on every request)
+> 6. Invalid .mdc frontmatter (only `description`, `alwaysApply`, `globs` are valid)
+>
+> Return a structured assessment with specific line numbers and content for each issue.
+
+**If `has_agents_md` (with or without rules):** Delegate to the `file-evaluator` agent with this task:
+
+> Evaluate all AGENTS.md files [if has_rules: and all `.cursor/rules/` files (.mdc and .md)] in the project at the current working directory. Check for:
+>
+> 1. Files over 200 lines
+> 2. Bloat indicators (directory listings, obvious conventions, vague instructions)
+> 3. Stale references (file paths that don't exist, commands that aren't in package.json)
+> 4. Contradictions between files (including between AGENTS.md and .cursor/rules/)
+> 5. Progressive disclosure opportunities (content that should be in separate files or auto-attached rules)
+> 6. Missing scope-specific files
+> 7. Rules with `alwaysApply: true` that should use globs or description instead (wasting tokens on every request)
+> 8. Content in root AGENTS.md that only applies to specific file patterns (should be in `.cursor/rules/*.mdc` with globs)
+> 9. Invalid .mdc frontmatter (only `description`, `alwaysApply`, `globs` are valid)
+>
+> Return a structured assessment with specific line numbers and content for each issue.
+
+The agent runs in an isolated context with read-only access. Wait for it to complete and parse its structured output.
+
+### Phase 2: Codebase Comparison
+
+Delegate to the `codebase-analyzer` agent with this task:
+
+> Analyze the project at the current working directory. Focus on:
+>
+> 1. Verifying that tooling commands documented in AGENTS.md and .cursor/rules/ files still work
+> 2. Identifying scopes that have distinct tooling but lack their own AGENTS.md — including library/shared packages in monorepos that have unique constraints (zero-dependency rules, dual exports, conditional imports, server-only markers)
+> 3. Detecting file patterns that have specific conventions but lack auto-attached `.cursor/rules/*.mdc` — check for BOTH convention rules (code style, test patterns) AND domain-critical rules (privacy, security, compliance) that should be auto-attached to sensitive file patterns
+> 4. Detecting new domain areas not covered by existing documentation
+>
+> Return ONLY actionable findings.
+
+Wait for it to complete and parse its structured output.
+
+### Phase 3: Generate Improvement Plan
+
+Read these reference documents:
+
+- `${CLAUDE_SKILL_DIR}/references/progressive-disclosure-guide.md` — hierarchy decisions and loading tiers
+- `${CLAUDE_SKILL_DIR}/references/what-not-to-include.md` — content exclusion criteria
+- `${CLAUDE_SKILL_DIR}/references/context-optimization.md` — token budget guidelines
+- `${CLAUDE_SKILL_DIR}/references/cursor-rules-system.md` — .cursor/rules/ conventions, .mdc format, activation modes
+- `${CLAUDE_SKILL_DIR}/references/automation-migration-guide.md` — automation migration decision criteria (skill vs. hook vs. rule vs. subagent)
+
+Based on both subagent reports, create improvement plan:
+
+#### Removal Actions (highest priority — reduce token waste)
+
+1. **Remove bloat**: Delete directory listings, obvious conventions, vague instructions
+2. **Remove stale content**: Delete references to files/commands that no longer exist
+3. **Remove duplicates**: Eliminate content duplicated across multiple files
+4. **Resolve contradictions**: Pick the correct version and remove the conflicting one
+
+#### Refactoring Actions (optimize loading behavior)
+
+1. **Extract scope-specific content** into subdirectory AGENTS.md files (on-demand loading) — only if `has_agents_md`
+2. **Convert pattern-specific rules** to `.cursor/rules/*.mdc` with `globs` frontmatter (auto-attached)
+3. **Convert always-loaded rules** to agent-requested (add `description`, set `alwaysApply: false`) when the agent can decide relevance
+4. **Extract domain content** into docs/TESTING.md, docs/BUILD.md, etc. (progressive disclosure)
+5. **Add progressive disclosure pointers** in root file to new split files
+6. **Fix invalid .mdc frontmatter** — remove unsupported fields, ensure only `description`, `alwaysApply`, `globs` are used
+7. **Consolidate fragmented files** that cover the same scope
+8. **Migrate automation candidates** — for each instruction flagged in Phase 1 as `HOOK_CANDIDATE`, `RULE_CANDIDATE`, or `SKILL_CANDIDATE`:
+   - Classify using the decision flowchart in automation-migration-guide.md
+   - Select target mechanism: hook (`.cursor/hooks.json` — deterministic enforcement), `.cursor/rules/*.mdc` with globs (file-pattern convention), skill (domain knowledge/infrequent workflow), or subagent (isolated analysis)
+   - Estimate token savings using the token impact estimation table
+   - This is the plugin distribution — suggest all mechanisms. Use the decision flowchart to select the best mechanism for each candidate.
+
+#### Redundancy Elimination (delete what agents already know)
+
+Apply the instruction test from what-not-to-include.md:
+
+> "Would removing this cause the agent to make mistakes? If not, cut it."
+
+1. **Delete agent-inferable content**: Standard conventions, obvious tooling, information discoverable from code
+2. **Delete vague/generic advice**: Instructions that cannot be verified or acted on
+3. **Delete auto-enforced rules**: Formatting or linting rules already enforced by project tooling
+
+For each deletion, document: the specific content being removed, WHY the agent doesn't need it, and the evidence source.
+
+#### Addition Actions (lowest priority — only if genuinely missing)
+
+1. **Add missing scope files** for detected scopes without configuration — including library/shared packages (only if `has_agents_md`)
+2. **Add missing tooling commands** that the codebase-analyzer identified as non-standard
+3. **Create missing `.cursor/rules/*.mdc`** for file patterns with non-obvious conventions — include both convention rules and domain-critical rules auto-attached to sensitive file patterns
+4. **Propose creating AGENTS.md** if `has_rules` but not `has_agents_md` and codebase-analyzer identified project-wide conventions that belong there — present this as an optional addition
+
+When generating new or restructured files, use these templates:
+
+- Root AGENTS.md (only if `has_agents_md`): Read `${CLAUDE_SKILL_DIR}/assets/templates/root-agents-md.md`
+- Scoped AGENTS.md (only if `has_agents_md`): Read `${CLAUDE_SKILL_DIR}/assets/templates/scoped-agents-md.md`
+- `.cursor/rules/*.mdc` files: Read `${CLAUDE_SKILL_DIR}/assets/templates/cursor-rule.mdc`
+- Domain docs: Read `${CLAUDE_SKILL_DIR}/assets/templates/domain-doc.md`
+- Skills (from automation migration): Read `${CLAUDE_SKILL_DIR}/assets/templates/skill.md`
+- Hook configs (from automation migration): Read `${CLAUDE_SKILL_DIR}/assets/templates/hook-config.md`
+
+### Phase 4: Self-Validation
+
+Read `${CLAUDE_SKILL_DIR}/references/validation-criteria.md` and execute its **Validation Loop Instructions** against every improved or newly created file.
+
+For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. For Cursor rules, also check:
+- `.mdc` files use ONLY valid frontmatter (`description`, `alwaysApply`, `globs`)
+- No `paths:` frontmatter (Claude-specific — invalid in Cursor)
+- Activation mode is appropriate for each rule's content
+- Always-loaded content is minimal
+
+Maximum 3 iterations.
+
+### Phase 5: Present and Apply
+
+1. Show a summary overview of all improvements found, grouped by category — include AGENTS.md rows only if `has_agents_md`:
+   - **Removals**: X items (bloat: X, stale: X, duplicates: X, contradictions: X)
+   - **Refactoring**: X items (scope extraction: X, rule conversion: X, activation mode fix: X, domain extraction: X, consolidation: X)
+   - **Automation Migrations**: X items (hooks: X, rules: X, skills: X, subagents: X)
+   - **Redundancy Eliminations**: X items
+   - **Additions**: X items (including AGENTS.md creation proposal if applicable)
+
+2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Automation Migrations → Redundancy Eliminations → Additions):
+
+   **WHAT**: The specific content and its current location (file:lines)
+   **WHY**: Evidence-based justification with source reference
+   **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
+   **OPTIONS**:
+   - **Option A** (recommended): Primary action
+   - **Option B**: Alternative action
+   - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
+   - *(Additional options when applicable)*
+
+   Wait for the user to select an option for each suggestion before proceeding to the next.
+   If the user selects "Keep as-is", preserve the content in its exact current location — no modification.
+
+3. After all suggestions are reviewed, show aggregate token impact analysis:
+   - **Always-loaded tokens**: before → after
+   - **On-demand tokens**: before → after
+   - **Removed tokens**: total waste eliminated
+   - **Deferred suggestions**: X items kept as-is (user chose to preserve)
+
+4. Apply ONLY the approved changes (options A or B selections):
+   - Execute each approved change in dependency order
+   - Verify after each change:
+     - All files under 200 lines
+     - No orphaned references
+     - Progressive disclosure tree is consistent
+     - `.mdc` files have valid frontmatter (only `description`, `alwaysApply`, `globs`)
+
+5. Report final metrics:
+   - Total lines before → after
+   - Always-loaded lines before → after
+   - Files before → after
+   - Estimated token savings per session
+   - Suggestions applied: X of Y (Z deferred)

--- a/plugins/cursor-initializer/skills/improve-cursor/SKILL.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/SKILL.md
@@ -47,7 +47,7 @@ Proceed to Phase 1 with `has_rules` and `has_agents_md` flags set.
 
 ### Phase 1: Current State Analysis
 
-Read `${CLAUDE_SKILL_DIR}/references/evaluation-criteria.md` for the scoring rubric and bloat/staleness indicators.
+Read `references/evaluation-criteria.md` for the scoring rubric and bloat/staleness indicators.
 
 Build the `file-evaluator` task dynamically based on what was found:
 
@@ -115,11 +115,11 @@ Wait for it to complete and parse its structured output.
 
 Read these reference documents:
 
-- `${CLAUDE_SKILL_DIR}/references/progressive-disclosure-guide.md` — hierarchy decisions and loading tiers
-- `${CLAUDE_SKILL_DIR}/references/what-not-to-include.md` — content exclusion criteria
-- `${CLAUDE_SKILL_DIR}/references/context-optimization.md` — token budget guidelines
-- `${CLAUDE_SKILL_DIR}/references/cursor-rules-system.md` — .cursor/rules/ conventions, .mdc format, activation modes
-- `${CLAUDE_SKILL_DIR}/references/automation-migration-guide.md` — automation migration decision criteria (skill vs. hook vs. rule vs. subagent)
+- `references/progressive-disclosure-guide.md` — hierarchy decisions and loading tiers
+- `references/what-not-to-include.md` — content exclusion criteria
+- `references/context-optimization.md` — token budget guidelines
+- `references/cursor-rules-system.md` — .cursor/rules/ conventions, .mdc format, activation modes
+- `references/automation-migration-guide.md` — automation migration decision criteria (skill vs. hook vs. rule vs. subagent)
 
 Based on both subagent reports, create improvement plan:
 
@@ -166,16 +166,16 @@ For each deletion, document: the specific content being removed, WHY the agent d
 
 When generating new or restructured files, use these templates:
 
-- Root AGENTS.md (only if `has_agents_md`): Read `${CLAUDE_SKILL_DIR}/assets/templates/root-agents-md.md`
-- Scoped AGENTS.md (only if `has_agents_md`): Read `${CLAUDE_SKILL_DIR}/assets/templates/scoped-agents-md.md`
-- `.cursor/rules/*.mdc` files: Read `${CLAUDE_SKILL_DIR}/assets/templates/cursor-rule.mdc`
-- Domain docs: Read `${CLAUDE_SKILL_DIR}/assets/templates/domain-doc.md`
-- Skills (from automation migration): Read `${CLAUDE_SKILL_DIR}/assets/templates/skill.md`
-- Hook configs (from automation migration): Read `${CLAUDE_SKILL_DIR}/assets/templates/hook-config.md`
+- Root AGENTS.md (only if `has_agents_md`): Read `assets/templates/root-agents-md.md`
+- Scoped AGENTS.md (only if `has_agents_md`): Read `assets/templates/scoped-agents-md.md`
+- `.cursor/rules/*.mdc` files: Read `assets/templates/cursor-rule.mdc`
+- Domain docs: Read `assets/templates/domain-doc.md`
+- Skills (from automation migration): Read `assets/templates/skill.md`
+- Hook configs (from automation migration): Read `assets/templates/hook-config.md`
 
 ### Phase 4: Self-Validation
 
-Read `${CLAUDE_SKILL_DIR}/references/validation-criteria.md` and execute its **Validation Loop Instructions** against every improved or newly created file.
+Read `references/validation-criteria.md` and execute its **Validation Loop Instructions** against every improved or newly created file.
 
 For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. For Cursor rules, also check:
 - `.mdc` files use ONLY valid frontmatter (`description`, `alwaysApply`, `globs`)

--- a/plugins/cursor-initializer/skills/improve-cursor/assets/templates/cursor-rule.mdc
+++ b/plugins/cursor-initializer/skills/improve-cursor/assets/templates/cursor-rule.mdc
@@ -1,0 +1,36 @@
+<!-- TEMPLATE: cursor-rule.mdc
+  Placement: .cursor/rules/[rule-name].mdc
+  Naming: kebab-case, descriptive of the rule's scope
+  Target: 10-50 lines of rule content
+  
+  ONLY these frontmatter fields are valid:
+  - description (string): What this rule is about — used for agent-requested activation
+  - alwaysApply (boolean): true = every conversation, false = conditional
+  - globs (string|array): File patterns for auto-attachment
+  
+  Activation modes (determined by frontmatter combination):
+  - Always: alwaysApply: true
+  - Auto-attached: globs set, alwaysApply: false
+  - Agent-requested: description set, no globs, alwaysApply: false
+  - Manual: no description, no globs, alwaysApply: false (user @-mentions)
+-->
+---
+description: "[RULE_DESCRIPTION]"
+globs: ["[GLOB_PATTERN]"]
+alwaysApply: false
+---
+
+<!-- CONDITIONAL: Remove globs if this is an agent-requested rule (description-only) -->
+<!-- CONDITIONAL: Set alwaysApply: true if this rule should load on every conversation -->
+<!-- CONDITIONAL: Remove description if this is a globs-only auto-attached rule -->
+
+[RULE_CONTENT]
+
+<!-- 
+  Content guidelines:
+  - Write rules as clear internal docs — direct, actionable
+  - Reference files with @filename.ts instead of copying content
+  - Each rule should focus on one concern
+  - Provide concrete examples, not vague guidance
+  - Keep under 500 lines per rule file
+-->

--- a/plugins/cursor-initializer/skills/improve-cursor/assets/templates/cursor-rule.mdc
+++ b/plugins/cursor-initializer/skills/improve-cursor/assets/templates/cursor-rule.mdc
@@ -32,5 +32,5 @@ alwaysApply: false
   - Reference files with @filename.ts instead of copying content
   - Each rule should focus on one concern
   - Provide concrete examples, not vague guidance
-  - Keep under 500 lines per rule file
+  - Keep under 200 lines per rule file
 -->

--- a/plugins/cursor-initializer/skills/improve-cursor/assets/templates/domain-doc.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/assets/templates/domain-doc.md
@@ -1,0 +1,45 @@
+<!-- TEMPLATE: Domain Documentation File
+     Purpose: Progressive disclosure — contains domain-specific guidance
+              referenced from root or scoped config files via pointers
+     Placement: docs/[TOPIC].md (e.g., docs/TESTING.md, docs/BUILD.md, docs/API.md)
+     Target: Under 200 lines
+     Rule: Only create when codebase analysis identified non-standard patterns in this domain
+     Rule: Every instruction must be specific, actionable, and based on analysis findings
+     Rule: May reference other domain docs for nested progressive disclosure
+-->
+
+# [Domain Topic Name]
+
+<!-- Name this based on the domain: Testing Conventions, Build System, API Design,
+     Deployment, Security, etc. Use the same name referenced in the root config file's
+     progressive disclosure pointer. -->
+
+[One-two sentences: what makes this domain non-standard in this project and why
+these instructions exist. Only include context that helps the agent understand
+WHY these conventions differ from standard practices.]
+
+## [Primary Section Name]
+
+<!-- Name based on the domain's main concern. Examples:
+     Testing: "Test Structure" or "Running Tests"
+     Build: "Build Pipeline" or "Build Configuration"
+     API: "Endpoint Patterns" or "Request/Response Format"
+     Each instruction must be specific and verifiable — not vague guidance. -->
+
+- [Specific, actionable instruction based on codebase analysis]
+- [Specific, actionable instruction based on codebase analysis]
+
+## [Additional Sections as Needed]
+
+<!-- Optional: Add more sections for distinct aspects of the domain.
+     Keep each section focused on one aspect.
+     Only add sections where non-standard patterns were detected. -->
+
+- [Specific, actionable instruction]
+
+## See Also
+
+<!-- CONDITIONAL: Include ONLY if this domain doc references other docs or resources.
+     Enables nested progressive disclosure (docs/TESTING.md → docs/VITEST.md).
+     Remove this section if no cross-references exist. -->
+- For [related topic], see `[path/to/other-doc.md]`

--- a/plugins/cursor-initializer/skills/improve-cursor/assets/templates/hook-config.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/assets/templates/hook-config.md
@@ -26,7 +26,7 @@
 <!-- CONDITIONAL: Use command hooks for deterministic enforcement that needs
      no LLM judgment (formatting, file blocking, validation scripts).
      Zero context cost. Highest enforcement reliability (100%). -->
-```json
+<!-- Emit raw JSON only. Do not include Markdown headings, tables, prose, or code fences in the generated `.cursor/hooks.json`. -->
 {
   "version": 1,
   "hooks": {
@@ -37,33 +37,3 @@
     ]
   }
 }
-```
-
-### When to Use Each Hook Event
-
-| Event | Use Case |
-|-------|----------|
-| `afterFileEdit` | Run formatters, linters after edits |
-| `beforeShellExecution` | Gate risky commands (e.g., SQL writes) |
-| `stop` | Continue agent loop with `followup_message` |
-| `sessionStart` | Inject context at conversation start |
-| `preToolUse` | Validate tool arguments before execution |
-| `postToolUseFailure` | Retry or log failed tool invocations |
-
-### Hook Script Pattern
-
-Scripts receive JSON on stdin and must output JSON on stdout:
-
-```json
-// Input (varies by event)
-{
-  "tool_name": "edit_file",
-  "file_path": "src/index.ts",
-  "conversation_id": "abc-123"
-}
-
-// Output options
-{ }                                        // Allow (no modification)
-{ "decision": "block", "reason": "..." }   // Block the action
-{ "followup_message": "Continue..." }      // Resume agent (stop hook)
-```

--- a/plugins/cursor-initializer/skills/improve-cursor/assets/templates/hook-config.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/assets/templates/hook-config.md
@@ -1,0 +1,69 @@
+<!-- TEMPLATE: hook-config.md
+  Placement: .cursor/hooks.json
+  Format: JSON with version field and event-keyed hook arrays
+  Rule: Hooks require Cursor; do NOT generate for standalone distribution
+  Rule: Choose the hook event that matches when enforcement should trigger
+
+  Hook events available:
+  - sessionStart / sessionEnd
+  - preToolUse / postToolUse / postToolUseFailure
+  - subagentStart / subagentStop
+  - beforeShellExecution / afterShellExecution
+  - beforeMCPExecution / afterMCPExecution
+  - beforeReadFile / afterFileEdit
+  - beforeSubmitPrompt
+  - preCompact
+  - stop
+  - afterAgentResponse / afterAgentThought
+
+  Source: automation-migration-guide.md — Mechanism Comparison table
+
+  MIGRATION: This template applies only in improve (not init) context.
+  Only suggest hooks when the automation-migration-guide.md classifies
+  an instruction as HOOK_CANDIDATE (deterministic enforcement).
+-->
+
+<!-- CONDITIONAL: Use command hooks for deterministic enforcement that needs
+     no LLM judgment (formatting, file blocking, validation scripts).
+     Zero context cost. Highest enforcement reliability (100%). -->
+```json
+{
+  "version": 1,
+  "hooks": {
+    "[HOOK_EVENT]": [
+      {
+        "command": "[path/to/hook-script.sh or inline shell command]"
+      }
+    ]
+  }
+}
+```
+
+### When to Use Each Hook Event
+
+| Event | Use Case |
+|-------|----------|
+| `afterFileEdit` | Run formatters, linters after edits |
+| `beforeShellExecution` | Gate risky commands (e.g., SQL writes) |
+| `stop` | Continue agent loop with `followup_message` |
+| `sessionStart` | Inject context at conversation start |
+| `preToolUse` | Validate tool arguments before execution |
+| `postToolUseFailure` | Retry or log failed tool invocations |
+
+### Hook Script Pattern
+
+Scripts receive JSON on stdin and must output JSON on stdout:
+
+```json
+// Input (varies by event)
+{
+  "tool_name": "edit_file",
+  "file_path": "src/index.ts",
+  "conversation_id": "abc-123"
+}
+
+// Output options
+{ }                                        // Allow (no modification)
+{ "decision": "block", "reason": "..." }   // Block the action
+{ "followup_message": "Continue..." }      // Resume agent (stop hook)
+```

--- a/plugins/cursor-initializer/skills/improve-cursor/assets/templates/root-agents-md.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/assets/templates/root-agents-md.md
@@ -1,0 +1,33 @@
+<!-- TEMPLATE: Root AGENTS.md
+     Target: 15-40 lines after placeholders are filled
+     Rule: Remove any section that would be empty after filling
+     Rule: Only include non-standard, non-obvious information
+     Rule: This file is loaded on every agent request — keep it minimal
+-->
+
+# [One-sentence project description from codebase analysis]
+
+## Tooling
+
+<!-- CONDITIONAL: Include ONLY if non-standard tooling was detected.
+     Remove the entire section if all tooling is standard for the language.
+     Remove individual lines where the command is the language/framework default. -->
+- Package manager: [only if not the language default]
+- Build: `[command]`
+- Test: `[command]`
+- Lint: `[command]`
+- Typecheck: `[command]`
+
+## Context
+
+<!-- CONDITIONAL: Include ONLY if scopes with genuinely different tooling were detected.
+     A simple single-package project should NOT have this section. -->
+See scope-specific AGENTS.md files:
+
+- `[scope-path/]` — [one-line scope purpose]
+
+## References
+
+<!-- CONDITIONAL: Include ONLY if domain documentation files were generated.
+     Use progressive disclosure: point to docs, don't inline their content. -->
+- For [domain topic], see `[path/to/domain-doc.md]`

--- a/plugins/cursor-initializer/skills/improve-cursor/assets/templates/scoped-agents-md.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/assets/templates/scoped-agents-md.md
@@ -1,0 +1,22 @@
+<!-- TEMPLATE: Scoped AGENTS.md (one per detected scope)
+     Target: 10-30 lines after placeholders are filled
+     Rule: Only include information that DIFFERS from root AGENTS.md
+     Rule: One scope per file — don't combine multiple scopes
+     Placement: [scope-path]/AGENTS.md (e.g., packages/api/AGENTS.md)
+-->
+
+# [One-sentence scope description]
+
+## Tooling
+
+<!-- CONDITIONAL: Include ONLY commands that differ from root.
+     Remove the entire section if this scope uses the same tooling as root. -->
+- Build: `[scope-specific command]`
+- Test: `[scope-specific command]`
+
+## Conventions
+
+<!-- Include ONLY non-obvious, scope-specific conventions.
+     Every instruction must be specific and verifiable.
+     Do NOT include standard language conventions the model already knows. -->
+- [Specific, verifiable instruction]

--- a/plugins/cursor-initializer/skills/improve-cursor/assets/templates/skill.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/assets/templates/skill.md
@@ -1,32 +1,24 @@
 ---
 name: [kebab-case-name]
 description: [One sentence: what this skill does — the agent uses this to decide when to invoke it]
-user-invocable: false
+disable-model-invocation: true
 ---
 <!-- TEMPLATE: Skill File (generated from automation migration)
      Placement: .cursor/skills/[kebab-case-name]/SKILL.md
      Naming: kebab-case, ≤64 chars, lowercase letters/numbers/hyphens only
      Target: Under 200 lines after placeholders are filled
      Rule: `description` is required — the agent uses it to decide when to invoke
-     Rule: `user-invocable: false` is the default for migrated skills (auto-invoked by agent)
+     Rule: `disable-model-invocation: true` is the default for migrated skills (manual invocation)
+     Rule: Remove `disable-model-invocation: true` ONLY when the skill should be auto-invoked
      Rule: Every instruction must be specific and verifiable
      Source attribution: add <!-- Migrated from [source-file]:lines [N-M] --> below frontmatter
 -->
 <!-- Migrated from [source-file]:lines [N-M] -->
 
-<!-- CONDITIONAL: Use `disable-model-invocation: true` instead of `user-invocable: false`
-     ONLY when the skill is heavy, rare, or has side effects (invoked <20% of sessions).
-     With this flag: zero passive context cost; user must invoke manually via slash command.
-     Replace `user-invocable: false` in frontmatter with:
-       disable-model-invocation: true
--->
-
-<!-- CONDITIONAL: Add `context: fork` to frontmatter ONLY when the skill performs
-     context-heavy isolated analysis (similar to a subagent task).
-     With this flag: skill runs in a forked context; parent context cost is zero.
-     Add to frontmatter:
-       context: fork
--->
+<!-- CONDITIONAL: Remove `disable-model-invocation: true` from frontmatter ONLY when
+     this skill should be auto-invoked by the agent based on context.
+     Auto-invocable skills have ~100 token passive context cost (name + description at startup).
+     Default for migrated skills is manual-only to avoid unintended side effects. -->
 
 <!-- CONDITIONAL: Add `allowed-tools` to frontmatter ONLY when the skill requires
      specific tools restricted to its scope.

--- a/plugins/cursor-initializer/skills/improve-cursor/assets/templates/skill.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/assets/templates/skill.md
@@ -1,0 +1,51 @@
+---
+name: [kebab-case-name]
+description: [One sentence: what this skill does — Claude uses this to decide when to invoke it]
+user-invocable: false
+---
+<!-- TEMPLATE: Skill File (generated from automation migration)
+     Placement: .claude/skills/[kebab-case-name]/SKILL.md
+     Naming: kebab-case, ≤64 chars, lowercase letters/numbers/hyphens only
+     Target: Under 200 lines after placeholders are filled
+     Rule: `description` is required — Claude uses it to decide when to invoke
+     Rule: `user-invocable: false` is the default for migrated skills (auto-invoked by Claude)
+     Rule: Every instruction must be specific and verifiable
+     Source attribution: add <!-- Migrated from [source-file]:lines [N-M] --> below frontmatter
+-->
+<!-- Migrated from [source-file]:lines [N-M] -->
+
+<!-- CONDITIONAL: Use `disable-model-invocation: true` instead of `user-invocable: false`
+     ONLY when the skill is heavy, rare, or has side effects (invoked <20% of sessions).
+     With this flag: zero passive context cost; user must invoke manually via slash command.
+     Replace `user-invocable: false` in frontmatter with:
+       disable-model-invocation: true
+-->
+
+<!-- CONDITIONAL: Add `context: fork` to frontmatter ONLY when the skill performs
+     context-heavy isolated analysis (similar to a subagent task).
+     With this flag: skill runs in a forked context; parent context cost is zero.
+     Add to frontmatter:
+       context: fork
+-->
+
+<!-- CONDITIONAL: Add `allowed-tools` to frontmatter ONLY when the skill requires
+     specific tools restricted to its scope.
+     Add to frontmatter:
+       allowed-tools: [Read, Glob, Grep]
+-->
+
+# [Skill Title]
+
+[One-two sentences describing what this skill does and when it applies.
+Only include context that helps the agent understand why this skill exists.]
+
+## Instructions
+
+- [Specific, actionable instruction migrated from source]
+- [Specific, actionable instruction migrated from source]
+
+<!-- CONDITIONAL: Include additional sections ONLY if the migrated content has
+     distinct phases or steps that benefit from headers. -->
+## [Additional Section if Needed]
+
+- [Specific, actionable instruction]

--- a/plugins/cursor-initializer/skills/improve-cursor/assets/templates/skill.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/assets/templates/skill.md
@@ -1,14 +1,14 @@
 ---
 name: [kebab-case-name]
-description: [One sentence: what this skill does — Claude uses this to decide when to invoke it]
+description: [One sentence: what this skill does — the agent uses this to decide when to invoke it]
 user-invocable: false
 ---
 <!-- TEMPLATE: Skill File (generated from automation migration)
-     Placement: .claude/skills/[kebab-case-name]/SKILL.md
+     Placement: .cursor/skills/[kebab-case-name]/SKILL.md
      Naming: kebab-case, ≤64 chars, lowercase letters/numbers/hyphens only
      Target: Under 200 lines after placeholders are filled
-     Rule: `description` is required — Claude uses it to decide when to invoke
-     Rule: `user-invocable: false` is the default for migrated skills (auto-invoked by Claude)
+     Rule: `description` is required — the agent uses it to decide when to invoke
+     Rule: `user-invocable: false` is the default for migrated skills (auto-invoked by agent)
      Rule: Every instruction must be specific and verifiable
      Source attribution: add <!-- Migrated from [source-file]:lines [N-M] --> below frontmatter
 -->

--- a/plugins/cursor-initializer/skills/improve-cursor/references/automation-migration-guide.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/automation-migration-guide.md
@@ -24,12 +24,11 @@ When evaluating an instruction block for migration, follow this decision path:
 1. **Is it always needed for every task and under 5 lines?** → Keep in AGENTS.md root
 2. **Can the agent infer it from code?** → DELETE — do not document
 3. **Is it a deterministic rule (no judgment needed)?** → Hook (`.cursor/hooks.json` entry)
-4. **Does enforcement require LLM judgment?** → Hook (`prompt` or `agent` type)
+4. **Does enforcement require LLM judgment?** → Hook (`prompt` type)
 5. **Is it path-specific and under 50 lines?** → `.cursor/rules/` with `globs:` frontmatter
-6. **Is it a workflow or domain block (50-500 lines)?** → Skill (`user-invocable: false`)
+6. **Is it a workflow or domain block (50-500 lines)?** → Skill (auto-invocable)
 7. **Is it heavy, rare, or has side effects?** → Skill (`disable-model-invocation: true`)
-8. **Is it context-heavy isolated analysis?** → Skill (`context: fork`)
-9. **None of the above?** → Keep in current location; reassess in next improvement cycle
+8. **None of the above?** → Keep in current location; reassess in next improvement cycle
 
 *Source: context-aware-improve-optimization.prd.md lines 346-358*
 
@@ -43,11 +42,10 @@ Classify each instruction block by content type, then recommend the correspondin
 |---|---|---|
 | Always-applicable universal rules (<5 lines) | AGENTS.md root or rule without `globs:` | research-context-engineering-comprehensive.md |
 | Path-specific conventions (5-50 lines) | `.cursor/rules/` with `globs:` frontmatter | analysis-how-claude-remembers-a-project.md |
-| Domain knowledge or workflows (50-500 lines) | Skill (`user-invocable: false`) | extend-claude-with-skills.md |
-| Heavy workflows with side effects | Skill (`disable-model-invocation: true`) | extend-claude-with-skills.md |
-| Isolated, context-heavy analysis | Skill (`context: fork`) | extend-claude-with-skills.md |
-| Must-enforce behavioral rules | Hook (`PreToolUse`/`PostToolUse`/`Stop`) | analysis-automate-workflow-with-hooks.md |
-| Enforcement needing LLM judgment | Hook (`type: "prompt"` or `type: "agent"`) | automate-workflow-with-hooks.md |
+| Domain knowledge or workflows (50-500 lines) | Skill (auto-invocable) | agentskills-specification.md |
+| Heavy workflows with side effects | Skill (`disable-model-invocation: true`) | agentskills-specification.md |
+| Must-enforce behavioral rules | Hook (`preToolUse`/`postToolUse`/`stop`) | analysis-automate-workflow-with-hooks.md |
+| Enforcement needing LLM judgment | Hook (`type: "prompt"`) | docs/cursor/hooks/hooks-guide.md |
 | Infrequently-needed deep reference | On-demand reference linked from SKILL.md | analysis-skill-authoring-best-practices.md |
 | Information agents can infer from code | DELETE — do not document | analysis-evaluating-agents-paper.md |
 
@@ -63,7 +61,7 @@ Use these signals to identify instructions that should migrate from always-loade
 |---|---|---|
 | Instructions mentioning specific file patterns | Path-scoped rule candidate | Any glob pattern → suggest `.cursor/rules/` with `globs:` |
 | Formatting, blocking, or notification behaviors | Hook candidate | Deterministic behavior → suggest `.cursor/hooks.json` entry |
-| "Always"/"never" enforcement semantics | Hook candidate | Binary enforcement → suggest `PreToolUse` hook |
+| "Always"/"never" enforcement semantics | Hook candidate | Binary enforcement → suggest `preToolUse` hook |
 | Domain knowledge blocks >50 lines | Skill candidate | >50 lines of domain content → suggest skill |
 | Workflow instructions invoked <20% of sessions | Low-frequency skill | Low usage → suggest `disable-model-invocation: true` |
 | Content agents can infer from code | DELETE candidate | Directory listings, codebase overviews, standard conventions |
@@ -80,18 +78,15 @@ Compare all available on-demand mechanisms when recommending a migration:
 
 | Mechanism | Context Cost | Enforcement | Best For |
 |---|---|---|---|
-| Skill (`user-invocable: false`) | ~100 tokens (name + description at startup) | Advisory — LLM decides when to invoke | Infrequent workflows, domain knowledge |
+| Skill (auto-invocable) | ~100 tokens (name + description at startup) | Advisory — LLM decides when to invoke | Infrequent workflows, domain knowledge |
 | Skill (`disable-model-invocation: true`) | Zero passive cost | Manual only — user invokes via slash command | Heavy/rare workflows with side effects |
-| Skill (`context: fork`) | Zero parent cost | Isolated — runs in forked context | Context-heavy analysis, subagent-like work |
 | Hook (`.cursor/hooks.json` — `command` type) | Zero | Deterministic (100%) | Formatting, validation, file blocking |
-| Hook (`.cursor/hooks.json` — `prompt` type) | Zero | LLM-judged (single turn) | Decisions requiring judgment |
-| Hook (`.cursor/hooks.json` — `agent` type) | Zero | LLM-judged (multi-turn with tools) | Complex verification against codebase |
-| Hook (`.cursor/hooks.json` — `http` type) | Zero | Webhook delivery | Audit logging, external service notification |
+| Hook (`.cursor/hooks.json` — `prompt` type) | Zero | LLM-judged | Decisions requiring judgment, complex verification |
 | Path-scoped rule (`.cursor/rules/` with `globs:`) | Zero until file match | Advisory, scoped to matched files | File-pattern-specific conventions |
-| Subagent (`skills: preload`) | Isolated context | Delegated execution | Parallel analysis, heavy processing |
+| Subagent (Task tool) | Isolated context | Delegated execution | Parallel analysis, heavy processing |
 | Auto memory | First 200 lines at startup | Advisory — system-managed | Cross-session learnings, preferences |
 
-Hook events: `PreToolUse` (can block via `hookSpecificOutput.permissionDecision`), `PostToolUse`, `Stop`, `SessionStart`, `UserPromptSubmit`, plus 17 others across session, subagent, compaction, and control lifecycles.
+Hook events: `preToolUse`, `postToolUse`, `postToolUseFailure`, `stop`, `sessionStart`, `beforeShellExecution`, and others — see `.cursor/hooks.json` schema for the full list. Block by returning `{"decision": "block"}` from a `prompt`-type hook.
 
 Path-scoped rules accept `globs:` as a string or array: `globs: ["src/**/*.ts", "!src/**/*.test.ts"]`
 
@@ -125,9 +120,8 @@ Estimate savings when recommending each migration type:
 |---|---|---|---|
 | Instruction → Hook | ~20-50 per rule | 0 (external execution) | Pure savings |
 | Instruction → Path-scoped rule | ~20-50 per rule | 0 until file match | Pure savings (most sessions) |
-| Block → Skill (`user-invocable: false`) | Full block size | ~100 (name + description) | Net = block size − 100 |
+| Block → Skill (auto-invocable) | Full block size | ~100 (name + description) | Net = block size − 100 |
 | Block → Skill (`disable-model-invocation: true`) | Full block size | 0 | Pure savings |
-| Block → Skill (`context: fork`) | Full block size | 0 (isolated context) | Pure savings |
 | Redundant content → DELETE | Full content size | 0 | Pure savings |
 | Duplicated content → single source | (N−1) × content size | 0 | Scales with copies |
 
@@ -145,7 +139,7 @@ Present token impact estimates alongside migration recommendations to help users
 | Codebase overviews do not help agents navigate | analysis-evaluating-agents-paper.md lines 36-41 |
 | Agent obedience turns unnecessary instructions into active cost | analysis-evaluating-agents-paper.md lines 42-52 |
 | 22 hook events across session, tool, and control lifecycle | analysis-automate-workflow-with-hooks.md lines 30-73 |
-| 4 hook types: command, http, prompt, agent | analysis-automate-workflow-with-hooks.md lines 21-28 |
+| 2 hook types: command, prompt | docs/cursor/hooks/hooks-guide.md |
 | Hooks enforce deterministically; rules advise with judgment | analysis-automate-workflow-with-hooks.md lines 433-445 |
 | Skill startup cost: ~100 tokens for name + description only | analysis-skill-authoring-best-practices.md lines 19-23 |
 | Reference depth: max 1 level from SKILL.md | analysis-skill-authoring-best-practices.md lines 131-143 |

--- a/plugins/cursor-initializer/skills/improve-cursor/references/automation-migration-guide.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/automation-migration-guide.md
@@ -1,0 +1,154 @@
+# Automation Migration Guide
+
+Decision criteria for migrating instructions from AGENTS.md to on-demand mechanisms.
+Source: context-aware-improve-optimization.prd.md, analysis-automate-workflow-with-hooks.md, analysis-skill-authoring-best-practices.md, analysis-how-claude-remembers-a-project.md
+
+---
+
+## Contents
+
+- Decision flowchart (classify content type → select mechanism)
+- Content type to mechanism mapping (9 content types with evidence)
+- Migration candidate indicators (signals that content should migrate)
+- Mechanism comparison (context cost, enforcement, best for)
+- Distribution-aware recommendations (plugin vs. standalone)
+- Token impact estimation (savings per mechanism type)
+- Evidence citations
+
+---
+
+## Decision Flowchart
+
+When evaluating an instruction block for migration, follow this decision path:
+
+1. **Is it always needed for every task and under 5 lines?** → Keep in AGENTS.md root
+2. **Can the agent infer it from code?** → DELETE — do not document
+3. **Is it a deterministic rule (no judgment needed)?** → Hook (`.cursor/hooks.json` entry)
+4. **Does enforcement require LLM judgment?** → Hook (`prompt` or `agent` type)
+5. **Is it path-specific and under 50 lines?** → `.cursor/rules/` with `globs:` frontmatter
+6. **Is it a workflow or domain block (50-500 lines)?** → Skill (`user-invocable: false`)
+7. **Is it heavy, rare, or has side effects?** → Skill (`disable-model-invocation: true`)
+8. **Is it context-heavy isolated analysis?** → Skill (`context: fork`)
+9. **None of the above?** → Keep in current location; reassess in next improvement cycle
+
+*Source: context-aware-improve-optimization.prd.md lines 346-358*
+
+---
+
+## Content Type to Mechanism Mapping
+
+Classify each instruction block by content type, then recommend the corresponding mechanism:
+
+| Content Type | Best Mechanism | Evidence Source |
+|---|---|---|
+| Always-applicable universal rules (<5 lines) | AGENTS.md root or rule without `globs:` | research-context-engineering-comprehensive.md |
+| Path-specific conventions (5-50 lines) | `.cursor/rules/` with `globs:` frontmatter | analysis-how-claude-remembers-a-project.md |
+| Domain knowledge or workflows (50-500 lines) | Skill (`user-invocable: false`) | extend-claude-with-skills.md |
+| Heavy workflows with side effects | Skill (`disable-model-invocation: true`) | extend-claude-with-skills.md |
+| Isolated, context-heavy analysis | Skill (`context: fork`) | extend-claude-with-skills.md |
+| Must-enforce behavioral rules | Hook (`PreToolUse`/`PostToolUse`/`Stop`) | analysis-automate-workflow-with-hooks.md |
+| Enforcement needing LLM judgment | Hook (`type: "prompt"` or `type: "agent"`) | automate-workflow-with-hooks.md |
+| Infrequently-needed deep reference | On-demand reference linked from SKILL.md | analysis-skill-authoring-best-practices.md |
+| Information agents can infer from code | DELETE — do not document | analysis-evaluating-agents-paper.md |
+
+*Source: context-aware-improve-optimization.prd.md lines 348-358*
+
+---
+
+## Migration Candidate Indicators
+
+Use these signals to identify instructions that should migrate from always-loaded to on-demand:
+
+| Indicator | What It Suggests | Threshold |
+|---|---|---|
+| Instructions mentioning specific file patterns | Path-scoped rule candidate | Any glob pattern → suggest `.cursor/rules/` with `globs:` |
+| Formatting, blocking, or notification behaviors | Hook candidate | Deterministic behavior → suggest `.cursor/hooks.json` entry |
+| "Always"/"never" enforcement semantics | Hook candidate | Binary enforcement → suggest `PreToolUse` hook |
+| Domain knowledge blocks >50 lines | Skill candidate | >50 lines of domain content → suggest skill |
+| Workflow instructions invoked <20% of sessions | Low-frequency skill | Low usage → suggest `disable-model-invocation: true` |
+| Content agents can infer from code | DELETE candidate | Directory listings, codebase overviews, standard conventions |
+| Instructions duplicated across files | Consolidation candidate | Same content in 2+ files → single source of truth |
+| Version numbers, team names, release info | DELETE or pointer | High-churn content → remove or use memory |
+
+*Source: analysis-evaluating-agents-paper.md lines 36-52, Anthropic Best Practices*
+
+---
+
+## Mechanism Comparison
+
+Compare all available on-demand mechanisms when recommending a migration:
+
+| Mechanism | Context Cost | Enforcement | Best For |
+|---|---|---|---|
+| Skill (`user-invocable: false`) | ~100 tokens (name + description at startup) | Advisory — LLM decides when to invoke | Infrequent workflows, domain knowledge |
+| Skill (`disable-model-invocation: true`) | Zero passive cost | Manual only — user invokes via slash command | Heavy/rare workflows with side effects |
+| Skill (`context: fork`) | Zero parent cost | Isolated — runs in forked context | Context-heavy analysis, subagent-like work |
+| Hook (`.cursor/hooks.json` — `command` type) | Zero | Deterministic (100%) | Formatting, validation, file blocking |
+| Hook (`.cursor/hooks.json` — `prompt` type) | Zero | LLM-judged (single turn) | Decisions requiring judgment |
+| Hook (`.cursor/hooks.json` — `agent` type) | Zero | LLM-judged (multi-turn with tools) | Complex verification against codebase |
+| Hook (`.cursor/hooks.json` — `http` type) | Zero | Webhook delivery | Audit logging, external service notification |
+| Path-scoped rule (`.cursor/rules/` with `globs:`) | Zero until file match | Advisory, scoped to matched files | File-pattern-specific conventions |
+| Subagent (`skills: preload`) | Isolated context | Delegated execution | Parallel analysis, heavy processing |
+| Auto memory | First 200 lines at startup | Advisory — system-managed | Cross-session learnings, preferences |
+
+Hook events: `PreToolUse` (can block via `hookSpecificOutput.permissionDecision`), `PostToolUse`, `Stop`, `SessionStart`, `UserPromptSubmit`, plus 17 others across session, subagent, compaction, and control lifecycles.
+
+Path-scoped rules accept `globs:` as a string or array: `globs: ["src/**/*.ts", "!src/**/*.test.ts"]`
+
+*Source: analysis-automate-workflow-with-hooks.md lines 21-130, 433-445*
+
+---
+
+## Distribution-Aware Recommendations
+
+When suggesting migrations, recommend only mechanisms available in the target distribution:
+
+| Mechanism | Plugin Distribution | Standalone Distribution | Reason |
+|---|---|---|---|
+| Skills | Suggest | Suggest | Both distributions support skills fully |
+| Path-scoped rules | Suggest | Suggest (as separate files) | Both support rules; standalone uses file conventions |
+| Hooks | Suggest | Do not suggest | Hooks require Claude Code; standalone tools lack hook support |
+| Subagents | Suggest | Do not suggest | Subagent delegation requires Claude Code plugin architecture |
+| Auto memory | Mention only | Mention only | System-managed; not a direct migration target |
+
+Check the distribution type before generating improvement suggestions. Filter mechanism recommendations to include only supported mechanisms for the detected distribution.
+
+*Source: DESIGN-GUIDELINES.md Guideline 11, project architecture*
+
+---
+
+## Token Impact Estimation
+
+Estimate savings when recommending each migration type:
+
+| Migration Type | Tokens Saved (Always-Loaded) | Tokens Added (On-Demand) | Net Impact |
+|---|---|---|---|
+| Instruction → Hook | ~20-50 per rule | 0 (external execution) | Pure savings |
+| Instruction → Path-scoped rule | ~20-50 per rule | 0 until file match | Pure savings (most sessions) |
+| Block → Skill (`user-invocable: false`) | Full block size | ~100 (name + description) | Net = block size − 100 |
+| Block → Skill (`disable-model-invocation: true`) | Full block size | 0 | Pure savings |
+| Block → Skill (`context: fork`) | Full block size | 0 (isolated context) | Pure savings |
+| Redundant content → DELETE | Full content size | 0 | Pure savings |
+| Duplicated content → single source | (N−1) × content size | 0 | Scales with copies |
+
+Present token impact estimates alongside migration recommendations to help users prioritize high-impact changes first.
+
+*Source: research-context-engineering-comprehensive.md, analysis-skill-authoring-best-practices.md lines 19-46*
+
+---
+
+## Evidence Citations
+
+| Claim | Source |
+|---|---|
+| 9 content types with mechanism mapping | context-aware-improve-optimization.prd.md lines 348-358 |
+| Codebase overviews do not help agents navigate | analysis-evaluating-agents-paper.md lines 36-41 |
+| Agent obedience turns unnecessary instructions into active cost | analysis-evaluating-agents-paper.md lines 42-52 |
+| 22 hook events across session, tool, and control lifecycle | analysis-automate-workflow-with-hooks.md lines 30-73 |
+| 4 hook types: command, http, prompt, agent | analysis-automate-workflow-with-hooks.md lines 21-28 |
+| Hooks enforce deterministically; rules advise with judgment | analysis-automate-workflow-with-hooks.md lines 433-445 |
+| Skill startup cost: ~100 tokens for name + description only | analysis-skill-authoring-best-practices.md lines 19-23 |
+| Reference depth: max 1 level from SKILL.md | analysis-skill-authoring-best-practices.md lines 131-143 |
+| Path-scoped rules: on-demand loading via `globs:` frontmatter | analysis-how-claude-remembers-a-project.md lines 53-64 |
+| ≤200 lines per config file; ~150-200 instruction limit | research-context-engineering-comprehensive.md |
+| Each converted rule saves ~20-50 tokens from always-loaded context | DESIGN-GUIDELINES.md Guideline 10 |

--- a/plugins/cursor-initializer/skills/improve-cursor/references/context-optimization.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/context-optimization.md
@@ -21,14 +21,14 @@ Source: research-context-engineering-comprehensive.md
 
 | Limit | Value | Source |
 |-------|-------|--------|
-| Lines per configuration file | ≤ 200 | Anthropic Docs: "Target under 200 lines per CLAUDE.md file." |
+| Lines per configuration file | ≤ 200 | Anthropic Docs: 200-line target for configuration files in this toolkit |
 | Instructions per file | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
-| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily." |
+| Contradictions between files | 0 | Anthropic: conflicting instructions make the model choose inconsistently. |
 
-> "Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"
+> Anthropic's warning generalizes here: bloated configuration files cause the model to miss important instructions.
 > — Anthropic Best Practices
 
-> "If Claude keeps doing something you don't want despite having a rule against it, the file is probably too long."
+> Anthropic's warning generalizes here: if a configuration file keeps growing, the model may ignore an instruction even when it is present.
 > — Anthropic Best Practices
 
 ---
@@ -95,7 +95,7 @@ Detect and remove these before generating or improving configuration files:
 | Failed approach accumulation | Look for rules added defensively after incidents | Remove rules that shouldn't be needed |
 | High-churn information | Look for version numbers, file counts, team names | Remove or move to a pointer |
 
-> "Treat CLAUDE.md like code: review it when things go wrong, prune it regularly." — Anthropic Best Practices
+> Treat configuration files like code: review them when things go wrong, prune them regularly. — Adapted from Anthropic Best Practices
 
 *Source: research-context-engineering-comprehensive.md lines 213-253*
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/context-optimization.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/context-optimization.md
@@ -1,0 +1,132 @@
+# Context Optimization
+
+Evidence-based instructions for managing token budgets and attention in agent configuration files.
+Source: research-context-engineering-comprehensive.md
+
+---
+
+## Contents
+
+- Hard limits (lines per file, instruction count, contradictions)
+- The attention budget (finite resource, n-squared constraint)
+- Lost in the middle (placement strategy for critical instructions)
+- Quality over quantity checklist (include/exclude decision table)
+- Context poisoning vectors (detection and removal)
+- JIT documentation patterns (on-demand loading strategies)
+- Key citations
+
+---
+
+## Hard Limits
+
+| Limit | Value | Source |
+|-------|-------|--------|
+| Lines per configuration file | ≤ 200 | Anthropic Docs: "Target under 200 lines per CLAUDE.md file." |
+| Instructions per file | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
+| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily." |
+
+> "Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"
+> — Anthropic Best Practices
+
+> "If Claude keeps doing something you don't want despite having a rule against it, the file is probably too long."
+> — Anthropic Best Practices
+
+---
+
+## The Attention Budget
+
+Context is a **finite resource with diminishing marginal returns**. Do not treat it as unlimited.
+
+> "LLMs have an 'attention budget' that they draw on when parsing large volumes of context. Every new token introduced depletes this budget by some amount."
+> — Anthropic Engineering: Effective Context Engineering
+
+Architectural reason: Transformers create **n² pairwise relationships** for n tokens — attention gets stretched thin as context grows. Models trained on shorter sequences have fewer parameters for long-range dependencies.
+
+**Key principle**: *"Good context engineering means finding the smallest possible set of high-signal tokens that maximize the likelihood of some desired outcome."* — Anthropic
+
+> Context rot: "As the number of tokens in the context window increases, the model's ability to accurately recall information from that context decreases." — Anthropic
+
+---
+
+## Lost in the Middle
+
+Critical instructions must be at the **start or end** of files, not buried in the middle.
+
+> Performance is "highest when relevant information is at the beginning or end of the context... degrades significantly for information in the middle of long contexts."
+> — Liu et al., Lost in the Middle (arXiv:2307.03172)
+
+**Apply this when generating files:** Place the most important instructions in the first 20% and last 20% of each configuration file.
+
+---
+
+## Quality Over Quantity Checklist
+
+For each instruction line, ask: **"Would removing this cause the agent to make mistakes? If not, cut it."**
+— Anthropic Best Practices
+
+| ✅ Include | ❌ Exclude |
+|-----------|-----------|
+| Bash commands the agent cannot guess | Anything the agent can figure out by reading code |
+| Code style rules that differ from defaults | Standard language conventions already known |
+| Testing instructions (non-standard) | Detailed API documentation (link instead) |
+| Non-obvious architectural decisions | Long explanations or tutorials |
+| Developer environment quirks | File-by-file descriptions of the codebase |
+| Non-standard tooling | Self-evident practices ("write clean code") |
+
+**Instruction specificity goldilocks:**
+
+- ✅ "Use 2-space indentation" vs. ❌ "Format code properly"
+- ✅ "Run `npm test` before committing" vs. ❌ "Test your changes"
+- ✅ "API handlers live in `src/api/handlers/`" vs. ❌ "Keep files organized"
+
+*Source: research-context-engineering-comprehensive.md lines 113-134*
+
+---
+
+## Context Poisoning Vectors
+
+Detect and remove these before generating or improving configuration files:
+
+| Poison vector | Detection | Fix |
+|---------------|-----------|-----|
+| Stale file paths | Check if referenced paths actually exist | Remove or update |
+| Contradictions | Compare instructions across all files | Remove the weaker/older rule |
+| Over-specification | Count lines; check if agent already follows rule | Delete or convert to hook |
+| Failed approach accumulation | Look for rules added defensively after incidents | Remove rules that shouldn't be needed |
+| High-churn information | Look for version numbers, file counts, team names | Remove or move to a pointer |
+
+> "Treat CLAUDE.md like code: review it when things go wrong, prune it regularly." — Anthropic Best Practices
+
+*Source: research-context-engineering-comprehensive.md lines 213-253*
+
+---
+
+## JIT Documentation Patterns
+
+Use these patterns to move content from always-consumed to on-demand locations:
+
+| Pattern | How it works | Token impact |
+|---------|-------------|-------------|
+| Skills | Description loaded at start; full body loaded on invocation | On-demand |
+| Path-scoped rules | Trigger only when matching files are read | On-demand |
+| Subdirectory config files | Load when working in that directory | On-demand |
+| `@path/to/import` | Expands when parent file loads | Controlled |
+| Domain docs (e.g., `docs/TESTING.md`) | Agent navigates when relevant | On-demand |
+
+> "Rather than pre-processing all relevant data up front, agents maintain lightweight identifiers and use these references to dynamically load data into context at runtime."
+> — Anthropic Engineering: Effective Context Engineering
+
+*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*
+
+---
+
+## Key Citations
+
+| Claim | Source |
+|-------|--------|
+| ≤200 lines per file | Anthropic Docs: claude-code/memory |
+| ~150-200 instruction limit | HumanLayer (Kyle) via a-guide-to-agents.md |
+| n² attention constraint / context rot | Anthropic Engineering Blog |
+| Lost-in-the-middle effect | Liu et al., arXiv:2307.03172 |
+| Quality over quantity heuristic | Anthropic Best Practices |
+| JIT documentation strategy | Anthropic Engineering: Effective Context Engineering |

--- a/plugins/cursor-initializer/skills/improve-cursor/references/cursor-rules-system.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/cursor-rules-system.md
@@ -1,0 +1,65 @@
+# Cursor Rules System
+
+Reference for generating and evaluating `.cursor/rules/` files. Source: [cursor.com/docs/context/rules](https://cursor.com/docs/context/rules).
+
+## File Format
+
+Cursor rules are markdown files in `.cursor/rules/` with optional `.mdc` extension for frontmatter support. Both `.md` and `.mdc` extensions are supported.
+
+### Frontmatter Fields (ONLY these three are valid)
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `description` | string | Tells the agent what this rule is about — used for "Apply Intelligently" mode |
+| `alwaysApply` | boolean | When `true`, rule loads on every conversation. When `false`, agent decides based on description |
+| `globs` | string or array | File patterns that trigger auto-attachment (e.g., `"**/*.test.ts"` or `["*.py", "*.pyi"]`) |
+
+### The Four Activation Modes
+
+Rules behave differently based on which frontmatter fields are set:
+
+| Mode | `alwaysApply` | `globs` | `description` | When it loads |
+|------|:---:|:---:|:---:|:---|
+| **Always** | `true` | — | optional | Every conversation |
+| **Auto-attached** | `false` | set | optional | When matching files are in context |
+| **Agent-requested** | `false` | — | set | When the agent decides based on description |
+| **Manual** | `false` | — | — | Only when user @-mentions the rule |
+
+### Best Practices
+
+- Keep rules under 500 lines
+- Split large rules into multiple composable rules
+- Provide concrete examples or reference files
+- Write rules like clear internal docs — avoid vague guidance
+- Reference files instead of copying their contents
+- Start simple — add rules only when the agent makes the same mistake repeatedly
+
+### What NOT to Put in Rules
+
+- Entire style guides (use a linter instead)
+- Every possible command (the agent knows common tools)
+- Instructions for edge cases that rarely apply
+- Content that duplicates what's in your codebase
+
+### When to Use Rules vs AGENTS.md
+
+| Use `.cursor/rules/` when... | Use `AGENTS.md` when... |
+|-------------------------------|-------------------------|
+| You need metadata-controlled activation (globs, description) | You want simple, portable, readable instructions |
+| You want auto-attachment based on file patterns | The project also needs AGENTS.md for other tools |
+| You need different activation modes for different content | All instructions should always load |
+| You want to organize rules in folders | You prefer a single-file approach |
+
+### File Example
+
+```
+---
+description: "Standards for React components including styling, animations, and naming"
+globs: ["src/components/**/*.tsx", "src/components/**/*.ts"]
+alwaysApply: false
+---
+
+- Use Tailwind for styling
+- Use Framer Motion for animations
+- See `components/Button.tsx` for canonical component structure
+```

--- a/plugins/cursor-initializer/skills/improve-cursor/references/cursor-rules-system.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/cursor-rules-system.md
@@ -27,8 +27,8 @@ Rules behave differently based on which frontmatter fields are set:
 
 ### Best Practices
 
-- Keep rules under 500 lines
-- Split large rules into multiple composable rules
+- Cursor generally allows larger rules, but this toolkit enforces a stricter ≤200-line limit per file
+- Split anything approaching 200 lines into multiple composable rules
 - Provide concrete examples or reference files
 - Write rules like clear internal docs — avoid vague guidance
 - Reference files instead of copying their contents

--- a/plugins/cursor-initializer/skills/improve-cursor/references/evaluation-criteria.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/evaluation-criteria.md
@@ -1,0 +1,171 @@
+# Evaluation Criteria
+
+Scoring rubric for assessing existing AGENTS.md and CLAUDE.md files before improvement.
+Used by IMPROVE skills only. Source: file-evaluator.md, research-context-engineering-comprehensive.md
+
+---
+
+## Contents
+
+- Hard limits table (file length, instruction count, contradictions)
+- Bloat indicators table (directory listings, vague instructions, duplicates)
+- Staleness indicators table (stale paths, failing commands, outdated refs)
+- Progressive disclosure assessment (root focus, domain separation, pointers)
+- Instruction specificity assessment (goldilocks zone examples)
+- Automation opportunity assessment (migration candidate signals and classification)
+- Quality score rubric (6-dimension scoring 1-10)
+- Evaluation output template
+
+---
+
+## Hard Limits Table
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
+| Instruction count | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions" |
+| Contradictions | 0 | Anthropic: "Claude may pick one arbitrarily" |
+
+A file violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
+
+---
+
+## Bloat Indicators Table
+
+Check each line of the file against these indicators:
+
+| Indicator | Why It's Bloat | Source |
+|-----------|---------------|--------|
+| Directory/file structure listings | "Not effective at providing repository overview" | ETH Zurich: Evaluating AGENTS.md |
+| Standard language conventions | Agent already knows from training data | Anthropic Best Practices |
+| Vague instructions ("write clean code") | Not actionable; wastes attention budget | a-guide-to-agents.md |
+| Codebase overview paragraphs | Increases steps without improving navigation | ETH Zurich: Evaluating AGENTS.md |
+| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it, delete it" |
+| Duplicated content across files | Wastes tokens on every request | research-context-engineering-comprehensive.md |
+
+*Source: file-evaluator.md lines 30-41*
+
+---
+
+## Staleness Indicators Table
+
+| Indicator | How to Detect |
+|-----------|---------------|
+| Referenced file paths that don't exist | Check if each `path/to/file` in the content actually exists |
+| Documented commands that fail | Run documented build/test commands |
+| Package references to uninstalled deps | Check if mentioned packages are in manifest files |
+| Outdated framework version references | Compare mentioned versions with actual installed versions |
+
+*Source: file-evaluator.md lines 43-50*
+
+---
+
+## Progressive Disclosure Assessment
+
+| Question | Good | Bad |
+|----------|------|-----|
+| Does root file stay focused on essentials? | One-sentence desc + tooling + pointers only | Inlines domain rules |
+| Are domain topics in separate files? | Testing in TESTING.md, build in BUILD.md | All topics in one file |
+| Do subdirectory files exist for distinct scopes? | packages/api/CLAUDE.md for API-specific rules | Everything in root |
+| Are pointers provided to detailed docs? | "See docs/TESTING.md" | No cross-references |
+
+*Source: file-evaluator.md lines 52-59*
+
+---
+
+## Instruction Specificity Assessment
+
+Every instruction should be in the Goldilocks zone:
+
+| Rating | Example | Problem |
+|--------|---------|---------|
+| ✅ Specific | "Use 2-space indentation" | None — clear and actionable |
+| ✅ Specific | "Run `npm test` before committing" | None — verifiable *(format example only; standard commands should still be excluded per what-not-to-include.md)* |
+| ❌ Too vague | "Format code properly" | Cannot be verified or acted on |
+| ❌ Too specific | "File `src/auth/handlers.ts` handles JWT" | Over-specified file path, will go stale |
+
+*Source: research-context-engineering-comprehensive.md lines 131-134*
+
+---
+
+## Automation Opportunity Assessment
+
+Check each instruction block for migration potential to on-demand mechanisms:
+
+| Signal | Classification | Priority |
+|--------|---------------|----------|
+| File pattern globs in instruction text | Path-scoped rule candidate (`RULE_CANDIDATE`) | HIGH — pure token savings |
+| "Always"/"never" deterministic enforcement | Hook candidate (`HOOK_CANDIDATE`) | HIGH — deterministic enforcement |
+| Domain knowledge or workflow block >50 lines | Skill candidate (`SKILL_CANDIDATE`) | MEDIUM — net savings = block − 100 tokens |
+| Standard conventions / agent-inferable content | DELETE candidate (`DELETE_CANDIDATE`) | HIGH — pure savings |
+| Content duplicated across multiple files | Consolidation candidate (`CONSOLIDATE`) | MEDIUM — saves (N−1) × content size |
+
+Flag each candidate in the Per-File Issues output under `**Automation Opportunity Issues:**`.
+
+*Source: automation-migration-guide.md lines 58-72*
+
+---
+
+## Quality Score Rubric
+
+Score each dimension 1-10 based on observed issues:
+
+| Dimension | 8-10 (Good) | 4-7 (Mixed) | 1-3 (Bad) |
+|-----------|-------------|-------------|-----------|
+| Conciseness | ≤200 lines, minimal bloat | 200-400 lines, some bloat | >400 lines, heavy bloat |
+| Accuracy | 0 stale references | 1-2 stale refs | 3+ stale refs |
+| Specificity | All instructions actionable | Mix of specific/vague | Mostly vague |
+| Progressive Disclosure | Content at right scope level | Some misplaced content | All inlined in root |
+| Consistency | 0 contradictions | 1 contradiction | 2+ contradictions |
+| Automation Opportunity | 0 migration candidates missed | 1-3 potential migrations | 4+ missed migrations |
+
+*Source: file-evaluator.md lines 132-141*
+
+---
+
+## Evaluation Output Template
+
+Return findings in exactly this format:
+
+```
+## File Evaluation Results
+
+### Files Found
+| File | Lines | Status |
+|------|-------|--------|
+| `./CLAUDE.md` | 342 | ⚠️ Over limit |
+
+### Per-File Issues
+
+#### `./CLAUDE.md` (342 lines — OVER 200 LINE LIMIT)
+
+**Bloat Issues:**
+- Lines 45-78: [specific issue with evidence]
+
+**Staleness Issues:**
+- Line 23: References `src/auth/handlers.ts` — file does not exist
+
+**Contradiction Issues:**
+- Line 12: "[rule A]" conflicts with "[rule B]" at line 89
+
+**Progressive Disclosure Issues:**
+- Lines 150-200: Testing conventions should be in separate `docs/TESTING.md`
+
+**Automation Opportunity Issues:**
+- Lines 45-60: Formatting enforcement (HOOK_CANDIDATE — deterministic behavior)
+- Lines 200-210: "*.test.ts" glob pattern (RULE_CANDIDATE — path-specific)
+
+### Cross-File Issues
+- [List cross-file contradictions or duplications, or "None"]
+
+### Quality Score
+| Dimension | Score (1-10) | Notes |
+|-----------|-------------|-------|
+| Conciseness | 3 | 342 lines, 70%+ over limit |
+| Accuracy | 6 | 2 stale references |
+| Specificity | 5 | Mix of specific and vague |
+| Progressive Disclosure | 4 | Most content inlined |
+| Consistency | 7 | 1 contradiction |
+| Automation Opportunity | 8 | 0 migration candidates missed |
+| **Overall** | **4** | Needs significant refactoring |
+```

--- a/plugins/cursor-initializer/skills/improve-cursor/references/evaluation-criteria.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/evaluation-criteria.md
@@ -1,6 +1,6 @@
 # Evaluation Criteria
 
-Scoring rubric for assessing existing AGENTS.md and CLAUDE.md files before improvement.
+Scoring rubric for assessing existing AGENTS.md files and `.cursor/rules/*` files before improvement.
 Used by IMPROVE skills only. Source: file-evaluator.md, research-context-engineering-comprehensive.md
 
 ---
@@ -22,9 +22,9 @@ Used by IMPROVE skills only. Source: file-evaluator.md, research-context-enginee
 
 | Criterion | Threshold | Source |
 |-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
+| File length | ≤ 200 lines | Anthropic Docs: 200-line target for configuration files in this toolkit |
 | Instruction count | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions" |
-| Contradictions | 0 | Anthropic: "Claude may pick one arbitrarily" |
+| Contradictions | 0 | Anthropic: conflicting instructions make the model choose inconsistently |
 
 A file violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
 
@@ -40,7 +40,7 @@ Check each line of the file against these indicators:
 | Standard language conventions | Agent already knows from training data | Anthropic Best Practices |
 | Vague instructions ("write clean code") | Not actionable; wastes attention budget | a-guide-to-agents.md |
 | Codebase overview paragraphs | Increases steps without improving navigation | ETH Zurich: Evaluating AGENTS.md |
-| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it, delete it" |
+| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic Best Practices |
 | Duplicated content across files | Wastes tokens on every request | research-context-engineering-comprehensive.md |
 
 *Source: file-evaluator.md lines 30-41*
@@ -66,7 +66,7 @@ Check each line of the file against these indicators:
 |----------|------|-----|
 | Does root file stay focused on essentials? | One-sentence desc + tooling + pointers only | Inlines domain rules |
 | Are domain topics in separate files? | Testing in TESTING.md, build in BUILD.md | All topics in one file |
-| Do subdirectory files exist for distinct scopes? | packages/api/CLAUDE.md for API-specific rules | Everything in root |
+| Do subdirectory files exist for distinct scopes? | packages/api/AGENTS.md or `.cursor/rules/api.mdc` for API-specific guidance | Everything in root |
 | Are pointers provided to detailed docs? | "See docs/TESTING.md" | No cross-references |
 
 *Source: file-evaluator.md lines 52-59*
@@ -133,11 +133,11 @@ Return findings in exactly this format:
 ### Files Found
 | File | Lines | Status |
 |------|-------|--------|
-| `./CLAUDE.md` | 342 | ⚠️ Over limit |
+| `./AGENTS.md` | 342 | ⚠️ Over limit |
 
 ### Per-File Issues
 
-#### `./CLAUDE.md` (342 lines — OVER 200 LINE LIMIT)
+#### `./AGENTS.md` (342 lines — OVER 200 LINE LIMIT)
 
 **Bloat Issues:**
 - Lines 45-78: [specific issue with evidence]
@@ -149,7 +149,7 @@ Return findings in exactly this format:
 - Line 12: "[rule A]" conflicts with "[rule B]" at line 89
 
 **Progressive Disclosure Issues:**
-- Lines 150-200: Testing conventions should be in separate `docs/TESTING.md`
+- Lines 150-200: Testing conventions should be in separate `.cursor/rules/testing.mdc`
 
 **Automation Opportunity Issues:**
 - Lines 45-60: Formatting enforcement (HOOK_CANDIDATE — deterministic behavior)

--- a/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
@@ -103,26 +103,6 @@ docs/
 
 ---
 
-## CLAUDE.md-Specific Hierarchy
-
-| Scope | Location | Loads when |
-|-------|----------|------------|
-| Org-wide | Managed policy (MDM) | Always |
-| Project | `./CLAUDE.md` or `./.claude/CLAUDE.md` | Session start (always) |
-| Personal | `~/.claude/CLAUDE.md` | Session start (always) |
-| Subdirectory | `./subdir/CLAUDE.md` | When reading files in that dir |
-| Path-scoped rules | `.claude/rules/*.md` with `paths:` | When matching files are read |
-
-**Priority rule**: Minimize content in always-loaded locations. Move to on-demand locations wherever possible.
-
-**@import syntax**: CLAUDE.md files can import additional files with `@path/to/file`. Imports expand at launch alongside the importing CLAUDE.md. Relative paths resolve relative to the importing file, not CWD. Max recursion depth: 5 hops. Requires one-time user approval per project.
-
-**Load order**: Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory CLAUDE.md files load on-demand only when Claude reads files in that directory — not at launch.
-
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
-
----
-
 ## AGENTS.md-Specific Notes
 
 - AGENTS.md is an **open standard** supported by most agent frameworks (not Claude Code)

--- a/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
@@ -1,6 +1,6 @@
 # Progressive Disclosure Guide
 
-Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
+Evidence-based instructions for structuring AGENTS.md hierarchies and `.cursor/rules/*.mdc` rules in Cursor.
 Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
@@ -9,10 +9,10 @@ Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, me
 
 - File hierarchy decision table (where to place content)
 - Root file requirements (minimal elements only)
-- Monorepo: what goes where (root vs package level, claudeMdExcludes)
+- Monorepo: what goes where (root vs package level)
 - Progressive disclosure patterns (domain files, nested docs, skills)
-- CLAUDE.md-specific hierarchy (5 scopes, @import, load order)
-- AGENTS.md-specific notes (open standard, symlinks, merging)
+- Cursor rule scoping notes
+- AGENTS.md in Cursor (root, subdirectory, merging)
 - Anti-patterns to detect and remove
 - Validation checklist
 
@@ -103,12 +103,20 @@ docs/
 
 ---
 
-## AGENTS.md-Specific Notes
+## Cursor Rule Scoping Notes
 
-- AGENTS.md is an **open standard** supported by most agent frameworks (not Claude Code)
-- Claude Code uses CLAUDE.md; create a symlink for cross-tool compatibility: `ln -s AGENTS.md CLAUDE.md`
-- AGENTS.md has **no `.claude/rules/` equivalent** — use subdirectory AGENTS.md files for scoped rules
-- Subdirectory AGENTS.md files **merge with root** (not replace)
+- Use `.cursor/rules/*.mdc` when guidance depends on file patterns, activation mode, or agent-requested loading
+- Keep rule metadata minimal: only `description`, `alwaysApply`, and `globs`
+- Prefer narrow `globs:` over `alwaysApply: true` when guidance applies to specific files only
+
+---
+
+## AGENTS.md in Cursor
+
+- Cursor supports `AGENTS.md` at the project root and in subdirectories
+- Nested `AGENTS.md` files merge with parent instructions; more specific scopes take precedence
+- Keep AGENTS.md for project-wide or directory-wide guidance; move file-pattern-specific instructions to `.cursor/rules/*.mdc`
+- Use root AGENTS.md for essentials and subdirectory AGENTS.md files for area-specific tooling or conventions
 
 ---
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
@@ -24,10 +24,10 @@ When deciding where to place content, use this table:
 
 | Location | Use when content is... | Load timing |
 |----------|------------------------|-------------|
-| Root AGENTS.md / CLAUDE.md | Relevant to **every single task** in the repo | Always (every request) |
+| Root AGENTS.md | Relevant to **every single task** in the repo | Always (every request) |
 | Separate domain file | Relevant to one domain (TypeScript, testing, API design) | On-demand |
-| Subdirectory AGENTS.md / CLAUDE.md | Specific to one package or area | On-demand when working there |
-| `.claude/rules/` (path-scoped) | Specific to certain file patterns | On-demand when files match |
+| Subdirectory AGENTS.md | Specific to one package or area | On-demand when working there |
+| `.cursor/rules/*.mdc` with `globs:` | Specific to certain file patterns | On-demand when files match |
 | Skill | A workflow the agent should invoke explicitly | On-demand when invoked |
 
 *Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
@@ -66,15 +66,9 @@ See each package's AGENTS.md for specific guidelines.
 > "Don't overload any level. The agent sees all merged files in its context."
 > — a-guide-to-agents.md lines 164-193
 
-**`claudeMdExcludes`**: In large monorepos, skip irrelevant ancestor CLAUDE.md files via `.claude/settings.local.json`:
+**Monorepo context scoping in Cursor**: In large monorepos, use `.cursor/rules/*.mdc` with narrow `globs:` patterns to limit rules to relevant packages. Rules with `alwaysApply: true` load for every request — keep them minimal.
 
-```json
-{ "claudeMdExcludes": ["**/other-team/CLAUDE.md", "**/other-team/.claude/rules/**"] }
-```
-
-Patterns match absolute paths with glob syntax. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded.
-
-*Source: memory/how-claude-remembers-a-project.md lines 243-260*
+*Source: memory/how-claude-remembers-a-project.md lines 243-260; docs/cursor/rules-and-memory.md*
 
 ---
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
@@ -1,0 +1,162 @@
+# Progressive Disclosure Guide
+
+Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
+Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
+
+---
+
+## Contents
+
+- File hierarchy decision table (where to place content)
+- Root file requirements (minimal elements only)
+- Monorepo: what goes where (root vs package level, claudeMdExcludes)
+- Progressive disclosure patterns (domain files, nested docs, skills)
+- CLAUDE.md-specific hierarchy (5 scopes, @import, load order)
+- AGENTS.md-specific notes (open standard, symlinks, merging)
+- Anti-patterns to detect and remove
+- Validation checklist
+
+---
+
+## File Hierarchy Decision Table
+
+When deciding where to place content, use this table:
+
+| Location | Use when content is... | Load timing |
+|----------|------------------------|-------------|
+| Root AGENTS.md / CLAUDE.md | Relevant to **every single task** in the repo | Always (every request) |
+| Separate domain file | Relevant to one domain (TypeScript, testing, API design) | On-demand |
+| Subdirectory AGENTS.md / CLAUDE.md | Specific to one package or area | On-demand when working there |
+| `.claude/rules/` (path-scoped) | Specific to certain file patterns | On-demand when files match |
+| Skill | A workflow the agent should invoke explicitly | On-demand when invoked |
+
+*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
+
+---
+
+## Root File Requirements
+
+Generate root files with **only** these elements:
+
+1. **One-sentence project description** — anchors every agent decision ("This is a React component library for accessible data visualization.")
+2. **Package manager** — only if non-standard (e.g., `pnpm`, `bun`; omit if npm)
+3. **Build/typecheck commands** — only if non-standard
+4. **Progressive disclosure pointers** — links to domain files, not inline content
+
+> "Consider this the absolute minimum... That's honestly it. Everything else should go elsewhere."
+> — a-guide-to-agents.md
+
+---
+
+## Monorepo: What Goes Where
+
+| Level | Generate here | Do NOT put here |
+|-------|---------------|-----------------|
+| Root | Monorepo purpose, how to navigate packages, shared tooling | Package-specific tech stacks, package conventions |
+| Package | Package purpose, specific tech stack, package-specific conventions | Cross-repo decisions |
+
+Root example:
+
+```markdown
+This is a monorepo containing web services and CLI tools.
+Use pnpm workspaces to manage dependencies.
+See each package's AGENTS.md for specific guidelines.
+```
+
+> "Don't overload any level. The agent sees all merged files in its context."
+> — a-guide-to-agents.md lines 164-193
+
+**`claudeMdExcludes`**: In large monorepos, skip irrelevant ancestor CLAUDE.md files via `.claude/settings.local.json`:
+
+```json
+{ "claudeMdExcludes": ["**/other-team/CLAUDE.md", "**/other-team/.claude/rules/**"] }
+```
+
+Patterns match absolute paths with glob syntax. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded.
+
+*Source: memory/how-claude-remembers-a-project.md lines 243-260*
+
+---
+
+## Progressive Disclosure Patterns
+
+Apply these patterns when content exceeds root-file scope:
+
+**Extraction trigger**: Extract a section to a separate domain file when it has 3+ distinct rules AND spans 10+ lines, OR when the topic is irrelevant to most work sessions (e.g., database migration conventions in a project where most work is UI changes).
+
+**Move domain rules to separate files:**
+
+```markdown
+# In root file — do this:
+For TypeScript conventions, see docs/TYPESCRIPT.md
+
+# NOT this (inline domain rules):
+Always use const instead of let. Never use var...
+```
+
+**Nest disclosure hierarchically:**
+
+```
+docs/
+├── TYPESCRIPT.md      → references TESTING.md
+├── TESTING.md         → references test runners
+└── BUILD.md           → references build config
+```
+
+**Use skills for workflows** — agents invoke skills only when needed, keeping base context minimal.
+
+*Source: a-guide-to-agents.md lines 110-163*
+
+---
+
+## CLAUDE.md-Specific Hierarchy
+
+| Scope | Location | Loads when |
+|-------|----------|------------|
+| Org-wide | Managed policy (MDM) | Always |
+| Project | `./CLAUDE.md` or `./.claude/CLAUDE.md` | Session start (always) |
+| Personal | `~/.claude/CLAUDE.md` | Session start (always) |
+| Subdirectory | `./subdir/CLAUDE.md` | When reading files in that dir |
+| Path-scoped rules | `.claude/rules/*.md` with `paths:` | When matching files are read |
+
+**Priority rule**: Minimize content in always-loaded locations. Move to on-demand locations wherever possible.
+
+**@import syntax**: CLAUDE.md files can import additional files with `@path/to/file`. Imports expand at launch alongside the importing CLAUDE.md. Relative paths resolve relative to the importing file, not CWD. Max recursion depth: 5 hops. Requires one-time user approval per project.
+
+**Load order**: Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory CLAUDE.md files load on-demand only when Claude reads files in that directory — not at launch.
+
+*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
+
+---
+
+## AGENTS.md-Specific Notes
+
+- AGENTS.md is an **open standard** supported by most agent frameworks (not Claude Code)
+- Claude Code uses CLAUDE.md; create a symlink for cross-tool compatibility: `ln -s AGENTS.md CLAUDE.md`
+- AGENTS.md has **no `.claude/rules/` equivalent** — use subdirectory AGENTS.md files for scoped rules
+- Subdirectory AGENTS.md files **merge with root** (not replace)
+
+---
+
+## Anti-Patterns to Detect and Remove
+
+| Anti-pattern | Why it fails | Fix |
+|--------------|--------------|-----|
+| Ball-of-mud growth | Each fix adds a rule; after hundreds of additions the file confuses agents | Refactor with progressive disclosure |
+| Auto-generated init files | "Prioritize comprehensiveness over restraint" — flood file with irrelevant content | Author manually, restraint first |
+| Everything in one file | Exceeds ~150-200 instruction attention budget | Split by domain |
+
+> "There's a natural feedback loop that causes AGENTS.md files to grow dangerously large."
+> — a-guide-to-agents.md lines 34-43
+
+---
+
+## Validation
+
+Before finalizing any generated hierarchy, check:
+
+- [ ] Root file contains ONLY: one-liner, package manager (if non-standard), build commands (if non-standard), pointers
+- [ ] Domain content lives in separate files, not inlined
+- [ ] No file exceeds 200 lines
+- [ ] Each file covers exactly one scope
+- [ ] Subdirectory files exist for areas with distinct tooling or conventions

--- a/plugins/cursor-initializer/skills/improve-cursor/references/validation-criteria.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/validation-criteria.md
@@ -11,11 +11,11 @@ Any file violating these criteria must be fixed before proceeding:
 
 | Criterion | Threshold | Source |
 |-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
+| File length | ≤ 200 lines | Anthropic Docs: 200-line target for configuration files in this toolkit |
 | Root file length (recommended) | 15-40 lines | Derived from "absolute minimum" guidance |
 | Scope file length (recommended) | 10-30 lines | One topic per file guideline |
 | Instruction count | ≤ 150-200 | HumanLayer: "~150-200 instructions with reasonable consistency" |
-| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily" |
+| Contradictions between files | 0 | Anthropic: conflicting instructions make the model choose inconsistently |
 | Language-specific rules in root | 0 | Domain rules belong in separate files |
 | Stale file path references | 0 | "File paths change constantly... actively poisons context" |
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/validation-criteria.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/validation-criteria.md
@@ -58,9 +58,9 @@ Any file violating these criteria must be fixed before proceeding:
 - [ ] Root file: one-liner + package manager (if non-standard) + build commands (if non-standard) + pointers
 - [ ] Domain content lives in separate files, not inline
 - [ ] Progressive disclosure pointers point to files that actually exist
-- [ ] **CLAUDE.md-specific**: `.claude/rules/` files have path-scoping (`paths:` frontmatter) when they apply to specific file patterns
-- [ ] **CLAUDE.md-specific**: Minimal content in always-loaded locations (`./CLAUDE.md`, `.claude/rules/*.md` without paths)
-- [ ] **AGENTS.md-specific**: Subdirectory AGENTS.md files used for monorepo package scoping (no `.claude/rules/` equivalent)
+- [ ] **Cursor rules**: `.cursor/rules/*.mdc` files use `globs:` for path-scoped activation (not `alwaysApply: true`) when they apply to specific file patterns
+- [ ] **Cursor rules**: `alwaysApply: true` used only for conventions relevant to every task — not as default
+- [ ] **AGENTS.md-specific**: Subdirectory AGENTS.md files used for monorepo package scoping; path-scoped rules go in `.cursor/rules/*.mdc` with `globs:`
 
 ---
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/validation-criteria.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/validation-criteria.md
@@ -1,0 +1,76 @@
+# Validation Criteria
+
+Quality checklist for generated and improved AGENTS.md / `.cursor/rules/` files.
+Source: plugins/agents-initializer/skills/improve-agents/SKILL.md:108-122, improve-cursor/SKILL.md, file-evaluator.md:23-59
+
+---
+
+## Hard Limits (Auto-fail if violated)
+
+Any file violating these criteria must be fixed before proceeding:
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
+| Root file length (recommended) | 15-40 lines | Derived from "absolute minimum" guidance |
+| Scope file length (recommended) | 10-30 lines | One topic per file guideline |
+| Instruction count | ≤ 150-200 | HumanLayer: "~150-200 instructions with reasonable consistency" |
+| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily" |
+| Language-specific rules in root | 0 | Domain rules belong in separate files |
+| Stale file path references | 0 | "File paths change constantly... actively poisons context" |
+
+---
+
+## Quality Checks (All must pass)
+
+- [ ] Every instruction is actionable (not vague like "write clean code")
+- [ ] Package manager specified if non-standard (pnpm, bun, yarn; omit if npm)
+- [ ] Build/test commands included if non-standard
+- [ ] Progressive disclosure applied: domain docs referenced, not inlined
+- [ ] No information that tools can enforce (linting, formatting rules → use hooks instead)
+- [ ] No duplication of content across files in the hierarchy
+- [ ] No directory/file structure listings
+- [ ] No standard language conventions the model already knows
+- [ ] No long explanations or tutorials (link to external docs instead)
+- [ ] Critical instructions appear at start or end of file (not buried in middle)
+- [ ] One scope per file (TypeScript rules in one file, testing rules in another)
+
+---
+
+## If This Is an IMPROVE Operation — Also Check
+
+**Information Preservation:**
+
+- [ ] Critical project information preserved (domain concepts, security notes, compliance requirements)
+- [ ] Custom commands/scripts referenced in the original file are retained
+- [ ] Existing progressive disclosure structure not flattened back into root
+- [ ] Non-obvious architectural decisions carried forward (not deleted as "bloat")
+
+**Structural:**
+
+- [ ] Files not merged that should stay separate (each scope gets its own file)
+- [ ] Scope widened rather than narrowed where the original had too little coverage
+
+---
+
+## Structural Checks
+
+- [ ] Root file: one-liner + package manager (if non-standard) + build commands (if non-standard) + pointers
+- [ ] Domain content lives in separate files, not inline
+- [ ] Progressive disclosure pointers point to files that actually exist
+- [ ] **CLAUDE.md-specific**: `.claude/rules/` files have path-scoping (`paths:` frontmatter) when they apply to specific file patterns
+- [ ] **CLAUDE.md-specific**: Minimal content in always-loaded locations (`./CLAUDE.md`, `.claude/rules/*.md` without paths)
+- [ ] **AGENTS.md-specific**: Subdirectory AGENTS.md files used for monorepo package scoping (no `.claude/rules/` equivalent)
+
+---
+
+## Validation Loop Instructions
+
+Execute this loop for each generated or improved file:
+
+1. Evaluate the file against ALL criteria above
+2. If ANY criterion fails: identify the specific failure, fix the file, restart evaluation
+3. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+4. Only proceed to writing files when ALL criteria pass for ALL files
+
+**Do not skip criteria for "minor" violations.** Hard limits are hard limits.

--- a/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
@@ -33,7 +33,7 @@ Not all excluded content should be deleted — some should migrate to on-demand 
 |-------------------|--------|-----------|
 | Hook-enforced behaviors | **Migrate** | `.cursor/hooks.json` (zero context cost, deterministic enforcement) |
 | Path-specific conventions | **Migrate** | `.cursor/rules/*.mdc` with `globs:` (loads on file match only) |
-| Domain knowledge blocks >50 lines | **Migrate** | Skill `user-invocable: false` (~100 token startup cost) |
+| Domain knowledge blocks >50 lines | **Migrate** | Skill (auto-invocable, ~100 token startup cost) |
 | Agent-inferable content | **Delete** | No migration — agents discover via tools |
 | Stale, vague, or duplicate content | **Delete** | No migration value |
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
@@ -15,13 +15,13 @@ Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-gu
 | Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | a-guide-to-agents.md |
 | File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | a-guide-to-agents.md |
 | Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | a-guide-to-agents.md |
-| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | Agent already does this correctly without extra instruction | Anthropic Best Practices |
 | Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" | research-context-engineering-comprehensive.md |
 | Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Anthropic Best Practices |
 | Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
 | Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" | Anthropic Best Practices |
-| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; config file instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | "Hooks provide deterministic control over Claude Code's behavior, ensuring certain actions always happen rather than relying on the LLM" | Anthropic Hooks Guide |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | Anything the agent can infer by reading code should stay out of configuration files | Anthropic Best Practices |
+| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; config file instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | Hooks provide deterministic control over agent behavior instead of repeated context instructions | Anthropic Hooks Guide |
 
 *Source: plugins/agents-initializer/skills/init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
@@ -52,7 +52,7 @@ If the instruction passes this test, include it. If it fails (agent would do the
 
 ## Common Traps
 
-**Auto-generated files trap**: Never use `/init` or initialization scripts to generate AGENTS.md/CLAUDE.md. Auto-generated files "flood the file with things that are 'useful for most scenarios' but would be better progressively disclosed. Generated files prioritize comprehensiveness over restraint." — a-guide-to-agents.md
+**Auto-generated files trap**: Never use `/init` or initialization scripts to generate AGENTS.md or `.cursor/rules/*` from generic boilerplate. Auto-generated files "flood the file with things that are 'useful for most scenarios' but would be better progressively disclosed. Generated files prioritize comprehensiveness over restraint." — a-guide-to-agents.md
 
 **Ball-of-mud growth**: Each time the agent does something wrong, adding a rule feels productive. After hundreds of iterations over months, the file becomes unmaintainable and hurts agent performance. Refactor instead.
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
@@ -1,6 +1,6 @@
 # What NOT to Include
 
-Evidence-based exclusion table for AGENTS.md and CLAUDE.md content.
+Evidence-based exclusion table for AGENTS.md and `.cursor/rules/*.mdc` content.
 Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md, hooks/automate-workflow-with-hooks.md
 
 ---
@@ -31,8 +31,8 @@ Not all excluded content should be deleted — some should migrate to on-demand 
 
 | Exclusion Category | Action | Mechanism |
 |-------------------|--------|-----------|
-| Hook-enforced behaviors | **Migrate** | Hook (zero context cost, deterministic enforcement) |
-| Path-specific conventions | **Migrate** | `.claude/rules/` with `paths:` (loads on file match only) |
+| Hook-enforced behaviors | **Migrate** | `.cursor/hooks.json` (zero context cost, deterministic enforcement) |
+| Path-specific conventions | **Migrate** | `.cursor/rules/*.mdc` with `globs:` (loads on file match only) |
 | Domain knowledge blocks >50 lines | **Migrate** | Skill `user-invocable: false` (~100 token startup cost) |
 | Agent-inferable content | **Delete** | No migration — agents discover via tools |
 | Stale, vague, or duplicate content | **Delete** | No migration value |

--- a/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
@@ -1,0 +1,72 @@
+# What NOT to Include
+
+Evidence-based exclusion table for AGENTS.md and CLAUDE.md content.
+Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md, hooks/automate-workflow-with-hooks.md
+
+---
+
+## Exclusion Evidence Table
+
+| Content Type | Why to Exclude | Evidence Quote | Source |
+|-------------|----------------|---------------|--------|
+| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" | ETH Zurich: Evaluating AGENTS.md |
+| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" | Anthropic Best Practices |
+| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" | ETH Zurich: Evaluating AGENTS.md |
+| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | a-guide-to-agents.md |
+| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | a-guide-to-agents.md |
+| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | a-guide-to-agents.md |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
+| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" | research-context-engineering-comprehensive.md |
+| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Anthropic Best Practices |
+| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
+| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" | Anthropic Best Practices |
+| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; config file instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | "Hooks provide deterministic control over Claude Code's behavior, ensuring certain actions always happen rather than relying on the LLM" | Anthropic Hooks Guide |
+
+*Source: plugins/agents-initializer/skills/init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
+
+### Exclusion Actions
+
+Not all excluded content should be deleted — some should migrate to on-demand mechanisms:
+
+| Exclusion Category | Action | Mechanism |
+|-------------------|--------|-----------|
+| Hook-enforced behaviors | **Migrate** | Hook (zero context cost, deterministic enforcement) |
+| Path-specific conventions | **Migrate** | `.claude/rules/` with `paths:` (loads on file match only) |
+| Domain knowledge blocks >50 lines | **Migrate** | Skill `user-invocable: false` (~100 token startup cost) |
+| Agent-inferable content | **Delete** | No migration — agents discover via tools |
+| Stale, vague, or duplicate content | **Delete** | No migration value |
+
+---
+
+## The Instruction Test
+
+Apply this test to each line before including it:
+
+> **"Would removing this cause the agent to make mistakes? If not, cut it."**
+> — Anthropic Best Practices
+
+If the instruction passes this test, include it. If it fails (agent would do the right thing anyway), delete it.
+
+---
+
+## Common Traps
+
+**Auto-generated files trap**: Never use `/init` or initialization scripts to generate AGENTS.md/CLAUDE.md. Auto-generated files "flood the file with things that are 'useful for most scenarios' but would be better progressively disclosed. Generated files prioritize comprehensiveness over restraint." — a-guide-to-agents.md
+
+**Ball-of-mud growth**: Each time the agent does something wrong, adding a rule feels productive. After hundreds of iterations over months, the file becomes unmaintainable and hurts agent performance. Refactor instead.
+
+**Comprehensive-over-restrained mindset**: More content feels safer but performs worse. "Unnecessary requirements from context files make tasks harder." — ETH Zurich, Evaluating AGENTS.md (abstract)
+
+---
+
+## What TO Include Instead
+
+| What to document | Why it belongs here |
+|-----------------|-------------------|
+| One-sentence project description | Anchors all agent decisions |
+| Non-standard package manager | Without this, agent defaults to wrong tooling |
+| Non-standard build/test commands | Agent cannot guess custom scripts |
+| Non-obvious architectural decisions | Agent would otherwise make different choices |
+| Domain concepts (not file paths) | More stable than paths; safer to document |
+| Progressive disclosure pointers | "See docs/TESTING.md" keeps root file minimal |

--- a/plugins/cursor-initializer/skills/init-cursor/SKILL.md
+++ b/plugins/cursor-initializer/skills/init-cursor/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: init-cursor
+description: "Initializes optimized Cursor rules hierarchy and AGENTS.md for projects. Uses subagent-driven codebase analysis to generate minimal, scoped .cursor/rules/*.mdc files following progressive disclosure — based on the ETH Zurich 'Evaluating AGENTS.md' study and Cursor's context engineering best practices."
+---
+
+# Initialize Cursor Rules
+
+Generate an evidence-based configuration hierarchy for this project, leveraging Cursor's full rule system: AGENTS.md files, `.cursor/rules/*.mdc` with metadata-controlled activation, and progressive disclosure pointers.
+
+## Why This Approach
+
+Research shows that auto-generated comprehensive configuration files **reduce** agent task success by ~3% while **increasing cost by 20%+** (Evaluating AGENTS.md, ETH Zurich, 2026). Developer-written **minimal** files improve success by ~4%. This skill generates files that mimic what an experienced developer would write: only non-obvious tooling and conventions.
+
+Cursor's configuration hierarchy enables powerful progressive disclosure:
+
+- **Root AGENTS.md** — always loaded, project-wide essentials
+- **Subdirectory AGENTS.md** — loaded on-demand when working in that area
+- **`.cursor/rules/*.mdc`** — metadata-controlled activation (always, auto-attached by globs, agent-requested by description, or manual @-mention)
+- **Domain files** — referenced via progressive disclosure pointers
+
+## Hard Rules
+
+<RULES>
+- **NEVER** generate a single file with everything — use hierarchical progressive disclosure
+- **NEVER** include directory/file structure listings (research proves these don't help agents navigate)
+- **NEVER** include obvious language conventions the model already knows
+- **NEVER** exceed 200 lines per file
+- **EVERY** instruction must pass: "Would removing this cause the agent to make mistakes?" If no, cut it.
+- Root AGENTS.md target: **15-40 lines**
+- Scope AGENTS.md target: **10-30 lines**
+- `.cursor/rules/` files: **focused, metadata-scoped, one topic per file**
+- `.mdc` frontmatter: ONLY `description`, `alwaysApply`, `globs` — no other fields
+- Domain files: only when non-standard patterns are detected
+</RULES>
+
+## Process
+
+### Preflight Check
+
+Check whether the project has **either**:
+- A `.cursor/rules/` directory containing any `.mdc` or `.md` files, OR
+- An `AGENTS.md` file in the current working directory
+
+**If either exists:**
+
+1. Inform the user: "Cursor configuration already exists in this project. Switching to the improve workflow to optimize your existing configuration."
+2. Invoke the `improve-cursor` skill and follow its complete process.
+3. **STOP** — do not proceed to Phase 1 or any subsequent phase of this init skill.
+
+**If neither exists:**
+Proceed to Phase 1 below.
+
+### Phase 1: Codebase Analysis
+
+Delegate to the `codebase-analyzer` agent with this task:
+
+> Analyze the project at the current working directory. Return ONLY non-standard, non-obvious information that would cause the agent to make mistakes if it didn't know them. Be ruthlessly minimal.
+
+The agent runs in an isolated context with read-only access. Wait for it to complete and parse its structured output.
+
+### Phase 2: Scope Detection
+
+Delegate to the `scope-detector` agent with this task:
+
+> Detect scopes in the project at the current working directory. Only flag scopes with genuinely different tooling or conventions. A simple single-package project should have ZERO additional scopes. Also identify areas that would benefit from auto-attached `.cursor/rules/*.mdc` files with globs patterns.
+
+Wait for it to complete and parse its structured output.
+
+### Phase 3: Generate Files
+
+Before generating, read these reference documents:
+
+- `${CLAUDE_SKILL_DIR}/references/progressive-disclosure-guide.md` — hierarchy decisions and loading tiers
+- `${CLAUDE_SKILL_DIR}/references/what-not-to-include.md` — content exclusion criteria
+- `${CLAUDE_SKILL_DIR}/references/context-optimization.md` — token budget guidelines
+- `${CLAUDE_SKILL_DIR}/references/cursor-rules-system.md` — .cursor/rules/ conventions, .mdc format, and activation modes
+
+Using ONLY the information from Phase 1 and Phase 2, generate the file hierarchy:
+
+#### Root AGENTS.md
+
+Read `${CLAUDE_SKILL_DIR}/assets/templates/root-agents-md.md`. Fill placeholders. Remove empty sections. Target: 15-40 lines.
+
+#### Subdirectory AGENTS.md (per detected scope)
+
+If scopes detected, read `${CLAUDE_SKILL_DIR}/assets/templates/scoped-agents-md.md`. Only scope-specific content differing from root.
+
+#### .cursor/rules/ Files (Metadata-Controlled Rules)
+
+If file-pattern-specific rules or agent-requested rules detected, read `${CLAUDE_SKILL_DIR}/assets/templates/cursor-rule.mdc`. Consult `${CLAUDE_SKILL_DIR}/references/cursor-rules-system.md` for:
+
+- When to create .mdc rules vs using AGENTS.md
+- Activation modes: Always (`alwaysApply: true`), Auto-attached (`globs`), Agent-requested (`description`), Manual
+- Valid frontmatter fields: ONLY `description`, `alwaysApply`, `globs`
+- File naming: kebab-case `.mdc` files in `.cursor/rules/`
+
+#### Domain Files
+
+If non-standard domain patterns detected, read `${CLAUDE_SKILL_DIR}/assets/templates/domain-doc.md`.
+
+### Phase 4: Self-Validation
+
+Read `${CLAUDE_SKILL_DIR}/references/validation-criteria.md` and execute its **Validation Loop Instructions** against every generated file.
+
+Check both general criteria AND the Cursor-specific structural checks:
+- `.mdc` files use ONLY valid frontmatter fields (`description`, `alwaysApply`, `globs`)
+- No `paths:` frontmatter (Claude-specific — invalid in Cursor)
+- Activation mode is appropriate for each rule's content
+- Always-loaded content is minimal (use auto-attached or agent-requested where possible)
+
+Maximum 3 iterations.
+
+### Phase 5: Present and Write
+
+1. Show the user ALL generated files with their content before writing
+2. Explain briefly why each file exists and what evidence supports its content
+3. Highlight which files are always-loaded (root AGENTS.md, `alwaysApply: true` rules) vs on-demand (subdirectory AGENTS.md, globs-based rules, agent-requested rules)
+4. Ask for confirmation before writing files
+5. Write all files to the project
+6. Create `.cursor/rules/` directory if generating rules files

--- a/plugins/cursor-initializer/skills/init-cursor/SKILL.md
+++ b/plugins/cursor-initializer/skills/init-cursor/SKILL.md
@@ -70,24 +70,24 @@ Wait for it to complete and parse its structured output.
 
 Before generating, read these reference documents:
 
-- `${CLAUDE_SKILL_DIR}/references/progressive-disclosure-guide.md` — hierarchy decisions and loading tiers
-- `${CLAUDE_SKILL_DIR}/references/what-not-to-include.md` — content exclusion criteria
-- `${CLAUDE_SKILL_DIR}/references/context-optimization.md` — token budget guidelines
-- `${CLAUDE_SKILL_DIR}/references/cursor-rules-system.md` — .cursor/rules/ conventions, .mdc format, and activation modes
+- `references/progressive-disclosure-guide.md` — hierarchy decisions and loading tiers
+- `references/what-not-to-include.md` — content exclusion criteria
+- `references/context-optimization.md` — token budget guidelines
+- `references/cursor-rules-system.md` — .cursor/rules/ conventions, .mdc format, and activation modes
 
 Using ONLY the information from Phase 1 and Phase 2, generate the file hierarchy:
 
 #### Root AGENTS.md
 
-Read `${CLAUDE_SKILL_DIR}/assets/templates/root-agents-md.md`. Fill placeholders. Remove empty sections. Target: 15-40 lines.
+Read `assets/templates/root-agents-md.md`. Fill placeholders. Remove empty sections. Target: 15-40 lines.
 
 #### Subdirectory AGENTS.md (per detected scope)
 
-If scopes detected, read `${CLAUDE_SKILL_DIR}/assets/templates/scoped-agents-md.md`. Only scope-specific content differing from root.
+If scopes detected, read `assets/templates/scoped-agents-md.md`. Only scope-specific content differing from root.
 
 #### .cursor/rules/ Files (Metadata-Controlled Rules)
 
-If file-pattern-specific rules or agent-requested rules detected, read `${CLAUDE_SKILL_DIR}/assets/templates/cursor-rule.mdc`. Consult `${CLAUDE_SKILL_DIR}/references/cursor-rules-system.md` for:
+If file-pattern-specific rules or agent-requested rules detected, read `assets/templates/cursor-rule.mdc`. Consult `references/cursor-rules-system.md` for:
 
 - When to create .mdc rules vs using AGENTS.md
 - Activation modes: Always (`alwaysApply: true`), Auto-attached (`globs`), Agent-requested (`description`), Manual
@@ -96,11 +96,11 @@ If file-pattern-specific rules or agent-requested rules detected, read `${CLAUDE
 
 #### Domain Files
 
-If non-standard domain patterns detected, read `${CLAUDE_SKILL_DIR}/assets/templates/domain-doc.md`.
+If non-standard domain patterns detected, read `assets/templates/domain-doc.md`.
 
 ### Phase 4: Self-Validation
 
-Read `${CLAUDE_SKILL_DIR}/references/validation-criteria.md` and execute its **Validation Loop Instructions** against every generated file.
+Read `references/validation-criteria.md` and execute its **Validation Loop Instructions** against every generated file.
 
 Check both general criteria AND the Cursor-specific structural checks:
 - `.mdc` files use ONLY valid frontmatter fields (`description`, `alwaysApply`, `globs`)

--- a/plugins/cursor-initializer/skills/init-cursor/SKILL.md
+++ b/plugins/cursor-initializer/skills/init-cursor/SKILL.md
@@ -43,7 +43,7 @@ Check whether the project has **either**:
 
 **If either exists:**
 
-1. Inform the user: "Cursor configuration already exists in this project. Switching to the improve workflow to optimize your existing configuration."
+1. Inform the user: "Existing AGENTS.md and/or Cursor rules were found in this project. Switching to the improve workflow to optimize your current configuration."
 2. Invoke the `improve-cursor` skill and follow its complete process.
 3. **STOP** — do not proceed to Phase 1 or any subsequent phase of this init skill.
 

--- a/plugins/cursor-initializer/skills/init-cursor/assets/templates/cursor-rule.mdc
+++ b/plugins/cursor-initializer/skills/init-cursor/assets/templates/cursor-rule.mdc
@@ -1,0 +1,36 @@
+<!-- TEMPLATE: cursor-rule.mdc
+  Placement: .cursor/rules/[rule-name].mdc
+  Naming: kebab-case, descriptive of the rule's scope
+  Target: 10-50 lines of rule content
+  
+  ONLY these frontmatter fields are valid:
+  - description (string): What this rule is about — used for agent-requested activation
+  - alwaysApply (boolean): true = every conversation, false = conditional
+  - globs (string|array): File patterns for auto-attachment
+  
+  Activation modes (determined by frontmatter combination):
+  - Always: alwaysApply: true
+  - Auto-attached: globs set, alwaysApply: false
+  - Agent-requested: description set, no globs, alwaysApply: false
+  - Manual: no description, no globs, alwaysApply: false (user @-mentions)
+-->
+---
+description: "[RULE_DESCRIPTION]"
+globs: ["[GLOB_PATTERN]"]
+alwaysApply: false
+---
+
+<!-- CONDITIONAL: Remove globs if this is an agent-requested rule (description-only) -->
+<!-- CONDITIONAL: Set alwaysApply: true if this rule should load on every conversation -->
+<!-- CONDITIONAL: Remove description if this is a globs-only auto-attached rule -->
+
+[RULE_CONTENT]
+
+<!-- 
+  Content guidelines:
+  - Write rules as clear internal docs — direct, actionable
+  - Reference files with @filename.ts instead of copying content
+  - Each rule should focus on one concern
+  - Provide concrete examples, not vague guidance
+  - Keep under 500 lines per rule file
+-->

--- a/plugins/cursor-initializer/skills/init-cursor/assets/templates/cursor-rule.mdc
+++ b/plugins/cursor-initializer/skills/init-cursor/assets/templates/cursor-rule.mdc
@@ -32,5 +32,5 @@ alwaysApply: false
   - Reference files with @filename.ts instead of copying content
   - Each rule should focus on one concern
   - Provide concrete examples, not vague guidance
-  - Keep under 500 lines per rule file
+  - Keep under 200 lines per rule file
 -->

--- a/plugins/cursor-initializer/skills/init-cursor/assets/templates/domain-doc.md
+++ b/plugins/cursor-initializer/skills/init-cursor/assets/templates/domain-doc.md
@@ -1,0 +1,45 @@
+<!-- TEMPLATE: Domain Documentation File
+     Purpose: Progressive disclosure — contains domain-specific guidance
+              referenced from root or scoped config files via pointers
+     Placement: docs/[TOPIC].md (e.g., docs/TESTING.md, docs/BUILD.md, docs/API.md)
+     Target: Under 200 lines
+     Rule: Only create when codebase analysis identified non-standard patterns in this domain
+     Rule: Every instruction must be specific, actionable, and based on analysis findings
+     Rule: May reference other domain docs for nested progressive disclosure
+-->
+
+# [Domain Topic Name]
+
+<!-- Name this based on the domain: Testing Conventions, Build System, API Design,
+     Deployment, Security, etc. Use the same name referenced in the root config file's
+     progressive disclosure pointer. -->
+
+[One-two sentences: what makes this domain non-standard in this project and why
+these instructions exist. Only include context that helps the agent understand
+WHY these conventions differ from standard practices.]
+
+## [Primary Section Name]
+
+<!-- Name based on the domain's main concern. Examples:
+     Testing: "Test Structure" or "Running Tests"
+     Build: "Build Pipeline" or "Build Configuration"
+     API: "Endpoint Patterns" or "Request/Response Format"
+     Each instruction must be specific and verifiable — not vague guidance. -->
+
+- [Specific, actionable instruction based on codebase analysis]
+- [Specific, actionable instruction based on codebase analysis]
+
+## [Additional Sections as Needed]
+
+<!-- Optional: Add more sections for distinct aspects of the domain.
+     Keep each section focused on one aspect.
+     Only add sections where non-standard patterns were detected. -->
+
+- [Specific, actionable instruction]
+
+## See Also
+
+<!-- CONDITIONAL: Include ONLY if this domain doc references other docs or resources.
+     Enables nested progressive disclosure (docs/TESTING.md → docs/VITEST.md).
+     Remove this section if no cross-references exist. -->
+- For [related topic], see `[path/to/other-doc.md]`

--- a/plugins/cursor-initializer/skills/init-cursor/assets/templates/root-agents-md.md
+++ b/plugins/cursor-initializer/skills/init-cursor/assets/templates/root-agents-md.md
@@ -1,0 +1,33 @@
+<!-- TEMPLATE: Root AGENTS.md
+     Target: 15-40 lines after placeholders are filled
+     Rule: Remove any section that would be empty after filling
+     Rule: Only include non-standard, non-obvious information
+     Rule: This file is loaded on every agent request — keep it minimal
+-->
+
+# [One-sentence project description from codebase analysis]
+
+## Tooling
+
+<!-- CONDITIONAL: Include ONLY if non-standard tooling was detected.
+     Remove the entire section if all tooling is standard for the language.
+     Remove individual lines where the command is the language/framework default. -->
+- Package manager: [only if not the language default]
+- Build: `[command]`
+- Test: `[command]`
+- Lint: `[command]`
+- Typecheck: `[command]`
+
+## Context
+
+<!-- CONDITIONAL: Include ONLY if scopes with genuinely different tooling were detected.
+     A simple single-package project should NOT have this section. -->
+See scope-specific AGENTS.md files:
+
+- `[scope-path/]` — [one-line scope purpose]
+
+## References
+
+<!-- CONDITIONAL: Include ONLY if domain documentation files were generated.
+     Use progressive disclosure: point to docs, don't inline their content. -->
+- For [domain topic], see `[path/to/domain-doc.md]`

--- a/plugins/cursor-initializer/skills/init-cursor/assets/templates/scoped-agents-md.md
+++ b/plugins/cursor-initializer/skills/init-cursor/assets/templates/scoped-agents-md.md
@@ -1,0 +1,22 @@
+<!-- TEMPLATE: Scoped AGENTS.md (one per detected scope)
+     Target: 10-30 lines after placeholders are filled
+     Rule: Only include information that DIFFERS from root AGENTS.md
+     Rule: One scope per file — don't combine multiple scopes
+     Placement: [scope-path]/AGENTS.md (e.g., packages/api/AGENTS.md)
+-->
+
+# [One-sentence scope description]
+
+## Tooling
+
+<!-- CONDITIONAL: Include ONLY commands that differ from root.
+     Remove the entire section if this scope uses the same tooling as root. -->
+- Build: `[scope-specific command]`
+- Test: `[scope-specific command]`
+
+## Conventions
+
+<!-- Include ONLY non-obvious, scope-specific conventions.
+     Every instruction must be specific and verifiable.
+     Do NOT include standard language conventions the model already knows. -->
+- [Specific, verifiable instruction]

--- a/plugins/cursor-initializer/skills/init-cursor/references/context-optimization.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/context-optimization.md
@@ -21,14 +21,14 @@ Source: research-context-engineering-comprehensive.md
 
 | Limit | Value | Source |
 |-------|-------|--------|
-| Lines per configuration file | ≤ 200 | Anthropic Docs: "Target under 200 lines per CLAUDE.md file." |
+| Lines per configuration file | ≤ 200 | Anthropic Docs: 200-line target for configuration files in this toolkit |
 | Instructions per file | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
-| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily." |
+| Contradictions between files | 0 | Anthropic: conflicting instructions make the model choose inconsistently. |
 
-> "Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"
+> Anthropic's warning generalizes here: bloated configuration files cause the model to miss important instructions.
 > — Anthropic Best Practices
 
-> "If Claude keeps doing something you don't want despite having a rule against it, the file is probably too long."
+> Anthropic's warning generalizes here: if a configuration file keeps growing, the model may ignore an instruction even when it is present.
 > — Anthropic Best Practices
 
 ---
@@ -95,7 +95,7 @@ Detect and remove these before generating or improving configuration files:
 | Failed approach accumulation | Look for rules added defensively after incidents | Remove rules that shouldn't be needed |
 | High-churn information | Look for version numbers, file counts, team names | Remove or move to a pointer |
 
-> "Treat CLAUDE.md like code: review it when things go wrong, prune it regularly." — Anthropic Best Practices
+> Treat configuration files like code: review them when things go wrong, prune them regularly. — Adapted from Anthropic Best Practices
 
 *Source: research-context-engineering-comprehensive.md lines 213-253*
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/context-optimization.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/context-optimization.md
@@ -1,0 +1,132 @@
+# Context Optimization
+
+Evidence-based instructions for managing token budgets and attention in agent configuration files.
+Source: research-context-engineering-comprehensive.md
+
+---
+
+## Contents
+
+- Hard limits (lines per file, instruction count, contradictions)
+- The attention budget (finite resource, n-squared constraint)
+- Lost in the middle (placement strategy for critical instructions)
+- Quality over quantity checklist (include/exclude decision table)
+- Context poisoning vectors (detection and removal)
+- JIT documentation patterns (on-demand loading strategies)
+- Key citations
+
+---
+
+## Hard Limits
+
+| Limit | Value | Source |
+|-------|-------|--------|
+| Lines per configuration file | ≤ 200 | Anthropic Docs: "Target under 200 lines per CLAUDE.md file." |
+| Instructions per file | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
+| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily." |
+
+> "Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"
+> — Anthropic Best Practices
+
+> "If Claude keeps doing something you don't want despite having a rule against it, the file is probably too long."
+> — Anthropic Best Practices
+
+---
+
+## The Attention Budget
+
+Context is a **finite resource with diminishing marginal returns**. Do not treat it as unlimited.
+
+> "LLMs have an 'attention budget' that they draw on when parsing large volumes of context. Every new token introduced depletes this budget by some amount."
+> — Anthropic Engineering: Effective Context Engineering
+
+Architectural reason: Transformers create **n² pairwise relationships** for n tokens — attention gets stretched thin as context grows. Models trained on shorter sequences have fewer parameters for long-range dependencies.
+
+**Key principle**: *"Good context engineering means finding the smallest possible set of high-signal tokens that maximize the likelihood of some desired outcome."* — Anthropic
+
+> Context rot: "As the number of tokens in the context window increases, the model's ability to accurately recall information from that context decreases." — Anthropic
+
+---
+
+## Lost in the Middle
+
+Critical instructions must be at the **start or end** of files, not buried in the middle.
+
+> Performance is "highest when relevant information is at the beginning or end of the context... degrades significantly for information in the middle of long contexts."
+> — Liu et al., Lost in the Middle (arXiv:2307.03172)
+
+**Apply this when generating files:** Place the most important instructions in the first 20% and last 20% of each configuration file.
+
+---
+
+## Quality Over Quantity Checklist
+
+For each instruction line, ask: **"Would removing this cause the agent to make mistakes? If not, cut it."**
+— Anthropic Best Practices
+
+| ✅ Include | ❌ Exclude |
+|-----------|-----------|
+| Bash commands the agent cannot guess | Anything the agent can figure out by reading code |
+| Code style rules that differ from defaults | Standard language conventions already known |
+| Testing instructions (non-standard) | Detailed API documentation (link instead) |
+| Non-obvious architectural decisions | Long explanations or tutorials |
+| Developer environment quirks | File-by-file descriptions of the codebase |
+| Non-standard tooling | Self-evident practices ("write clean code") |
+
+**Instruction specificity goldilocks:**
+
+- ✅ "Use 2-space indentation" vs. ❌ "Format code properly"
+- ✅ "Run `npm test` before committing" vs. ❌ "Test your changes"
+- ✅ "API handlers live in `src/api/handlers/`" vs. ❌ "Keep files organized"
+
+*Source: research-context-engineering-comprehensive.md lines 113-134*
+
+---
+
+## Context Poisoning Vectors
+
+Detect and remove these before generating or improving configuration files:
+
+| Poison vector | Detection | Fix |
+|---------------|-----------|-----|
+| Stale file paths | Check if referenced paths actually exist | Remove or update |
+| Contradictions | Compare instructions across all files | Remove the weaker/older rule |
+| Over-specification | Count lines; check if agent already follows rule | Delete or convert to hook |
+| Failed approach accumulation | Look for rules added defensively after incidents | Remove rules that shouldn't be needed |
+| High-churn information | Look for version numbers, file counts, team names | Remove or move to a pointer |
+
+> "Treat CLAUDE.md like code: review it when things go wrong, prune it regularly." — Anthropic Best Practices
+
+*Source: research-context-engineering-comprehensive.md lines 213-253*
+
+---
+
+## JIT Documentation Patterns
+
+Use these patterns to move content from always-consumed to on-demand locations:
+
+| Pattern | How it works | Token impact |
+|---------|-------------|-------------|
+| Skills | Description loaded at start; full body loaded on invocation | On-demand |
+| Path-scoped rules | Trigger only when matching files are read | On-demand |
+| Subdirectory config files | Load when working in that directory | On-demand |
+| `@path/to/import` | Expands when parent file loads | Controlled |
+| Domain docs (e.g., `docs/TESTING.md`) | Agent navigates when relevant | On-demand |
+
+> "Rather than pre-processing all relevant data up front, agents maintain lightweight identifiers and use these references to dynamically load data into context at runtime."
+> — Anthropic Engineering: Effective Context Engineering
+
+*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*
+
+---
+
+## Key Citations
+
+| Claim | Source |
+|-------|--------|
+| ≤200 lines per file | Anthropic Docs: claude-code/memory |
+| ~150-200 instruction limit | HumanLayer (Kyle) via a-guide-to-agents.md |
+| n² attention constraint / context rot | Anthropic Engineering Blog |
+| Lost-in-the-middle effect | Liu et al., arXiv:2307.03172 |
+| Quality over quantity heuristic | Anthropic Best Practices |
+| JIT documentation strategy | Anthropic Engineering: Effective Context Engineering |

--- a/plugins/cursor-initializer/skills/init-cursor/references/cursor-rules-system.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/cursor-rules-system.md
@@ -1,0 +1,65 @@
+# Cursor Rules System
+
+Reference for generating and evaluating `.cursor/rules/` files. Source: [cursor.com/docs/context/rules](https://cursor.com/docs/context/rules).
+
+## File Format
+
+Cursor rules are markdown files in `.cursor/rules/` with optional `.mdc` extension for frontmatter support. Both `.md` and `.mdc` extensions are supported.
+
+### Frontmatter Fields (ONLY these three are valid)
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `description` | string | Tells the agent what this rule is about — used for "Apply Intelligently" mode |
+| `alwaysApply` | boolean | When `true`, rule loads on every conversation. When `false`, agent decides based on description |
+| `globs` | string or array | File patterns that trigger auto-attachment (e.g., `"**/*.test.ts"` or `["*.py", "*.pyi"]`) |
+
+### The Four Activation Modes
+
+Rules behave differently based on which frontmatter fields are set:
+
+| Mode | `alwaysApply` | `globs` | `description` | When it loads |
+|------|:---:|:---:|:---:|:---|
+| **Always** | `true` | — | optional | Every conversation |
+| **Auto-attached** | `false` | set | optional | When matching files are in context |
+| **Agent-requested** | `false` | — | set | When the agent decides based on description |
+| **Manual** | `false` | — | — | Only when user @-mentions the rule |
+
+### Best Practices
+
+- Keep rules under 500 lines
+- Split large rules into multiple composable rules
+- Provide concrete examples or reference files
+- Write rules like clear internal docs — avoid vague guidance
+- Reference files instead of copying their contents
+- Start simple — add rules only when the agent makes the same mistake repeatedly
+
+### What NOT to Put in Rules
+
+- Entire style guides (use a linter instead)
+- Every possible command (the agent knows common tools)
+- Instructions for edge cases that rarely apply
+- Content that duplicates what's in your codebase
+
+### When to Use Rules vs AGENTS.md
+
+| Use `.cursor/rules/` when... | Use `AGENTS.md` when... |
+|-------------------------------|-------------------------|
+| You need metadata-controlled activation (globs, description) | You want simple, portable, readable instructions |
+| You want auto-attachment based on file patterns | The project also needs AGENTS.md for other tools |
+| You need different activation modes for different content | All instructions should always load |
+| You want to organize rules in folders | You prefer a single-file approach |
+
+### File Example
+
+```
+---
+description: "Standards for React components including styling, animations, and naming"
+globs: ["src/components/**/*.tsx", "src/components/**/*.ts"]
+alwaysApply: false
+---
+
+- Use Tailwind for styling
+- Use Framer Motion for animations
+- See `components/Button.tsx` for canonical component structure
+```

--- a/plugins/cursor-initializer/skills/init-cursor/references/cursor-rules-system.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/cursor-rules-system.md
@@ -27,8 +27,8 @@ Rules behave differently based on which frontmatter fields are set:
 
 ### Best Practices
 
-- Keep rules under 500 lines
-- Split large rules into multiple composable rules
+- Cursor generally allows larger rules, but this toolkit enforces a stricter ≤200-line limit per file
+- Split anything approaching 200 lines into multiple composable rules
 - Provide concrete examples or reference files
 - Write rules like clear internal docs — avoid vague guidance
 - Reference files instead of copying their contents

--- a/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
@@ -103,26 +103,6 @@ docs/
 
 ---
 
-## CLAUDE.md-Specific Hierarchy
-
-| Scope | Location | Loads when |
-|-------|----------|------------|
-| Org-wide | Managed policy (MDM) | Always |
-| Project | `./CLAUDE.md` or `./.claude/CLAUDE.md` | Session start (always) |
-| Personal | `~/.claude/CLAUDE.md` | Session start (always) |
-| Subdirectory | `./subdir/CLAUDE.md` | When reading files in that dir |
-| Path-scoped rules | `.claude/rules/*.md` with `paths:` | When matching files are read |
-
-**Priority rule**: Minimize content in always-loaded locations. Move to on-demand locations wherever possible.
-
-**@import syntax**: CLAUDE.md files can import additional files with `@path/to/file`. Imports expand at launch alongside the importing CLAUDE.md. Relative paths resolve relative to the importing file, not CWD. Max recursion depth: 5 hops. Requires one-time user approval per project.
-
-**Load order**: Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory CLAUDE.md files load on-demand only when Claude reads files in that directory — not at launch.
-
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
-
----
-
 ## AGENTS.md-Specific Notes
 
 - AGENTS.md is an **open standard** supported by most agent frameworks (not Claude Code)

--- a/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
@@ -1,6 +1,6 @@
 # Progressive Disclosure Guide
 
-Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
+Evidence-based instructions for structuring AGENTS.md hierarchies and `.cursor/rules/*.mdc` rules in Cursor.
 Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
@@ -9,10 +9,10 @@ Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, me
 
 - File hierarchy decision table (where to place content)
 - Root file requirements (minimal elements only)
-- Monorepo: what goes where (root vs package level, claudeMdExcludes)
+- Monorepo: what goes where (root vs package level)
 - Progressive disclosure patterns (domain files, nested docs, skills)
-- CLAUDE.md-specific hierarchy (5 scopes, @import, load order)
-- AGENTS.md-specific notes (open standard, symlinks, merging)
+- Cursor rule scoping notes
+- AGENTS.md in Cursor (root, subdirectory, merging)
 - Anti-patterns to detect and remove
 - Validation checklist
 
@@ -103,12 +103,20 @@ docs/
 
 ---
 
-## AGENTS.md-Specific Notes
+## Cursor Rule Scoping Notes
 
-- AGENTS.md is an **open standard** supported by most agent frameworks (not Claude Code)
-- Claude Code uses CLAUDE.md; create a symlink for cross-tool compatibility: `ln -s AGENTS.md CLAUDE.md`
-- AGENTS.md has **no `.claude/rules/` equivalent** — use subdirectory AGENTS.md files for scoped rules
-- Subdirectory AGENTS.md files **merge with root** (not replace)
+- Use `.cursor/rules/*.mdc` when guidance depends on file patterns, activation mode, or agent-requested loading
+- Keep rule metadata minimal: only `description`, `alwaysApply`, and `globs`
+- Prefer narrow `globs:` over `alwaysApply: true` when guidance applies to specific files only
+
+---
+
+## AGENTS.md in Cursor
+
+- Cursor supports `AGENTS.md` at the project root and in subdirectories
+- Nested `AGENTS.md` files merge with parent instructions; more specific scopes take precedence
+- Keep AGENTS.md for project-wide or directory-wide guidance; move file-pattern-specific instructions to `.cursor/rules/*.mdc`
+- Use root AGENTS.md for essentials and subdirectory AGENTS.md files for area-specific tooling or conventions
 
 ---
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
@@ -24,10 +24,10 @@ When deciding where to place content, use this table:
 
 | Location | Use when content is... | Load timing |
 |----------|------------------------|-------------|
-| Root AGENTS.md / CLAUDE.md | Relevant to **every single task** in the repo | Always (every request) |
+| Root AGENTS.md | Relevant to **every single task** in the repo | Always (every request) |
 | Separate domain file | Relevant to one domain (TypeScript, testing, API design) | On-demand |
-| Subdirectory AGENTS.md / CLAUDE.md | Specific to one package or area | On-demand when working there |
-| `.claude/rules/` (path-scoped) | Specific to certain file patterns | On-demand when files match |
+| Subdirectory AGENTS.md | Specific to one package or area | On-demand when working there |
+| `.cursor/rules/*.mdc` with `globs:` | Specific to certain file patterns | On-demand when files match |
 | Skill | A workflow the agent should invoke explicitly | On-demand when invoked |
 
 *Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
@@ -66,15 +66,9 @@ See each package's AGENTS.md for specific guidelines.
 > "Don't overload any level. The agent sees all merged files in its context."
 > — a-guide-to-agents.md lines 164-193
 
-**`claudeMdExcludes`**: In large monorepos, skip irrelevant ancestor CLAUDE.md files via `.claude/settings.local.json`:
+**Monorepo context scoping in Cursor**: In large monorepos, use `.cursor/rules/*.mdc` with narrow `globs:` patterns to limit rules to relevant packages. Rules with `alwaysApply: true` load for every request — keep them minimal.
 
-```json
-{ "claudeMdExcludes": ["**/other-team/CLAUDE.md", "**/other-team/.claude/rules/**"] }
-```
-
-Patterns match absolute paths with glob syntax. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded.
-
-*Source: memory/how-claude-remembers-a-project.md lines 243-260*
+*Source: memory/how-claude-remembers-a-project.md lines 243-260; docs/cursor/rules-and-memory.md*
 
 ---
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
@@ -1,0 +1,162 @@
+# Progressive Disclosure Guide
+
+Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
+Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
+
+---
+
+## Contents
+
+- File hierarchy decision table (where to place content)
+- Root file requirements (minimal elements only)
+- Monorepo: what goes where (root vs package level, claudeMdExcludes)
+- Progressive disclosure patterns (domain files, nested docs, skills)
+- CLAUDE.md-specific hierarchy (5 scopes, @import, load order)
+- AGENTS.md-specific notes (open standard, symlinks, merging)
+- Anti-patterns to detect and remove
+- Validation checklist
+
+---
+
+## File Hierarchy Decision Table
+
+When deciding where to place content, use this table:
+
+| Location | Use when content is... | Load timing |
+|----------|------------------------|-------------|
+| Root AGENTS.md / CLAUDE.md | Relevant to **every single task** in the repo | Always (every request) |
+| Separate domain file | Relevant to one domain (TypeScript, testing, API design) | On-demand |
+| Subdirectory AGENTS.md / CLAUDE.md | Specific to one package or area | On-demand when working there |
+| `.claude/rules/` (path-scoped) | Specific to certain file patterns | On-demand when files match |
+| Skill | A workflow the agent should invoke explicitly | On-demand when invoked |
+
+*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
+
+---
+
+## Root File Requirements
+
+Generate root files with **only** these elements:
+
+1. **One-sentence project description** — anchors every agent decision ("This is a React component library for accessible data visualization.")
+2. **Package manager** — only if non-standard (e.g., `pnpm`, `bun`; omit if npm)
+3. **Build/typecheck commands** — only if non-standard
+4. **Progressive disclosure pointers** — links to domain files, not inline content
+
+> "Consider this the absolute minimum... That's honestly it. Everything else should go elsewhere."
+> — a-guide-to-agents.md
+
+---
+
+## Monorepo: What Goes Where
+
+| Level | Generate here | Do NOT put here |
+|-------|---------------|-----------------|
+| Root | Monorepo purpose, how to navigate packages, shared tooling | Package-specific tech stacks, package conventions |
+| Package | Package purpose, specific tech stack, package-specific conventions | Cross-repo decisions |
+
+Root example:
+
+```markdown
+This is a monorepo containing web services and CLI tools.
+Use pnpm workspaces to manage dependencies.
+See each package's AGENTS.md for specific guidelines.
+```
+
+> "Don't overload any level. The agent sees all merged files in its context."
+> — a-guide-to-agents.md lines 164-193
+
+**`claudeMdExcludes`**: In large monorepos, skip irrelevant ancestor CLAUDE.md files via `.claude/settings.local.json`:
+
+```json
+{ "claudeMdExcludes": ["**/other-team/CLAUDE.md", "**/other-team/.claude/rules/**"] }
+```
+
+Patterns match absolute paths with glob syntax. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded.
+
+*Source: memory/how-claude-remembers-a-project.md lines 243-260*
+
+---
+
+## Progressive Disclosure Patterns
+
+Apply these patterns when content exceeds root-file scope:
+
+**Extraction trigger**: Extract a section to a separate domain file when it has 3+ distinct rules AND spans 10+ lines, OR when the topic is irrelevant to most work sessions (e.g., database migration conventions in a project where most work is UI changes).
+
+**Move domain rules to separate files:**
+
+```markdown
+# In root file — do this:
+For TypeScript conventions, see docs/TYPESCRIPT.md
+
+# NOT this (inline domain rules):
+Always use const instead of let. Never use var...
+```
+
+**Nest disclosure hierarchically:**
+
+```
+docs/
+├── TYPESCRIPT.md      → references TESTING.md
+├── TESTING.md         → references test runners
+└── BUILD.md           → references build config
+```
+
+**Use skills for workflows** — agents invoke skills only when needed, keeping base context minimal.
+
+*Source: a-guide-to-agents.md lines 110-163*
+
+---
+
+## CLAUDE.md-Specific Hierarchy
+
+| Scope | Location | Loads when |
+|-------|----------|------------|
+| Org-wide | Managed policy (MDM) | Always |
+| Project | `./CLAUDE.md` or `./.claude/CLAUDE.md` | Session start (always) |
+| Personal | `~/.claude/CLAUDE.md` | Session start (always) |
+| Subdirectory | `./subdir/CLAUDE.md` | When reading files in that dir |
+| Path-scoped rules | `.claude/rules/*.md` with `paths:` | When matching files are read |
+
+**Priority rule**: Minimize content in always-loaded locations. Move to on-demand locations wherever possible.
+
+**@import syntax**: CLAUDE.md files can import additional files with `@path/to/file`. Imports expand at launch alongside the importing CLAUDE.md. Relative paths resolve relative to the importing file, not CWD. Max recursion depth: 5 hops. Requires one-time user approval per project.
+
+**Load order**: Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory CLAUDE.md files load on-demand only when Claude reads files in that directory — not at launch.
+
+*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
+
+---
+
+## AGENTS.md-Specific Notes
+
+- AGENTS.md is an **open standard** supported by most agent frameworks (not Claude Code)
+- Claude Code uses CLAUDE.md; create a symlink for cross-tool compatibility: `ln -s AGENTS.md CLAUDE.md`
+- AGENTS.md has **no `.claude/rules/` equivalent** — use subdirectory AGENTS.md files for scoped rules
+- Subdirectory AGENTS.md files **merge with root** (not replace)
+
+---
+
+## Anti-Patterns to Detect and Remove
+
+| Anti-pattern | Why it fails | Fix |
+|--------------|--------------|-----|
+| Ball-of-mud growth | Each fix adds a rule; after hundreds of additions the file confuses agents | Refactor with progressive disclosure |
+| Auto-generated init files | "Prioritize comprehensiveness over restraint" — flood file with irrelevant content | Author manually, restraint first |
+| Everything in one file | Exceeds ~150-200 instruction attention budget | Split by domain |
+
+> "There's a natural feedback loop that causes AGENTS.md files to grow dangerously large."
+> — a-guide-to-agents.md lines 34-43
+
+---
+
+## Validation
+
+Before finalizing any generated hierarchy, check:
+
+- [ ] Root file contains ONLY: one-liner, package manager (if non-standard), build commands (if non-standard), pointers
+- [ ] Domain content lives in separate files, not inlined
+- [ ] No file exceeds 200 lines
+- [ ] Each file covers exactly one scope
+- [ ] Subdirectory files exist for areas with distinct tooling or conventions

--- a/plugins/cursor-initializer/skills/init-cursor/references/validation-criteria.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/validation-criteria.md
@@ -11,11 +11,11 @@ Any file violating these criteria must be fixed before proceeding:
 
 | Criterion | Threshold | Source |
 |-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
+| File length | ≤ 200 lines | Anthropic Docs: 200-line target for configuration files in this toolkit |
 | Root file length (recommended) | 15-40 lines | Derived from "absolute minimum" guidance |
 | Scope file length (recommended) | 10-30 lines | One topic per file guideline |
 | Instruction count | ≤ 150-200 | HumanLayer: "~150-200 instructions with reasonable consistency" |
-| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily" |
+| Contradictions between files | 0 | Anthropic: conflicting instructions make the model choose inconsistently |
 | Language-specific rules in root | 0 | Domain rules belong in separate files |
 | Stale file path references | 0 | "File paths change constantly... actively poisons context" |
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/validation-criteria.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/validation-criteria.md
@@ -58,9 +58,9 @@ Any file violating these criteria must be fixed before proceeding:
 - [ ] Root file: one-liner + package manager (if non-standard) + build commands (if non-standard) + pointers
 - [ ] Domain content lives in separate files, not inline
 - [ ] Progressive disclosure pointers point to files that actually exist
-- [ ] **CLAUDE.md-specific**: `.claude/rules/` files have path-scoping (`paths:` frontmatter) when they apply to specific file patterns
-- [ ] **CLAUDE.md-specific**: Minimal content in always-loaded locations (`./CLAUDE.md`, `.claude/rules/*.md` without paths)
-- [ ] **AGENTS.md-specific**: Subdirectory AGENTS.md files used for monorepo package scoping (no `.claude/rules/` equivalent)
+- [ ] **Cursor rules**: `.cursor/rules/*.mdc` files use `globs:` for path-scoped activation (not `alwaysApply: true`) when they apply to specific file patterns
+- [ ] **Cursor rules**: `alwaysApply: true` used only for conventions relevant to every task — not as default
+- [ ] **AGENTS.md-specific**: Subdirectory AGENTS.md files used for monorepo package scoping; path-scoped rules go in `.cursor/rules/*.mdc` with `globs:`
 
 ---
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/validation-criteria.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/validation-criteria.md
@@ -1,0 +1,76 @@
+# Validation Criteria
+
+Quality checklist for generated and improved AGENTS.md / `.cursor/rules/` files.
+Source: plugins/agents-initializer/skills/improve-agents/SKILL.md:108-122, improve-cursor/SKILL.md, file-evaluator.md:23-59
+
+---
+
+## Hard Limits (Auto-fail if violated)
+
+Any file violating these criteria must be fixed before proceeding:
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
+| Root file length (recommended) | 15-40 lines | Derived from "absolute minimum" guidance |
+| Scope file length (recommended) | 10-30 lines | One topic per file guideline |
+| Instruction count | ≤ 150-200 | HumanLayer: "~150-200 instructions with reasonable consistency" |
+| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily" |
+| Language-specific rules in root | 0 | Domain rules belong in separate files |
+| Stale file path references | 0 | "File paths change constantly... actively poisons context" |
+
+---
+
+## Quality Checks (All must pass)
+
+- [ ] Every instruction is actionable (not vague like "write clean code")
+- [ ] Package manager specified if non-standard (pnpm, bun, yarn; omit if npm)
+- [ ] Build/test commands included if non-standard
+- [ ] Progressive disclosure applied: domain docs referenced, not inlined
+- [ ] No information that tools can enforce (linting, formatting rules → use hooks instead)
+- [ ] No duplication of content across files in the hierarchy
+- [ ] No directory/file structure listings
+- [ ] No standard language conventions the model already knows
+- [ ] No long explanations or tutorials (link to external docs instead)
+- [ ] Critical instructions appear at start or end of file (not buried in middle)
+- [ ] One scope per file (TypeScript rules in one file, testing rules in another)
+
+---
+
+## If This Is an IMPROVE Operation — Also Check
+
+**Information Preservation:**
+
+- [ ] Critical project information preserved (domain concepts, security notes, compliance requirements)
+- [ ] Custom commands/scripts referenced in the original file are retained
+- [ ] Existing progressive disclosure structure not flattened back into root
+- [ ] Non-obvious architectural decisions carried forward (not deleted as "bloat")
+
+**Structural:**
+
+- [ ] Files not merged that should stay separate (each scope gets its own file)
+- [ ] Scope widened rather than narrowed where the original had too little coverage
+
+---
+
+## Structural Checks
+
+- [ ] Root file: one-liner + package manager (if non-standard) + build commands (if non-standard) + pointers
+- [ ] Domain content lives in separate files, not inline
+- [ ] Progressive disclosure pointers point to files that actually exist
+- [ ] **CLAUDE.md-specific**: `.claude/rules/` files have path-scoping (`paths:` frontmatter) when they apply to specific file patterns
+- [ ] **CLAUDE.md-specific**: Minimal content in always-loaded locations (`./CLAUDE.md`, `.claude/rules/*.md` without paths)
+- [ ] **AGENTS.md-specific**: Subdirectory AGENTS.md files used for monorepo package scoping (no `.claude/rules/` equivalent)
+
+---
+
+## Validation Loop Instructions
+
+Execute this loop for each generated or improved file:
+
+1. Evaluate the file against ALL criteria above
+2. If ANY criterion fails: identify the specific failure, fix the file, restart evaluation
+3. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+4. Only proceed to writing files when ALL criteria pass for ALL files
+
+**Do not skip criteria for "minor" violations.** Hard limits are hard limits.

--- a/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
@@ -33,7 +33,7 @@ Not all excluded content should be deleted — some should migrate to on-demand 
 |-------------------|--------|-----------|
 | Hook-enforced behaviors | **Migrate** | `.cursor/hooks.json` (zero context cost, deterministic enforcement) |
 | Path-specific conventions | **Migrate** | `.cursor/rules/*.mdc` with `globs:` (loads on file match only) |
-| Domain knowledge blocks >50 lines | **Migrate** | Skill `user-invocable: false` (~100 token startup cost) |
+| Domain knowledge blocks >50 lines | **Migrate** | Skill (auto-invocable, ~100 token startup cost) |
 | Agent-inferable content | **Delete** | No migration — agents discover via tools |
 | Stale, vague, or duplicate content | **Delete** | No migration value |
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
@@ -15,13 +15,13 @@ Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-gu
 | Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | a-guide-to-agents.md |
 | File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | a-guide-to-agents.md |
 | Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | a-guide-to-agents.md |
-| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | Agent already does this correctly without extra instruction | Anthropic Best Practices |
 | Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" | research-context-engineering-comprehensive.md |
 | Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Anthropic Best Practices |
 | Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
 | Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" | Anthropic Best Practices |
-| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; config file instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | "Hooks provide deterministic control over Claude Code's behavior, ensuring certain actions always happen rather than relying on the LLM" | Anthropic Hooks Guide |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | Anything the agent can infer by reading code should stay out of configuration files | Anthropic Best Practices |
+| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; config file instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | Hooks provide deterministic control over agent behavior instead of repeated context instructions | Anthropic Hooks Guide |
 
 *Source: plugins/agents-initializer/skills/init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
@@ -52,7 +52,7 @@ If the instruction passes this test, include it. If it fails (agent would do the
 
 ## Common Traps
 
-**Auto-generated files trap**: Never use `/init` or initialization scripts to generate AGENTS.md/CLAUDE.md. Auto-generated files "flood the file with things that are 'useful for most scenarios' but would be better progressively disclosed. Generated files prioritize comprehensiveness over restraint." — a-guide-to-agents.md
+**Auto-generated files trap**: Never use `/init` or initialization scripts to generate AGENTS.md or `.cursor/rules/*` from generic boilerplate. Auto-generated files "flood the file with things that are 'useful for most scenarios' but would be better progressively disclosed. Generated files prioritize comprehensiveness over restraint." — a-guide-to-agents.md
 
 **Ball-of-mud growth**: Each time the agent does something wrong, adding a rule feels productive. After hundreds of iterations over months, the file becomes unmaintainable and hurts agent performance. Refactor instead.
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
@@ -1,6 +1,6 @@
 # What NOT to Include
 
-Evidence-based exclusion table for AGENTS.md and CLAUDE.md content.
+Evidence-based exclusion table for AGENTS.md and `.cursor/rules/*.mdc` content.
 Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md, hooks/automate-workflow-with-hooks.md
 
 ---
@@ -31,8 +31,8 @@ Not all excluded content should be deleted — some should migrate to on-demand 
 
 | Exclusion Category | Action | Mechanism |
 |-------------------|--------|-----------|
-| Hook-enforced behaviors | **Migrate** | Hook (zero context cost, deterministic enforcement) |
-| Path-specific conventions | **Migrate** | `.claude/rules/` with `paths:` (loads on file match only) |
+| Hook-enforced behaviors | **Migrate** | `.cursor/hooks.json` (zero context cost, deterministic enforcement) |
+| Path-specific conventions | **Migrate** | `.cursor/rules/*.mdc` with `globs:` (loads on file match only) |
 | Domain knowledge blocks >50 lines | **Migrate** | Skill `user-invocable: false` (~100 token startup cost) |
 | Agent-inferable content | **Delete** | No migration — agents discover via tools |
 | Stale, vague, or duplicate content | **Delete** | No migration value |

--- a/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
@@ -1,0 +1,72 @@
+# What NOT to Include
+
+Evidence-based exclusion table for AGENTS.md and CLAUDE.md content.
+Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md, hooks/automate-workflow-with-hooks.md
+
+---
+
+## Exclusion Evidence Table
+
+| Content Type | Why to Exclude | Evidence Quote | Source |
+|-------------|----------------|---------------|--------|
+| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" | ETH Zurich: Evaluating AGENTS.md |
+| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" | Anthropic Best Practices |
+| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" | ETH Zurich: Evaluating AGENTS.md |
+| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | a-guide-to-agents.md |
+| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | a-guide-to-agents.md |
+| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | a-guide-to-agents.md |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
+| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" | research-context-engineering-comprehensive.md |
+| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Anthropic Best Practices |
+| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
+| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" | Anthropic Best Practices |
+| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; config file instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | "Hooks provide deterministic control over Claude Code's behavior, ensuring certain actions always happen rather than relying on the LLM" | Anthropic Hooks Guide |
+
+*Source: plugins/agents-initializer/skills/init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
+
+### Exclusion Actions
+
+Not all excluded content should be deleted — some should migrate to on-demand mechanisms:
+
+| Exclusion Category | Action | Mechanism |
+|-------------------|--------|-----------|
+| Hook-enforced behaviors | **Migrate** | Hook (zero context cost, deterministic enforcement) |
+| Path-specific conventions | **Migrate** | `.claude/rules/` with `paths:` (loads on file match only) |
+| Domain knowledge blocks >50 lines | **Migrate** | Skill `user-invocable: false` (~100 token startup cost) |
+| Agent-inferable content | **Delete** | No migration — agents discover via tools |
+| Stale, vague, or duplicate content | **Delete** | No migration value |
+
+---
+
+## The Instruction Test
+
+Apply this test to each line before including it:
+
+> **"Would removing this cause the agent to make mistakes? If not, cut it."**
+> — Anthropic Best Practices
+
+If the instruction passes this test, include it. If it fails (agent would do the right thing anyway), delete it.
+
+---
+
+## Common Traps
+
+**Auto-generated files trap**: Never use `/init` or initialization scripts to generate AGENTS.md/CLAUDE.md. Auto-generated files "flood the file with things that are 'useful for most scenarios' but would be better progressively disclosed. Generated files prioritize comprehensiveness over restraint." — a-guide-to-agents.md
+
+**Ball-of-mud growth**: Each time the agent does something wrong, adding a rule feels productive. After hundreds of iterations over months, the file becomes unmaintainable and hurts agent performance. Refactor instead.
+
+**Comprehensive-over-restrained mindset**: More content feels safer but performs worse. "Unnecessary requirements from context files make tasks harder." — ETH Zurich, Evaluating AGENTS.md (abstract)
+
+---
+
+## What TO Include Instead
+
+| What to document | Why it belongs here |
+|-----------------|-------------------|
+| One-sentence project description | Anchors all agent decisions |
+| Non-standard package manager | Without this, agent defaults to wrong tooling |
+| Non-standard build/test commands | Agent cannot guess custom scripts |
+| Non-obvious architectural decisions | Agent would otherwise make different choices |
+| Domain concepts (not file paths) | More stable than paths; safer to document |
+| Progressive disclosure pointers | "See docs/TESTING.md" keeps root file minimal |


### PR DESCRIPTION
## Summary

Introduces the `cursor-initializer` Cursor IDE plugin — an evidence-based toolkit for generating and optimizing `AGENTS.md` and `.cursor/rules/*.mdc` configuration files. Built on the ETH Zurich *Evaluating AGENTS.md* study and Cursor's official best practices, it mirrors the `agents-initializer` Claude Code plugin with Cursor-native conventions.

Design decisions trace to `docs/cursor/` research docs, `DESIGN-GUIDELINES.md`, and the Agent Skills open standard. Research was gathered from Cursor's official docs and saved to `docs/cursor/` before implementation.

## Type of Change

- [x] `feat` — new skill, agent, reference, or template
- [x] `refactor` — restructure without behavior change (portable skills removed; only Cursor-specific skills remain)
- [x] `docs` — documentation, analysis, or research additions
- [x] `chore` — configuration, CI/CD, version bumps

## Changes

**Plugin Skills** (`plugins/cursor-initializer/skills/`)
- `init-cursor` — generates `AGENTS.md` + scoped `.cursor/rules/*.mdc` files via subagent-driven analysis; preflight redirects if artifacts already exist
- `improve-cursor` — evaluates and improves existing `.cursor/rules/*.mdc` and (conditionally) `AGENTS.md`; proposals driven by `has_rules`/`has_agents_md` flags from Preflight Check
- Both skills ship with `references/` (7 files each) and `assets/templates/` (4–6 files each)

**Agent Definitions** (`plugins/cursor-initializer/agents/`)
- `codebase-analyzer.md` — tech stack and tooling detection (readonly: true, model: inherit)
- `scope-detector.md` — project scope/context detection (readonly: true, model: inherit)
- `file-evaluator.md` — `.mdc` and `AGENTS.md` quality assessment (readonly: true, model: inherit)
- Cursor-native format: `readonly: true`, `model: inherit`, no tools whitelist (differs from Claude Code agents)

**Rules** (`.claude/rules/`)
- `cursor-plugin-skills.md` — path-scoped constraints for cursor-initializer skills (Cursor-native patterns: `.mdc` format, readonly agents, no hooks in AGENTS.md suggestions)
- `cursor-agent-files.md` — mandatory fields and constraints for Cursor agent definitions

**Documentation** (`docs/`)
- `docs/cursor/best-practices/agent-best-practices.md` — sourced from cursor.com blog; covers subagent patterns
- `docs/cursor/README.md` — updated with new research files
- `DESIGN-GUIDELINES.md` — cursor-initializer added to Self-Application Record

**Configuration** (`CLAUDE.md`, `.cursor-plugin`, `README.md`)
- `.cursor-plugin/marketplace.json` at repo root — Cursor multi-plugin marketplace registration (mirrors `.claude-plugin/marketplace.json`); uses `pluginRoot: "plugins"`
- `plugins/cursor-initializer/.cursor-plugin/plugin.json` — per-plugin manifest
- `plugins/cursor-initializer/AGENTS.md` — Cursor-native dev config for working in the plugin source tree (NOT distributed behavior)
- `plugins/cursor-initializer/CLAUDE.md` — plugin-specific conventions (2-skill structure, conditional AGENTS.md)
- `CLAUDE.md` (root) — updated with cursor-initializer reference
- `README.md` — updated structure tree, Cursor usage section, both marketplace manifests documented

**Meta-Skills / Dev Tooling** (`.claude/skills/`)
- Copilot review instructions updated for cursor-initializer scope (`.github/instructions/`)

## Convention Compliance

- [x] No file exceeds 200 lines (references, rules, templates, CLAUDE.md)
- [x] SKILL.md files: name ≤64 chars, description ≤1024 chars, body <500 lines
- [x] Shared references updated in ALL copies across both distributions
- [x] Plugin skills delegate to Cursor subagents; standalone pattern not mixed
- [x] Agent definitions use `readonly: true` and `model: inherit` with no `tools` or `maxTurns` fields (Cursor-native format)
- [x] Root CLAUDE.md stays within 15-40 line target
- [x] Commits are atomic — one logical change per commit

## Evidence & Quality

- [x] All instructions pass: "Would removing this cause the agent to make mistakes?"
- [x] Reference files have source attribution (Cursor docs, ETH Zurich paper, Agent Skills standard)
- [x] No stale file paths or commands introduced
- [x] Cursor vs Claude platform differences enforced: `.mdc` rules format, `readonly:` agents, no hooks/subagents in AGENTS.md suggestions

## Related Issues / PRD

Implements the Cursor IDE plugin replication task — session checkpoints 001–004.
References `docs/cursor/`, `DESIGN-GUIDELINES.md`, and `docs/general-llm/Evaluating-AGENTS-paper.md`.
