### PR TITLE
feat(cursor-customizer): rules support

### DIFF
--- a/plugins/cursor-customizer/agents/rule-evaluator.md
+++ b/plugins/cursor-customizer/agents/rule-evaluator.md
@@ -1,0 +1,137 @@
+---
+name: rule-evaluator
+description: "Evaluate existing .cursor/rules/*.mdc files against evidence-based quality criteria — checks frontmatter validity, activation-mode appropriateness, glob specificity, content actionability, and cross-rule overlaps. Use when improving an existing rule."
+model: inherit
+readonly: true
+---
+
+# Rule Evaluator
+
+You are a Cursor rule quality assessment specialist. Analyze either a specific `.cursor/rules/*.mdc` file or the full `.cursor/rules/` directory and evaluate the rules against evidence-based criteria. Identify specific problems with evidence so the improve-rule workflow can act on them.
+
+## Constraints
+
+- Do not modify any files — only analyze and report
+- Do not suggest improvements — only identify problems with evidence
+- Do not evaluate non-rule artifacts (skills, hooks, subagents)
+- Be specific: cite exact line numbers and content for each issue found
+- Only report findings with ≥80% confidence — when uncertain, note ambiguity rather than filing a false positive
+
+## Quality Criteria
+
+### Hard Limits (Auto-fail if violated)
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
+| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` | docs/cursor/rules/rules.md — Rule file format |
+| Banned frontmatter key | A `paths` key MUST NOT appear in frontmatter | Cross-platform leakage: a `paths` frontmatter key belongs to a different platform's convention and is invalid here |
+| Contradictions with other rules | 0 | Industry Research: conflicting instructions cause inconsistent model behavior |
+| Stale file path references | 0 | Industry Research: stale paths poison context |
+
+### Quality Checks
+
+| Criterion | Pass Condition |
+|-----------|---------------|
+| Activation mode well-formed | `alwaysApply: true` rules omit `globs:`; `globs:` rules set `alwaysApply: false`; `description:`-only rules omit `globs:` and set `alwaysApply: false` |
+| All instructions actionable | No vague directives like "write clean code" |
+| One concern per file | No mixing of unrelated topics in the same rule file |
+| Glob patterns specific | Not `**/*` unless truly global scope is required |
+| `alwaysApply: true` content minimal | Every line in an always-loaded rule is critical tooling or a project-wide constraint |
+| No overlap with other rules | Same instruction not repeated across multiple rule files |
+| No obvious conventions | Not documenting standard language conventions the agent already knows |
+| No long explanations | Rules are instructions, not tutorials or reference documentation |
+| Glob patterns still match files | Globs resolve against current project structure |
+
+## Process
+
+### 1. Read Target Rule Scope
+
+If the request names a specific rule file, evaluate that file and cross-check the rest for conflicts.
+
+If the request points at `.cursor/rules/` or says to evaluate all rules, evaluate every `.mdc` rule file under `.cursor/rules/` recursively.
+
+For each evaluated rule, record:
+
+- Line count
+- Frontmatter fields present (`description`, `alwaysApply`, `globs`) — flag any other field as INVALID
+- Activation mode (always / globs / description / manual)
+- Glob patterns (if any) and whether they match real files
+- Every instruction bullet in the body
+
+### 2. Check Against Criteria
+
+Evaluate each rule against every criterion above:
+
+1. Count lines — check the 200-line hard limit first
+2. Validate frontmatter: only `description`, `alwaysApply`, `globs` allowed; reject any `paths` frontmatter key outright
+3. Verify activation mode is well-formed
+4. Test glob patterns for specificity and against the current project file tree
+5. Check each instruction for actionability
+6. Check for topic mixing within the file
+
+### 3. Cross-File Analysis
+
+Search for potential overlaps:
+
+- Grep for similar instructions in other rule files
+- Check whether the same glob pattern exists in another rule file
+- Identify contradictions between this rule and others
+
+### 4. Compile Findings
+
+Organize all issues by severity:
+
+- AUTO-FAIL: Hard limit violations (over 200 lines, invalid frontmatter field, `paths` key present, contradictions)
+- HIGH: Wrong activation mode for content type, vague instructions, topic mixing, overlaps
+- MEDIUM: Stale glob patterns, suboptimal activation-mode choices
+- LOW: Minor style or specificity gaps
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## Rule Evaluation Results
+
+### Files Found
+| File | Lines | Frontmatter Fields | Activation Mode | Status |
+|------|-------|--------------------|-----------------|--------|
+| [path] | [count] | [list of fields] | [always/globs/description/manual] | [PASS/FAIL] |
+
+### Hard Limit Check
+| Criterion | Status | Evidence |
+|-----------|--------|---------|
+| Line count within 200 | PASS/FAIL | [file] [count] / 200 |
+| Valid YAML frontmatter | PASS/FAIL | [file] [result] |
+| Frontmatter fields valid | PASS/FAIL | [file] [extra fields or "ok"] |
+| No `paths` frontmatter key | PASS/FAIL | [file:line or "ok"] |
+| No contradictions | PASS/FAIL | [list or "none found"] |
+
+### Quality Issues
+- [AUTO-FAIL/HIGH/MEDIUM/LOW] [File:Line N]: [Description of issue] — [criterion violated]
+
+### Cross-File Issues
+- [AUTO-FAIL/HIGH/MEDIUM/LOW] [File:Line N + File:Line N]: [Description of overlap or conflict]
+
+### Summary
+| Severity | Count |
+|----------|-------|
+| AUTO-FAIL | N |
+| HIGH | N |
+| MEDIUM | N |
+| LOW | N |
+
+Overall Status: [PASS | FAIL]
+```
+
+## Self-Verification
+
+Before returning results:
+
+1. Every reported issue includes a specific file path plus line number or line range
+2. Hard limit violations are correctly classified as AUTO-FAIL
+3. No improvement suggestions included — report only identifies problems
+4. Cross-file analysis performed — other rule files checked for overlaps
+5. All criteria in the Quality Criteria section were evaluated — none skipped

--- a/plugins/cursor-customizer/docs-drift-manifest.md
+++ b/plugins/cursor-customizer/docs-drift-manifest.md
@@ -27,15 +27,26 @@ The check runs as part of the plugin's quality gate and may also be invoked manu
 
 ## Reference File Registry
 
-> Empty until artifact-type slices populate it. Each slice (rules / hooks / skills / subagents support) adds one section per skill it ships, listing every reference file in that skill's `references/` directory alongside its source documents.
+> Each slice (rules / hooks / skills / subagents support) adds one section per skill it ships, listing every reference file in that skill's `references/` directory alongside its source documents.
+
+## Slice C: rules
 
 ### create-rule
 
-_(populated by the rules-support slice)_
+| Reference File | Source Document(s) | Derivation |
+|----------------|-------------------|------------|
+| `references/rule-authoring-guide.md` | `docs/cursor/rules/rules.md` | Derived: distilled guidance on activation modes, frontmatter contract, glob syntax, and anti-patterns. ≤200 lines. Source attribution at top. |
+| `references/rule-validation-criteria.md` | `docs/cursor/rules/rules.md`; Industry Research (`research-context-engineering-comprehensive.md`) | Derived: hard limits, quality checks, `.mdc`-specific checks, validation-loop instructions. |
+| `references/prompt-engineering-strategies.md` | `plugins/agent-customizer/skills/create-rule/references/prompt-engineering-strategies.md` | Verbatim copy. Vendor-neutral content; per the per-skill-copy convention this file is duplicated, not symlinked. |
 
 ### improve-rule
 
-_(populated by the rules-support slice)_
+| Reference File | Source Document(s) | Derivation |
+|----------------|-------------------|------------|
+| `references/rule-authoring-guide.md` | `docs/cursor/rules/rules.md` | Verbatim copy of `create-rule/references/rule-authoring-guide.md` (per the per-skill-copy convention). |
+| `references/rule-validation-criteria.md` | `docs/cursor/rules/rules.md`; Industry Research (`research-context-engineering-comprehensive.md`) | Verbatim copy of `create-rule/references/rule-validation-criteria.md`. |
+| `references/rule-evaluation-criteria.md` | `docs/cursor/rules/rules.md`; Industry Research (`research-context-engineering-comprehensive.md`) | Derived: bloat / staleness / activation-mode appropriateness rubric and quality scoring. Improve-only reference. |
+| `references/prompt-engineering-strategies.md` | `plugins/agent-customizer/skills/create-rule/references/prompt-engineering-strategies.md` | Verbatim copy. Vendor-neutral content; per the per-skill-copy convention this file is duplicated, not symlinked. |
 
 ### create-hook
 
@@ -69,4 +80,6 @@ _(populated as reference files land; lists each source document and the count of
 
 | Source Doc | Referenced By (count) |
 |------------|----------------------|
-| _(empty until artifact-type slices add entries)_ | — |
+| `docs/cursor/rules/rules.md` | 5 (create-rule: authoring-guide, validation-criteria; improve-rule: authoring-guide, validation-criteria, evaluation-criteria) |
+| Industry Research: `research-context-engineering-comprehensive.md` | 3 (create-rule: validation-criteria; improve-rule: validation-criteria, evaluation-criteria) |
+| `plugins/agent-customizer/skills/create-rule/references/prompt-engineering-strategies.md` | 2 (create-rule, improve-rule — verbatim copy) |

--- a/plugins/cursor-customizer/skills/create-rule/SKILL.md
+++ b/plugins/cursor-customizer/skills/create-rule/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: create-rule
+description: "Creates a new .cursor/rules/*.mdc rule grounded in the docs corpus. Selects one of three activation modes (always, globs, description) by user intent, generates minimal, specific instructions with the correct frontmatter, and writes the rule into an already-initialized Cursor project."
+---
+
+# Create Rule
+
+Generates a new `.cursor/rules/*.mdc` rule with the correct activation-mode frontmatter and minimal, specific instructions grounded in the Cursor docs corpus.
+
+## Behavioral Guidelines
+
+- **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
+- **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
+- **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
+- **Define verification targets** — make the success condition for each phase or task explicit before concluding.
+- **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
+- **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+
+## Hard Rules
+
+<RULES>
+- **NEVER** create rules longer than 200 lines
+- **NEVER** create rules for standard conventions the agent already knows (e.g., "write clean code")
+- **NEVER** use overly broad globs (`**/*`) on auto-attached rules unless truly global scope is required
+- **NEVER** use any frontmatter key other than `description`, `alwaysApply`, `globs`
+- **NEVER** include a `paths` frontmatter key — it belongs to a different platform's convention and is invalid here
+- **EVERY** generated rule MUST set exactly one well-formed activation mode (always / globs / description)
+- **EVERY** instruction must be specific and verifiable — not vague guidance
+- **ONE** concern per rule file — do not bundle unrelated instructions
+</RULES>
+
+## Process
+
+### Preflight Check
+
+Confirm the project is already initialized for Cursor (`.cursor/rules/` directory exists or the user is creating the first rule). Then check for conflicts:
+
+- Same filename (e.g., `.cursor/rules/{topic}.mdc` already exists)
+- Existing rule with overlapping globs that would create contradiction or duplication
+- Existing rule covering the same topic via `description:`-mode
+
+**If a conflicting or duplicate rule already exists:**
+
+1. Inform the user: "A rule covering `{topic}` or overlapping globs already exists."
+2. Suggest using `/cursor-customizer:improve-rule` to evaluate and optimize it instead.
+3. **STOP** — do not proceed. The user should either choose a different topic/scope or use the improve skill.
+
+**If no conflicting rule exists:**
+Proceed to Phase 1 below.
+
+### Phase 1: Project Context Analysis
+
+Delegate to the `artifact-analyzer` agent with this task:
+
+> Analyze the project to understand existing rules in `.cursor/rules/`. Focus on: rule filenames and topics, activation modes in use, glob patterns in use, any overlaps or contradictions between rules, gaps where a rule would add value, and the conventions in any present `AGENTS.md` files that could inform rule content. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in glob scoping.
+
+The agent runs in an isolated context with read-only access. Wait for it to complete and parse its structured output.
+
+### Phase 2: Activation-Mode Selection and Generation
+
+Before generating, read these reference documents:
+
+- `references/rule-authoring-guide.md` — when to use rules, frontmatter contract, the four activation modes, glob syntax, and anti-patterns
+- `references/prompt-engineering-strategies.md` — rule-specific prompting (zero-shot, no examples in rules)
+
+Map the user's intent to one activation mode using the rules-authoring guide:
+
+- **Critical tooling / project-wide constraint** → `alwaysApply: true` → read `assets/templates/cursor-rule-always.mdc`
+- **Pattern-relative convention** (test files, generated code, monorepo packages, sensitive-handler files) → `globs:` → read `assets/templates/cursor-rule-globs.mdc`
+- **Cross-cutting / domain topic the agent should pull in by name** (authentication, observability, accessibility, API design) → `description:` → read `assets/templates/cursor-rule-description.mdc`
+
+Fill the chosen template's placeholders using:
+
+- User requirements for the new rule (topic, target globs or description sentence, instructions)
+- Phase 1 analysis output (existing rules, gaps, potential contradictions)
+- Evidence from the reference files above
+
+Generate a single rule:
+
+- Frontmatter contains ONLY the three permitted fields and matches the chosen activation mode
+- Body ≤ 200 lines (significantly shorter for `alwaysApply: true` — every line loads on every conversation)
+- In a monorepo with `globs:`-mode, scope the glob to the relevant package subtree (e.g., `services/api/**/*.go`), not a language-only glob (`**/*.go`)
+
+Write target: `.cursor/rules/{topic-name}.mdc` (kebab-case).
+
+### Phase 3: Self-Validation
+
+Read `references/rule-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated rule.
+
+The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Failed checks re-enter Phase 2's generation step. Additionally, cross-check against ALL existing rule files in `.cursor/rules/` for contradictions and overlapping globs. Do not proceed to Phase 4 until ALL criteria pass.
+
+### Phase 4: Present and Write
+
+1. Show the user the complete generated rule file
+2. Cite the evidence from reference files that informed key decisions:
+   - Why this activation mode (what content nature drove the choice)
+   - Why this glob pattern or description sentence (what scope it targets and why)
+   - Why each instruction is necessary (what mistake it prevents)
+3. Ask for confirmation before writing any files
+4. On approval, write the rule file to `.cursor/rules/{topic-name}.mdc`

--- a/plugins/cursor-customizer/skills/create-rule/assets/templates/cursor-rule-always.mdc
+++ b/plugins/cursor-customizer/skills/create-rule/assets/templates/cursor-rule-always.mdc
@@ -1,0 +1,30 @@
+<!-- TEMPLATE: cursor-rule-always.mdc
+  Activation mode: Always
+  Placement: .cursor/rules/[rule-name].mdc
+  Naming: kebab-case, descriptive of the rule's scope
+  Target: Short — critical-tooling bullets only. 5-30 lines of rule content.
+
+  Reminder: this rule loads on EVERY chat. Every line consumes attention budget
+  on every conversation. Use this variant ONLY for content the agent must see
+  on every task — non-default tooling commands, hard project-wide constraints.
+  When in doubt, prefer cursor-rule-globs.mdc or cursor-rule-description.mdc.
+
+  Frontmatter (only these three fields are valid):
+  - alwaysApply (boolean): MUST be true for this variant
+  - description (optional): one-sentence summary of the rule
+  - globs (omit): not used by always-apply rules
+-->
+---
+alwaysApply: true
+description: "[ONE-SENTENCE SUMMARY OF THIS ALWAYS-APPLY RULE]"
+---
+
+<!-- Content guidelines for the always-apply variant:
+  - Short critical-tooling bullets only — every line loads on every chat
+  - No directory listings, no codebase overviews, no standard conventions
+  - Each bullet must be specific and verifiable
+  - If the section grows beyond ~20 bullets, split it into a globs- or description-mode rule
+-->
+
+- [Critical tooling command or project-wide constraint]
+- [Critical tooling command or project-wide constraint]

--- a/plugins/cursor-customizer/skills/create-rule/assets/templates/cursor-rule-description.mdc
+++ b/plugins/cursor-customizer/skills/create-rule/assets/templates/cursor-rule-description.mdc
@@ -1,0 +1,32 @@
+<!-- TEMPLATE: cursor-rule-description.mdc
+  Activation mode: Agent-requested
+  Placement: .cursor/rules/[rule-name].mdc
+  Naming: kebab-case, descriptive of the topic the agent will be looking for
+  Target: 10-150 lines of reference content
+
+  The agent decides to attach this rule based on the description sentence.
+  Use this variant for cross-cutting / domain content the agent should pull
+  in by topic — authentication, observability, accessibility, API design.
+  The body is reference material the agent attaches when relevant; it is
+  NOT loaded on every chat.
+
+  Frontmatter (only these three fields are valid):
+  - description (string): REQUIRED — a focused topic-attractor sentence
+  - alwaysApply (boolean): MUST be false for this variant
+  - globs (omit): not used by agent-requested rules
+-->
+---
+description: "[FOCUSED TOPIC-ATTRACTOR SENTENCE — what task or concern triggers this rule]"
+alwaysApply: false
+---
+
+<!-- Content guidelines for the description variant:
+  - The description sentence is the attractor — write it from the agent's point of view:
+    "Use this when working on [topic / concern / surface]."
+  - The body is reference content the agent reads after deciding the rule is relevant
+  - Reference canonical files with @path/to/file rather than copying their content
+  - One topic per file; split when the rule covers more than one concern
+-->
+
+- [Reference instruction relevant to the topic in the description]
+- [Reference instruction relevant to the topic in the description]

--- a/plugins/cursor-customizer/skills/create-rule/assets/templates/cursor-rule-globs.mdc
+++ b/plugins/cursor-customizer/skills/create-rule/assets/templates/cursor-rule-globs.mdc
@@ -1,0 +1,31 @@
+<!-- TEMPLATE: cursor-rule-globs.mdc
+  Activation mode: Auto-attached
+  Placement: .cursor/rules/[rule-name].mdc
+  Naming: kebab-case, descriptive of the matched file scope
+  Target: 10-50 lines of pattern-relative instructions
+
+  This rule loads only when files matching its globs enter the agent's context.
+  Use this variant for conventions that apply ONLY to specific file patterns
+  (test files, generated code, migration scripts, sensitive-handler files,
+  monorepo workspace packages).
+
+  Frontmatter (only these three fields are valid):
+  - globs (string or array): REQUIRED — file patterns triggering auto-attachment
+  - alwaysApply (boolean): MUST be false for this variant
+  - description (optional): one-sentence summary of the rule
+-->
+---
+globs: ["[PATTERN]", "[PATTERN]"]
+alwaysApply: false
+description: "[ONE-SENTENCE SUMMARY OF WHAT MATCHED FILES NEED]"
+---
+
+<!-- Content guidelines for the globs variant:
+  - Write instructions relative to the matched files — assume the agent is editing them now
+  - Reference adjacent files with @path/to/file when canonical examples exist in the repo
+  - One concern per file: do not bundle unrelated conventions under the same glob
+  - If the rule must apply to several disjoint patterns, prefer one rule per pattern set
+-->
+
+- [Pattern-relative instruction the agent will need when editing matched files]
+- [Pattern-relative instruction the agent will need when editing matched files]

--- a/plugins/cursor-customizer/skills/create-rule/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/create-rule/references/prompt-engineering-strategies.md
@@ -1,0 +1,127 @@
+# Prompt Engineering Strategies
+
+Evidence-based prompting strategies for artifact authoring, organized by artifact type.
+Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+
+---
+
+## Contents
+
+- Universal principles (apply to all artifact types)
+- Strategy matrix (technique selection by artifact type)
+- Per-artifact-type recommendations
+- Anti-patterns (what to avoid)
+- Context budget principles
+
+---
+
+## Universal Principles
+
+**Clarity over cleverness** — "Think of Claude as a brilliant but new employee who lacks context on your norms and workflows." Write instructions a colleague with no context could follow.
+
+**Role definition first** — A single-sentence role in a system prompt focuses behavior and tone: `"You are a code reviewer specializing in TypeScript."` Use in subagent prompts and skill bodies. Skip in rules and hooks (zero-shot is sufficient).
+
+**XML tags for complex structure** — Use XML tags to disambiguate prompts mixing instructions, context, examples, and inputs:
+
+```
+<instructions>...</instructions>
+<context>...</context>
+<example>...</example>
+```
+
+**Critical instructions at start or end** — The "lost-in-the-middle" effect degrades performance for instructions buried in the middle of long contexts. Place key rules in the first and last 20% of each file.
+
+**Describe desired behavior, not prohibited behavior** — Instead of "Do not use markdown", write "Your response should be smooth flowing prose."
+
+**Behavioral discipline beats clever prompting** — surface assumptions before acting, prefer the simplest sufficient change, keep edits surgical, and define explicit validation targets before concluding.
+
+**Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
+
+*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
+
+---
+
+## Strategy Matrix
+
+| Technique | Skill (SKILL.md) | Hook | Rule | Subagent |
+|-----------|-----------------|------|------|----------|
+| Role prompting | ✅ First line of body | ❌ Skip (implicit) | ❌ Skip | ✅ Strong use |
+| Zero-shot | ✅ Most phases | ✅ Default | ✅ Always | ✅ Simple tasks |
+| Few-shot examples | ✅ Critical output formats | ❌ Too token-costly | ❌ Too token-costly | ✅ Complex formats |
+| XML structuring | ✅ Multi-section bodies | ❌ Too verbose | ❌ Too verbose | ✅ Rich context |
+| Chain-of-thought | ❌ Slows execution | ❌ Not applicable | ❌ Not applicable | ✅ Reasoning tasks |
+| Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
+| Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
+
+*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160*
+
+---
+
+## Per-Artifact Recommendations
+
+### Skills (SKILL.md)
+
+- Open body with role definition (1-2 sentences max)
+- Make Phase 1 a low-risk warm-up before higher-effort phases
+- Use progressive disclosure: reference files loaded per phase, not all upfront
+- Load curated references before asking for synthesis or edits
+- Use zero-shot for most phases; reserve few-shot for phases with strict output format
+- Make constraints concrete: scope limits, output shape, and stop conditions
+- Self-check instruction in final phase: "Before completing, verify all criteria in skill-validation-criteria.md"
+- Final validation should confirm Karpathy-style discipline and the ethical constraint on persuasion
+- Keep each phase instruction ≤10 lines; reference files for depth
+
+### Hooks
+
+- Zero-shot only — hooks are short and tokens are expensive
+- Avoid role prompting; context of the event implies the role
+- Be explicit about output format: `{"ok": true/false, "reason": "..."}`
+- For `prompt` and `agent` hooks: write simple, direct evaluation criteria
+- Test with `--debug` to verify hook output is parsed as intended
+
+### Rules
+
+- Zero-shot always — rules are factual instructions, not prompted behaviors
+- No examples (too token-costly for always-loaded context)
+- One instruction per bullet; no compound sentences
+- Specificity goldilocks: "Use 2-space indentation" not "Format code properly" not "src/auth/handlers.ts handles JWT"
+
+### Subagents
+
+- Role prompting is the primary specialization mechanism — invest here
+- Structure system prompt: Role → Responsibilities → Process → Checklist → Output Format
+- Include confidence threshold for review agents: "Report only when >80% confident"
+- Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with Opus 4.6
+- Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
+
+*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80*
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| "CRITICAL: You MUST always..." | Overtriggering with Claude 4.6 (especially Opus) | Use "Use this when..." |
+| Vague instructions ("be thorough") | Not verifiable or actionable | Specify exactly what to check |
+| Few-shot examples in rules | Token waste on every session | Delete examples; be specific in instruction text |
+| Over-explaining what Claude already knows | Wastes context budget | Trust model knowledge; add only novel context |
+| Prescriptive step-by-step plans | Forces rigid execution; misses edge cases | "Think thoroughly" outperforms manual step lists |
+| Contradictory instructions | Claude picks one arbitrarily | Audit for conflicts before writing |
+| Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
+
+*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
+
+---
+
+## Context Budget Principles
+
+Every token in an artifact competes with conversation history and other context. Apply these before writing:
+
+- Challenge each instruction: "Would removing this cause the agent to make mistakes? If not, cut it."
+- Prefer pointers to full content: link to reference files instead of inlining detailed material
+- Path-scoped rules and per-phase reference loading are the primary token-saving mechanisms
+- Short artifacts (rules, validation criteria) should be zero-shot and minimal
+- Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
+
+*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*

--- a/plugins/cursor-customizer/skills/create-rule/references/rule-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/create-rule/references/rule-authoring-guide.md
@@ -1,0 +1,151 @@
+# Rule Authoring Guide
+
+Evidence-based guidance for creating effective Cursor rule files (`.cursor/rules/*.mdc`).
+Source: docs/cursor/rules/rules.md (Cursor official documentation)
+
+---
+
+## Contents
+
+- When to use rules (vs hooks, skills, manual prompting)
+- Rule file structure and location
+- Frontmatter contract (`description`, `alwaysApply`, `globs` only)
+- The four activation modes
+- Glob pattern syntax
+- Writing effective rule content
+- Anti-patterns
+
+---
+
+## When to Use Rules
+
+Rules are markdown files placed in `.cursor/rules/`. Their contents are included at the start of the model context based on their activation mode. Use rules to:
+
+- Encode domain-specific knowledge about a codebase
+- Standardize style or architecture decisions
+- Automate project-specific workflows or templates
+
+| Use rules when | Use hooks when | Use skills when |
+|----------------|---------------|----------------|
+| Guidance should attach automatically | Deterministic enforcement is needed | Instructions should run only on explicit invocation |
+| Conventions apply to a file pattern or topic | Side effects must always happen | Multi-phase workflows are required |
+| Domain expertise scoped to a path or topic | No agent judgment is required | Rich, progressive-disclosure references are needed |
+
+*Source: docs/cursor/rules/rules.md — How rules work, Project rules*
+
+---
+
+## Rule File Structure and Location
+
+```
+.cursor/rules/
+  api-guidelines.mdc       # Rule with frontmatter (description, globs)
+  react-patterns.mdc       # Rule with frontmatter
+  frontend/                # Subfolder organisation supported
+    components.mdc
+```
+
+Each file should cover **one topic** with a kebab-case filename. Both `.md` and `.mdc` extensions are recognised; this distribution generates `.mdc` so that frontmatter can specify activation mode.
+
+*Source: docs/cursor/rules/rules.md — Rule file structure*
+
+---
+
+## Frontmatter Contract
+
+Cursor rule frontmatter is restricted to **three fields**. No other key is valid in this distribution:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `description` | string | Topic-attractor sentence the agent reads to decide whether to attach the rule |
+| `alwaysApply` | boolean | When `true`, the rule loads on every conversation |
+| `globs` | string or array | File patterns that trigger auto-attachment |
+
+The token used by other agent platforms to scope rules by file pattern is NOT supported here — Cursor uses `globs` for the same role. Any other frontmatter key is invalid and must be removed.
+
+*Source: docs/cursor/rules/rules.md — Rule file format*
+
+---
+
+## The Four Activation Modes
+
+Activation mode is determined by which frontmatter fields are set:
+
+| Mode | `alwaysApply` | `globs` | `description` | When it loads |
+|------|:---:|:---:|:---:|:---|
+| **Always** | `true` | — | optional | Every conversation |
+| **Auto-attached** | `false` | set | optional | When matching files enter context |
+| **Agent-requested** | `false` | — | set | When the agent decides the topic is relevant |
+| **Manual** | `false` | — | — | Only when the user @-mentions the rule |
+
+Pick the mode that matches the **content's nature**:
+
+- Always → critical tooling commands and project-wide constraints (short — every line loads on every chat)
+- Auto-attached → conventions tied to a specific file pattern (test files, generated code, monorepo packages)
+- Agent-requested → cross-cutting / domain content the agent should pull in by name (authentication, observability, accessibility, API design)
+- Manual → templates and reference snippets the user explicitly opts into
+
+*Source: docs/cursor/rules/rules.md — Rule anatomy*
+
+---
+
+## Glob Pattern Syntax
+
+| Pattern | Matches |
+|---------|---------|
+| `**/*.ts` | All TypeScript files in any directory |
+| `src/**/*` | All files under `src/` |
+| `*.md` | Markdown files in project root only |
+| `src/components/*.tsx` | React components in a specific directory |
+| `src/**/*.{ts,tsx}` | TypeScript and TSX in any subdir of src |
+| `tests/**/*.spec.*` | All spec files in tests/ |
+
+Auto-attached rules trigger when files matching the pattern enter the agent's context, not on every tool use.
+
+In monorepos, scope globs to the relevant package subtree (e.g., `services/api/**/*.go` rather than `**/*.go`). Language-only globs match across every package and defeat scoping.
+
+*Source: docs/cursor/rules/rules.md — Project rules; Industry Research on monorepo scoping*
+
+---
+
+## Writing Effective Rule Content
+
+**Size guidelines:**
+
+- Cursor accepts large rules, but this toolkit enforces ≤200 lines per `.mdc` file
+- Split anything approaching 200 lines into multiple composable rules
+- Always-apply rules should be SHORT — every line loads on every conversation
+
+**Specificity** — write instructions concrete enough to verify:
+
+- Good: "Use 2-space indentation"
+- Bad: "Format code properly"
+- Good: "All API endpoints must return `{error: string, code: number}`"
+- Bad: "Return consistent errors"
+
+**One concern per file** — each rule file should cover exactly one topic or subdomain. Mixing concerns makes rules harder to maintain and creates contradictions.
+
+**Reference, do not copy** — point to canonical files with `@path/to/file` rather than inlining their content. This keeps rules short and prevents staleness as code evolves.
+
+**No contradictions** — if two rules conflict, the agent may pick one inconsistently. Review `.cursor/rules/` periodically to remove outdated or conflicting instructions.
+
+*Source: docs/cursor/rules/rules.md — Best practices*
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| Overly broad globs (`**/*`) on auto-attached rules | Rule loads on most file reads, wastes context | Scope to specific extensions or directories |
+| Always-apply rules longer than ~30 lines | Burns context budget on every conversation | Convert to auto-attached or agent-requested |
+| Duplicated content across multiple rule files | Contradictions plus wasted tokens | Consolidate into one file |
+| Vague instructions ("keep code clean") | Not actionable; ignored | Write verifiable, specific instructions |
+| Rules for what the agent already knows | Unnecessary token waste | Delete standard conventions the agent already follows |
+| Copying entire style guides | Linter handles this faster and more reliably | Use a linter; reference its config from a rule if needed |
+| Documenting every command | The agent knows common tools | Mention only non-default commands |
+| Edge-case instructions | Rare branches steal attention from common paths | Keep rules focused on patterns used frequently |
+| Rule files exceeding 200 lines | Poor adherence; attention fragmentation | Split into multiple focused files |
+| Mixing activation modes in one file | Activation-mode contract is per file | One activation mode per file |
+
+*Source: docs/cursor/rules/rules.md — What to avoid in rules; Best practices*

--- a/plugins/cursor-customizer/skills/create-rule/references/rule-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-rule/references/rule-validation-criteria.md
@@ -1,0 +1,80 @@
+# Rule Validation Criteria
+
+Quality checklist for generated and improved `.cursor/rules/*.mdc` rule files.
+Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineering-comprehensive.md)
+
+---
+
+## Hard Limits (Auto-fail if violated)
+
+Any rule file violating these criteria must be fixed before proceeding:
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
+| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` are valid; ALL others are AUTO-FAIL | docs/cursor/rules/rules.md — Rule file format |
+| Banned frontmatter key | A `paths` key MUST NOT appear; it belongs to a different platform's convention | Cross-platform leakage check |
+| Activation-mode well-formedness | `alwaysApply: true` must omit `globs`; `globs:` rules must set `alwaysApply: false`; `description:`-only rules must omit `globs` and set `alwaysApply: false` | docs/cursor/rules/rules.md — Rule anatomy |
+| Contradictions with other rules | 0 | Industry Research: conflicting instructions cause inconsistent agent behavior |
+| Stale file path references | 0 | Industry Research: stale paths poison context |
+
+*Source: docs/cursor/rules/rules.md — Rule file format, Best practices*
+
+---
+
+## Quality Checks (All must pass)
+
+- [ ] All instructions actionable and verifiable (not "write clean code")
+- [ ] One concern per file (no mixing of unrelated topics)
+- [ ] Activation mode chosen matches the content's nature: critical tooling → `alwaysApply: true`; pattern-relative → `globs`; topic-attractor → `description`
+- [ ] `alwaysApply: true` rules are short — every line is critical for every conversation
+- [ ] Glob patterns specific (not `**/*` unless truly global); in a monorepo, use a package-path prefix (`services/api/**/*.go`), not a language-only glob (`**/*.go`)
+- [ ] No overlap with existing rules (same instruction not in multiple files)
+- [ ] No standard language conventions the agent already knows from training
+- [ ] No long explanations or tutorials — rules are instructions, not documentation
+- [ ] Files referenced via `@path/to/file` rather than copied inline where practical
+- [ ] Evidence citations present: rule instructions justify their existence with reference to project conventions or `docs/cursor/`
+- [ ] Prompt engineering strategy applied: rule uses zero-shot imperative instructions only (no examples, no tutorials, no explanations)
+- [ ] Critical instructions appear at the start or end of the rule body, not buried in the middle
+
+---
+
+## `.mdc`-Specific Checks
+
+- [ ] Frontmatter contains ONLY `description`, `alwaysApply`, and `globs` — any other key is AUTO-FAIL
+- [ ] No `paths` frontmatter key anywhere in the file
+- [ ] `globs:`-mode rules use `globs:` and set `alwaysApply: false`
+- [ ] `description:`-mode rules use `description:`, omit `globs:`, and set `alwaysApply: false`
+- [ ] `alwaysApply: true` rules are reserved for content the agent must see on every conversation
+- [ ] Filename is kebab-case and ends in `.mdc`
+
+---
+
+## If This Is an IMPROVE Operation — Also Check
+
+**Information Preservation:**
+
+- [ ] Activation mode not weakened without rationale (auto-attached not silently demoted to manual)
+- [ ] Existing coverage not reduced (rules not deleted when they apply to real scenarios)
+- [ ] Custom project-specific instructions preserved
+- [ ] Glob scope not broadened without rationale (specific glob not replaced with `**/*`)
+
+**Structural:**
+
+- [ ] Line count reduction doesn't remove actionable instructions (only bloat removed)
+- [ ] Single file not split into too many files (aim for 1 topic = 1 file, not 1 instruction = 1 file)
+- [ ] Activation-mode change is justified by content nature, not convenience
+
+---
+
+## Validation Loop Instructions
+
+Execute this loop for each generated or improved rule file:
+
+1. Evaluate the rule against ALL criteria above
+2. If ANY criterion fails: identify the specific failure, fix the rule, restart evaluation
+3. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+4. Only proceed to writing rules when ALL criteria pass
+
+**Do not skip criteria for "minor" violations.** Hard limits are hard limits. A `paths` frontmatter key, a non-permitted frontmatter field, or a length over 200 lines is automatic re-entry into generation.

--- a/plugins/cursor-customizer/skills/improve-rule/SKILL.md
+++ b/plugins/cursor-customizer/skills/improve-rule/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: improve-rule
+description: "Evaluates and optimizes a single existing .cursor/rules/*.mdc file against evidence-based quality criteria from the Cursor docs corpus. Checks frontmatter validity, activation-mode appropriateness, glob specificity, and cross-rule overlaps. Use when improving an existing rule."
+---
+
+# Improve Rule
+
+Evaluate an existing `.cursor/rules/*.mdc` file against evidence-based quality criteria and apply improvements to fix the 200-line limit, repair frontmatter, realign activation mode, tighten globs, and resolve cross-file contradictions.
+
+## Behavioral Guidelines
+
+- **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
+- **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
+- **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
+- **Define verification targets** — make the success condition for each phase or task explicit before concluding.
+- **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
+- **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+
+## Hard Rules
+
+<RULES>
+- **ALWAYS** evaluate before modifying — never change rules without analysis
+- **ALWAYS** present changes to the user before applying them
+- **NEVER** broaden glob scope without rationale (specific glob → `**/*`)
+- **NEVER** weaken activation mode (auto-attached → manual) without rationale
+- **NEVER** delete rules that apply to real scenarios
+- **NEVER** exceed 200 lines after improvements
+- **NEVER** introduce a `paths` frontmatter key — `description`, `alwaysApply`, `globs` are the only valid keys
+- **PRESERVE** project-specific custom instructions — only remove generic waste
+</RULES>
+
+## Process
+
+### Preflight Check
+
+Check if rule files exist at:
+
+- The user-provided path (if given)
+- Any `.mdc` or `.md` file under `.cursor/rules/`
+
+**If no rule files found:**
+
+1. Inform the user: "No rule files found at `.cursor/rules/`."
+2. Suggest using `/cursor-customizer:create-rule` to create a new one instead.
+3. **STOP**
+
+**If rule files found:**
+Proceed to Phase 1 below.
+
+### Phase 1: Evaluate
+
+Delegate to the `rule-evaluator` agent with this task:
+
+> Evaluate rule files in `.cursor/rules/`. Check line counts against the 200-line limit, YAML frontmatter validity, frontmatter-field whitelist (`description`, `alwaysApply`, `globs` only), the absence of any `paths` frontmatter key, activation-mode well-formedness, glob specificity, instruction actionability, one-concern-per-file adherence, and cross-file contradictions / overlaps. Return structured results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+
+- If the user provides a specific rule file → scope to that file (still cross-check others for conflicts).
+- If no specific file → evaluate ALL `.mdc` and `.md` rule files under `.cursor/rules/` recursively.
+
+The agent runs in an isolated context with read-only access. Wait for it to complete and parse its structured output.
+
+### Phase 2: Project Context
+
+Delegate to the `artifact-analyzer` agent with this task:
+
+> Analyze the project to understand the context around rule files. Focus on: all rule files and their topics, activation modes in use, glob patterns in use, overlaps between rules, whether globs still match existing files (stale patterns), and conventions in any present `AGENTS.md` files that overlap with rules.
+
+Wait for it to complete and parse its structured output.
+
+### Phase 3: Generate Improvement Plan
+
+Read these reference documents:
+
+- `references/rule-authoring-guide.md` — when to use rules, frontmatter contract, the four activation modes, glob syntax, anti-patterns
+- `references/rule-evaluation-criteria.md` — bloat / staleness indicators, activation-mode appropriateness, quality rubric
+- `references/prompt-engineering-strategies.md` — rule-specific prompting (zero-shot only)
+
+Based on both agent reports, create an improvement plan with categories:
+
+1. **Removals** — bloat (instructions the agent already knows), stale globs / `@`-references (matching no files), duplicates with other rules
+2. **Refactoring** — split oversized files, fix frontmatter (remove invalid keys, repair activation-mode field set), tighten globs, demote always-apply to a more appropriate activation mode, resolve contradictions
+3. **Additions** — missing activation-mode frontmatter for rules that need it; missing glob scoping for rules that should be auto-attached
+
+If all three categories yield zero items after analysis, conclude: "No improvements needed — rule is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+
+### Phase 4: Self-Validation
+
+Read `references/rule-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved rule files.
+
+For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Failed checks re-enter Phase 3's plan-generation step with the failures as new constraints. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass. Additionally, verify that every suggestion in the improvement plan has a WHY field citing a source document — no suggestion may lack a source reference.
+
+### Phase 5: Present and Apply
+
+1. Show a summary overview of all improvements found, grouped by category:
+   - **Removals**: X items (bloat: X, stale: X, duplicates: X, contradictions resolved: X)
+   - **Refactoring**: X items (splits: X, frontmatter fixes: X, activation-mode realignments: X, glob tightening: X)
+   - **Additions**: X items
+
+2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+
+   **WHAT**: The specific content and its current location (file:lines)
+   **WHY**: Evidence-based justification with source reference
+   **TOKEN IMPACT**: Estimated impact from removing waste, tightening scope, or demoting always-apply so the rule loads in fewer contexts
+   **OPTIONS**:
+   - **Option A** (recommended): Primary action
+   - **Option B**: Alternative action
+   - **Option C**: Keep as-is
+
+   Wait for the user to select an option for each suggestion before proceeding to the next.
+
+   For rule splits, show both the reduced original and the new split file.
+   For activation-mode realignments, show the before/after frontmatter and explain which content nature drove the choice.
+   For contradiction resolution, show both conflicting rules side-by-side.
+
+3. After all suggestions are reviewed, show aggregate impact:
+   - **Files with invalid frontmatter**: before → after
+   - **Always-apply rule lines**: before → after
+   - **Rules**: before → after
+   - **Deferred suggestions**: X items kept as-is
+
+4. Apply ONLY the approved changes. When changing activation mode, select the matching template from `assets/templates/cursor-rule-{always,globs,description}.mdc` to preserve frontmatter shape.
+
+5. Report final metrics:
+   - Total lines before → after
+   - Files with invalid frontmatter before → after
+   - Files affected
+   - Suggestions applied: X of Y (Z deferred)

--- a/plugins/cursor-customizer/skills/improve-rule/assets/templates/cursor-rule-always.mdc
+++ b/plugins/cursor-customizer/skills/improve-rule/assets/templates/cursor-rule-always.mdc
@@ -1,0 +1,30 @@
+<!-- TEMPLATE: cursor-rule-always.mdc
+  Activation mode: Always
+  Placement: .cursor/rules/[rule-name].mdc
+  Naming: kebab-case, descriptive of the rule's scope
+  Target: Short — critical-tooling bullets only. 5-30 lines of rule content.
+
+  Reminder: this rule loads on EVERY chat. Every line consumes attention budget
+  on every conversation. Use this variant ONLY for content the agent must see
+  on every task — non-default tooling commands, hard project-wide constraints.
+  When in doubt, prefer cursor-rule-globs.mdc or cursor-rule-description.mdc.
+
+  Frontmatter (only these three fields are valid):
+  - alwaysApply (boolean): MUST be true for this variant
+  - description (optional): one-sentence summary of the rule
+  - globs (omit): not used by always-apply rules
+-->
+---
+alwaysApply: true
+description: "[ONE-SENTENCE SUMMARY OF THIS ALWAYS-APPLY RULE]"
+---
+
+<!-- Content guidelines for the always-apply variant:
+  - Short critical-tooling bullets only — every line loads on every chat
+  - No directory listings, no codebase overviews, no standard conventions
+  - Each bullet must be specific and verifiable
+  - If the section grows beyond ~20 bullets, split it into a globs- or description-mode rule
+-->
+
+- [Critical tooling command or project-wide constraint]
+- [Critical tooling command or project-wide constraint]

--- a/plugins/cursor-customizer/skills/improve-rule/assets/templates/cursor-rule-description.mdc
+++ b/plugins/cursor-customizer/skills/improve-rule/assets/templates/cursor-rule-description.mdc
@@ -1,0 +1,32 @@
+<!-- TEMPLATE: cursor-rule-description.mdc
+  Activation mode: Agent-requested
+  Placement: .cursor/rules/[rule-name].mdc
+  Naming: kebab-case, descriptive of the topic the agent will be looking for
+  Target: 10-150 lines of reference content
+
+  The agent decides to attach this rule based on the description sentence.
+  Use this variant for cross-cutting / domain content the agent should pull
+  in by topic — authentication, observability, accessibility, API design.
+  The body is reference material the agent attaches when relevant; it is
+  NOT loaded on every chat.
+
+  Frontmatter (only these three fields are valid):
+  - description (string): REQUIRED — a focused topic-attractor sentence
+  - alwaysApply (boolean): MUST be false for this variant
+  - globs (omit): not used by agent-requested rules
+-->
+---
+description: "[FOCUSED TOPIC-ATTRACTOR SENTENCE — what task or concern triggers this rule]"
+alwaysApply: false
+---
+
+<!-- Content guidelines for the description variant:
+  - The description sentence is the attractor — write it from the agent's point of view:
+    "Use this when working on [topic / concern / surface]."
+  - The body is reference content the agent reads after deciding the rule is relevant
+  - Reference canonical files with @path/to/file rather than copying their content
+  - One topic per file; split when the rule covers more than one concern
+-->
+
+- [Reference instruction relevant to the topic in the description]
+- [Reference instruction relevant to the topic in the description]

--- a/plugins/cursor-customizer/skills/improve-rule/assets/templates/cursor-rule-globs.mdc
+++ b/plugins/cursor-customizer/skills/improve-rule/assets/templates/cursor-rule-globs.mdc
@@ -1,0 +1,31 @@
+<!-- TEMPLATE: cursor-rule-globs.mdc
+  Activation mode: Auto-attached
+  Placement: .cursor/rules/[rule-name].mdc
+  Naming: kebab-case, descriptive of the matched file scope
+  Target: 10-50 lines of pattern-relative instructions
+
+  This rule loads only when files matching its globs enter the agent's context.
+  Use this variant for conventions that apply ONLY to specific file patterns
+  (test files, generated code, migration scripts, sensitive-handler files,
+  monorepo workspace packages).
+
+  Frontmatter (only these three fields are valid):
+  - globs (string or array): REQUIRED — file patterns triggering auto-attachment
+  - alwaysApply (boolean): MUST be false for this variant
+  - description (optional): one-sentence summary of the rule
+-->
+---
+globs: ["[PATTERN]", "[PATTERN]"]
+alwaysApply: false
+description: "[ONE-SENTENCE SUMMARY OF WHAT MATCHED FILES NEED]"
+---
+
+<!-- Content guidelines for the globs variant:
+  - Write instructions relative to the matched files — assume the agent is editing them now
+  - Reference adjacent files with @path/to/file when canonical examples exist in the repo
+  - One concern per file: do not bundle unrelated conventions under the same glob
+  - If the rule must apply to several disjoint patterns, prefer one rule per pattern set
+-->
+
+- [Pattern-relative instruction the agent will need when editing matched files]
+- [Pattern-relative instruction the agent will need when editing matched files]

--- a/plugins/cursor-customizer/skills/improve-rule/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/prompt-engineering-strategies.md
@@ -1,0 +1,127 @@
+# Prompt Engineering Strategies
+
+Evidence-based prompting strategies for artifact authoring, organized by artifact type.
+Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+
+---
+
+## Contents
+
+- Universal principles (apply to all artifact types)
+- Strategy matrix (technique selection by artifact type)
+- Per-artifact-type recommendations
+- Anti-patterns (what to avoid)
+- Context budget principles
+
+---
+
+## Universal Principles
+
+**Clarity over cleverness** — "Think of Claude as a brilliant but new employee who lacks context on your norms and workflows." Write instructions a colleague with no context could follow.
+
+**Role definition first** — A single-sentence role in a system prompt focuses behavior and tone: `"You are a code reviewer specializing in TypeScript."` Use in subagent prompts and skill bodies. Skip in rules and hooks (zero-shot is sufficient).
+
+**XML tags for complex structure** — Use XML tags to disambiguate prompts mixing instructions, context, examples, and inputs:
+
+```
+<instructions>...</instructions>
+<context>...</context>
+<example>...</example>
+```
+
+**Critical instructions at start or end** — The "lost-in-the-middle" effect degrades performance for instructions buried in the middle of long contexts. Place key rules in the first and last 20% of each file.
+
+**Describe desired behavior, not prohibited behavior** — Instead of "Do not use markdown", write "Your response should be smooth flowing prose."
+
+**Behavioral discipline beats clever prompting** — surface assumptions before acting, prefer the simplest sufficient change, keep edits surgical, and define explicit validation targets before concluding.
+
+**Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
+
+*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
+
+---
+
+## Strategy Matrix
+
+| Technique | Skill (SKILL.md) | Hook | Rule | Subagent |
+|-----------|-----------------|------|------|----------|
+| Role prompting | ✅ First line of body | ❌ Skip (implicit) | ❌ Skip | ✅ Strong use |
+| Zero-shot | ✅ Most phases | ✅ Default | ✅ Always | ✅ Simple tasks |
+| Few-shot examples | ✅ Critical output formats | ❌ Too token-costly | ❌ Too token-costly | ✅ Complex formats |
+| XML structuring | ✅ Multi-section bodies | ❌ Too verbose | ❌ Too verbose | ✅ Rich context |
+| Chain-of-thought | ❌ Slows execution | ❌ Not applicable | ❌ Not applicable | ✅ Reasoning tasks |
+| Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
+| Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
+
+*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160*
+
+---
+
+## Per-Artifact Recommendations
+
+### Skills (SKILL.md)
+
+- Open body with role definition (1-2 sentences max)
+- Make Phase 1 a low-risk warm-up before higher-effort phases
+- Use progressive disclosure: reference files loaded per phase, not all upfront
+- Load curated references before asking for synthesis or edits
+- Use zero-shot for most phases; reserve few-shot for phases with strict output format
+- Make constraints concrete: scope limits, output shape, and stop conditions
+- Self-check instruction in final phase: "Before completing, verify all criteria in skill-validation-criteria.md"
+- Final validation should confirm Karpathy-style discipline and the ethical constraint on persuasion
+- Keep each phase instruction ≤10 lines; reference files for depth
+
+### Hooks
+
+- Zero-shot only — hooks are short and tokens are expensive
+- Avoid role prompting; context of the event implies the role
+- Be explicit about output format: `{"ok": true/false, "reason": "..."}`
+- For `prompt` and `agent` hooks: write simple, direct evaluation criteria
+- Test with `--debug` to verify hook output is parsed as intended
+
+### Rules
+
+- Zero-shot always — rules are factual instructions, not prompted behaviors
+- No examples (too token-costly for always-loaded context)
+- One instruction per bullet; no compound sentences
+- Specificity goldilocks: "Use 2-space indentation" not "Format code properly" not "src/auth/handlers.ts handles JWT"
+
+### Subagents
+
+- Role prompting is the primary specialization mechanism — invest here
+- Structure system prompt: Role → Responsibilities → Process → Checklist → Output Format
+- Include confidence threshold for review agents: "Report only when >80% confident"
+- Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with Opus 4.6
+- Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
+
+*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80*
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| "CRITICAL: You MUST always..." | Overtriggering with Claude 4.6 (especially Opus) | Use "Use this when..." |
+| Vague instructions ("be thorough") | Not verifiable or actionable | Specify exactly what to check |
+| Few-shot examples in rules | Token waste on every session | Delete examples; be specific in instruction text |
+| Over-explaining what Claude already knows | Wastes context budget | Trust model knowledge; add only novel context |
+| Prescriptive step-by-step plans | Forces rigid execution; misses edge cases | "Think thoroughly" outperforms manual step lists |
+| Contradictory instructions | Claude picks one arbitrarily | Audit for conflicts before writing |
+| Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
+
+*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
+
+---
+
+## Context Budget Principles
+
+Every token in an artifact competes with conversation history and other context. Apply these before writing:
+
+- Challenge each instruction: "Would removing this cause the agent to make mistakes? If not, cut it."
+- Prefer pointers to full content: link to reference files instead of inlining detailed material
+- Path-scoped rules and per-phase reference loading are the primary token-saving mechanisms
+- Short artifacts (rules, validation criteria) should be zero-shot and minimal
+- Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
+
+*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*

--- a/plugins/cursor-customizer/skills/improve-rule/references/rule-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/rule-authoring-guide.md
@@ -1,0 +1,151 @@
+# Rule Authoring Guide
+
+Evidence-based guidance for creating effective Cursor rule files (`.cursor/rules/*.mdc`).
+Source: docs/cursor/rules/rules.md (Cursor official documentation)
+
+---
+
+## Contents
+
+- When to use rules (vs hooks, skills, manual prompting)
+- Rule file structure and location
+- Frontmatter contract (`description`, `alwaysApply`, `globs` only)
+- The four activation modes
+- Glob pattern syntax
+- Writing effective rule content
+- Anti-patterns
+
+---
+
+## When to Use Rules
+
+Rules are markdown files placed in `.cursor/rules/`. Their contents are included at the start of the model context based on their activation mode. Use rules to:
+
+- Encode domain-specific knowledge about a codebase
+- Standardize style or architecture decisions
+- Automate project-specific workflows or templates
+
+| Use rules when | Use hooks when | Use skills when |
+|----------------|---------------|----------------|
+| Guidance should attach automatically | Deterministic enforcement is needed | Instructions should run only on explicit invocation |
+| Conventions apply to a file pattern or topic | Side effects must always happen | Multi-phase workflows are required |
+| Domain expertise scoped to a path or topic | No agent judgment is required | Rich, progressive-disclosure references are needed |
+
+*Source: docs/cursor/rules/rules.md — How rules work, Project rules*
+
+---
+
+## Rule File Structure and Location
+
+```
+.cursor/rules/
+  api-guidelines.mdc       # Rule with frontmatter (description, globs)
+  react-patterns.mdc       # Rule with frontmatter
+  frontend/                # Subfolder organisation supported
+    components.mdc
+```
+
+Each file should cover **one topic** with a kebab-case filename. Both `.md` and `.mdc` extensions are recognised; this distribution generates `.mdc` so that frontmatter can specify activation mode.
+
+*Source: docs/cursor/rules/rules.md — Rule file structure*
+
+---
+
+## Frontmatter Contract
+
+Cursor rule frontmatter is restricted to **three fields**. No other key is valid in this distribution:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `description` | string | Topic-attractor sentence the agent reads to decide whether to attach the rule |
+| `alwaysApply` | boolean | When `true`, the rule loads on every conversation |
+| `globs` | string or array | File patterns that trigger auto-attachment |
+
+The token used by other agent platforms to scope rules by file pattern is NOT supported here — Cursor uses `globs` for the same role. Any other frontmatter key is invalid and must be removed.
+
+*Source: docs/cursor/rules/rules.md — Rule file format*
+
+---
+
+## The Four Activation Modes
+
+Activation mode is determined by which frontmatter fields are set:
+
+| Mode | `alwaysApply` | `globs` | `description` | When it loads |
+|------|:---:|:---:|:---:|:---|
+| **Always** | `true` | — | optional | Every conversation |
+| **Auto-attached** | `false` | set | optional | When matching files enter context |
+| **Agent-requested** | `false` | — | set | When the agent decides the topic is relevant |
+| **Manual** | `false` | — | — | Only when the user @-mentions the rule |
+
+Pick the mode that matches the **content's nature**:
+
+- Always → critical tooling commands and project-wide constraints (short — every line loads on every chat)
+- Auto-attached → conventions tied to a specific file pattern (test files, generated code, monorepo packages)
+- Agent-requested → cross-cutting / domain content the agent should pull in by name (authentication, observability, accessibility, API design)
+- Manual → templates and reference snippets the user explicitly opts into
+
+*Source: docs/cursor/rules/rules.md — Rule anatomy*
+
+---
+
+## Glob Pattern Syntax
+
+| Pattern | Matches |
+|---------|---------|
+| `**/*.ts` | All TypeScript files in any directory |
+| `src/**/*` | All files under `src/` |
+| `*.md` | Markdown files in project root only |
+| `src/components/*.tsx` | React components in a specific directory |
+| `src/**/*.{ts,tsx}` | TypeScript and TSX in any subdir of src |
+| `tests/**/*.spec.*` | All spec files in tests/ |
+
+Auto-attached rules trigger when files matching the pattern enter the agent's context, not on every tool use.
+
+In monorepos, scope globs to the relevant package subtree (e.g., `services/api/**/*.go` rather than `**/*.go`). Language-only globs match across every package and defeat scoping.
+
+*Source: docs/cursor/rules/rules.md — Project rules; Industry Research on monorepo scoping*
+
+---
+
+## Writing Effective Rule Content
+
+**Size guidelines:**
+
+- Cursor accepts large rules, but this toolkit enforces ≤200 lines per `.mdc` file
+- Split anything approaching 200 lines into multiple composable rules
+- Always-apply rules should be SHORT — every line loads on every conversation
+
+**Specificity** — write instructions concrete enough to verify:
+
+- Good: "Use 2-space indentation"
+- Bad: "Format code properly"
+- Good: "All API endpoints must return `{error: string, code: number}`"
+- Bad: "Return consistent errors"
+
+**One concern per file** — each rule file should cover exactly one topic or subdomain. Mixing concerns makes rules harder to maintain and creates contradictions.
+
+**Reference, do not copy** — point to canonical files with `@path/to/file` rather than inlining their content. This keeps rules short and prevents staleness as code evolves.
+
+**No contradictions** — if two rules conflict, the agent may pick one inconsistently. Review `.cursor/rules/` periodically to remove outdated or conflicting instructions.
+
+*Source: docs/cursor/rules/rules.md — Best practices*
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| Overly broad globs (`**/*`) on auto-attached rules | Rule loads on most file reads, wastes context | Scope to specific extensions or directories |
+| Always-apply rules longer than ~30 lines | Burns context budget on every conversation | Convert to auto-attached or agent-requested |
+| Duplicated content across multiple rule files | Contradictions plus wasted tokens | Consolidate into one file |
+| Vague instructions ("keep code clean") | Not actionable; ignored | Write verifiable, specific instructions |
+| Rules for what the agent already knows | Unnecessary token waste | Delete standard conventions the agent already follows |
+| Copying entire style guides | Linter handles this faster and more reliably | Use a linter; reference its config from a rule if needed |
+| Documenting every command | The agent knows common tools | Mention only non-default commands |
+| Edge-case instructions | Rare branches steal attention from common paths | Keep rules focused on patterns used frequently |
+| Rule files exceeding 200 lines | Poor adherence; attention fragmentation | Split into multiple focused files |
+| Mixing activation modes in one file | Activation-mode contract is per file | One activation mode per file |
+
+*Source: docs/cursor/rules/rules.md — What to avoid in rules; Best practices*

--- a/plugins/cursor-customizer/skills/improve-rule/references/rule-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/rule-evaluation-criteria.md
@@ -1,0 +1,146 @@
+# Rule Evaluation Criteria
+
+Scoring rubric for assessing existing `.cursor/rules/*.mdc` rule files before improvement.
+Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineering-comprehensive.md)
+
+---
+
+## Contents
+
+- Hard limits table (frontmatter validity, line counts)
+- Bloat indicators table (broad globs, duplicates, vague instructions, oversized always-apply rules)
+- Staleness indicators table (globs matching no files, removed conventions)
+- Activation-mode appropriateness table
+- Quality assessment (specificity, actionability, scope separation)
+- Quality score rubric (5-dimension scoring 1-10)
+- Evaluation output template
+
+---
+
+## Hard Limits Table
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
+| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` | docs/cursor/rules/rules.md — Rule file format |
+| Banned frontmatter key | `paths` MUST NOT appear | Cross-platform leakage |
+| Activation-mode well-formedness | One of always / globs / description, with the matching field set | docs/cursor/rules/rules.md — Rule anatomy |
+| Instruction actionability | Verifiable, not vague | docs/cursor/rules/rules.md — Best practices |
+
+A rule violating any hard limit is flagged **OVER LIMIT** or **INVALID**.
+
+*Source: docs/cursor/rules/rules.md — Best practices, Rule file format*
+
+---
+
+## Bloat Indicators Table
+
+| Indicator | Why It's Bloat |
+|-----------|---------------|
+| `**/*` glob on auto-attached rule | Rule loads on most file reads; too broad |
+| `alwaysApply: true` rule longer than ~30 lines | Every line burns context budget on every conversation |
+| Duplicate instructions across rule files | Contradictions plus wasted tokens on every load |
+| Vague instructions ("write clean code") | Not actionable; ignored in practice |
+| Standard language conventions the agent already knows | "If the agent already does it, delete it" |
+| Long explanations or tutorials | Rules are instructions, not documentation |
+| Inlined file content that could be `@path/to/file` reference | Token waste; staleness risk |
+| Edge-case instructions for situations that rarely apply | Steals attention from common paths |
+
+*Source: docs/cursor/rules/rules.md — What to avoid in rules*
+
+---
+
+## Staleness Indicators Table
+
+| Indicator | How to Detect |
+|-----------|---------------|
+| `globs:` pattern matching no existing files | Run glob against current project structure |
+| References to removed or renamed tools | Verify tool names are still valid |
+| Instructions for conventions no longer used | Check if convention is still in use |
+| Globs pointing to deleted or moved directories | Verify directory paths exist |
+| `@path/to/file` references to deleted files | Resolve every `@`-reference |
+
+*Source: Industry Research: stale paths poison context*
+
+---
+
+## Activation-Mode Appropriateness Table
+
+| Content Nature | Correct Mode | Common Mistake |
+|----------------|--------------|----------------|
+| Critical tooling command, project-wide constraint | `alwaysApply: true` | Buried in a description-mode rule the agent rarely attaches |
+| Convention tied to a file pattern (test files, generated code, monorepo packages) | `globs:` | Always-apply, wasting context on non-matching tasks |
+| Cross-cutting / domain topic (auth, observability, accessibility) | `description:` | Always-apply, when the agent only needs it on relevant tasks |
+| User-controlled template or snippet | Manual (no frontmatter trigger) | Auto-attached with overly broad globs |
+
+*Source: docs/cursor/rules/rules.md — Rule anatomy*
+
+---
+
+## Quality Assessment
+
+| Question | Good | Bad |
+|----------|------|-----|
+| Instructions specific enough to verify? | "Use 2-space indentation" | "Format code properly" |
+| One concern per file? | One topic per rule file | Multiple unrelated topics in one file |
+| Globs specific enough? | `src/api/**/*.ts` | `**/*` |
+| Activation mode matches content nature? | Auto-attached for pattern-specific conventions | Always-apply for content the agent rarely needs |
+| `alwaysApply: true` rule short? | ≤ 30 lines of critical bullets | Long always-apply rule |
+| References instead of inlined file content? | `@components/Button.tsx` | Whole file body pasted into the rule |
+| No overlap with other rules? | Each rule covers a distinct topic | Same instruction in 3 rule files |
+
+*Source: docs/cursor/rules/rules.md — Best practices*
+
+---
+
+## Quality Score Rubric
+
+| Dimension | 8-10 (Good) | 4-7 (Mixed) | 1-3 (Bad) |
+|-----------|-------------|-------------|-----------|
+| Activation-mode fit | Mode matches content nature | Mismatch on a few rules | Always-apply abuse or wrong mode for most rules |
+| Instruction Actionability | All instructions verifiable | Mix of specific and vague | Mostly vague |
+| Scope Separation | One topic per file; no overlap | Some overlap | Everything in one file |
+| Conciseness | ≤200 lines; always-apply rules tight | Some over limit or bloated always-apply | Multiple files far over limit |
+| Consistency | 0 contradictions across files | 1 contradiction | 2+ contradictions |
+| **Overall** | | | |
+
+*Source: docs/cursor/rules/rules.md — Best practices; Industry Research on context budgets*
+
+---
+
+## Evaluation Output Template
+
+```
+## Rule Evaluation Results
+
+### Files Found
+| File | Lines | Activation Mode | Status |
+|------|-------|-----------------|--------|
+| `code-style.mdc` | 220 | always | FAIL Over 200 lines and wrong activation mode |
+| `api-design.mdc` | 28 | globs (`src/api/**/*.ts`) | PASS |
+
+### Per-File Issues
+
+#### `code-style.mdc` (220 lines — over 200-line limit; always-apply too long)
+
+**Bloat Issues:**
+- Lines 30-45: Testing conventions — should be in separate `testing.mdc`
+- Lines 80-150: Standard language conventions the agent already knows
+
+**Staleness Issues:**
+- Line 12: References `src/helpers/` — directory was removed
+
+**Activation-Mode Issues:**
+- Always-apply for content that should be `description:`-mode (cross-cutting auth conventions)
+
+### Quality Score
+| Dimension | Score (1-10) | Notes |
+|-----------|-------------|-------|
+| Activation-mode fit | 4 | code-style.mdc wrong mode; api-design.mdc correct |
+| Instruction Actionability | 7 | Most instructions specific |
+| Scope Separation | 4 | code-style.mdc covers two topics |
+| Conciseness | 4 | code-style.mdc 220 lines |
+| Consistency | 8 | No contradictions |
+| **Overall** | **5** | Split code-style.mdc, demote to description-mode, remove stale ref |
+```

--- a/plugins/cursor-customizer/skills/improve-rule/references/rule-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/rule-validation-criteria.md
@@ -1,0 +1,80 @@
+# Rule Validation Criteria
+
+Quality checklist for generated and improved `.cursor/rules/*.mdc` rule files.
+Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineering-comprehensive.md)
+
+---
+
+## Hard Limits (Auto-fail if violated)
+
+Any rule file violating these criteria must be fixed before proceeding:
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
+| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` are valid; ALL others are AUTO-FAIL | docs/cursor/rules/rules.md — Rule file format |
+| Banned frontmatter key | A `paths` key MUST NOT appear; it belongs to a different platform's convention | Cross-platform leakage check |
+| Activation-mode well-formedness | `alwaysApply: true` must omit `globs`; `globs:` rules must set `alwaysApply: false`; `description:`-only rules must omit `globs` and set `alwaysApply: false` | docs/cursor/rules/rules.md — Rule anatomy |
+| Contradictions with other rules | 0 | Industry Research: conflicting instructions cause inconsistent agent behavior |
+| Stale file path references | 0 | Industry Research: stale paths poison context |
+
+*Source: docs/cursor/rules/rules.md — Rule file format, Best practices*
+
+---
+
+## Quality Checks (All must pass)
+
+- [ ] All instructions actionable and verifiable (not "write clean code")
+- [ ] One concern per file (no mixing of unrelated topics)
+- [ ] Activation mode chosen matches the content's nature: critical tooling → `alwaysApply: true`; pattern-relative → `globs`; topic-attractor → `description`
+- [ ] `alwaysApply: true` rules are short — every line is critical for every conversation
+- [ ] Glob patterns specific (not `**/*` unless truly global); in a monorepo, use a package-path prefix (`services/api/**/*.go`), not a language-only glob (`**/*.go`)
+- [ ] No overlap with existing rules (same instruction not in multiple files)
+- [ ] No standard language conventions the agent already knows from training
+- [ ] No long explanations or tutorials — rules are instructions, not documentation
+- [ ] Files referenced via `@path/to/file` rather than copied inline where practical
+- [ ] Evidence citations present: rule instructions justify their existence with reference to project conventions or `docs/cursor/`
+- [ ] Prompt engineering strategy applied: rule uses zero-shot imperative instructions only (no examples, no tutorials, no explanations)
+- [ ] Critical instructions appear at the start or end of the rule body, not buried in the middle
+
+---
+
+## `.mdc`-Specific Checks
+
+- [ ] Frontmatter contains ONLY `description`, `alwaysApply`, and `globs` — any other key is AUTO-FAIL
+- [ ] No `paths` frontmatter key anywhere in the file
+- [ ] `globs:`-mode rules use `globs:` and set `alwaysApply: false`
+- [ ] `description:`-mode rules use `description:`, omit `globs:`, and set `alwaysApply: false`
+- [ ] `alwaysApply: true` rules are reserved for content the agent must see on every conversation
+- [ ] Filename is kebab-case and ends in `.mdc`
+
+---
+
+## If This Is an IMPROVE Operation — Also Check
+
+**Information Preservation:**
+
+- [ ] Activation mode not weakened without rationale (auto-attached not silently demoted to manual)
+- [ ] Existing coverage not reduced (rules not deleted when they apply to real scenarios)
+- [ ] Custom project-specific instructions preserved
+- [ ] Glob scope not broadened without rationale (specific glob not replaced with `**/*`)
+
+**Structural:**
+
+- [ ] Line count reduction doesn't remove actionable instructions (only bloat removed)
+- [ ] Single file not split into too many files (aim for 1 topic = 1 file, not 1 instruction = 1 file)
+- [ ] Activation-mode change is justified by content nature, not convenience
+
+---
+
+## Validation Loop Instructions
+
+Execute this loop for each generated or improved rule file:
+
+1. Evaluate the rule against ALL criteria above
+2. If ANY criterion fails: identify the specific failure, fix the rule, restart evaluation
+3. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+4. Only proceed to writing rules when ALL criteria pass
+
+**Do not skip criteria for "minor" violations.** Hard limits are hard limits. A `paths` frontmatter key, a non-permitted frontmatter field, or a length over 200 lines is automatic re-entry into generation.


### PR DESCRIPTION
## Summary

Adds rules support to the `cursor-customizer` plugin — slice C of the umbrella rollout (PRD #77).

- **`agents/rule-evaluator.md`** — Cursor-native subagent (frontmatter: `name`, `description`, `model: inherit`, `readonly: true`) that evaluates `.cursor/rules/*.mdc` artifacts against the rule-validation criteria.
- **`skills/create-rule/`** — five-phase orchestration (preflight → context analysis → generation → self-validation → presentation) for new rules. Includes the three canonical activation-mode templates (`alwaysApply: true`, `globs:`, `description:`) reused from `cursor-initializer/init-cursor`.
- **`skills/improve-rule/`** — same orchestration shape for improvement workflows; adds `rule-evaluation-criteria.md` for the gap-analysis phase.
- **`docs-drift-manifest.md`** — slice-C source-doc → reference mappings recorded for drift detection.

Closes #80.
Tracks PRD #77.

## Test plan

- [x] Banned-token grep clean across slice files: `grep -rE '(\$\{CLAUDE_SKILL_DIR\}|CLAUDE\.md|\.claude/|maxTurns:|tools:|paths:|docs\.anthropic\.com/en/docs/claude-code)' plugins/cursor-customizer/{agents/rule-evaluator.md,skills/{create,improve}-rule}` → no matches in slice-authored content.
- [x] Topology parity with `plugins/agent-customizer/skills/{create,improve}-rule/` confirmed (SKILL.md + references/ + assets/templates/).
- [x] Activation-mode templates match canonical forms from `cursor-initializer/init-cursor/assets/templates/`.

## Notes

- `references/prompt-engineering-strategies.md` is copied verbatim per the per-skill no-symlink mandate; it retains 4 bare "Claude" mentions in prompting-anti-pattern context (not Cost-and-Model-Guidance). Verbatim-copy directive is the more specific instruction; flagged here for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)