### PR TITLE
feat(cursor-customizer): hooks support

### DIFF
--- a/plugins/cursor-customizer/agents/hook-evaluator.md
+++ b/plugins/cursor-customizer/agents/hook-evaluator.md
@@ -1,0 +1,130 @@
+---
+name: hook-evaluator
+description: "Evaluate existing Cursor hook configurations against evidence-based quality criteria — checks event names against Cursor's native event vocabulary, JSON structure, matcher specificity, exit-code handling, and security. Use when improving Cursor hooks."
+model: inherit
+readonly: true
+---
+
+# Hook Evaluator
+
+You are a Cursor hook configuration quality assessment specialist. Analyze the target hook configuration and evaluate it against evidence-based criteria. Identify specific problems with evidence so the improve-hook workflow can act on them.
+
+## Constraints
+
+- Do not modify any files — only analyze and report
+- Do not suggest improvements — only identify problems with evidence
+- Do not evaluate non-hook artifacts (skills, rules, subagents)
+- Be specific: cite exact JSON paths and values for each issue found
+- Only report findings with ≥80% confidence — when uncertain, note ambiguity rather than filing a false positive
+
+## Quality Criteria
+
+### Hard Limits (Auto-fail if violated)
+
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON structure | Valid JSON; `version` present; `hooks` is an object |
+| Event name | From the Cursor-native event vocabulary (camelCase) — see Valid Hook Event Names below |
+| Handler type | `command` (default) or `prompt` only |
+| `command` path | Script file resolves correctly per the configuration scope's working directory |
+| Exit-code semantics | `0` = success, `2` = block (fail-open by default for other non-zero exits unless `failClosed: true` is set) |
+
+### Valid Hook Event Names
+
+Agent (Cmd+K / Agent Chat) events:
+`sessionStart`, `sessionEnd`, `preToolUse`, `postToolUse`, `postToolUseFailure`, `subagentStart`, `subagentStop`, `beforeShellExecution`, `afterShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterFileEdit`, `beforeSubmitPrompt`, `preCompact`, `stop`, `afterAgentResponse`, `afterAgentThought`
+
+Tab (inline completions) events:
+`beforeTabFileRead`, `afterTabFileEdit`
+
+Reject any event name not in this list (in particular, PascalCase Claude Code names that have no Cursor analogue).
+
+### Quality Checks
+
+| Criterion | Pass Condition |
+|-----------|---------------|
+| Event matches intent | Block-capable events for blocking intent (`preToolUse`, `beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`, `beforeSubmitPrompt`, `subagentStart`); observation-only events for non-blocking intent (`postToolUse`, `afterShellExecution`, `afterMCPExecution`, `afterFileEdit`, `sessionStart`, `sessionEnd`, `preCompact`) |
+| Matcher specificity | Hook does not use the broadest matcher available for blocking events (e.g., a `preToolUse` blocking hook should target a specific tool name, not match every tool) |
+| Matcher applicability | Matcher is only set on events whose matcher field is documented in the Cursor hooks guide |
+| Error handling | Exit `2` with meaningful stderr for blocking intent; security-critical blocking hooks set `failClosed: true` |
+| Silent success | Exit `0` without spurious stderr output |
+| No hardcoded secrets | `command` strings reference environment variables, not literal credentials |
+| Handler appropriateness | `command` for deterministic checks; `prompt` only when natural-language judgment is genuinely needed |
+
+## Process
+
+### 1. Locate Hook Configuration
+
+Search for hook definitions in (priority order, highest to lowest):
+
+- Project: `<project-root>/.cursor/hooks.json`
+- User: `~/.cursor/hooks.json`
+
+If the user supplies a specific path, scope evaluation to that file.
+
+### 2. Check Against Criteria
+
+Evaluate every hook definition against the Quality Criteria above:
+
+1. Validate JSON structure first — parse errors are AUTO-FAIL
+2. Check each event name against the valid event names list
+3. Check handler type for each entry (`command` is the implicit default when omitted)
+4. For `command` type: verify the script path is plausible relative to the configuration scope's working directory (project hooks run from the project root; user hooks run from `~/.cursor/`)
+5. Check matcher applicability: matchers apply to `preToolUse`, `postToolUse`, `postToolUseFailure`, `subagentStart`, `subagentStop`, `beforeShellExecution`, `afterShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterFileEdit`, `beforeSubmitPrompt`, `stop`, `afterAgentResponse`, `afterAgentThought` — flag any matcher set on an event not in this list
+6. Check for hardcoded secrets in `command` strings and other configuration values
+
+### 3. Compile Findings
+
+Organize all issues by severity:
+
+- AUTO-FAIL: Hard-limit violations
+- HIGH: Security issues or blocking hooks that may not work correctly
+- MEDIUM: Specificity or handler-type mismatches
+- LOW: Style or documentation gaps
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## Hook Evaluation Results
+
+### Hooks Found
+| Event | Matcher | Type | Location |
+|-------|---------|------|----------|
+| [event] | [matcher] | [type] | [file] |
+
+### Hard Limit Check
+| Criterion | Status | Evidence |
+|-----------|--------|----------|
+| Valid JSON | PASS/FAIL | [parse result] |
+| Valid event names | PASS/FAIL | [event list or "invalid: X"] |
+| Valid handler types | PASS/FAIL | [types found or "invalid: X"] |
+| Command paths plausible | PASS/FAIL | [path check result] |
+
+### Quality Issues
+- [Hook: event/matcher]: [Description of issue] — [criterion violated]
+
+### Security Issues
+- [Hook: event/matcher]: [Description of security concern]
+
+### Summary
+| Severity | Count |
+|----------|-------|
+| AUTO-FAIL | N |
+| HIGH | N |
+| MEDIUM | N |
+| LOW | N |
+
+Overall Status: [PASS | FAIL]
+```
+
+## Self-Verification
+
+Before returning results:
+
+1. Every reported issue cites the specific hook (event + matcher) it applies to
+2. Hard-limit violations are correctly classified as AUTO-FAIL
+3. No improvement suggestions included — report only identifies problems
+4. Valid event names verified against the Cursor-native event-vocabulary list above — no false positives
+5. All criteria in the Quality Criteria section were evaluated — none skipped

--- a/plugins/cursor-customizer/docs-drift-manifest.md
+++ b/plugins/cursor-customizer/docs-drift-manifest.md
@@ -70,3 +70,25 @@ _(populated as reference files land; lists each source document and the count of
 | Source Doc | Referenced By (count) |
 |------------|----------------------|
 | _(empty until artifact-type slices add entries)_ | — |
+
+---
+
+## Slice D: hooks
+
+Mappings added by the hooks-support slice. Both `create-hook` and `improve-hook` ship the same two derived references and one verbatim copy.
+
+### Derived references (distilled from a Cursor source doc)
+
+| Reference file | Source doc | Notes |
+|----------------|------------|-------|
+| `create-hook/references/hook-authoring-guide.md` | `docs/cursor/hooks/hooks-guide.md` | ≤200 lines; covers when-to-use, config structure, two handler types, exit codes + `failClosed`, matchers, locations, security |
+| `improve-hook/references/hook-authoring-guide.md` | `docs/cursor/hooks/hooks-guide.md` | Identical to the `create-hook` copy (intra-plugin shared) |
+| `create-hook/references/hook-events-reference.md` | `docs/cursor/hooks/hooks-guide.md` | Authoritative Cursor-native event vocabulary the orchestration consults during validation |
+| `improve-hook/references/hook-events-reference.md` | `docs/cursor/hooks/hooks-guide.md` | Identical to the `create-hook` copy (intra-plugin shared) |
+
+### Verbatim copy (from the agent-customizer plugin)
+
+| Reference file | Source | Notes |
+|----------------|--------|-------|
+| `create-hook/references/prompt-engineering-strategies.md` | `plugins/agent-customizer/skills/create-hook/references/prompt-engineering-strategies.md` | Copied verbatim; vendor-neutral prompt-engineering guidance |
+| `improve-hook/references/prompt-engineering-strategies.md` | `plugins/agent-customizer/skills/improve-hook/references/prompt-engineering-strategies.md` | Copied verbatim; vendor-neutral prompt-engineering guidance |

--- a/plugins/cursor-customizer/skills/create-hook/SKILL.md
+++ b/plugins/cursor-customizer/skills/create-hook/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: create-hook
+description: "Creates new Cursor hook configurations grounded in Cursor's native event model. Generates the right event, handler, matcher, and exit-code behavior with JSON-schema compliance. Use when creating a new hook from scratch."
+---
+
+# Create Hook
+
+Generates a new hook configuration for a Cursor lifecycle event, with correct JSON shape, handler type, and exit-code behavior grounded in `docs/cursor/hooks/hooks-guide.md`.
+
+## Behavioral Guidelines
+
+- **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
+- **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
+- **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
+- **Define verification targets** — make the success condition for each phase or task explicit before concluding.
+- **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
+- **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+
+## Hard Rules
+
+<RULES>
+- **NEVER** create hooks with event names outside the Cursor-native vocabulary listed in `references/hook-events-reference.md`
+- **NEVER** omit the matcher on a blocking hook when the event supports one — overly permissive matchers fire on every occurrence
+- **NEVER** hardcode secrets in any configuration field — use environment variables and quote them at use sites in the script
+- **EVERY** hook must use a handler type valid for Cursor: `command` (default) or `prompt` only
+- **EVERY** `command` hook must document the decision path used by the script: exit `2` + stderr for blocking, or exit `0` with JSON decision output (e.g., `permission`, `additional_context`, `updated_input`)
+- **EVERY** security-critical blocking hook (`beforeMCPExecution`, `beforeShellExecution`, `beforeReadFile`) must set `"failClosed": true`
+- **EVERY** hook configuration must produce valid JSON before writing
+</RULES>
+
+## Process
+
+### Preflight Check
+
+Check whether hooks already exist for the target event in:
+
+- `<project-root>/.cursor/hooks.json` (project scope)
+- `~/.cursor/hooks.json` (user scope)
+
+**If the exact same event + matcher combination already exists:**
+
+1. Inform the user: "A hook for `{event}` with this matcher already exists."
+2. Suggest using `/cursor-customizer:improve-hook` to evaluate and optimize it instead.
+3. **STOP** — do not proceed. The user should either choose a different matcher/event combination or use the improve skill.
+
+**If no hook exists for this event+matcher combination:**
+Proceed to Phase 1 below.
+
+### Phase 1: Codebase Analysis
+
+Delegate to the `artifact-analyzer` agent with this task:
+
+> Analyze the project to understand existing hook configurations. Focus on: hooks defined in `<project-root>/.cursor/hooks.json` and `~/.cursor/hooks.json` (when accessible); project hook scripts under `.cursor/hooks/`; user-scope hook scripts under `~/.cursor/hooks/`; the event names currently in use; the handler types used (`command` vs `prompt`); and any gaps in lifecycle-event coverage. Also identify project layout: whether this is a monorepo with multiple service packages or a single-package project, and report any service directory paths for use in hook script path resolution.
+
+The agent runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+
+### Phase 2: Generate Hook
+
+Before generating, read these reference documents:
+
+- `references/hook-authoring-guide.md` — when to use hooks, two handler types, exit-code semantics, blocking vs non-blocking behavior, security
+- `references/hook-events-reference.md` — Cursor-native event vocabulary, matcher fields per event, full JSON schema, handler-type support matrix
+- `references/prompt-engineering-strategies.md` — hook-specific prompting (zero-shot only for hooks)
+
+Read `assets/templates/hook-config.md` and fill its placeholders using:
+
+- User requirements for the new hook (event, purpose, handler type)
+- Phase 1 analysis output (existing hooks, coverage gaps)
+- Evidence from the reference files above
+
+For blocking hooks (e.g., `preToolUse`, `beforeShellExecution`, `beforeReadFile`, `subagentStart`, `beforeSubmitPrompt`, `beforeMCPExecution`), translate the user intent into a concrete matcher when the event supports one:
+
+- `preToolUse` blocking write tools → matcher like `Write|Edit|Create`
+- `beforeShellExecution` blocking network commands → matcher like `curl|wget|nc`
+- `subagentStart` gating specific subagent types → matcher like `explore|shell`
+
+If the event has no matcher field (per `references/hook-events-reference.md`), omit the matcher entirely — never set one on an event that does not support it.
+
+Before choosing the handler, verify in `references/hook-events-reference.md` that the selected event supports it. Cursor exposes `command` and `prompt` only; if the user requested any other handler, stop and explain that Cursor's native model has only those two types.
+
+For security-critical blocking hooks (`beforeMCPExecution`, `beforeShellExecution`, `beforeReadFile`), set `"failClosed": true` on the hook definition so a crash, timeout, or invalid-JSON response blocks the action instead of failing open.
+
+Choose the target location based on the requested scope:
+
+- `<project-root>/.cursor/hooks.json` — committed project hook (working dir = project root)
+- `~/.cursor/hooks.json` — user-only hook (working dir = `~/.cursor/`)
+
+In a monorepo with multiple service packages, hook script paths must be workspace-relative (e.g., `.cursor/hooks/api/validate.sh`, not just `validate.sh`). Confirm the correct path from the Phase 1 analysis before writing.
+
+Generate the complete hook configuration:
+
+1. Hook JSON block — to be merged into the `hooks` key of the selected target file
+2. Shell script (if `command` type):
+   - Project hook: write to `.cursor/hooks/{name}.sh` with executable permissions; the path inside `hooks.json` is `.cursor/hooks/{name}.sh` (relative to project root)
+   - User hook: write to `~/.cursor/hooks/{name}.sh` with executable permissions; the path inside `hooks.json` is `./hooks/{name}.sh` (relative to `~/.cursor/`)
+
+**Important**: The hook JSON must be merged into the selected target file, not replace it. Read the current target file first and produce the merged result. If the target file does not yet exist, generate it with `version: 1` and the new event entry.
+
+### Phase 3: Self-Validation
+
+Read `references/hook-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated hook configuration.
+
+The loop evaluates all hard limits, quality checks, and security gap checks (command injection via unescaped variables, path traversal, secret exposure in logs), fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+
+### Phase 4: Present and Write
+
+1. Show the user the complete hook configuration (JSON + shell script if applicable)
+2. Cite the evidence from reference files that informed key decisions:
+   - Which event was chosen and why
+   - Why this handler type (`command` vs `prompt`)
+   - What the exit-code behavior means for this event, including whether `failClosed: true` was set
+3. Ask for confirmation before writing any files
+4. On approval:
+   - Merge the hook JSON into the selected target file (creating it with `version: 1` if missing)
+   - Write the shell script to `.cursor/hooks/{name}.sh` (project) or `~/.cursor/hooks/{name}.sh` (user) and set executable (`chmod +x`)

--- a/plugins/cursor-customizer/skills/create-hook/SKILL.md
+++ b/plugins/cursor-customizer/skills/create-hook/SKILL.md
@@ -70,7 +70,7 @@ Read `assets/templates/hook-config.md` and fill its placeholders using:
 
 For blocking hooks (e.g., `preToolUse`, `beforeShellExecution`, `beforeReadFile`, `subagentStart`, `beforeSubmitPrompt`, `beforeMCPExecution`), translate the user intent into a concrete matcher when the event supports one:
 
-- `preToolUse` blocking write tools → matcher like `Write|Edit|Create`
+- `preToolUse` blocking write or delete tools → matcher like `Write|Delete`
 - `beforeShellExecution` blocking network commands → matcher like `curl|wget|nc`
 - `subagentStart` gating specific subagent types → matcher like `explore|shell`
 

--- a/plugins/cursor-customizer/skills/create-hook/assets/templates/hook-config.md
+++ b/plugins/cursor-customizer/skills/create-hook/assets/templates/hook-config.md
@@ -1,0 +1,52 @@
+<!-- TEMPLATE: Hook Configuration
+     Placement: <project-root>/.cursor/hooks.json (project) or ~/.cursor/hooks.json (user)
+     Format: JSON with `version` and `hooks` keys; each event maps to an array of definitions
+     Rule: Use only Cursor-native event names (camelCase). Reject any name that is not in
+           `references/hook-events-reference.md`.
+     Rule: Valid Agent events: sessionStart, sessionEnd, preToolUse, postToolUse,
+           postToolUseFailure, subagentStart, subagentStop, beforeShellExecution,
+           afterShellExecution, beforeMCPExecution, afterMCPExecution, beforeReadFile,
+           afterFileEdit, beforeSubmitPrompt, preCompact, stop, afterAgentResponse,
+           afterAgentThought
+     Rule: Valid Tab events: beforeTabFileRead, afterTabFileEdit
+     Rule: Handler types are `command` (default) or `prompt` only — there is no `http` or
+           `agent` handler in Cursor's native model
+     Rule: Matchers apply only to events documented as supporting matchers in
+           `references/hook-events-reference.md`. Setting a matcher on an event that does
+           not support one (e.g., sessionStart, beforeMCPExecution, afterMCPExecution,
+           preCompact, beforeTabFileRead, afterTabFileEdit) is a structural error
+     Rule: Exit-code semantics — `0` = success, `2` = block; other non-zero exits fail open
+           by default. Set `"failClosed": true` on security-critical blocking hooks
+           (beforeMCPExecution, beforeShellExecution, beforeReadFile) so a crash, timeout,
+           or invalid-JSON response blocks the action
+     Rule: Hook input arrives as JSON on stdin; the script's stdout JSON is consumed for
+           `permission`, `additional_context`, `updated_input`, etc.
+-->
+
+<!-- Emit raw JSON only. Do not include Markdown headings, tables, prose, or code fences in
+     the generated `.cursor/hooks.json`. -->
+{
+  "version": 1,
+  "hooks": {
+    "[hookEvent]": [
+      {
+        "command": "[script-path-or-shell-string]",
+        "matcher": "[regex-string-or-omit-when-event-has-no-matcher-field]",
+        "timeout": 30,
+        "failClosed": false
+      }
+    ]
+  }
+}
+
+<!-- CONDITIONAL: For blocking events (preToolUse, beforeShellExecution, beforeMCPExecution,
+     beforeReadFile, beforeSubmitPrompt, subagentStart) provide a concrete matcher when the
+     event supports one. Avoid omitting the matcher just to fire on every occurrence. -->
+
+<!-- CONDITIONAL: For prompt-handler hooks, replace the per-script body with:
+     {
+       "type": "prompt",
+       "prompt": "[natural-language criterion; $ARGUMENTS is auto-replaced with hook input]",
+       "timeout": 10
+     }
+     Use `prompt` only when natural-language judgment is genuinely required. -->

--- a/plugins/cursor-customizer/skills/create-hook/references/hook-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/hook-authoring-guide.md
@@ -1,0 +1,160 @@
+# Hook Authoring Guide
+
+Evidence-based guidance for creating Cursor hooks that enforce deterministic behavior.
+Source: docs/cursor/hooks/hooks-guide.md
+
+---
+
+## Contents
+
+- When to use hooks (vs rules, skills, subagents)
+- Hook configuration structure (`version` + `hooks` map)
+- Two handler types and when to use each
+- Matcher patterns and event-field mapping
+- Hook locations and scope
+- Exit codes, communication protocol, and `failClosed`
+- Security considerations and best practices
+
+---
+
+## When to Use Hooks
+
+Hooks provide **deterministic control** — they always fire, regardless of model judgment. Use hooks when you need guaranteed enforcement, not best-effort compliance.
+
+| Use hooks when | Use rules when | Use skills when |
+|----------------|---------------|----------------|
+| Action must ALWAYS happen | Behavior guidance is sufficient | Complex workflow orchestration |
+| Side effects must be prevented | Contextual judgment acceptable | Multi-step instruction execution |
+| Consistency across all sessions | Occasional exception is OK | On-demand user-triggered action |
+| External system integration | Content is knowledge, not enforcement | |
+
+Examples: auto-formatting after edits, blocking destructive shell commands, sending notifications, auditing config changes, redacting secrets before file reads.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Hooks" introduction*
+
+---
+
+## Hook Configuration Structure
+
+Cursor hooks live in `hooks.json` with two top-level keys:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/approve-network.sh",
+        "matcher": "curl|wget|nc",
+        "timeout": 30
+      }
+    ]
+  }
+}
+```
+
+Level 1: **`hooks` map** — keys are event names, values are arrays of hook definitions
+Level 2: **Hook definition** — at minimum a `command`; optionally `type`, `matcher`, `timeout`, `failClosed`, `loop_limit`
+
+Omit `matcher` to fire on every occurrence of the event.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Configuration file"*
+
+---
+
+## Two Handler Types
+
+| Type | Mechanism | Best for |
+|------|-----------|----------|
+| `command` (default) | Shell script (stdin → stdout) | Formatting, validation, logging |
+| `prompt` | LLM single-turn evaluation | Decisions requiring natural-language judgment |
+
+**Use `command`** for deterministic checks (regex patterns, file existence, format enforcement). It is the implicit default when `type` is omitted.
+
+**Use `prompt`** when a natural-language criterion is genuinely required:
+
+```json
+{
+  "type": "prompt",
+  "prompt": "Does this command look safe to execute? Only allow read-only operations.",
+  "timeout": 10
+}
+```
+
+Prompt hooks return a structured `{ ok: boolean, reason?: string }` response. The `$ARGUMENTS` placeholder in the prompt is auto-replaced with the hook input JSON.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
+
+---
+
+## Matcher Patterns
+
+The `matcher` field is a **regex string**. Which field it filters depends on the event:
+
+| Event | Matcher filters | Example values |
+|-------|-----------------|----------------|
+| `preToolUse`, `postToolUse`, `postToolUseFailure` | tool type | `Shell`, `Read`, `Write`, `Grep`, `Delete`, `Task`, `MCP:<tool_name>` |
+| `subagentStart`, `subagentStop` | subagent type | `generalPurpose`, `explore`, `shell` |
+| `beforeShellExecution`, `afterShellExecution` | full shell command string | `curl|wget|nc`, `rm -rf` |
+| `beforeReadFile` | tool type | `TabRead`, `Read` |
+| `afterFileEdit` | tool type | `TabWrite`, `Write` |
+| No matcher support | always fires | `sessionStart`, `sessionEnd`, `beforeMCPExecution`, `afterMCPExecution`, `preCompact`, `beforeTabFileRead`, `afterTabFileEdit` |
+
+Matchers on `beforeSubmitPrompt`, `stop`, `afterAgentResponse`, and `afterAgentThought` are matched against fixed literal values documented in the Cursor hooks guide; in practice these matchers add no filtering value and may be omitted.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
+
+---
+
+## Hook Locations
+
+| Location | Scope | Working directory | Shareable |
+|----------|-------|-------------------|-----------|
+| `<project-root>/.cursor/hooks.json` | This project | Project root | Yes (commit to repo) |
+| `~/.cursor/hooks.json` | All your projects | `~/.cursor/` | No (local only) |
+| Enterprise system-wide config | Org-wide | Enterprise config dir | Yes, admin-controlled |
+| Team cloud config | Team-wide | Managed hooks dir | Yes, dashboard-controlled |
+
+Priority order (highest to lowest): Enterprise → Team → Project → User. All matching hooks from every source run; merge conflicts resolve toward the higher-priority source.
+
+For project hooks, write paths relative to the project root (e.g., `.cursor/hooks/script.sh`). For user hooks, write paths relative to `~/.cursor/` (e.g., `./hooks/script.sh`).
+
+*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
+
+---
+
+## Exit Codes and Communication Protocol
+
+For **command** hooks:
+
+- Input: JSON event data on **stdin**
+- Output: JSON decision on **stdout**
+- Errors/messages: **stderr**
+
+| Exit code | Effect |
+|-----------|--------|
+| `0` | Hook succeeded; stdout JSON is consumed (e.g., `permission`, `additional_context`, `updated_input`) |
+| `2` | Action blocked (equivalent to returning `permission: "deny"`) |
+| Other | Hook failed; action proceeds (fail-open by default) |
+
+To make a security-critical hook **fail closed** instead, set `"failClosed": true` on the hook definition. With `failClosed: true`, a crash, timeout, or invalid-JSON response blocks the action.
+
+For **prompt** hooks: the LLM returns `{ ok: boolean, reason?: string }`. When `ok: false`, the action is denied and `reason` is surfaced to the user.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Per-Script Configuration Options"*
+
+---
+
+## Security Considerations
+
+- **Validate and sanitize stdin input** — never trust event data blindly; parse the JSON, then check fields.
+- **Always quote shell variables** — write `"$VAR"`, never bare `$VAR`, to avoid command injection from values containing spaces or special characters.
+- **Block path traversal** — when a hook receives a `file_path`, reject inputs containing `..` segments before using them.
+- **Use `CURSOR_PROJECT_DIR`** — anchor file paths to the workspace root via this environment variable rather than hardcoding paths.
+- **Skip sensitive files** — `beforeReadFile` is the right place to redact or deny reads of `.env`, key files, and `.git/` internals.
+- **Never log secrets** — `afterShellExecution` and `afterMCPExecution` see full outputs; redact credentials before forwarding to external systems.
+- **Set `failClosed: true` for security-critical hooks** — `beforeMCPExecution`, `beforeShellExecution`, and `beforeReadFile` should fail closed when a denial is the safer outcome.
+
+Use the Hooks tab in Cursor Settings to confirm hooks are loaded and to inspect execution traces.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Troubleshooting", "Environment Variables"*

--- a/plugins/cursor-customizer/skills/create-hook/references/hook-events-reference.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/hook-events-reference.md
@@ -1,0 +1,161 @@
+# Hook Events Reference
+
+Complete reference for Cursor's native hook events: triggers, matcher fields, and handler-type support.
+Source: docs/cursor/hooks/hooks-guide.md
+
+---
+
+## Contents
+
+- Event summary table (Agent and Tab events)
+- Matcher field by event type
+- JSON configuration schema
+- Handler type support matrix
+- Common patterns (pre-validation, post-formatting, session injection)
+
+---
+
+## Event Summary Table
+
+Cursor exposes two families of hook events: Agent (Cmd+K / Agent Chat) and Tab (inline completions).
+
+### Agent events
+
+| Event | When it fires | Can block? |
+|-------|--------------|-----------|
+| `sessionStart` | A new composer conversation is created | No (fire-and-forget) |
+| `sessionEnd` | A composer conversation ends | No (fire-and-forget) |
+| `preToolUse` | Before any tool call executes (generic — fires for all tools) | Yes (`permission: "deny"`) |
+| `postToolUse` | After a tool call succeeds | No (output replacement / context injection) |
+| `postToolUseFailure` | After a tool call fails, times out, or is denied | No (observation only) |
+| `subagentStart` | Before a Task-tool subagent spawns | Yes (`permission: "deny"`) |
+| `subagentStop` | When a subagent finishes | No (may set `followup_message`) |
+| `beforeShellExecution` | Before any shell command runs | Yes (`permission: "deny"`) |
+| `afterShellExecution` | After a shell command completes | No (audit/metrics only) |
+| `beforeMCPExecution` | Before an MCP tool call runs | Yes (`permission: "deny"`) |
+| `afterMCPExecution` | After an MCP tool call completes | No (audit only) |
+| `beforeReadFile` | Before the agent reads a file | Yes (`permission: "deny"`) |
+| `afterFileEdit` | After the agent edits a file | No (formatters / accounting) |
+| `beforeSubmitPrompt` | After the user hits send, before backend request | Yes (`continue: false`) |
+| `preCompact` | Before context-window compaction | No (observational) |
+| `stop` | When the agent loop ends | No (may set `followup_message` to auto-continue) |
+| `afterAgentResponse` | After the agent completes an assistant message | No |
+| `afterAgentThought` | After the agent completes a thinking block | No |
+
+### Tab events
+
+| Event | When it fires | Can block? |
+|-------|--------------|-----------|
+| `beforeTabFileRead` | Before Tab reads a file for inline completions | Yes (`permission: "deny"`) |
+| `afterTabFileEdit` | After Tab edits a file | No |
+
+*Source: docs/cursor/hooks/hooks-guide.md "Agent and Tab Support"*
+
+---
+
+## Matcher Field by Event Type
+
+The `matcher` is a regex string. The field it matches against depends on the event:
+
+| Event | Matcher filters on | Example values |
+|-------|-------------------|----------------|
+| `preToolUse`, `postToolUse`, `postToolUseFailure` | tool type | `Shell`, `Read`, `Write`, `Grep`, `Delete`, `Task`, or `MCP:<tool_name>` |
+| `subagentStart`, `subagentStop` | subagent type | `generalPurpose`, `explore`, `shell` |
+| `beforeShellExecution`, `afterShellExecution` | full shell command string | `curl|wget|nc`, `rm -rf` |
+| `beforeReadFile` | tool type | `TabRead`, `Read` |
+| `afterFileEdit` | tool type | `TabWrite`, `Write` |
+| `beforeSubmitPrompt` | the literal value documented in the Cursor hooks guide | (matched against the documented literal) |
+| `stop` | the literal value documented in the Cursor hooks guide | (matched against the documented literal) |
+| `afterAgentResponse` | the literal value documented in the Cursor hooks guide | (matched against the documented literal) |
+| `afterAgentThought` | the literal value documented in the Cursor hooks guide | (matched against the documented literal) |
+| No matcher support | always fires | `sessionStart`, `sessionEnd`, `beforeMCPExecution`, `afterMCPExecution`, `preCompact`, `beforeTabFileRead`, `afterTabFileEdit` |
+
+For MCP tool filtering on `preToolUse`/`postToolUse`/`postToolUseFailure`, use the `MCP:<tool_name>` format.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
+
+---
+
+## JSON Configuration Schema
+
+Cursor hooks live in a `hooks.json` file at the project or user scope. The top level is two keys: `version` and `hooks`. Under `hooks`, each event maps to an array of hook definitions.
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "<eventName>": [
+      {
+        "command": "<script-path-or-shell-string>",
+        "matcher": "<regex-string>",
+        "timeout": 30,
+        "failClosed": false
+      }
+    ]
+  }
+}
+```
+
+**Per-script options:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `command` | string | required | Script path (relative or absolute) or inline shell command |
+| `type` | `"command"` or `"prompt"` | `"command"` | Hook execution type |
+| `timeout` | number | platform default | Execution timeout in seconds |
+| `loop_limit` | number or `null` | `5` | Per-script auto-followup cap for `stop` and `subagentStop` |
+| `failClosed` | boolean | `false` | When `true`, hook failures (crash, timeout, invalid JSON) block the action instead of failing open |
+| `matcher` | string | — | Regex filter; meaning depends on the event (see table above) |
+
+**Prompt-hook fields:** add `"type": "prompt"` and a `"prompt": "<natural-language criterion>"` field; an optional `"model"` field overrides the default fast model. The prompt receives the hook input via the auto-replaced `$ARGUMENTS` placeholder.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
+
+---
+
+## Handler Type Support Matrix
+
+| Handler type | Supported events | Notes |
+|--------------|-----------------|-------|
+| `command` | All events | Default; shell script over stdin/stdout |
+| `prompt` | All events | LLM evaluates a natural-language criterion; returns `{ ok, reason }` |
+
+Unlike some agent platforms, Cursor exposes only these two handler types — there is no separate `http` or `agent` handler. Use `command` for deterministic checks; reserve `prompt` for cases where natural-language judgment is genuinely required.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
+
+---
+
+## Common Patterns
+
+### Pre-validation (`beforeShellExecution` + command matcher)
+
+Block dangerous network commands:
+
+```json
+{ "version": 1, "hooks": { "beforeShellExecution": [{ "command": ".cursor/hooks/approve-network.sh", "matcher": "curl|wget|nc" }] } }
+```
+
+Exit `2` from the script blocks the action; exit `0` allows it.
+
+### Post-formatting (`afterFileEdit`)
+
+Run a formatter after every agent edit:
+
+```json
+{ "version": 1, "hooks": { "afterFileEdit": [{ "command": ".cursor/hooks/format.sh" }] } }
+```
+
+`afterFileEdit` is non-blocking — its job is observation and side effects.
+
+### Session context injection (`sessionStart`)
+
+Inject dynamic context at session start:
+
+```json
+{ "version": 1, "hooks": { "sessionStart": [{ "command": ".cursor/hooks/inject-context.sh" }] } }
+```
+
+The script's stdout JSON may include `additional_context` to add to the conversation's initial system context.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Examples" and "Hook events"*

--- a/plugins/cursor-customizer/skills/create-hook/references/hook-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/hook-validation-criteria.md
@@ -1,0 +1,87 @@
+# Hook Validation Criteria
+
+Quality checklist for generated and improved Cursor hook configurations.
+Source: docs/cursor/hooks/hooks-guide.md
+
+---
+
+## Contents
+
+- Hard limits (auto-fail)
+- Quality checks (event/intent fit, matcher specificity, error handling, secrets)
+- Security gap checks (command injection, path traversal, secret exposure)
+- Improve-operation additions (preservation, citation traceability)
+- Validation loop instructions
+
+---
+
+## Hard Limits (Auto-fail if violated)
+
+Any hook violating these criteria must be fixed before proceeding:
+
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON structure | Valid JSON; `version` present; `hooks` is an object |
+| Event name | From the Cursor-native event vocabulary in `hook-events-reference.md`; reject any name not on that list (in particular, PascalCase event names that have no Cursor analogue) |
+| Handler type | `command` (default) or `prompt` only |
+| `command` path | Plausible relative to the configuration scope's working directory (project root for project hooks; `~/.cursor/` for user hooks); absolute paths must point to an existing executable |
+| Matcher applicability | Matcher set only on events whose matcher field is documented in `hook-events-reference.md` |
+| Exit-code semantics | `0` = success, `2` = block; other non-zero exits fail open by default — security-critical blocking hooks must set `failClosed: true` |
+
+*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Configuration", "Per-Script Configuration Options"*
+
+---
+
+## Quality Checks (All must pass)
+
+- [ ] Event matches intent — block-capable event used for blocking intent (`preToolUse`, `beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`, `beforeSubmitPrompt`, `subagentStart`); observation-only event used for non-blocking intent (`postToolUse`, `afterShellExecution`, `afterMCPExecution`, `afterFileEdit`, `sessionStart`, `sessionEnd`, `preCompact`, `afterAgentResponse`, `afterAgentThought`)
+- [ ] Matcher is specific — blocking hooks do not omit the matcher when the event supports one and the intent targets a specific tool, subagent type, or command pattern
+- [ ] Matcher uses a regex value valid for the event's matcher field (per `hook-events-reference.md`)
+- [ ] Error handling defined — exit `2` with meaningful stderr for blocking intent; `failClosed: true` set on security-critical blocking hooks (`beforeMCPExecution`, `beforeShellExecution`, `beforeReadFile`)
+- [ ] Silent success — exit `0` does not leave spurious stderr output
+- [ ] `command` hook used for deterministic checks (not `prompt` for simple regex checks)
+- [ ] `prompt` hook used only when natural-language judgment is genuinely required
+- [ ] Evidence citations present — the task card or improvement plan documents why this event/handler/matcher was chosen, referencing `hook-events-reference.md`. **Note:** JSON has no comment syntax; for `command` hooks, evidence lives in the task card / improvement plan, not in the hooks file itself
+- [ ] Prompt-engineering strategy applied — zero-shot only; no few-shot examples in the hook configuration
+
+---
+
+## Security Gap Checks (All must pass)
+
+- [ ] **Command injection** — `command` strings do not interpolate raw stdin fields without quoting; the documented hook script reads stdin into a variable and quotes every variable expansion (`"$VAR"`, never bare `$VAR`)
+- [ ] **Path traversal** — when the hook receives a `file_path` from stdin, the script rejects values containing `..` segments before opening or executing
+- [ ] **Secret exposure in logs** — `afterShellExecution`, `afterMCPExecution`, and any audit hook that forwards `output` / `result_json` redacts known secret patterns (API keys, tokens, passwords) before logging or transmitting them
+- [ ] **Hardcoded secrets** — no literal credentials anywhere in the hook configuration (`command` strings, prompt text, headers, or other fields); environment variables (referenced via `$VAR` and quoted at use sites) are the only acceptable source
+- [ ] **Workspace anchoring** — file paths used inside hook scripts derive from `CURSOR_PROJECT_DIR` rather than being hardcoded
+
+---
+
+## If This Is an IMPROVE Operation — Also Check
+
+**Information Preservation:**
+
+- [ ] Existing blocking behavior not weakened (exit `2` not changed to exit `0`; `failClosed: true` not silently flipped to `false`)
+- [ ] Matcher not broadened unintentionally (a specific regex not replaced with a permissive one)
+- [ ] Valid hooks not removed while fixing structure
+
+**Structural:**
+
+- [ ] Hook location remains appropriate (project vs user scope matches intended sharing)
+- [ ] Multiple hooks for the same event not consolidated if they serve distinct purposes
+
+**Citation Traceability:**
+
+- [ ] Every change made during improvement cites the specific evaluator finding (e.g., `V1`, `V3`) from the Phase 1 evaluation output that motivated the change — not just a generic reference to documentation
+
+---
+
+## Validation Loop Instructions
+
+Execute this loop for each generated or improved hook:
+
+1. Evaluate the hook against ALL criteria above
+2. If ANY criterion fails: identify the specific failure, fix the hook, restart evaluation
+3. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+4. Only proceed to writing hooks when ALL criteria pass
+
+**Do not skip criteria for "minor" violations.** Hard limits are hard limits.

--- a/plugins/cursor-customizer/skills/create-hook/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/prompt-engineering-strategies.md
@@ -1,0 +1,127 @@
+# Prompt Engineering Strategies
+
+Evidence-based prompting strategies for artifact authoring, organized by artifact type.
+Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+
+---
+
+## Contents
+
+- Universal principles (apply to all artifact types)
+- Strategy matrix (technique selection by artifact type)
+- Per-artifact-type recommendations
+- Anti-patterns (what to avoid)
+- Context budget principles
+
+---
+
+## Universal Principles
+
+**Clarity over cleverness** — "Think of Claude as a brilliant but new employee who lacks context on your norms and workflows." Write instructions a colleague with no context could follow.
+
+**Role definition first** — A single-sentence role in a system prompt focuses behavior and tone: `"You are a code reviewer specializing in TypeScript."` Use in subagent prompts and skill bodies. Skip in rules and hooks (zero-shot is sufficient).
+
+**XML tags for complex structure** — Use XML tags to disambiguate prompts mixing instructions, context, examples, and inputs:
+
+```
+<instructions>...</instructions>
+<context>...</context>
+<example>...</example>
+```
+
+**Critical instructions at start or end** — The "lost-in-the-middle" effect degrades performance for instructions buried in the middle of long contexts. Place key rules in the first and last 20% of each file.
+
+**Describe desired behavior, not prohibited behavior** — Instead of "Do not use markdown", write "Your response should be smooth flowing prose."
+
+**Behavioral discipline beats clever prompting** — surface assumptions before acting, prefer the simplest sufficient change, keep edits surgical, and define explicit validation targets before concluding.
+
+**Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
+
+*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
+
+---
+
+## Strategy Matrix
+
+| Technique | Skill (SKILL.md) | Hook | Rule | Subagent |
+|-----------|-----------------|------|------|----------|
+| Role prompting | ✅ First line of body | ❌ Skip (implicit) | ❌ Skip | ✅ Strong use |
+| Zero-shot | ✅ Most phases | ✅ Default | ✅ Always | ✅ Simple tasks |
+| Few-shot examples | ✅ Critical output formats | ❌ Too token-costly | ❌ Too token-costly | ✅ Complex formats |
+| XML structuring | ✅ Multi-section bodies | ❌ Too verbose | ❌ Too verbose | ✅ Rich context |
+| Chain-of-thought | ❌ Slows execution | ❌ Not applicable | ❌ Not applicable | ✅ Reasoning tasks |
+| Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
+| Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
+
+*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160*
+
+---
+
+## Per-Artifact Recommendations
+
+### Skills (SKILL.md)
+
+- Open body with role definition (1-2 sentences max)
+- Make Phase 1 a low-risk warm-up before higher-effort phases
+- Use progressive disclosure: reference files loaded per phase, not all upfront
+- Load curated references before asking for synthesis or edits
+- Use zero-shot for most phases; reserve few-shot for phases with strict output format
+- Make constraints concrete: scope limits, output shape, and stop conditions
+- Self-check instruction in final phase: "Before completing, verify all criteria in skill-validation-criteria.md"
+- Final validation should confirm Karpathy-style discipline and the ethical constraint on persuasion
+- Keep each phase instruction ≤10 lines; reference files for depth
+
+### Hooks
+
+- Zero-shot only — hooks are short and tokens are expensive
+- Avoid role prompting; context of the event implies the role
+- Be explicit about output format: `{"ok": true/false, "reason": "..."}`
+- For `prompt` and `agent` hooks: write simple, direct evaluation criteria
+- Test with `--debug` to verify hook output is parsed as intended
+
+### Rules
+
+- Zero-shot always — rules are factual instructions, not prompted behaviors
+- No examples (too token-costly for always-loaded context)
+- One instruction per bullet; no compound sentences
+- Specificity goldilocks: "Use 2-space indentation" not "Format code properly" not "src/auth/handlers.ts handles JWT"
+
+### Subagents
+
+- Role prompting is the primary specialization mechanism — invest here
+- Structure system prompt: Role → Responsibilities → Process → Checklist → Output Format
+- Include confidence threshold for review agents: "Report only when >80% confident"
+- Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with Opus 4.6
+- Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
+
+*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80*
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| "CRITICAL: You MUST always..." | Overtriggering with Claude 4.6 (especially Opus) | Use "Use this when..." |
+| Vague instructions ("be thorough") | Not verifiable or actionable | Specify exactly what to check |
+| Few-shot examples in rules | Token waste on every session | Delete examples; be specific in instruction text |
+| Over-explaining what Claude already knows | Wastes context budget | Trust model knowledge; add only novel context |
+| Prescriptive step-by-step plans | Forces rigid execution; misses edge cases | "Think thoroughly" outperforms manual step lists |
+| Contradictory instructions | Claude picks one arbitrarily | Audit for conflicts before writing |
+| Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
+
+*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
+
+---
+
+## Context Budget Principles
+
+Every token in an artifact competes with conversation history and other context. Apply these before writing:
+
+- Challenge each instruction: "Would removing this cause the agent to make mistakes? If not, cut it."
+- Prefer pointers to full content: link to reference files instead of inlining detailed material
+- Path-scoped rules and per-phase reference loading are the primary token-saving mechanisms
+- Short artifacts (rules, validation criteria) should be zero-shot and minimal
+- Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
+
+*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*

--- a/plugins/cursor-customizer/skills/improve-hook/SKILL.md
+++ b/plugins/cursor-customizer/skills/improve-hook/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: improve-hook
+description: "Evaluates and optimizes existing Cursor hook configurations against evidence-based quality criteria. Checks event names against Cursor's native vocabulary, matcher specificity, exit-code handling, and security gaps. Use when improving an existing hook."
+---
+
+# Improve Hook
+
+Evaluate existing Cursor hook configurations against evidence-based quality criteria and apply improvements to fix invalid event names, tighten matchers, and eliminate security gaps.
+
+## Behavioral Guidelines
+
+- **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
+- **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
+- **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
+- **Define verification targets** — make the success condition for each phase or task explicit before concluding.
+- **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
+- **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+
+## Hard Rules
+
+<RULES>
+- **ALWAYS** evaluate before modifying — never change hooks without analysis
+- **ALWAYS** present changes to the user before applying them
+- **NEVER** weaken existing blocking behavior (exit `2` → exit `0`; `failClosed: true` → `false`) without explicit user approval
+- **NEVER** broaden matchers unintentionally (specific regex → permissive regex or omitted matcher)
+- **NEVER** remove valid hooks while fixing structure
+- **EVERY** improved hook must produce valid JSON and use only Cursor-native event names from `references/hook-events-reference.md`
+</RULES>
+
+## Process
+
+### Preflight Check
+
+Check whether hooks exist in:
+
+- The user-provided path (if given)
+- `<project-root>/.cursor/hooks.json` (project scope)
+- `~/.cursor/hooks.json` (user scope)
+
+**If no hooks found:**
+
+1. Inform the user: "No hook configurations found in the project."
+2. Suggest using `/cursor-customizer:create-hook` to create a new one instead.
+3. **STOP**
+
+**If hooks found:**
+Proceed to Phase 1 below.
+
+### Phase 1: Evaluate
+
+Delegate to the `hook-evaluator` agent with this task:
+
+> Evaluate hook configurations in `<project-root>/.cursor/hooks.json` and (when accessible) `~/.cursor/hooks.json`. Check JSON validity, event names against the Cursor-native event vocabulary, handler types (`command` or `prompt`), matcher specificity, matcher applicability per event, exit-code behavior, command-script existence and plausibility, and security gaps. For `command` handlers, read the referenced script files (resolved relative to the configuration scope's working directory: project root for project hooks, `~/.cursor/` for user hooks) to verify exit-code handling. Flag any script that always exits 0 (has no non-zero exit path) and lacks an explicit comment documenting that always-exit-0 is intentional — for `afterFileEdit`, `afterShellExecution`, `afterMCPExecution`, `postToolUse`, `postToolUseFailure`, and other observation-only events, always-exit-0 is acceptable only when explicitly documented; for blocking events (`preToolUse`, `beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`, `beforeSubmitPrompt`, `subagentStart`), always-exit-0 is never acceptable. Return structured results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+
+- If the user provides a specific event/matcher to improve, scope evaluation to that hook.
+- If no specific hook provided, evaluate ALL hooks in the project.
+- If any hook file is malformed JSON, report the parse error to the user and stop — do not attempt to evaluate a broken file.
+
+The agent runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+
+### Phase 2: Codebase Context
+
+Delegate to the `artifact-analyzer` agent with this task:
+
+> Analyze the project to understand the context around hook configurations. Focus on: all hooks defined in `<project-root>/.cursor/hooks.json` and `~/.cursor/hooks.json` (when accessible); project hook scripts under `.cursor/hooks/`; user hook scripts under `~/.cursor/hooks/`; event coverage gaps; and the matcher patterns already used in the project.
+
+Wait for it to complete and parse its structured output.
+
+### Phase 3: Generate Improvement Plan
+
+Read these reference documents:
+
+- `references/hook-authoring-guide.md` — when to use hooks, two handler types, exit codes, security
+- `references/hook-evaluation-criteria.md` — bloat / staleness indicators, quality rubric
+- `references/hook-events-reference.md` — Cursor-native event vocabulary, matchers, JSON schema
+- `references/prompt-engineering-strategies.md` — hook-specific prompting
+
+Based on both agent reports, create an improvement plan with categories:
+
+1. **Removals** — invalid event names (not in Cursor's vocabulary), redundant hooks, observation-only hooks replaceable by rules
+2. **Refactoring** — tighten overly permissive matchers, fix exit-code misuse, correct script paths, add `failClosed: true` to security-critical blocking hooks
+3. **Additions** — missing error handling, missing events for key tool-use patterns
+
+If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+
+### Phase 4: Self-Validation
+
+Read `references/hook-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved hook configurations.
+
+For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass. Additionally, verify that every suggestion in the improvement plan has a WHY field citing a source document — no suggestion may lack a source reference.
+
+### Phase 5: Present and Apply
+
+1. Show a summary overview of all improvements found, grouped by category:
+   - **Removals**: X items (invalid event names: X, redundant: X)
+   - **Refactoring**: X items (matchers: X, exit codes: X, script-path fixes: X, `failClosed` additions: X)
+   - **Additions**: X items
+
+2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+
+   **WHAT**: The specific hook entry and its current location (file:key path)
+   **WHY**: Evidence-based justification with source reference
+   **TOKEN IMPACT**: Estimated impact (hooks fire on every matching event — overly permissive matchers run on every occurrence)
+   **OPTIONS**:
+   - **Option A** (recommended): Primary action
+   - **Option B**: Alternative action
+   - **Option C**: Keep as-is
+
+   Wait for the user to select an option for each suggestion before proceeding to the next.
+   Warn if any option would weaken blocking behavior (exit `2` → exit `0`, or `failClosed: true` → `false`).
+
+3. After all suggestions are reviewed:
+   - Show the complete merged JSON after all approved changes (not just diff)
+   - For hook script changes, show the script diff
+   - Show aggregate impact summary
+
+4. Apply ONLY the approved changes.
+   - Always read current state before writing — never overwrite; merge changes.
+
+5. Report final metrics:
+   - Hooks before → after
+   - Security issues resolved
+   - Suggestions applied: X of Y (Z deferred)

--- a/plugins/cursor-customizer/skills/improve-hook/assets/templates/hook-config.md
+++ b/plugins/cursor-customizer/skills/improve-hook/assets/templates/hook-config.md
@@ -1,0 +1,52 @@
+<!-- TEMPLATE: Hook Configuration
+     Placement: <project-root>/.cursor/hooks.json (project) or ~/.cursor/hooks.json (user)
+     Format: JSON with `version` and `hooks` keys; each event maps to an array of definitions
+     Rule: Use only Cursor-native event names (camelCase). Reject any name that is not in
+           `references/hook-events-reference.md`.
+     Rule: Valid Agent events: sessionStart, sessionEnd, preToolUse, postToolUse,
+           postToolUseFailure, subagentStart, subagentStop, beforeShellExecution,
+           afterShellExecution, beforeMCPExecution, afterMCPExecution, beforeReadFile,
+           afterFileEdit, beforeSubmitPrompt, preCompact, stop, afterAgentResponse,
+           afterAgentThought
+     Rule: Valid Tab events: beforeTabFileRead, afterTabFileEdit
+     Rule: Handler types are `command` (default) or `prompt` only — there is no `http` or
+           `agent` handler in Cursor's native model
+     Rule: Matchers apply only to events documented as supporting matchers in
+           `references/hook-events-reference.md`. Setting a matcher on an event that does
+           not support one (e.g., sessionStart, beforeMCPExecution, afterMCPExecution,
+           preCompact, beforeTabFileRead, afterTabFileEdit) is a structural error
+     Rule: Exit-code semantics — `0` = success, `2` = block; other non-zero exits fail open
+           by default. Set `"failClosed": true` on security-critical blocking hooks
+           (beforeMCPExecution, beforeShellExecution, beforeReadFile) so a crash, timeout,
+           or invalid-JSON response blocks the action
+     Rule: Hook input arrives as JSON on stdin; the script's stdout JSON is consumed for
+           `permission`, `additional_context`, `updated_input`, etc.
+-->
+
+<!-- Emit raw JSON only. Do not include Markdown headings, tables, prose, or code fences in
+     the generated `.cursor/hooks.json`. -->
+{
+  "version": 1,
+  "hooks": {
+    "[hookEvent]": [
+      {
+        "command": "[script-path-or-shell-string]",
+        "matcher": "[regex-string-or-omit-when-event-has-no-matcher-field]",
+        "timeout": 30,
+        "failClosed": false
+      }
+    ]
+  }
+}
+
+<!-- CONDITIONAL: For blocking events (preToolUse, beforeShellExecution, beforeMCPExecution,
+     beforeReadFile, beforeSubmitPrompt, subagentStart) provide a concrete matcher when the
+     event supports one. Avoid omitting the matcher just to fire on every occurrence. -->
+
+<!-- CONDITIONAL: For prompt-handler hooks, replace the per-script body with:
+     {
+       "type": "prompt",
+       "prompt": "[natural-language criterion; $ARGUMENTS is auto-replaced with hook input]",
+       "timeout": 10
+     }
+     Use `prompt` only when natural-language judgment is genuinely required. -->

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-authoring-guide.md
@@ -1,0 +1,160 @@
+# Hook Authoring Guide
+
+Evidence-based guidance for creating Cursor hooks that enforce deterministic behavior.
+Source: docs/cursor/hooks/hooks-guide.md
+
+---
+
+## Contents
+
+- When to use hooks (vs rules, skills, subagents)
+- Hook configuration structure (`version` + `hooks` map)
+- Two handler types and when to use each
+- Matcher patterns and event-field mapping
+- Hook locations and scope
+- Exit codes, communication protocol, and `failClosed`
+- Security considerations and best practices
+
+---
+
+## When to Use Hooks
+
+Hooks provide **deterministic control** — they always fire, regardless of model judgment. Use hooks when you need guaranteed enforcement, not best-effort compliance.
+
+| Use hooks when | Use rules when | Use skills when |
+|----------------|---------------|----------------|
+| Action must ALWAYS happen | Behavior guidance is sufficient | Complex workflow orchestration |
+| Side effects must be prevented | Contextual judgment acceptable | Multi-step instruction execution |
+| Consistency across all sessions | Occasional exception is OK | On-demand user-triggered action |
+| External system integration | Content is knowledge, not enforcement | |
+
+Examples: auto-formatting after edits, blocking destructive shell commands, sending notifications, auditing config changes, redacting secrets before file reads.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Hooks" introduction*
+
+---
+
+## Hook Configuration Structure
+
+Cursor hooks live in `hooks.json` with two top-level keys:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/approve-network.sh",
+        "matcher": "curl|wget|nc",
+        "timeout": 30
+      }
+    ]
+  }
+}
+```
+
+Level 1: **`hooks` map** — keys are event names, values are arrays of hook definitions
+Level 2: **Hook definition** — at minimum a `command`; optionally `type`, `matcher`, `timeout`, `failClosed`, `loop_limit`
+
+Omit `matcher` to fire on every occurrence of the event.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Configuration file"*
+
+---
+
+## Two Handler Types
+
+| Type | Mechanism | Best for |
+|------|-----------|----------|
+| `command` (default) | Shell script (stdin → stdout) | Formatting, validation, logging |
+| `prompt` | LLM single-turn evaluation | Decisions requiring natural-language judgment |
+
+**Use `command`** for deterministic checks (regex patterns, file existence, format enforcement). It is the implicit default when `type` is omitted.
+
+**Use `prompt`** when a natural-language criterion is genuinely required:
+
+```json
+{
+  "type": "prompt",
+  "prompt": "Does this command look safe to execute? Only allow read-only operations.",
+  "timeout": 10
+}
+```
+
+Prompt hooks return a structured `{ ok: boolean, reason?: string }` response. The `$ARGUMENTS` placeholder in the prompt is auto-replaced with the hook input JSON.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
+
+---
+
+## Matcher Patterns
+
+The `matcher` field is a **regex string**. Which field it filters depends on the event:
+
+| Event | Matcher filters | Example values |
+|-------|-----------------|----------------|
+| `preToolUse`, `postToolUse`, `postToolUseFailure` | tool type | `Shell`, `Read`, `Write`, `Grep`, `Delete`, `Task`, `MCP:<tool_name>` |
+| `subagentStart`, `subagentStop` | subagent type | `generalPurpose`, `explore`, `shell` |
+| `beforeShellExecution`, `afterShellExecution` | full shell command string | `curl|wget|nc`, `rm -rf` |
+| `beforeReadFile` | tool type | `TabRead`, `Read` |
+| `afterFileEdit` | tool type | `TabWrite`, `Write` |
+| No matcher support | always fires | `sessionStart`, `sessionEnd`, `beforeMCPExecution`, `afterMCPExecution`, `preCompact`, `beforeTabFileRead`, `afterTabFileEdit` |
+
+Matchers on `beforeSubmitPrompt`, `stop`, `afterAgentResponse`, and `afterAgentThought` are matched against fixed literal values documented in the Cursor hooks guide; in practice these matchers add no filtering value and may be omitted.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
+
+---
+
+## Hook Locations
+
+| Location | Scope | Working directory | Shareable |
+|----------|-------|-------------------|-----------|
+| `<project-root>/.cursor/hooks.json` | This project | Project root | Yes (commit to repo) |
+| `~/.cursor/hooks.json` | All your projects | `~/.cursor/` | No (local only) |
+| Enterprise system-wide config | Org-wide | Enterprise config dir | Yes, admin-controlled |
+| Team cloud config | Team-wide | Managed hooks dir | Yes, dashboard-controlled |
+
+Priority order (highest to lowest): Enterprise → Team → Project → User. All matching hooks from every source run; merge conflicts resolve toward the higher-priority source.
+
+For project hooks, write paths relative to the project root (e.g., `.cursor/hooks/script.sh`). For user hooks, write paths relative to `~/.cursor/` (e.g., `./hooks/script.sh`).
+
+*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
+
+---
+
+## Exit Codes and Communication Protocol
+
+For **command** hooks:
+
+- Input: JSON event data on **stdin**
+- Output: JSON decision on **stdout**
+- Errors/messages: **stderr**
+
+| Exit code | Effect |
+|-----------|--------|
+| `0` | Hook succeeded; stdout JSON is consumed (e.g., `permission`, `additional_context`, `updated_input`) |
+| `2` | Action blocked (equivalent to returning `permission: "deny"`) |
+| Other | Hook failed; action proceeds (fail-open by default) |
+
+To make a security-critical hook **fail closed** instead, set `"failClosed": true` on the hook definition. With `failClosed: true`, a crash, timeout, or invalid-JSON response blocks the action.
+
+For **prompt** hooks: the LLM returns `{ ok: boolean, reason?: string }`. When `ok: false`, the action is denied and `reason` is surfaced to the user.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Per-Script Configuration Options"*
+
+---
+
+## Security Considerations
+
+- **Validate and sanitize stdin input** — never trust event data blindly; parse the JSON, then check fields.
+- **Always quote shell variables** — write `"$VAR"`, never bare `$VAR`, to avoid command injection from values containing spaces or special characters.
+- **Block path traversal** — when a hook receives a `file_path`, reject inputs containing `..` segments before using them.
+- **Use `CURSOR_PROJECT_DIR`** — anchor file paths to the workspace root via this environment variable rather than hardcoding paths.
+- **Skip sensitive files** — `beforeReadFile` is the right place to redact or deny reads of `.env`, key files, and `.git/` internals.
+- **Never log secrets** — `afterShellExecution` and `afterMCPExecution` see full outputs; redact credentials before forwarding to external systems.
+- **Set `failClosed: true` for security-critical hooks** — `beforeMCPExecution`, `beforeShellExecution`, and `beforeReadFile` should fail closed when a denial is the safer outcome.
+
+Use the Hooks tab in Cursor Settings to confirm hooks are loaded and to inspect execution traces.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Troubleshooting", "Environment Variables"*

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
@@ -1,0 +1,123 @@
+# Hook Evaluation Criteria
+
+Scoring rubric for assessing existing Cursor hook configurations before improvement.
+Source: docs/cursor/hooks/hooks-guide.md
+
+---
+
+## Contents
+
+- Hard limits table (JSON validity, recognized events, valid matchers)
+- Bloat indicators table (overly broad matchers, redundant hooks)
+- Staleness indicators table (deprecated event names, invalid tools)
+- Quality assessment (event selection, error handling, security)
+- Quality score rubric (5-dimension scoring 1-10)
+- Evaluation output template
+
+---
+
+## Hard Limits Table
+
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON configuration | Valid JSON; `version` present; `hooks` is an object |
+| Event name | From the Cursor-native event vocabulary in `hook-events-reference.md` |
+| Handler type | `command` (default) or `prompt` |
+| Matcher field | Valid regex string or empty / omitted |
+| Command path | Absolute paths must resolve to an existing executable; relative paths (e.g., `.cursor/hooks/*.sh`) are plausible relative to the configuration scope's working directory and must not be flagged INVALID |
+
+A hook configuration violating any hard limit is flagged **INVALID** regardless of intent.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Configuration", "Per-Script Configuration Options"*
+
+---
+
+## Bloat Indicators Table
+
+| Indicator | Why It's Bloat |
+|-----------|----------------|
+| Blocking hook with omitted or overly permissive matcher when the event supports filtering | Fires on every occurrence; high performance cost and high false-positive rate |
+| Multiple hooks for the same event doing redundant work | Consolidate into one hook with combined logic |
+| `prompt` hook used for a check expressible as a regex or string match | Prompt hooks add LLM cost; use `command` for deterministic checks |
+| Hook commands that always exit `0` (never block) on a blocking event | Observation-only hooks belong on the post-/after-* event family, not the pre-/before-* family |
+| Sensitive data in `command` strings | Use environment variables instead |
+| `failClosed: true` set on non-security-critical hooks | Increases false-deny rate without security benefit |
+
+*Source: docs/cursor/hooks/hooks-guide.md "Examples", "Per-Script Configuration Options"*
+
+---
+
+## Staleness Indicators Table
+
+| Indicator | How to Detect |
+|-----------|---------------|
+| Deprecated or non-Cursor event names | Verify against the Cursor event vocabulary in `hook-events-reference.md` |
+| Invalid tool names in matcher | Check tool-type matcher values against current Cursor tool names |
+| Hardcoded absolute paths to scripts that don't exist | Verify each absolute `command` path; relative paths (not starting with `/`) are plausible and not a staleness indicator *(staleness-evaluation heuristic only; Phase 4 validation uses a stricter existence check — see `hook-validation-criteria.md`)* |
+| Outdated subagent-type matcher values | Verify against documented subagent types (`generalPurpose`, `explore`, `shell`) |
+| Matcher set on an event that does not support matchers | Cross-check against `hook-events-reference.md` "Matcher Field by Event Type" |
+
+*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
+
+---
+
+## Quality Assessment
+
+| Question | Good | Bad |
+|----------|------|-----|
+| Event type matches intent? | Block-capable event for blocking intent; observation-only event for non-blocking intent | Using a non-blocking event to try to block actions |
+| Matcher is specific? | `Edit|Write` for file hooks, `curl|wget|nc` for network shell hooks | Omitted matcher on a blocking hook when the event supports filtering |
+| Error handling defined? | Exit `2` with clear stderr on failure; `failClosed: true` on security-critical blocking hooks | Silent failure — no error path, no stderr, no `failClosed` setting on a security-critical hook |
+| Security posture appropriate? | Hook validates before allowing; secrets in env vars; stdin variables quoted | Hook only logs, never blocks; secrets hardcoded; unquoted variable expansion |
+| Hook type appropriate for task? | `command` for deterministic, `prompt` for natural-language judgment | `prompt` for a simple regex check |
+
+*Source: docs/cursor/hooks/hooks-guide.md "Hook Types", "Command-Based Hooks"*
+
+---
+
+## Quality Score Rubric
+
+| Dimension | 8-10 (Good) | 4-7 (Mixed) | 1-3 (Bad) |
+|-----------|-------------|-------------|-----------|
+| Event Selection | Event matches intent; blocking uses block-capable events | Some mismatches | Events don't match intent |
+| Matcher Specificity | Specific regex; matcher omitted only when event has no matcher field | Some overly permissive matchers | All matchers permissive or absent on blocking hooks |
+| Error Handling | Exit `2` with reason; stderr feedback; `failClosed` set where appropriate | Some events handled | Silent failures only |
+| Security Posture | Validates before allowing; secrets in env vars; quoted variables | Partial validation | No blocking, secrets exposed |
+| Handler Efficiency | Right type for each task | Some oversized handlers | Prompt hooks for trivial regex tasks |
+| **Overall** | | | |
+
+*Source: docs/cursor/hooks/hooks-guide.md "Configuration", "Hook Types"*
+
+> **UNCERTAIN classification**: When the `command` handler references an external script that cannot be read from the repository, classify Error Handling as **UNCERTAIN** (not Bad) — exit-code behavior cannot be verified from the hook configuration alone. Report it as a gap rather than a violation.
+
+---
+
+## Evaluation Output Template
+
+```
+## Hook Evaluation Results
+
+### Hooks Found
+| Event | Matcher | Type | Status |
+|-------|---------|------|--------|
+| `preToolUse` | (omitted) | command | Overly broad matcher |
+| `afterFileEdit` | `Edit|Write` | command | OK |
+
+### Issues
+
+**Bloat Issues:**
+- `preToolUse` matcher omitted: fires on every tool use; narrow to a specific tool type
+
+**Error Handling Issues:**
+- `validate.sh` always exits 0; never blocks — `preToolUse` hook has no effect
+
+### Quality Score
+| Dimension | Score (1-10) | Notes |
+|-----------|--------------|-------|
+| Event Selection | 8 | Events match intent |
+| Matcher Specificity | 3 | Permissive matcher on blocking hook |
+| Error Handling | 2 | Always exits 0 |
+| Security Posture | 4 | Intent to validate, no enforcement |
+| Handler Efficiency | 7 | Appropriate types |
+| **Overall** | **5** | Fix matcher and exit codes |
+```

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
@@ -66,7 +66,7 @@ A hook configuration violating any hard limit is flagged **INVALID** regardless 
 | Question | Good | Bad |
 |----------|------|-----|
 | Event type matches intent? | Block-capable event for blocking intent; observation-only event for non-blocking intent | Using a non-blocking event to try to block actions |
-| Matcher is specific? | `Edit|Write` for file hooks, `curl|wget|nc` for network shell hooks | Omitted matcher on a blocking hook when the event supports filtering |
+| Matcher is specific? | `Write|Delete` for file-write/delete hooks, `curl|wget|nc` for network shell hooks | Omitted matcher on a blocking hook when the event supports filtering |
 | Error handling defined? | Exit `2` with clear stderr on failure; `failClosed: true` on security-critical blocking hooks | Silent failure — no error path, no stderr, no `failClosed` setting on a security-critical hook |
 | Security posture appropriate? | Hook validates before allowing; secrets in env vars; stdin variables quoted | Hook only logs, never blocks; secrets hardcoded; unquoted variable expansion |
 | Hook type appropriate for task? | `command` for deterministic, `prompt` for natural-language judgment | `prompt` for a simple regex check |
@@ -101,7 +101,7 @@ A hook configuration violating any hard limit is flagged **INVALID** regardless 
 | Event | Matcher | Type | Status |
 |-------|---------|------|--------|
 | `preToolUse` | (omitted) | command | Overly broad matcher |
-| `afterFileEdit` | `Edit|Write` | command | OK |
+| `afterFileEdit` | `Write` | command | OK |
 
 ### Issues
 

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-events-reference.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-events-reference.md
@@ -1,0 +1,161 @@
+# Hook Events Reference
+
+Complete reference for Cursor's native hook events: triggers, matcher fields, and handler-type support.
+Source: docs/cursor/hooks/hooks-guide.md
+
+---
+
+## Contents
+
+- Event summary table (Agent and Tab events)
+- Matcher field by event type
+- JSON configuration schema
+- Handler type support matrix
+- Common patterns (pre-validation, post-formatting, session injection)
+
+---
+
+## Event Summary Table
+
+Cursor exposes two families of hook events: Agent (Cmd+K / Agent Chat) and Tab (inline completions).
+
+### Agent events
+
+| Event | When it fires | Can block? |
+|-------|--------------|-----------|
+| `sessionStart` | A new composer conversation is created | No (fire-and-forget) |
+| `sessionEnd` | A composer conversation ends | No (fire-and-forget) |
+| `preToolUse` | Before any tool call executes (generic — fires for all tools) | Yes (`permission: "deny"`) |
+| `postToolUse` | After a tool call succeeds | No (output replacement / context injection) |
+| `postToolUseFailure` | After a tool call fails, times out, or is denied | No (observation only) |
+| `subagentStart` | Before a Task-tool subagent spawns | Yes (`permission: "deny"`) |
+| `subagentStop` | When a subagent finishes | No (may set `followup_message`) |
+| `beforeShellExecution` | Before any shell command runs | Yes (`permission: "deny"`) |
+| `afterShellExecution` | After a shell command completes | No (audit/metrics only) |
+| `beforeMCPExecution` | Before an MCP tool call runs | Yes (`permission: "deny"`) |
+| `afterMCPExecution` | After an MCP tool call completes | No (audit only) |
+| `beforeReadFile` | Before the agent reads a file | Yes (`permission: "deny"`) |
+| `afterFileEdit` | After the agent edits a file | No (formatters / accounting) |
+| `beforeSubmitPrompt` | After the user hits send, before backend request | Yes (`continue: false`) |
+| `preCompact` | Before context-window compaction | No (observational) |
+| `stop` | When the agent loop ends | No (may set `followup_message` to auto-continue) |
+| `afterAgentResponse` | After the agent completes an assistant message | No |
+| `afterAgentThought` | After the agent completes a thinking block | No |
+
+### Tab events
+
+| Event | When it fires | Can block? |
+|-------|--------------|-----------|
+| `beforeTabFileRead` | Before Tab reads a file for inline completions | Yes (`permission: "deny"`) |
+| `afterTabFileEdit` | After Tab edits a file | No |
+
+*Source: docs/cursor/hooks/hooks-guide.md "Agent and Tab Support"*
+
+---
+
+## Matcher Field by Event Type
+
+The `matcher` is a regex string. The field it matches against depends on the event:
+
+| Event | Matcher filters on | Example values |
+|-------|-------------------|----------------|
+| `preToolUse`, `postToolUse`, `postToolUseFailure` | tool type | `Shell`, `Read`, `Write`, `Grep`, `Delete`, `Task`, or `MCP:<tool_name>` |
+| `subagentStart`, `subagentStop` | subagent type | `generalPurpose`, `explore`, `shell` |
+| `beforeShellExecution`, `afterShellExecution` | full shell command string | `curl|wget|nc`, `rm -rf` |
+| `beforeReadFile` | tool type | `TabRead`, `Read` |
+| `afterFileEdit` | tool type | `TabWrite`, `Write` |
+| `beforeSubmitPrompt` | the literal value documented in the Cursor hooks guide | (matched against the documented literal) |
+| `stop` | the literal value documented in the Cursor hooks guide | (matched against the documented literal) |
+| `afterAgentResponse` | the literal value documented in the Cursor hooks guide | (matched against the documented literal) |
+| `afterAgentThought` | the literal value documented in the Cursor hooks guide | (matched against the documented literal) |
+| No matcher support | always fires | `sessionStart`, `sessionEnd`, `beforeMCPExecution`, `afterMCPExecution`, `preCompact`, `beforeTabFileRead`, `afterTabFileEdit` |
+
+For MCP tool filtering on `preToolUse`/`postToolUse`/`postToolUseFailure`, use the `MCP:<tool_name>` format.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
+
+---
+
+## JSON Configuration Schema
+
+Cursor hooks live in a `hooks.json` file at the project or user scope. The top level is two keys: `version` and `hooks`. Under `hooks`, each event maps to an array of hook definitions.
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "<eventName>": [
+      {
+        "command": "<script-path-or-shell-string>",
+        "matcher": "<regex-string>",
+        "timeout": 30,
+        "failClosed": false
+      }
+    ]
+  }
+}
+```
+
+**Per-script options:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `command` | string | required | Script path (relative or absolute) or inline shell command |
+| `type` | `"command"` or `"prompt"` | `"command"` | Hook execution type |
+| `timeout` | number | platform default | Execution timeout in seconds |
+| `loop_limit` | number or `null` | `5` | Per-script auto-followup cap for `stop` and `subagentStop` |
+| `failClosed` | boolean | `false` | When `true`, hook failures (crash, timeout, invalid JSON) block the action instead of failing open |
+| `matcher` | string | — | Regex filter; meaning depends on the event (see table above) |
+
+**Prompt-hook fields:** add `"type": "prompt"` and a `"prompt": "<natural-language criterion>"` field; an optional `"model"` field overrides the default fast model. The prompt receives the hook input via the auto-replaced `$ARGUMENTS` placeholder.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
+
+---
+
+## Handler Type Support Matrix
+
+| Handler type | Supported events | Notes |
+|--------------|-----------------|-------|
+| `command` | All events | Default; shell script over stdin/stdout |
+| `prompt` | All events | LLM evaluates a natural-language criterion; returns `{ ok, reason }` |
+
+Unlike some agent platforms, Cursor exposes only these two handler types — there is no separate `http` or `agent` handler. Use `command` for deterministic checks; reserve `prompt` for cases where natural-language judgment is genuinely required.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
+
+---
+
+## Common Patterns
+
+### Pre-validation (`beforeShellExecution` + command matcher)
+
+Block dangerous network commands:
+
+```json
+{ "version": 1, "hooks": { "beforeShellExecution": [{ "command": ".cursor/hooks/approve-network.sh", "matcher": "curl|wget|nc" }] } }
+```
+
+Exit `2` from the script blocks the action; exit `0` allows it.
+
+### Post-formatting (`afterFileEdit`)
+
+Run a formatter after every agent edit:
+
+```json
+{ "version": 1, "hooks": { "afterFileEdit": [{ "command": ".cursor/hooks/format.sh" }] } }
+```
+
+`afterFileEdit` is non-blocking — its job is observation and side effects.
+
+### Session context injection (`sessionStart`)
+
+Inject dynamic context at session start:
+
+```json
+{ "version": 1, "hooks": { "sessionStart": [{ "command": ".cursor/hooks/inject-context.sh" }] } }
+```
+
+The script's stdout JSON may include `additional_context` to add to the conversation's initial system context.
+
+*Source: docs/cursor/hooks/hooks-guide.md "Examples" and "Hook events"*

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-validation-criteria.md
@@ -1,0 +1,87 @@
+# Hook Validation Criteria
+
+Quality checklist for generated and improved Cursor hook configurations.
+Source: docs/cursor/hooks/hooks-guide.md
+
+---
+
+## Contents
+
+- Hard limits (auto-fail)
+- Quality checks (event/intent fit, matcher specificity, error handling, secrets)
+- Security gap checks (command injection, path traversal, secret exposure)
+- Improve-operation additions (preservation, citation traceability)
+- Validation loop instructions
+
+---
+
+## Hard Limits (Auto-fail if violated)
+
+Any hook violating these criteria must be fixed before proceeding:
+
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON structure | Valid JSON; `version` present; `hooks` is an object |
+| Event name | From the Cursor-native event vocabulary in `hook-events-reference.md`; reject any name not on that list (in particular, PascalCase event names that have no Cursor analogue) |
+| Handler type | `command` (default) or `prompt` only |
+| `command` path | Plausible relative to the configuration scope's working directory (project root for project hooks; `~/.cursor/` for user hooks); absolute paths must point to an existing executable |
+| Matcher applicability | Matcher set only on events whose matcher field is documented in `hook-events-reference.md` |
+| Exit-code semantics | `0` = success, `2` = block; other non-zero exits fail open by default — security-critical blocking hooks must set `failClosed: true` |
+
+*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Configuration", "Per-Script Configuration Options"*
+
+---
+
+## Quality Checks (All must pass)
+
+- [ ] Event matches intent — block-capable event used for blocking intent (`preToolUse`, `beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`, `beforeSubmitPrompt`, `subagentStart`); observation-only event used for non-blocking intent (`postToolUse`, `afterShellExecution`, `afterMCPExecution`, `afterFileEdit`, `sessionStart`, `sessionEnd`, `preCompact`, `afterAgentResponse`, `afterAgentThought`)
+- [ ] Matcher is specific — blocking hooks do not omit the matcher when the event supports one and the intent targets a specific tool, subagent type, or command pattern
+- [ ] Matcher uses a regex value valid for the event's matcher field (per `hook-events-reference.md`)
+- [ ] Error handling defined — exit `2` with meaningful stderr for blocking intent; `failClosed: true` set on security-critical blocking hooks (`beforeMCPExecution`, `beforeShellExecution`, `beforeReadFile`)
+- [ ] Silent success — exit `0` does not leave spurious stderr output
+- [ ] `command` hook used for deterministic checks (not `prompt` for simple regex checks)
+- [ ] `prompt` hook used only when natural-language judgment is genuinely required
+- [ ] Evidence citations present — the task card or improvement plan documents why this event/handler/matcher was chosen, referencing `hook-events-reference.md`. **Note:** JSON has no comment syntax; for `command` hooks, evidence lives in the task card / improvement plan, not in the hooks file itself
+- [ ] Prompt-engineering strategy applied — zero-shot only; no few-shot examples in the hook configuration
+
+---
+
+## Security Gap Checks (All must pass)
+
+- [ ] **Command injection** — `command` strings do not interpolate raw stdin fields without quoting; the documented hook script reads stdin into a variable and quotes every variable expansion (`"$VAR"`, never bare `$VAR`)
+- [ ] **Path traversal** — when the hook receives a `file_path` from stdin, the script rejects values containing `..` segments before opening or executing
+- [ ] **Secret exposure in logs** — `afterShellExecution`, `afterMCPExecution`, and any audit hook that forwards `output` / `result_json` redacts known secret patterns (API keys, tokens, passwords) before logging or transmitting them
+- [ ] **Hardcoded secrets** — no literal credentials anywhere in the hook configuration (`command` strings, prompt text, headers, or other fields); environment variables (referenced via `$VAR` and quoted at use sites) are the only acceptable source
+- [ ] **Workspace anchoring** — file paths used inside hook scripts derive from `CURSOR_PROJECT_DIR` rather than being hardcoded
+
+---
+
+## If This Is an IMPROVE Operation — Also Check
+
+**Information Preservation:**
+
+- [ ] Existing blocking behavior not weakened (exit `2` not changed to exit `0`; `failClosed: true` not silently flipped to `false`)
+- [ ] Matcher not broadened unintentionally (a specific regex not replaced with a permissive one)
+- [ ] Valid hooks not removed while fixing structure
+
+**Structural:**
+
+- [ ] Hook location remains appropriate (project vs user scope matches intended sharing)
+- [ ] Multiple hooks for the same event not consolidated if they serve distinct purposes
+
+**Citation Traceability:**
+
+- [ ] Every change made during improvement cites the specific evaluator finding (e.g., `V1`, `V3`) from the Phase 1 evaluation output that motivated the change — not just a generic reference to documentation
+
+---
+
+## Validation Loop Instructions
+
+Execute this loop for each generated or improved hook:
+
+1. Evaluate the hook against ALL criteria above
+2. If ANY criterion fails: identify the specific failure, fix the hook, restart evaluation
+3. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+4. Only proceed to writing hooks when ALL criteria pass
+
+**Do not skip criteria for "minor" violations.** Hard limits are hard limits.

--- a/plugins/cursor-customizer/skills/improve-hook/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/prompt-engineering-strategies.md
@@ -1,0 +1,127 @@
+# Prompt Engineering Strategies
+
+Evidence-based prompting strategies for artifact authoring, organized by artifact type.
+Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+
+---
+
+## Contents
+
+- Universal principles (apply to all artifact types)
+- Strategy matrix (technique selection by artifact type)
+- Per-artifact-type recommendations
+- Anti-patterns (what to avoid)
+- Context budget principles
+
+---
+
+## Universal Principles
+
+**Clarity over cleverness** — "Think of Claude as a brilliant but new employee who lacks context on your norms and workflows." Write instructions a colleague with no context could follow.
+
+**Role definition first** — A single-sentence role in a system prompt focuses behavior and tone: `"You are a code reviewer specializing in TypeScript."` Use in subagent prompts and skill bodies. Skip in rules and hooks (zero-shot is sufficient).
+
+**XML tags for complex structure** — Use XML tags to disambiguate prompts mixing instructions, context, examples, and inputs:
+
+```
+<instructions>...</instructions>
+<context>...</context>
+<example>...</example>
+```
+
+**Critical instructions at start or end** — The "lost-in-the-middle" effect degrades performance for instructions buried in the middle of long contexts. Place key rules in the first and last 20% of each file.
+
+**Describe desired behavior, not prohibited behavior** — Instead of "Do not use markdown", write "Your response should be smooth flowing prose."
+
+**Behavioral discipline beats clever prompting** — surface assumptions before acting, prefer the simplest sufficient change, keep edits surgical, and define explicit validation targets before concluding.
+
+**Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
+
+*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
+
+---
+
+## Strategy Matrix
+
+| Technique | Skill (SKILL.md) | Hook | Rule | Subagent |
+|-----------|-----------------|------|------|----------|
+| Role prompting | ✅ First line of body | ❌ Skip (implicit) | ❌ Skip | ✅ Strong use |
+| Zero-shot | ✅ Most phases | ✅ Default | ✅ Always | ✅ Simple tasks |
+| Few-shot examples | ✅ Critical output formats | ❌ Too token-costly | ❌ Too token-costly | ✅ Complex formats |
+| XML structuring | ✅ Multi-section bodies | ❌ Too verbose | ❌ Too verbose | ✅ Rich context |
+| Chain-of-thought | ❌ Slows execution | ❌ Not applicable | ❌ Not applicable | ✅ Reasoning tasks |
+| Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
+| Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
+
+*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160*
+
+---
+
+## Per-Artifact Recommendations
+
+### Skills (SKILL.md)
+
+- Open body with role definition (1-2 sentences max)
+- Make Phase 1 a low-risk warm-up before higher-effort phases
+- Use progressive disclosure: reference files loaded per phase, not all upfront
+- Load curated references before asking for synthesis or edits
+- Use zero-shot for most phases; reserve few-shot for phases with strict output format
+- Make constraints concrete: scope limits, output shape, and stop conditions
+- Self-check instruction in final phase: "Before completing, verify all criteria in skill-validation-criteria.md"
+- Final validation should confirm Karpathy-style discipline and the ethical constraint on persuasion
+- Keep each phase instruction ≤10 lines; reference files for depth
+
+### Hooks
+
+- Zero-shot only — hooks are short and tokens are expensive
+- Avoid role prompting; context of the event implies the role
+- Be explicit about output format: `{"ok": true/false, "reason": "..."}`
+- For `prompt` and `agent` hooks: write simple, direct evaluation criteria
+- Test with `--debug` to verify hook output is parsed as intended
+
+### Rules
+
+- Zero-shot always — rules are factual instructions, not prompted behaviors
+- No examples (too token-costly for always-loaded context)
+- One instruction per bullet; no compound sentences
+- Specificity goldilocks: "Use 2-space indentation" not "Format code properly" not "src/auth/handlers.ts handles JWT"
+
+### Subagents
+
+- Role prompting is the primary specialization mechanism — invest here
+- Structure system prompt: Role → Responsibilities → Process → Checklist → Output Format
+- Include confidence threshold for review agents: "Report only when >80% confident"
+- Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with Opus 4.6
+- Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
+
+*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80*
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| "CRITICAL: You MUST always..." | Overtriggering with Claude 4.6 (especially Opus) | Use "Use this when..." |
+| Vague instructions ("be thorough") | Not verifiable or actionable | Specify exactly what to check |
+| Few-shot examples in rules | Token waste on every session | Delete examples; be specific in instruction text |
+| Over-explaining what Claude already knows | Wastes context budget | Trust model knowledge; add only novel context |
+| Prescriptive step-by-step plans | Forces rigid execution; misses edge cases | "Think thoroughly" outperforms manual step lists |
+| Contradictory instructions | Claude picks one arbitrarily | Audit for conflicts before writing |
+| Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
+
+*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
+
+---
+
+## Context Budget Principles
+
+Every token in an artifact competes with conversation history and other context. Apply these before writing:
+
+- Challenge each instruction: "Would removing this cause the agent to make mistakes? If not, cut it."
+- Prefer pointers to full content: link to reference files instead of inlining detailed material
+- Path-scoped rules and per-phase reference loading are the primary token-saving mechanisms
+- Short artifacts (rules, validation criteria) should be zero-shot and minimal
+- Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
+
+*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*


### PR DESCRIPTION
## Summary

Adds hooks support to the `cursor-customizer` plugin — slice D of the umbrella rollout (PRD #77).

- **`agents/hook-evaluator.md`** — Cursor-native subagent that evaluates hook configurations against Cursor's hook contract (no Claude Code event names; matchers aligned with Cursor tools).
- **`skills/create-hook/`** — five-phase orchestration for new hooks. Templates and authoring guide derive from `docs/cursor/hooks/hooks-guide.md`.
- **`skills/improve-hook/`** — improvement workflow with `hook-evaluation-criteria.md` for gap analysis.
- **`docs-drift-manifest.md`** — slice-D source-doc → reference mappings recorded.
- Hook-matcher examples corrected to align with Cursor's tool surface (no Claude-Code-only event names like `PreToolUse`/`PostToolUse`).

Closes #81.
Tracks PRD #77.

## Test plan

- [x] Banned-token grep clean: `grep -rE '(\$\{CLAUDE_SKILL_DIR\}|CLAUDE\.md|\.claude/|maxTurns:|tools:|paths:|docs\.anthropic\.com/en/docs/claude-code)' plugins/cursor-customizer/{agents/hook-evaluator.md,skills/{create,improve}-hook}` → no matches.
- [x] Claude Code event name grep clean: `grep -rE '\b(PreToolUse|PostToolUse|UserPromptSubmit|Notification|Stop|SubagentStop|SessionStart|SessionEnd|PreCompact)\b' plugins/cursor-customizer/{agents/hook-evaluator.md,skills/{create,improve}-hook}` → no matches.
- [x] Topology parity with `plugins/agent-customizer/skills/{create,improve}-hook/` confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)