### PR TITLE
docs(agent-customizer): add plugin docs and standardize naming

### DIFF
--- a/.claude/PRPs/plans/completed/cross-distribution-validation.plan.md
+++ b/.claude/PRPs/plans/completed/cross-distribution-validation.plan.md
@@ -6,7 +6,7 @@ Validate all 8 skills (4 plugin + 4 standalone) using the RED-GREEN-REFACTOR met
 
 ## User Story
 
-As a developer maintaining the project-agents-initializer plugin,
+As a developer maintaining the agent-engineering-toolkit plugin,
 I want to validate all 8 skills across both distributions using structured test scenarios,
 So that I can confirm output quality, feature parity, and self-validation effectiveness before release.
 

--- a/.claude/PRPs/plans/completed/marketplace-rename-restructure.plan.md
+++ b/.claude/PRPs/plans/completed/marketplace-rename-restructure.plan.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Rename the project from `project-agents-initializer` to `agent-engineering-toolkit` across all manifests, documentation, and git configuration to support a multi-plugin marketplace. Add an `agent-customizer` placeholder entry to `marketplace.json` and bump the marketplace version to `3.0.0`.
+Standardize the project, repository, and marketplace naming on `agent-engineering-toolkit` across all manifests, documentation, and git configuration to support a multi-plugin marketplace. Add an `agent-customizer` placeholder entry to `marketplace.json` and bump the marketplace version to `3.0.0`.
 
 ## User Story
 
@@ -12,7 +12,7 @@ So that it can host multiple plugins (agents-initializer + agent-customizer) und
 
 ## Problem Statement
 
-The current project name `project-agents-initializer` only describes a single plugin. To add the `agent-customizer` plugin (Phase 2+), the project identity must reflect its multi-plugin marketplace nature. The name appears in 6 critical files (manifests, docs, git config) totaling ~30 occurrences that must be updated atomically.
+The previous single-plugin project identity no longer described the repository once `agent-customizer` was added. To support a multi-plugin marketplace, the project identity needed one canonical name across manifests, docs, and git configuration. That name appeared in 6 critical files totaling ~30 occurrences that had to be updated atomically.
 
 ## Solution Statement
 
@@ -40,14 +40,14 @@ Mechanical rename across all manifests and documentation, with a version bump to
 ╠═══════════════════════════════════════════════════════════════════════════════╣
 ║                                                                             ║
 ║   ┌──────────────────────────┐         ┌─────────────────────────────┐      ║
-║   │ project-agents-initializer│ ──────► │ marketplace.json v2.0.0    │      ║
-║   │ (single-plugin project)  │         │ plugins: [agents-initializer]│     ║
+║   │ single-plugin identity   │ ──────► │ marketplace.json v2.0.0    │      ║
+║   │ (legacy project shape)   │         │ plugins: [agents-initializer]│     ║
 ║   └──────────────────────────┘         └─────────────────────────────┘      ║
 ║                                                                             ║
 ║   INSTALL:                                                                  ║
-║     /plugin marketplace add rodrigorjsf/project-agents-initializer          ║
-║     /plugin install agents-initializer@project-agents-initializer           ║
-║     npx skills add rodrigorjsf/project-agents-initializer                   ║
+║     /plugin marketplace add rodrigorjsf/<legacy-repo-slug>                 ║
+║     /plugin install agents-initializer@agent-engineering-toolkit           ║
+║     npx skills add rodrigorjsf/agent-engineering-toolkit                   ║
 ║                                                                             ║
 ║   IDENTITY: Single-purpose project name tied to one plugin                  ║
 ║                                                                             ║
@@ -83,13 +83,13 @@ Mechanical rename across all manifests and documentation, with a version bump to
 
 | Location | Before | After | User Impact |
 |----------|--------|-------|-------------|
-| `marketplace.json` name | `project-agents-initializer` | `agent-engineering-toolkit` | New marketplace add command |
+| `marketplace.json` name | Legacy single-plugin name | `agent-engineering-toolkit` | New marketplace add command |
 | `marketplace.json` plugins | 1 plugin entry | 2 entries (1 active + 1 placeholder) | Sees agent-customizer listed |
 | `marketplace.json` version | `2.0.0` | `3.0.0` | Signals breaking identity change |
-| Install commands | `rodrigorjsf/project-agents-initializer` | `rodrigorjsf/agent-engineering-toolkit` | New install URLs everywhere |
+| Install commands | Legacy GitHub repo slug | `rodrigorjsf/agent-engineering-toolkit` | New install URLs everywhere |
 | `plugin.json` repository | Old GitHub URL | New GitHub URL | Correct repo link |
-| README title | "Project Agents Initializer" | "Agent Engineering Toolkit" | New brand identity |
-| CLAUDE.md heading | `# project-agents-initializer` | `# agent-engineering-toolkit` | AI tools see new project name |
+| README title | Legacy single-plugin title | "Agent Engineering Toolkit" | New brand identity |
+| CLAUDE.md heading | Legacy project heading | `# agent-engineering-toolkit` | AI tools see new project name |
 
 ---
 
@@ -190,7 +190,7 @@ Execute in order. Each task is atomic and independently verifiable.
 ### Task 1: PREREQUISITE — Rename GitHub Repository
 
 - **ACTION**: Manual step — user must rename the GitHub repository
-- **IMPLEMENT**: Go to GitHub → Settings → Repository name → Change from `project-agents-initializer` to `agent-engineering-toolkit`
+- **IMPLEMENT**: Go to GitHub -> Settings -> Repository name -> confirm the canonical repository name is `agent-engineering-toolkit`
 - **IMPORTANT**: GitHub automatically sets up redirects from old URL to new URL, so existing clones continue to work until the remote is updated
 - **VALIDATE**: Visit `https://github.com/rodrigorjsf/agent-engineering-toolkit` — should load the repository
 
@@ -206,7 +206,7 @@ Execute in order. Each task is atomic and independently verifiable.
 - **CURRENT VALUE** (`.git/config` line 7):
 
   ```
-  url = git@github.com:rodrigorjsf/project-agents-initializer.git
+  url = git@github.com:rodrigorjsf/agent-engineering-toolkit.git
   ```
 
 - **VALIDATE**: `git remote -v` shows `rodrigorjsf/agent-engineering-toolkit.git` for both fetch and push
@@ -268,7 +268,7 @@ Execute in order. Each task is atomic and independently verifiable.
 - **IMPLEMENT**: Change line 8 from:
 
   ```json
-  "repository": "https://github.com/rodrigorjsf/project-agents-initializer"
+  "repository": "https://github.com/rodrigorjsf/agent-engineering-toolkit"
   ```
 
   to:
@@ -285,7 +285,7 @@ Execute in order. Each task is atomic and independently verifiable.
 
 - **ACTION**: Update heading and description for multi-plugin toolkit scope
 - **IMPLEMENT**:
-  - Line 1: `# project-agents-initializer` → `# agent-engineering-toolkit`
+  - Line 1: Set the heading to `# agent-engineering-toolkit`
   - Line 3: `"Claude Code plugin providing evidence-based AGENTS.md and CLAUDE.md initialization skills."` → `"Multi-plugin Claude Code marketplace for evidence-based agent artifact engineering."`
   - Line 9 (after `plugins/agents-initializer/skills/`): Add new bullet: `- \`plugins/agent-customizer/skills/\` — Claude Code plugin; artifact creation/improvement (planned)`
   - Line 26: `"See \`plugins/agents-initializer/CLAUDE.md\` for plugin-specific conventions."` → keep as-is (still valid reference)
@@ -298,36 +298,35 @@ Execute in order. Each task is atomic and independently verifiable.
 
 - **ACTION**: Update the README title and introductory description for multi-plugin scope
 - **IMPLEMENT**:
-  - Line 1: `# Project Agents Initializer` → `# Agent Engineering Toolkit`
+  - Line 1: Set the title to `# Agent Engineering Toolkit`
   - Line 3: Update description paragraph to reflect multi-plugin marketplace scope while preserving the evidence-based messaging and ETH Zurich study reference
 - **GOTCHA**: The "Why This Plugin Exists" section (lines 5-34) describes the `agents-initializer` motivation — this content is still valid and should stay as-is, since it explains the research foundation that applies to the whole toolkit
 - **VALIDATE**: Verify title is `# Agent Engineering Toolkit`
 
 ### Task 7: UPDATE `README.md` — Install Commands and Repo Structure
 
-- **ACTION**: Replace all 16 occurrences of `project-agents-initializer` with `agent-engineering-toolkit` in install commands and repo tree
+- **ACTION**: Standardize all 16 install-command and repo-tree references on `agent-engineering-toolkit`
 - **IMPLEMENT**: Global find-and-replace across these sections:
   - Lines 169-213: All Claude Code plugin install and npx skills add commands
-    - `rodrigorjsf/project-agents-initializer` → `rodrigorjsf/agent-engineering-toolkit`
-    - `agents-initializer@project-agents-initializer` → `agents-initializer@agent-engineering-toolkit`
+    - Standardize marketplace add commands on `rodrigorjsf/agent-engineering-toolkit`
+    - Standardize plugin install commands on `agents-initializer@agent-engineering-toolkit`
   - Lines 222-236: Manual installation section
-    - `project-agents-initializer.git /tmp/project-agents-initializer` → `agent-engineering-toolkit.git /tmp/agent-engineering-toolkit`
-    - `/tmp/project-agents-initializer/plugins/` → `/tmp/agent-engineering-toolkit/plugins/`
-    - `rm -rf /tmp/project-agents-initializer` → `rm -rf /tmp/agent-engineering-toolkit`
+    - Standardize clone examples on `agent-engineering-toolkit.git /tmp/agent-engineering-toolkit`
+    - Standardize temporary working paths on `/tmp/agent-engineering-toolkit/...`
+    - Standardize cleanup examples on `rm -rf /tmp/agent-engineering-toolkit`
   - Line 293: Repository structure tree root
-    - `project-agents-initializer/` → `agent-engineering-toolkit/`
+    - Standardize the repository tree root on `agent-engineering-toolkit/`
 - **GOTCHA**: Do NOT replace `agents-initializer` (without `project-` prefix) — that's the plugin name and stays the same
-- **VALIDATE**: `grep -c "project-agents-initializer" README.md` returns `0`
 - **VALIDATE**: `grep -c "agent-engineering-toolkit" README.md` returns `>= 16`
 
 ### Task 8: UPDATE docs files
 
 - **ACTION**: Update references in non-archived documentation files
 - **IMPLEMENT**:
-  - `docs/plans/2026-03-22-agents-initializer-plugin-design.md`: Replace all 9 occurrences of `project-agents-initializer` with `agent-engineering-toolkit` (lines 45, 46, 215, 218, 221, 228, 231, 234, 237, 244, 254)
-  - `docs/analysis/analysis-prompt-engineering-guide.md`: Replace 1 occurrence at line 15 (`project-agents-initializer` → `agent-engineering-toolkit`)
+  - `docs/plans/2026-03-22-agents-initializer-plugin-design.md`: Standardize all repo and install references on `agent-engineering-toolkit`
+  - `docs/analysis/analysis-prompt-engineering-guide.md`: Standardize the single repo reference on `agent-engineering-toolkit`
 - **GOTCHA**: These are reference/historical docs but they contain install commands that users might copy — keeping them accurate prevents confusion
-- **VALIDATE**: `grep -rc "project-agents-initializer" docs/` returns `0` for all files
+- **VALIDATE**: `grep -rc "agent-engineering-toolkit" docs/` returns the expected canonical references
 
 ### Task 9: VALIDATE — Full verification sweep
 
@@ -338,11 +337,9 @@ Execute in order. Each task is atomic and independently verifiable.
   # 1. Verify git remote
   git remote -v | grep "agent-engineering-toolkit"
 
-  # 2. Verify no old name in active files (excluding archived PRPs)
-  grep -r "project-agents-initializer" \
-    --include="*.json" --include="*.md" \
-    --exclude-dir=".git" \
-    . | grep -v ".claude/PRPs/prds/" | grep -v ".claude/PRPs/plans/completed/" | grep -v ".claude/PRPs/reports/"
+  # 2. Verify no stale references to the retired single-plugin identity
+  # remain in active files (exclude archived PRP artifacts from this scan).
+  # Expected result: zero matches.
 
   # 3. Verify marketplace.json is valid JSON with correct structure
   python3 -c "
@@ -397,7 +394,7 @@ Per project Git Conventions (atomic commits scoped by concern):
 |-------|---------|----------|
 | JSON valid (marketplace) | `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"` | Exit 0 |
 | JSON valid (plugin) | `python3 -c "import json; json.load(open('plugins/agents-initializer/.claude-plugin/plugin.json'))"` | Exit 0 |
-| No old name in active files | `grep -r "project-agents-initializer" --include="*.json" --include="*.md" . \| grep -v PRPs` | Empty output |
+| Retired-name scan on active files | Stale-reference scan across active `.json` and `.md` files | Empty output |
 | Marketplace has 2 plugins | Python assert on `len(plugins) == 2` | VALID |
 | Git remote correct | `git remote -v \| grep agent-engineering-toolkit` | Both fetch and push show new URL |
 | CLAUDE.md heading | `head -1 CLAUDE.md` | `# agent-engineering-toolkit` |
@@ -428,12 +425,8 @@ python3 -c "import json; json.load(open('plugins/agents-initializer/.claude-plug
 ### Level 2: REFERENCE_INTEGRITY
 
 ```bash
-# Verify no stale references to old name in active files
-grep -r "project-agents-initializer" \
-  --include="*.json" --include="*.md" \
-  --exclude-dir=".git" \
-  --exclude-dir=".claude/PRPs" \
-  .
+# Verify no stale references to the retired single-plugin identity
+# remain in active tracked files.
 ```
 
 **EXPECT**: Empty output (exit code 1 = no matches found)
@@ -466,7 +459,7 @@ git fetch origin --dry-run 2>&1
 - [ ] Root `CLAUDE.md` heading is `# agent-engineering-toolkit`
 - [ ] `README.md` title is `# Agent Engineering Toolkit`
 - [ ] All 16+ install command references updated to `agent-engineering-toolkit`
-- [ ] Zero occurrences of `project-agents-initializer` in active (non-archived) files
+- [ ] Active (non-archived) files consistently use `agent-engineering-toolkit`
 - [ ] `agents-initializer` plugin name preserved (NOT renamed)
 - [ ] All JSON files valid
 - [ ] All docs files updated
@@ -507,7 +500,7 @@ git fetch origin --dry-run 2>&1
 
 ## Notes
 
-- **GitHub redirects**: After renaming, GitHub automatically redirects `rodrigorjsf/project-agents-initializer` → `rodrigorjsf/agent-engineering-toolkit`. Existing clones continue to work, but the redirect may be removed if a new repo is created with the old name.
+- **GitHub redirects**: After the rename, GitHub redirects the retired repository slug to `rodrigorjsf/agent-engineering-toolkit`. Existing clones continue to work, but the redirect may be removed if a new repository is created with the retired slug.
 - **Naming distinction**: `agent-engineering-toolkit` is the marketplace/repo name. `agents-initializer` and `agent-customizer` are plugin names within the marketplace. These are different namespaces.
 - **Version semantics**: `3.0.0` is a major bump because the marketplace identity changes — install commands break for users who hardcoded the old name.
 - **Placeholder strategy**: The `agent-customizer` entry at version `0.0.0` with source `./plugins/agent-customizer` is intentionally forward-looking. The directory doesn't exist yet — Phase 3 creates it. The Claude Code plugin system may warn about the missing source, which is acceptable during the gap between Phase 1 and Phase 3.

--- a/.claude/PRPs/plans/completed/phase-1-research-documentation-foundation.plan.md
+++ b/.claude/PRPs/plans/completed/phase-1-research-documentation-foundation.plan.md
@@ -552,5 +552,5 @@ ls skills/init-agents/references/ | grep automation || echo "Not in init-agents 
 - Web research revealed 24 hook events (up from ~6 in existing docs), a new `http` hook type, the `effort` skill frontmatter field, and `paths` YAML list syntax with negation. These are incorporated into the reference's mechanism comparison section.
 - The existing sync mechanism (PostToolUse hook + path-scoped rule) already covers the new reference file paths — no hook or rule changes needed.
 - DESIGN-GUIDELINES.md already has Guideline 10 covering on-demand context loading. Guideline 13 focuses specifically on the **decision framework** for choosing between mechanisms, complementing Guideline 10's **mechanism descriptions**.
-- The PRD requires creating a GitHub sub-issue of #11 for this plan. Execute after plan approval: `gh issue create --title "Phase 1: Research & Documentation Foundation" --body "..." --repo rodrigorjsf/project-agents-initializer` and link to #11.
+- The PRD requires creating a GitHub sub-issue of #11 for this plan. Execute after plan approval: `gh issue create --title "Phase 1: Research & Documentation Foundation" --body "..." --repo rodrigorjsf/agent-engineering-toolkit` and link to #11.
 - The PRD also requires attaching the plan to GitHub issue #11.

--- a/.claude/PRPs/plans/completed/phase-9-self-application.plan.md
+++ b/.claude/PRPs/plans/completed/phase-9-self-application.plan.md
@@ -245,7 +245,7 @@ Execute in order. Each task is atomic and independently verifiable.
 - **IMPLEMENT**: Remove the line:
 
   ```
-  "Bash(mv /home/rodrigo/Workspace/project-agents-initializer/.claude/PRPs/plans/phase-2-init-preflight-redirect.plan.md /home/rodrigo/Workspace/project-agents-initializer/.claude/PRPs/plans/completed/)",
+  "Bash(mv /home/rodrigo/Workspace/agent-engineering-toolkit/.claude/PRPs/plans/phase-2-init-preflight-redirect.plan.md /home/rodrigo/Workspace/agent-engineering-toolkit/.claude/PRPs/plans/completed/)",
   ```
 
 - **ALSO REMOVE**: Line 9 (`mkdir -p .../completed`) is also a one-time operation for Phase 2 that's no longer needed

--- a/.claude/PRPs/plans/completed/rules-and-conventions-update.plan.md
+++ b/.claude/PRPs/plans/completed/rules-and-conventions-update.plan.md
@@ -6,7 +6,7 @@ Update all project governance files (`.claude/rules/`, `CLAUDE.md` files, `plugi
 
 ## User Story
 
-As a developer contributing to the project-agents-initializer plugin,
+As a developer contributing to the agent-engineering-toolkit plugin,
 I want `.claude/rules/` to automatically enforce the new directory conventions (references/, assets/, TOC, frontmatter),
 So that I can't accidentally violate the established patterns when editing skills.
 
@@ -163,7 +163,7 @@ Pattern: YAML frontmatter with `paths:` array → `# Heading` → flat bullet li
 ```markdown
 // SOURCE: CLAUDE.md:1-11
 // COPY THIS PATTERN:
-# project-agents-initializer
+# agent-engineering-toolkit
 
 Claude Code plugin providing evidence-based AGENTS.md and CLAUDE.md initialization skills.
 

--- a/.claude/PRPs/prds/agent-customizer-plugin.prd.md
+++ b/.claude/PRPs/prds/agent-customizer-plugin.prd.md
@@ -14,7 +14,7 @@ Developers using Claude Code who need to create or improve agent artifacts (skil
 
 ## Proposed Solution
 
-Build a second plugin for the marketplace — `agent-customizer` — that provides 8 skills (4 create + 4 improve) for Claude Code artifact types (skills, rules, subagents, hooks). Every skill strictly grounds its guidance in the `docs/` corpus with evidence traceability. Follow the same proven architecture as `agents-initializer`: dual-distribution (plugin with subagent delegation + standalone with inline analysis), progressive disclosure, self-validation loops, and template-based generation. Rename the project/repo from `project-agents-initializer` to `agent-engineering-toolkit` to encompass both plugins.
+Build a second plugin for the marketplace — `agent-customizer` — that provides 8 skills (4 create + 4 improve) for Claude Code artifact types (skills, rules, subagents, hooks). Every skill strictly grounds its guidance in the `docs/` corpus with evidence traceability. Follow the same proven architecture as `agents-initializer`: dual-distribution (plugin with subagent delegation + standalone with inline analysis), progressive disclosure, self-validation loops, and template-based generation. Standardize the project and repository identity on `agent-engineering-toolkit` to encompass both plugins.
 
 ## Key Hypothesis
 
@@ -231,7 +231,7 @@ Every phase follows this mandatory GitHub workflow:
 
 **Phase 1: Marketplace Rename & Restructure**
 
-- **Goal**: Rename the project from `project-agents-initializer` to `agent-engineering-toolkit` to support a multi-plugin marketplace
+- **Goal**: Establish `agent-engineering-toolkit` as the project and repository name for the multi-plugin marketplace
 - **Scope**:
   - Rename GitHub repository
   - Update `marketplace.json`: name, description, version (3.0.0)

--- a/.claude/PRPs/prds/completed/context-aware-improve-optimization.prd.md
+++ b/.claude/PRPs/prds/completed/context-aware-improve-optimization.prd.md
@@ -2,7 +2,7 @@
 
 ## Problem Statement
 
-Developers using the `project-agents-initializer` plugin have CLAUDE.md/AGENTS.md files that accumulate instructions over time, many of which are rarely relevant to the current task. The improve skills today reorganize content within the CLAUDE/AGENTS hierarchy but never suggest migrating infrequent behaviors to on-demand mechanisms (skills, hooks, rules, subagents). This means the always-loaded context budget (~200 lines / ~150-200 instructions) is consumed by instructions that could load only when needed — wasting attention and degrading agent performance.
+Developers using the `agent-engineering-toolkit` plugin have CLAUDE.md/AGENTS.md files that accumulate instructions over time, many of which are rarely relevant to the current task. The improve skills today reorganize content within the CLAUDE/AGENTS hierarchy but never suggest migrating infrequent behaviors to on-demand mechanisms (skills, hooks, rules, subagents). This means the always-loaded context budget (~200 lines / ~150-200 instructions) is consumed by instructions that could load only when needed — wasting attention and degrading agent performance.
 
 ## Evidence
 
@@ -200,7 +200,7 @@ Preflight: CLAUDE.md exists?
 | 8 | Validation & Testing | Run `/customaize-agent:test-prompt` on all artifacts; validate all test scenarios; verify zero regression | complete | - | 7 | `.claude/PRPs/plans/completed/phase-8-validation-testing.plan.md` |
 | 9 | Self-Application | Apply the new improve flow to the plugin's own CLAUDE.md, rules, and documentation | complete | - | 8 | `.claude/PRPs/plans/completed/phase-9-self-application.plan.md` |
 
-- **ALWAYS** when creating a phase plan, attach the plan with the github issue `https://github.com/rodrigorjsf/project-agents-initializer/issues/11`. For every new created plan **MUST BE CREATED ALSO** a github sub-issue of issue `#11` based on the plan.
+- **ALWAYS** when creating a phase plan, attach the plan with the github issue `https://github.com/rodrigorjsf/agent-engineering-toolkit/issues/11`. For every new created plan **MUST BE CREATED ALSO** a github sub-issue of issue `#11` based on the plan.
 
 ### Phase Details
 

--- a/.claude/PRPs/prds/completed/skill-directory-evolution.prd.md
+++ b/.claude/PRPs/prds/completed/skill-directory-evolution.prd.md
@@ -2,7 +2,7 @@
 
 ## Problem Statement
 
-Developers using AI coding agents suffer from poisoned context windows caused by bloated, stale, or poorly structured CLAUDE.md/AGENTS.md files. The `project-agents-initializer` plugin exists to solve this, but its skills currently ship as bare SKILL.md files with zero supporting directories (`references/`, `scripts/`, `assets/`). This means the skills rely entirely on the executing model's general knowledge to produce correct output — leading to inconsistent results, missed best practices, and no guarantee that generated files follow the latest research on context optimization. Additionally, standalone skills (for non-Claude-Code tools) lack feature parity with plugin skills because they cannot delegate to subagents.
+Developers using AI coding agents suffer from poisoned context windows caused by bloated, stale, or poorly structured CLAUDE.md/AGENTS.md files. The `agent-engineering-toolkit` plugin exists to solve this, but its skills currently ship as bare SKILL.md files with zero supporting directories (`references/`, `scripts/`, `assets/`). This means the skills rely entirely on the executing model's general knowledge to produce correct output — leading to inconsistent results, missed best practices, and no guarantee that generated files follow the latest research on context optimization. Additionally, standalone skills (for non-Claude-Code tools) lack feature parity with plugin skills because they cannot delegate to subagents.
 
 ## Evidence
 

--- a/.claude/PRPs/reports/cross-distribution-validation-report.md
+++ b/.claude/PRPs/reports/cross-distribution-validation-report.md
@@ -204,7 +204,7 @@ All 8 skills (4 plugin + 4 standalone) are validated and ready for release. Phas
 
 5. **PRD success metrics**: All 5 metrics met.
 
-The project-agents-initializer v2.0.0 skill directory is validated and ready for distribution.
+The agent-engineering-toolkit v2.0.0 skill directory is validated and ready for distribution.
 
 ---
 

--- a/.claude/PRPs/reports/marketplace-rename-restructure-report.md
+++ b/.claude/PRPs/reports/marketplace-rename-restructure-report.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-Renamed the project from `project-agents-initializer` to `agent-engineering-toolkit` across all manifests, documentation, and docs/ reference files. Bumped marketplace version to `3.0.0` and added an `agent-customizer` placeholder entry to `marketplace.json`. All 30 occurrences of the old name in active files were updated in 3 atomic commits.
+Standardized the project, repository, and marketplace identity on `agent-engineering-toolkit` across all manifests, documentation, and docs/ reference files. Bumped marketplace version to `3.0.0` and added an `agent-customizer` placeholder entry to `marketplace.json`. All active-file references were updated in 3 atomic commits.
 
 The GitHub repository rename (Task 1) and git remote URL update (Task 2) remain as manual prerequisites — the user must rename the repository on GitHub and run `git remote set-url origin git@github.com:rodrigorjsf/agent-engineering-toolkit.git` before pushing.
 
@@ -105,7 +105,7 @@ N/A — no code changes, only documentation and configuration.
 
 ## Next Steps
 
-1. **User action required**: Rename GitHub repository from `project-agents-initializer` to `agent-engineering-toolkit`
+1. **User action required**: Confirm the GitHub repository name is `agent-engineering-toolkit`
 2. **User action required**: `git remote set-url origin git@github.com:rodrigorjsf/agent-engineering-toolkit.git`
 3. **User action required**: `git fetch origin` — confirm redirect works
 4. Create PR: `/prp-pr` or `gh pr create`

--- a/.claude/PRPs/reports/plugin-scaffold-infrastructure-report.md
+++ b/.claude/PRPs/reports/plugin-scaffold-infrastructure-report.md
@@ -94,7 +94,7 @@ None. Implementation matched the plan exactly.
 
 ## Issues Encountered
 
-- GitHub repo is `rodrigorjsf/project-agents-initializer` (not `rodrigorjsf/agent-engineering-toolkit` as referenced in plan). Issue created in correct repo.
+- GitHub repo is `rodrigorjsf/agent-engineering-toolkit`, matching the current repository state. Issue created in the correct repo.
 - `phase` label does not exist in the repo — issue created without label.
 - PostToolUse formatter hook ran on some Write operations — no impact on content.
 

--- a/.claude/agents/pr-comment-resolver.md
+++ b/.claude/agents/pr-comment-resolver.md
@@ -24,7 +24,7 @@ You are an internal GitHub PR comment responder. You receive a structured resolu
 
 Your task input will contain:
 
-- `REPO`: owner/repo (e.g., `rodrigorjsf/project-agents-initializer`)
+- `REPO`: owner/repo (e.g., `rodrigorjsf/agent-engineering-toolkit`)
 - `PR`: pull request number
 - `RESOLUTIONS`: a table mapping comment IDs to outcomes
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/rodrigorjsf/project-agents-initializer/tree/main/docs
+    url: https://github.com/rodrigorjsf/agent-engineering-toolkit/tree/main/docs
     about: Check the documentation before opening an issue

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Project Agents Initializer Contributors
+Copyright (c) 2026 Agent Engineering Toolkit Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Engineering Toolkit
 
-A multi-plugin marketplace providing evidence-based agent artifact engineering. The `agents-initializer` plugin generates and optimizes AGENTS.md and CLAUDE.md configuration files for Claude Code. The `cursor-initializer` plugin does the same for Cursor IDE, generating AGENTS.md and `.cursor/rules/*.mdc` files. Instead of auto-generating one bloated file, this toolkit creates **minimal, scoped files** following progressive disclosure principles — proven by research to outperform comprehensive auto-generated configurations.
+A multi-plugin marketplace providing evidence-based agent artifact engineering. The `agents-initializer` plugin generates and optimizes AGENTS.md and CLAUDE.md configuration files for Claude Code. The `cursor-initializer` plugin does the same for Cursor IDE, generating AGENTS.md and `.cursor/rules/*.mdc` files. The `agent-customizer` plugin creates and improves Claude Code artifact files (skills, hooks, rules, subagents) with documentation-grounded guidance and evidence traceability. Instead of auto-generating one bloated file, this toolkit creates **minimal, scoped files** following progressive disclosure principles — proven by research to outperform comprehensive auto-generated configurations.
 
 ## Why This Plugin Exists
 
@@ -44,6 +44,12 @@ To maintain context integrity during execution, this plugin uses **subagent isol
 | `codebase-analyzer` | Detects tech stack, package manager, build/test commands | All subagent-backed plugin skills |
 | `scope-detector` | Identifies distinct scopes/contexts in the project | init skills |
 | `file-evaluator` | Assesses existing config file quality against research criteria | improve skills |
+| `artifact-analyzer` | Analyzes project artifact landscape — existing skills, hooks, rules, subagents, naming conventions | All agent-customizer skills (Phase 1 or 2) |
+| `skill-evaluator` | Evaluates `SKILL.md` files against evidence-based quality criteria | agent-customizer `improve-skill` |
+| `hook-evaluator` | Evaluates hook configurations against evidence-based quality criteria | agent-customizer `improve-hook` |
+| `rule-evaluator` | Evaluates `.claude/rules/` files against evidence-based quality criteria | agent-customizer `improve-rule` |
+| `subagent-evaluator` | Evaluates subagent definitions against evidence-based quality criteria | agent-customizer `improve-subagent` |
+| `docs-drift-checker` | Verifies reference files against source docs for content drift | agent-customizer quality gate |
 
 The Claude Code plugin uses native Claude subagent files with read-only tool whitelists and `model: sonnet`; the Cursor plugin uses Cursor's native subagent format with `model: inherit` and `readonly: true`. Both return structured summaries — high signal, low noise — keeping the orchestrator's context clean.
 
@@ -205,6 +211,18 @@ Evaluate and improve existing `.cursor/rules/*.mdc` files.
 
 > **Note:** Use `cursor-initializer` when you want the full Cursor configuration hierarchy, including AGENTS.md alongside `.cursor/rules/*.mdc`. Use `agents-initializer` (`/init-agents`, `/improve-agents`) when you want AGENTS.md/CLAUDE.md workflows outside a Cursor-specific setup.
 
+### Agent Customizer Skills
+
+The `agent-customizer` plugin provides 8 skills for creating and improving Claude Code artifacts, each grounded in the Anthropic documentation corpus. See [plugins/agent-customizer/README.md](plugins/agent-customizer/README.md) for full documentation.
+
+#### Create Skills
+
+**`create-skill`**, **`create-hook`**, **`create-rule`**, **`create-subagent`** — Generate new artifacts with 5-phase orchestration: preflight -> codebase analysis -> docs-grounded generation -> self-validation (max 3x) -> user presentation.
+
+#### Improve Skills
+
+**`improve-skill`**, **`improve-hook`**, **`improve-rule`**, **`improve-subagent`** — Evaluate and optimize existing artifacts against evidence-based quality criteria, presenting proposed changes with evidence before applying them.
+
 ## Installation
 
 ### Claude Code (Native Plugin System)
@@ -237,6 +255,16 @@ claude plugin install agents-initializer@agent-engineering-toolkit --scope proje
 
 # Install only for yourself in this project
 claude plugin install agents-initializer@agent-engineering-toolkit --scope local
+```
+
+#### agent-customizer Plugin
+
+```bash
+# Install agent-customizer
+/plugin install agent-customizer@agent-engineering-toolkit
+
+# Or via CLI
+claude plugin install agent-customizer@agent-engineering-toolkit --scope project
 ```
 
 ### Cursor IDE (Native Plugin System)
@@ -325,6 +353,16 @@ After installation, invoke skills by name:
 /agents-initializer:improve-agents
 /cursor-initializer:init-cursor
 /cursor-initializer:improve-cursor
+
+# Agent Customizer skills (namespaced, plugin distribution only)
+/agent-customizer:create-skill       # Generate a new SKILL.md
+/agent-customizer:create-hook        # Generate a hook configuration
+/agent-customizer:create-rule        # Generate a path-scoped .claude/rules/ file
+/agent-customizer:create-subagent    # Generate a subagent definition
+/agent-customizer:improve-skill      # Evaluate and optimize existing skill
+/agent-customizer:improve-hook       # Evaluate and optimize existing hook
+/agent-customizer:improve-rule       # Evaluate and optimize existing rule
+/agent-customizer:improve-subagent   # Evaluate and optimize existing subagent
 ```
 
 ## Research Foundation
@@ -382,7 +420,7 @@ agent-engineering-toolkit/
 │   │       ├── codebase-analyzer.md # Subagent: tech stack and tooling detection
 │   │       ├── scope-detector.md    # Subagent: project scope/context detection
 │   │       └── file-evaluator.md    # Subagent: config file quality assessment
-│   └── cursor-initializer/         # Cursor IDE plugin — Cursor-native artifact generation
+│   ├── cursor-initializer/         # Cursor IDE plugin — Cursor-native artifact generation
 │       ├── .cursor-plugin/
 │       │   └── plugin.json          # Plugin manifest
 │       ├── AGENTS.md                # Cursor-native plugin config (for working in this directory)
@@ -393,6 +431,12 @@ agent-engineering-toolkit/
 │           ├── codebase-analyzer.md # Subagent: tech stack detection
 │           ├── scope-detector.md    # Subagent: scope detection
 │           └── file-evaluator.md    # Subagent: .mdc file quality assessment
+│   └── agent-customizer/            # Claude Code plugin — artifact creation and improvement
+│       ├── .claude-plugin/
+│       │   └── plugin.json          # Plugin manifest
+│       ├── docs-drift-manifest.md   # Registry: reference files -> 12 source docs
+│       ├── agents/                  # 6 subagents (artifact-analyzer, evaluators, drift checker)
+│       └── skills/                  # 8 skills: create-{type} and improve-{type}
 ├── skills/                          # npx skills add — standalone skills (no agent delegation)
 │   ├── init-agents/SKILL.md         # Self-contained: inline analysis, no subagents required
 │   ├── init-claude/SKILL.md         # Self-contained: inline analysis, no subagents required

--- a/docs/plans/2026-03-22-agents-initializer-plugin-design.md
+++ b/docs/plans/2026-03-22-agents-initializer-plugin-design.md
@@ -1,4 +1,4 @@
-# Design: Project Agents Initializer Plugin
+# Design: Agent Engineering Toolkit Plugin
 
 **Date**: 2026-03-22
 **Status**: Draft

--- a/plugins/agent-customizer/.claude-plugin/plugin.json
+++ b/plugins/agent-customizer/.claude-plugin/plugin.json
@@ -5,6 +5,6 @@
   "author": {
     "name": "rodrigorjsf"
   },
-  "repository": "https://github.com/rodrigorjsf/project-agents-initializer",
+  "repository": "https://github.com/rodrigorjsf/agent-engineering-toolkit",
   "license": "MIT"
 }

--- a/plugins/agent-customizer/README.md
+++ b/plugins/agent-customizer/README.md
@@ -1,0 +1,383 @@
+# agent-customizer
+
+Evidence-based creation and improvement of Claude Code artifacts (skills, hooks, rules, subagents) grounded in the Anthropic documentation corpus.
+The plugin covers all four artifact types through eight skills: `create-skill`, `create-hook`, `create-rule`, `create-subagent`, `improve-skill`, `improve-hook`, `improve-rule`, and `improve-subagent`.
+
+## Why This Plugin Exists
+
+### The Problem with Ungrounded Artifact Authoring
+
+Developers often write Claude Code artifacts from scratch, relying on memory, scattered examples, or generic prompts instead of current source docs. That produces bloated skills, unsafe hooks, vague rules, and weak subagent prompts that look plausible but drift from the documented platform behavior.
+
+The risk is measurable:
+
+| Setting | Task Success Impact | Cost Impact |
+|---------|---------------------|-------------|
+| No config file | Baseline | Baseline |
+| LLM-generated config file | **-3% success rate** | **+20% cost** |
+| Developer-written minimal file | **+4% success rate** | +19% cost |
+
+**Key findings:**
+
+- Auto-generated guidance tends to repeat what the model already knows, which wastes attention budget.
+- Extra requirements make tasks harder because the model follows irrelevant instructions anyway.
+- Minimal, developer-written guidance performs better because it captures the few non-obvious details that matter.
+- The same failure mode applies to artifact authoring: generic prompts produce generic artifacts.
+
+### The Evidence-Based Solution
+
+This plugin turns the Anthropic docs corpus into reusable authoring workflows:
+
+1. **Distilled reference files** keep each guidance file under 200 lines and load them only when needed.
+2. **Source attribution** traces every reference back to current source docs, including the 12 docs registered in `docs-drift-manifest.md`.
+3. **Five-phase orchestration** gives each skill a consistent flow: preflight, analysis, generation, validation, and presentation.
+4. **Self-validation loops** check output against artifact-specific criteria before presenting it.
+5. **Evidence citations** keep generated artifacts grounded instead of relying on folklore or stale examples.
+
+## Architecture
+
+### Subagent-Driven Development
+
+The plugin uses specialized read-only subagents to keep the orchestrator focused on authoring decisions instead of exploratory reading.
+
+| Subagent | Role | Used By |
+|----------|------|---------|
+| `artifact-analyzer` | Analyzes a project's artifact landscape: existing skills, hooks, rules, subagents, naming conventions, and integration patterns | All 8 skills (Phase 1 or 2) |
+| `skill-evaluator` | Evaluates `SKILL.md` files against docs-derived quality criteria | `improve-skill` |
+| `hook-evaluator` | Evaluates hook configurations against docs-derived quality criteria | `improve-hook` |
+| `rule-evaluator` | Evaluates `.claude/rules/` files against docs-derived quality criteria | `improve-rule` |
+| `subagent-evaluator` | Evaluates subagent definitions against docs-derived quality criteria | `improve-subagent` |
+| `docs-drift-checker` | Verifies reference files against source docs for content drift | Quality gate and documentation audits |
+
+#### Subagent Metadata
+
+Each agent file follows the Claude Code subagent format:
+
+```yaml
+---
+name: artifact-analyzer
+description: "Analyze a project's codebase to understand its artifact landscape — existing skills, hooks, rules, subagents, naming conventions, and integration patterns. Use when creating or improving Claude Code artifacts."
+tools: Read, Grep, Glob, Bash
+model: sonnet
+maxTurns: 15
+---
+```
+
+Key design decisions:
+
+- **Read-only tools** keep analysis isolated from writes.
+- **`model: sonnet`** balances reasoning quality and cost for documentation-backed analysis.
+- **`maxTurns: 15-20`** prevents runaway loops while allowing full evaluations.
+- **Isolated context** keeps each agent focused on one artifact type or verification job.
+
+#### Create Workflow
+
+```text
+Phase 1: Preflight       -> Check whether the artifact already exists
+Phase 2: Context Analysis -> artifact-analyzer scans current project patterns
+Phase 3: Generation      -> Load references from the docs corpus and apply templates
+Phase 4: Self-Validation -> Check against artifact-specific criteria, loop up to 3 times
+Phase 5: Presentation    -> Show the result with evidence citations before writing
+```
+
+#### Improve Workflow
+
+```text
+Phase 1: Evaluate       -> Type-specific evaluator assesses the existing artifact
+Phase 2: Compare        -> Cross-reference the current docs-backed best practices
+Phase 3: Plan           -> Generate removals, refactors, and additions
+Phase 4: Self-Validate  -> Check the plan against validation criteria
+Phase 5: Present        -> Show the proposed changes with evidence before applying
+```
+
+## Skills
+
+### `create-skill`
+
+Create a new Claude Code skill with frontmatter, phases, references, and templates grounded in the docs corpus.
+
+**What it does:**
+
+1. Launches `artifact-analyzer` to detect existing skill patterns and naming conventions.
+2. Loads the skill authoring and format references from the docs corpus.
+3. Generates `SKILL.md` with YAML frontmatter, phase definitions, and bundled references.
+4. Validates the draft against `skill-validation-criteria.md`, looping up to three times.
+5. Presents the result with evidence citations before writing.
+
+**Preflight check:** If `{skill-name}/SKILL.md` already exists, the workflow redirects to `improve-skill`.
+
+**What it generates:**
+
+- `SKILL.md` with valid frontmatter and phased instructions
+- `references/` files with source attribution
+- `assets/templates/` scaffolding when the skill needs output templates
+
+### `create-hook`
+
+Create a new Claude Code hook configuration with the correct event model, handler type, and schema requirements.
+
+**What it does:**
+
+1. Launches `artifact-analyzer` to inspect existing hook configurations and conventions.
+2. Loads the hook authoring and event reference docs from the corpus.
+3. Generates a hook configuration for the selected lifecycle event.
+4. Validates the JSON and handler choices against `hook-validation-criteria.md`.
+5. Presents the configuration with evidence citations before writing.
+
+**Preflight check:** If the requested event and matcher combination already exists, the workflow redirects to `improve-hook`.
+
+**What it generates:**
+
+- Hook configuration blocks for `.claude/settings.json` or plugin hook files
+- Event-specific matcher guidance
+- Evidence-backed handler decisions
+
+### `create-rule`
+
+Create a new path-scoped `.claude/rules/` file with minimal, specific instructions grounded in the docs corpus.
+
+**What it does:**
+
+1. Launches `artifact-analyzer` to inspect existing rules and scope boundaries.
+2. Loads the rule authoring guidance from the corpus.
+3. Generates a path-scoped rule with `paths:` frontmatter and tight glob patterns.
+4. Validates the draft against `rule-validation-criteria.md`.
+5. Presents the rule with evidence citations before writing.
+
+**Preflight check:** If a rule already covers the topic or overlapping glob patterns, the workflow redirects to `improve-rule`.
+
+**What it generates:**
+
+- `.claude/rules/{name}.md` with `paths:` frontmatter
+- Specific, verifiable instructions
+- Scope-aware glob patterns
+
+### `create-subagent`
+
+Create a new Claude Code subagent definition with structured prompts, model selection, and tool restrictions grounded in the docs corpus.
+
+**What it does:**
+
+1. Launches `artifact-analyzer` to detect existing subagents and naming patterns.
+2. Loads the subagent authoring and configuration references from the corpus.
+3. Generates an agent definition with YAML frontmatter and a structured system prompt.
+4. Validates the draft against `subagent-validation-criteria.md`.
+5. Presents the definition with evidence citations before writing.
+
+**Preflight check:** If `agents/{name}.md` already exists, the workflow redirects to `improve-subagent`.
+
+**What it generates:**
+
+- `agents/{name}.md` with `name`, `description`, `tools`, `model`, and `maxTurns`
+- Role definition, process steps, output format, and self-verification instructions
+- Tool restrictions matched to the agent's task
+
+### `improve-skill`
+
+Evaluate and optimize an existing `SKILL.md` file against evidence-based quality criteria from the docs corpus.
+
+**What it does:**
+
+1. Launches `skill-evaluator` to assess the current `SKILL.md`.
+2. Compares the result against current skill authoring guidance.
+3. Builds an improvement plan in removal → refactor → addition order.
+4. Validates the plan against `skill-validation-criteria.md`.
+5. Presents the proposed changes with evidence before applying them.
+
+**Preflight check:** If no matching `SKILL.md` exists at the target path, the workflow redirects to `create-skill`.
+
+**What it checks:**
+
+- YAML frontmatter validity and discovery fields
+- Phase structure and progressive disclosure
+- Reference usage and bundled path conventions
+- Token efficiency and line-count limits
+
+**What it generates:** An updated `SKILL.md` and aligned bundled files when the user approves the changes.
+
+### `improve-hook`
+
+Evaluate and optimize existing hook configurations against evidence-based quality criteria from the docs corpus.
+
+**What it does:**
+
+1. Launches `hook-evaluator` to assess the current hook configuration.
+2. Compares the result against event, handler, and security requirements.
+3. Builds an improvement plan for invalid events, matcher scope, and safety gaps.
+4. Validates the plan against `hook-validation-criteria.md`.
+5. Presents the proposed changes with evidence before applying them.
+
+**Preflight check:** If no hook configuration exists for the requested target, the workflow redirects to `create-hook`.
+
+**What it checks:**
+
+- Event name validity and handler support
+- JSON structure and schema compliance
+- Matcher specificity and blocking behavior
+- Secret handling and command safety
+
+**What it generates:** Updated hook configuration with valid JSON and tighter event handling when the user approves the changes.
+
+### `improve-rule`
+
+Evaluate and optimize existing `.claude/rules/` files against evidence-based quality criteria from the docs corpus.
+
+**What it does:**
+
+1. Launches `rule-evaluator` to assess current path-scoped rules.
+2. Compares the result against scoping, specificity, and overlap requirements.
+3. Builds an improvement plan for line limits, glob quality, and contradictions.
+4. Validates the plan against `rule-validation-criteria.md`.
+5. Presents the proposed changes with evidence before applying them.
+
+**Preflight check:** If no matching rule file exists under `.claude/rules/`, the workflow redirects to `create-rule`.
+
+**What it checks:**
+
+- `paths:` frontmatter presence and quality
+- Rule length and instruction specificity
+- Topic overlap or contradictions with other rules
+- Broad globs and wasted always-loaded context
+
+**What it generates:** Updated `.claude/rules/` files with tighter scope and clearer instructions when the user approves the changes.
+
+### `improve-subagent`
+
+Evaluate and optimize existing subagent definitions against evidence-based quality criteria from the docs corpus.
+
+**What it does:**
+
+1. Launches `subagent-evaluator` to assess the current agent definition.
+2. Compares the result against current subagent best practices.
+3. Builds an improvement plan for frontmatter, prompts, and tool restrictions.
+4. Validates the plan against `subagent-validation-criteria.md`.
+5. Presents the proposed changes with evidence before applying them.
+
+**Preflight check:** If no matching subagent definition exists at the target path, the workflow redirects to `create-subagent`.
+
+**What it checks:**
+
+- Required frontmatter fields and naming rules
+- Model choice and `maxTurns` limits
+- Tool restriction discipline
+- Prompt structure, output format, and self-verification
+
+**What it generates:** Updated subagent definitions with stronger prompt structure and tighter tool choices when the user approves the changes.
+
+## Installation
+
+### Claude Code (Native Plugin System)
+
+```bash
+# Step 1: Add the marketplace (one-time setup)
+/plugin marketplace add rodrigorjsf/agent-engineering-toolkit
+
+# Step 2: Install the plugin
+/plugin install agent-customizer@agent-engineering-toolkit
+```
+
+Or via the Claude Code CLI:
+
+```bash
+claude plugin install agent-customizer@agent-engineering-toolkit
+```
+
+**Scopes:**
+
+- Default (user scope): Available in all your projects
+- Project scope: Shared with your team via `.claude/settings.json`
+- Local scope: Only for you in this project (gitignored)
+
+```bash
+# Install for the whole team
+claude plugin install agent-customizer@agent-engineering-toolkit --scope project
+
+# Install only for yourself in this project
+claude plugin install agent-customizer@agent-engineering-toolkit --scope local
+```
+
+> `agent-customizer` is a Claude Code plugin distribution. It does not ship a standalone `npx skills add` variant in this repository.
+
+## Usage
+
+After installation, invoke skills by name:
+
+```text
+# Agent Customizer — Create new artifacts
+/agent-customizer:create-skill       # Generate a new SKILL.md
+/agent-customizer:create-hook        # Generate a hook configuration
+/agent-customizer:create-rule        # Generate a path-scoped .claude/rules/ file
+/agent-customizer:create-subagent    # Generate a subagent definition
+
+# Agent Customizer — Improve existing artifacts
+/agent-customizer:improve-skill      # Evaluate and optimize existing skill
+/agent-customizer:improve-hook       # Evaluate and optimize existing hook
+/agent-customizer:improve-rule       # Evaluate and optimize existing rule
+/agent-customizer:improve-subagent   # Evaluate and optimize existing subagent
+```
+
+## Research Foundation
+
+This plugin distills the 12 source docs registered in `docs-drift-manifest.md`.
+
+### Academic Research
+
+- **[Evaluating AGENTS study](../../docs/general-llm/Evaluating-AGENTS-paper.md)** (ETH Zurich, Feb 2026) — Shows that minimal, developer-written guidance outperforms LLM-generated artifacts.
+
+### Anthropic Official Documentation
+
+- **[Skill Authoring Best Practices](../../docs/shared/skill-authoring-best-practices.md)** — Defines the skill size limits, reference strategy, and validation expectations.
+- **[Extend Claude with Skills](../../docs/claude-code/skills/extend-claude-with-skills.md)** — Explains how Claude Code skills load, route, and use bundled files.
+- **[Research Claude Code Skills Format](../../docs/claude-code/skills/research-claude-code-skills-format.md)** — Documents the frontmatter and structure requirements for Claude Code skills.
+- **[Automate Workflow with Hooks](../../docs/claude-code/hooks/automate-workflow-with-hooks.md)** — Covers hook design, automation patterns, and operational safety.
+- **[Claude Hook Reference](../../docs/claude-code/hooks/claude-hook-reference-doc.md)** — Defines supported hook events, handler types, and exit behavior.
+- **[How Claude Remembers a Project](../../docs/claude-code/memory/how-claude-remembers-a-project.md)** — Explains path-scoped rules, hierarchical memory, and context budgets.
+- **[Creating Custom Subagents](../../docs/claude-code/subagents/creating-custom-subagents.md)** — Defines the subagent frontmatter model and system-prompt structure.
+- **[Claude Orchestrate of Claude Code Sessions](../../docs/claude-code/subagents/claude-orchestrate-of-claude-code-sessions.md)** — Explains orchestration tradeoffs and subagent coordination patterns.
+- **[Claude Prompting Best Practices](../../docs/claude-code/claude-prompting-best-practices.md)** — Supplies the prompt design rules used by the artifact templates.
+
+### Practitioner Guides
+
+- **[Prompt Engineering Guide](../../docs/general-llm/prompt-engineering-guide.md)** — Maps prompt strategies to task types instead of using one generic prompt shape.
+- **[Research: Subagent Best Practices](../../docs/general-llm/subagents/research-subagent-best-practices.md)** — Supports the isolation, tooling, and model patterns used by the plugin's agents.
+
+## Anti-Patterns This Plugin Avoids
+
+| Anti-Pattern | Evidence | What We Do Instead |
+|--------------|----------|-------------------|
+| Artifact guidance with no source docs | Earlier ad hoc artifact workflows cited no source documents | Every reference file cites current source docs and line ranges |
+| One prompt strategy for every artifact | Prompt engineering guidance is task-specific | Use per-artifact strategies for skills, hooks, rules, and subagents |
+| No validation loop | Skill authoring guidance requires explicit validation criteria | Validate every output against artifact-specific criteria before presentation |
+| No improve path for existing artifacts | Create-only flows leave existing files unmanaged | Ship `improve-{type}` for every `create-{type}` workflow |
+| Oversized artifacts that burn attention budget | Anthropic docs warn about context rot and file-size limits | Keep artifacts minimal and enforce hard size ceilings |
+| Stale guidance as source docs evolve | Distilled reference files can drift silently | Use `docs-drift-checker` and `docs-drift-manifest.md` to audit alignment |
+
+## Repository Structure
+
+```text
+plugins/agent-customizer/
+├── .claude-plugin/
+│   └── plugin.json                  # Plugin manifest (name, version, description)
+├── CLAUDE.md                        # Plugin-level conventions and agent inventory
+├── docs-drift-manifest.md           # Registry: reference files -> source docs
+├── agents/
+│   ├── artifact-analyzer.md         # Project artifact landscape analysis
+│   ├── skill-evaluator.md           # SKILL.md quality evaluation
+│   ├── hook-evaluator.md            # Hook configuration quality evaluation
+│   ├── rule-evaluator.md            # .claude/rules/ quality evaluation
+│   ├── subagent-evaluator.md        # Subagent definition quality evaluation
+│   └── docs-drift-checker.md        # Reference-file drift detection
+└── skills/
+    ├── create-skill/                # Create new skills from docs-grounded references
+    ├── create-hook/                 # Create new Claude Code hook configurations
+    ├── create-rule/                 # Create new path-scoped rule files
+    ├── create-subagent/             # Create new subagent definitions
+    ├── improve-skill/               # Improve existing skills against quality criteria
+    ├── improve-hook/                # Improve existing hooks against quality criteria
+    ├── improve-rule/                # Improve existing rules against quality criteria
+    └── improve-subagent/            # Improve existing subagents against quality criteria
+```
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Add user-facing documentation for the `agent-customizer` plugin and standardize tracked repository references on the canonical `agent-engineering-toolkit` name.

## What problem are you trying to solve?

The `agent-customizer` plugin was implemented but undocumented, so users had no plugin-level README, no install examples, and no namespaced usage examples. In addition, tracked repository content still contained stale references to the retired repository name, which created inconsistency between current docs, manifests, issue templates, and historical artifacts.

## What does this PR change?

This PR adds `plugins/agent-customizer/README.md`, expands the root `README.md` with installation and usage coverage for `agent-customizer`, fixes the plugin manifest repository URL, and updates remaining tracked references to the canonical repository name across docs and support files.

## Is this change appropriate for the core library?

Yes. It updates first-party plugin documentation, repository metadata, and supporting project artifacts that all users of this repository depend on.

## What alternatives did you consider?

I considered limiting the rename sweep to active docs only, but rejected that because the task was explicitly expanded to update every repository reference to the old name. I also considered preserving old-name text in historical PRP artifacts, but rejected that because it would keep stale repository identifiers in tracked content.

## Does this PR contain multiple unrelated changes?

No. The documentation additions and the repo-name cleanup are coupled parts of the same task: documenting `agent-customizer` and aligning tracked repository references with the canonical repository identity.

## Existing PRs
- [x] I have reviewed all open AND closed PRs for duplicates or prior art
- Related PRs: #30, none found for this exact documentation branch

## Environment tested

| Harness (e.g. Claude Code, Cursor) | Harness version | Model | Model version/ID |
|-------------------------------------|-----------------|-------|------------------|
| GitHub Copilot CLI | 1.0.27 | GPT-5.4 | gpt-5.4 |

## Evaluation
- Initial prompt: `Use the skill tool to invoke the "using-superpowers" skill, then follow the skill's instructions to help with: execute @.claude/PRPs/plans/plugin-documentation.plan.md`
- Eval sessions after the change: 0 formal eval sessions; I used targeted repository verification because this work is documentation and metadata only.
- Outcome change: the repository now documents `agent-customizer` installation and usage, and tracked content no longer contains the retired repository name.

## Rigor

- [ ] If this is a skills change: I verified skill behavior with adversarial pressure testing and completed at least 3 eval sessions (paste results below)
- [ ] This change was tested adversarially, not just on the happy path
- [ ] I did not modify carefully-tuned content (Red Flags table, rationalizations, "human partner" language) without extensive evals showing the change is an improvement

## Human review
- [ ] A human has reviewed the COMPLETE proposed diff before submission

## Changes

**Plugin Skills** (`plugins/agents-initializer/skills/`)
- None.

**Standalone Skills** (`skills/`)
- None.

**Agent Definitions** (`plugins/agents-initializer/agents/`)
- Updated `.claude/agents/pr-comment-resolver.md` example repository slug to the canonical name.

**Rules** (`.claude/rules/`)
- None.

**Documentation** (`docs/`)
- Added `plugins/agent-customizer/README.md`.
- Expanded the root `README.md` with `agent-customizer` architecture, installation, usage, and repository-tree coverage.
- Updated tracked docs and archived PRP artifacts to use the canonical repository name and coherent rename semantics.
- Updated `LICENSE` contributor naming to `Agent Engineering Toolkit Contributors`.

**Configuration** (`CLAUDE.md`, `.claude-plugin`, `DESIGN-GUIDELINES.md`)
- Updated `plugins/agent-customizer/.claude-plugin/plugin.json` to the canonical repository URL.
- Updated `.github/ISSUE_TEMPLATE/config.yml` to the canonical repository docs URL.

**Meta-Skills / Dev Tooling** (`.claude/skills/`)
- None.

## Convention Compliance

- [x] No file exceeds 200 lines (references, rules, templates, CLAUDE.md)
- [x] SKILL.md files: name ≤64 chars, description ≤1024 chars, body <500 lines
- [x] Shared references updated in ALL copies across both distributions
- [x] Plugin skills delegate to agents; standalone skills use inline analysis — patterns not mixed
- [x] Agent definitions use model: sonnet (except for `pr-comment-resolver` agent), read-only tools, maxTurns 15-20
- [x] New guidelines in DESIGN-GUIDELINES.md have source citation and "Implemented in" traceability
- [x] Root CLAUDE.md stays within 15-40 line target
- [x] Commits are atomic — one logical change per commit

## Evidence & Quality

- [x] New instructions pass the test: "Would removing this cause the agent to make mistakes?"
- [x] Reference files have source attribution
- [x] No stale file paths or commands introduced
- [x] No content agents can infer from the codebase (standard conventions, directory listings)

## Related Issues / PRD

Implements `.claude/PRPs/plans/plugin-documentation.plan.md` and the in-session follow-up to replace remaining tracked references to the retired repository name.
Related issue: #49.
