### PR TITLE
docs: foundation for Cursor distribution (CONTEXT.md + ADRs)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,70 @@
+# agent-engineering-toolkit
+
+Multi-plugin marketplace where each distribution authors agent artifacts (skills, hooks, rules, subagents) for one specific agent platform. Plugins fall into two complementary roles per platform: an **initializer** that bootstraps platform-wide configuration for a project, and a **customizer** that creates and improves individual artifacts within that project.
+
+## Language
+
+### Distribution roles
+
+**Initializer**:
+A plugin that bootstraps the platform-wide configuration of a target project (one-shot setup of the rule/memory hierarchy).
+_Avoid_: setup plugin, scaffolder
+
+**Customizer**:
+A plugin that creates and improves individual agent artifacts (skills, hooks, rules, subagents) inside a project that is already initialized.
+_Avoid_: artifact builder, generator plugin
+
+### Platforms and namespaces
+
+**Claude Code distribution**:
+The pair of plugins targeting the Claude Code platform — `agents-initializer` (initializer) + `agent-customizer` (customizer). Generated artifacts target `.claude/`.
+_Avoid_: Claude flavor, Anthropic plugins
+
+**Cursor distribution**:
+The pair of plugins targeting Cursor — `cursor-initializer` (initializer) + `cursor-customizer` (customizer, planned). Generated artifacts target `.cursor/`.
+_Avoid_: Cursor flavor, IDE plugins
+
+**Standalone distribution**:
+The npx-installable skills under repo-root `skills/` that perform inline analysis without subagent delegation. Single distribution, no initializer/customizer split.
+_Avoid_: CLI skills, plain skills
+
+### Artifact vocabulary
+
+**Artifact**:
+One of four agent-platform configuration units — **Skill**, **Hook**, **Rule**, or **Subagent**.
+_Avoid_: file, config, asset
+
+**Skill** (Claude Code or Cursor sense):
+A `SKILL.md`-rooted package with phases, references, and templates that teaches an agent how to perform a domain task.
+
+**Hook**:
+A platform-specific event handler that runs on lifecycle events. Claude Code and Cursor both have hooks, with different event models.
+
+**Rule**:
+A path- or pattern-scoped instruction file. In Claude Code, `.claude/rules/*.md` with `paths:` frontmatter. In Cursor, `.cursor/rules/*.mdc` with `description`/`alwaysApply`/`globs` frontmatter.
+
+**Rules-first** (Cursor distribution stance):
+Design posture of the Cursor distribution: `.cursor/rules/*.mdc` is the canonical surface for project conventions. AGENTS.md is recognized only as **legacy input** that the customizer's improve flow can migrate into modular rules — it is never generated.
+_Avoid_: rules-only (rules-first leaves room for legacy migration; rules-only would mean ignoring AGENTS.md entirely)
+
+**Subagent**:
+A YAML-fronted agent definition spawned for delegated, isolated work. Claude Code uses `tools:`/`maxTurns:`; Cursor uses `readonly:`/`model: inherit`.
+
+**Product-strict (Cursor distribution stance)**:
+Branding rule for Cursor distribution artifacts: zero textual references to Claude Code, `.claude/`, `CLAUDE.md`, `tools:` whitelists, `maxTurns:`, `paths:` frontmatter, or any other Claude Code-specific construct. Vendor-neutral research (ETH study, "Lost in the Middle", "Effective Context Engineering") may be cited as "Industry Research" without product branding.
+_Avoid_: claude-free, vendor-pure (these miss the product-vs-research distinction)
+
+## Relationships
+
+- A **Distribution** owns at most one **Initializer** and at most one **Customizer**.
+- An **Initializer** generates platform-wide files; a **Customizer** generates individual **Artifacts** of the four supported types.
+- The **Claude Code distribution** and the **Cursor distribution** are siblings — same conceptual roles, different platform formats and conventions.
+
+## Example dialogue
+
+> **Dev:** "If I want to create a new path-scoped rule inside an already-set-up Cursor project, which plugin runs?"
+> **Domain expert:** "The **Cursor customizer** — `cursor-customizer:create-rule`. The **Cursor initializer** would only run on a project without existing Cursor configuration."
+
+## Flagged ambiguities
+
+- "Cursor CLI" was used by the user to mean the full Cursor distribution surface (IDE + CLI share the `.cursor/rules/` system). Resolved: in this repo, **Cursor distribution** covers both surfaces — they consume the same artifact files.

--- a/docs/adr/0001-cursor-distribution-rules-first.md
+++ b/docs/adr/0001-cursor-distribution-rules-first.md
@@ -1,0 +1,11 @@
+# Cursor distribution is rules-first; AGENTS.md is legacy input only
+
+The Cursor distribution (`cursor-initializer` + `cursor-customizer`) treats `.cursor/rules/*.mdc` as the canonical surface for project conventions. Plugins **never generate** AGENTS.md — when an existing project has one, `cursor-initializer:improve-cursor` recognises it as **legacy input** and proposes a non-destructive migration that decomposes its content into modular rules (the original file is preserved intact; the user removes it manually after validating the generated rules).
+
+This deviates from Cursor's official documentation, which lists AGENTS.md as one of four valid rule types. The deviation is deliberate: a single monolithic AGENTS.md couples unrelated concerns and forces continuous edits to one file, while `.cursor/rules/*.mdc` supports four orthogonal activation modes (`alwaysApply`, `globs`, `description`, manual) that map cleanly to one-concern-per-rule. The trade-off is loss of "developer-written minimal file" gains from the ETH "Evaluating AGENTS.md" study; the mitigation is that the same minimalism principles are encoded into rule-authoring guidance (rule-domain hierarchy: tooling-non-obvious → file-pattern → monorepo-scope → on-demand), not in a separate AGENTS.md template.
+
+## Considered options
+
+- **(A) Strip AGENTS.md entirely** — rejected: legacy projects with significant AGENTS.md investment lose that input silently
+- **(B) Rules-first with explicit legacy migration** — accepted
+- **(C) Rules-first with optional minimal AGENTS.md** — rejected: reintroduces the monolithic file the posture is trying to eliminate

--- a/docs/adr/0002-product-strict-research-foundation.md
+++ b/docs/adr/0002-product-strict-research-foundation.md
@@ -1,0 +1,11 @@
+# Cursor distribution is product-strict on Claude branding
+
+Plugins in the Cursor distribution (`cursor-initializer`, `cursor-customizer`) contain **zero textual references** to Claude Code, `CLAUDE.md`, `.claude/`, `tools:` whitelists, `maxTurns:`, `paths:` frontmatter, `${CLAUDE_SKILL_DIR}`, or any other Claude Code-specific construct. Vendor-neutral research that happens to be Anthropic-authored (Effective Context Engineering, Lost in the Middle) is permitted under a "Industry Research" framing, without product branding.
+
+The distinction matters: the goal is to prevent Claude Code conventions from leaking into Cursor outputs (templates, generated artifacts, references), not to suppress the public research that legitimately informs context-engineering decisions across all platforms. Banning that research would dilute the evidence base without changing user-visible artefacts. The boundary is concrete: every README citation, every reference file source attribution, every template, every subagent frontmatter, every example in generated artifacts must use Cursor-native paths and formats; research papers are cited as research, never as product guidance.
+
+## Consequences
+
+- `plugins/cursor-initializer/README.md` "Anthropic Official Documentation" section is rewritten to remove `docs.anthropic.com/en/docs/claude-code/memory` links and reframe Anthropic-engineering posts as "Industry Research"
+- `plugins/cursor-customizer/docs-drift-manifest.md` cites `docs/cursor/*` as canonical sources; ETH paper and arxiv research as secondary
+- All Cursor-distribution subagent frontmatter uses `model: inherit` + `readonly: true` exclusively

--- a/docs/adr/0003-cursor-skills-default-path.md
+++ b/docs/adr/0003-cursor-skills-default-path.md
@@ -1,0 +1,5 @@
+# cursor-customizer:create-skill defaults to .cursor/skills/
+
+Cursor's Agent Skills standard recognises three project-level discovery paths: `.agents/skills/` (open-standard, portable across Agent Skills implementations), `.cursor/skills/` (Cursor-specific), and `~/.cursor/skills/` (user-global). The `cursor-customizer:create-skill` skill writes new skills to `.cursor/skills/` by default and documents the user-driven move to `.agents/skills/` for projects that need cross-tool portability.
+
+The decision aligns the generated artifact with the plugin's namespace (`cursor-customizer`), which simplifies troubleshooting and matches the user's stated intent of a Cursor-targeted distribution. The portable `.agents/skills/` path was rejected as the default because it introduces an implicit coupling to other Agent Skills consumers that the user may not want; the interactive-prompt option was rejected because it adds friction to a one-time investment workflow.


### PR DESCRIPTION
## Summary

- Adds `CONTEXT.md` establishing toolkit-wide domain vocabulary: Initializer/Customizer plugin roles, the Claude Code/Cursor/Standalone distributions, the four artifact types (Skill/Hook/Rule/Subagent), and the rules-first + product-strict postures of the Cursor distribution.
- Adds three ADRs that lock the design direction for the Cursor distribution before code changes land:
  - `0001-cursor-distribution-rules-first.md` — `.cursor/rules/*.mdc` is canonical; AGENTS.md is legacy input only, migrated non-destructively
  - `0002-product-strict-research-foundation.md` — zero references to Claude Code conventions in Cursor distribution artifacts; vendor-neutral research permitted under "Industry Research" framing
  - `0003-cursor-skills-default-path.md` — `.cursor/skills/` as default destination for `cursor-customizer:create-skill`, prioritising namespace alignment over open-standard portability
- Foundation PR for the upcoming `cursor-initializer` rules-first refactor and the new `cursor-customizer` plugin.

## Test plan

- [ ] `CONTEXT.md` vocabulary covers every term used by subsequent PRs (cursor-initializer refactor, cursor-customizer creation, governance updates)
- [ ] Each ADR is referenced from the relevant plugin README/CLAUDE.md in subsequent PRs
- [ ] Subsequent PRs follow the rules-first + product-strict postures defined here

🤖 Generated with [Claude Code](https://claude.com/claude-code)