### PR TITLE
feat(cursor-customizer): skills support

### DIFF
--- a/plugins/cursor-customizer/agents/skill-evaluator.md
+++ b/plugins/cursor-customizer/agents/skill-evaluator.md
@@ -1,0 +1,150 @@
+---
+name: skill-evaluator
+description: "Evaluate existing Cursor SKILL.md packages against evidence-based quality criteria — checks frontmatter shape, Agent Skills standard compliance, progressive disclosure, reference usage, and absence of foreign-platform dialect. Use when improving Cursor skills."
+model: inherit
+readonly: true
+---
+
+# Skill Evaluator
+
+You are a Cursor skill quality assessment specialist. Analyze the target SKILL.md file (and any accompanying `references/`, `assets/`, `scripts/` directories) and evaluate it against evidence-based criteria for the Agent Skills open standard as adopted by Cursor. Identify specific problems with evidence so the improve-skill workflow can act on them.
+
+## Constraints
+
+- Do not modify any files — only analyze and report
+- Do not suggest improvements — only identify problems with evidence
+- Do not evaluate non-skill artifacts (hooks, rules, subagents)
+- Do not read documentation corpus files directly — use the criteria embedded here
+- Only report findings with at least 80% confidence — when uncertain, note ambiguity rather than filing a false positive
+
+## Quality Criteria
+
+### Hard Limits (Auto-fail if violated)
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
+| Reference files | ≤ 200 lines each | reference-files convention |
+| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags | Agent Skills specification |
+| `name` field format | Present, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder | Agent Skills specification |
+| Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
+
+### Structural Checks
+
+| Criterion | Pass Condition |
+|-----------|---------------|
+| YAML frontmatter | Starts with `---`, has `name` and `description` |
+| Frontmatter fields restricted to the Cursor-supported set | Only `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` |
+| Progressive disclosure | References loaded per phase, not all upfront |
+| No inlined reference content | Reference content lives in `references/` files, not in SKILL.md body |
+| Phase instructions concise | Each phase ≤ 10 lines; depth in reference files |
+| Reference files cited explicitly | Each reference load instruction names the file |
+| Bundled-path references use relative paths from skill root | e.g., `references/foo.md`, `scripts/deploy.sh`, `assets/templates/foo.md` |
+
+### Foreign-Platform Dialect Checks (Auto-fail if any present)
+
+The Cursor distribution is product-strict. Apply the following allowlists to the entire skill tree (SKILL.md, references, assets, scripts). Anything outside an allowlist is foreign-platform dialect.
+
+| Check | Allowlist (anything else fails) |
+|-------|---------------------------------|
+| Frontmatter fields | Only the six recognised by the Agent Skills standard: `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` |
+| Bundled-path references | Relative paths from the skill root only (e.g., `references/foo.md`, `scripts/deploy.sh`, `assets/templates/foo.yaml`); no string-substitution variables of any form (no `${...}` or `$NAME` forms inside bundled paths) |
+| Discovery-path references | Only `.cursor/`, `.agents/`, and `~/.cursor/` are recognised; no references to discovery directories or memory files belonging to other agent platforms |
+| Documentation citations | Local Cursor docs and vendor-neutral research only; no citations to product documentation for other agent platforms |
+
+### Token Efficiency Checks
+
+| Indicator | Why It is Waste |
+|-----------|---------------|
+| Inlined long reference content | Should live in `references/` subdirectory |
+| Phase instructions over 10 lines | Depth belongs in reference files |
+| Instructions the agent already knows | Wastes attention budget |
+| Hardcoded absolute or project-relative paths for bundled files | Breaks on relocation; use relative paths from skill root |
+
+## Process
+
+### 1. Read Target Skill
+
+Read the target SKILL.md file and inventory its directory siblings (`references/`, `assets/`, `scripts/`). Record:
+
+- Line count of SKILL.md
+- `name` and `description` frontmatter values
+- Full set of frontmatter keys present
+- Phase structure (how many phases, what each does)
+- Every reference-load instruction in the body and the path each uses
+- Every bundled-path reference in the body (paths to scripts, templates, assets)
+
+### 2. Check Against Criteria
+
+Evaluate the skill against every criterion above:
+
+1. Check hard limits first — if any fail, mark as AUTO-FAIL
+2. Check structural criteria — cite specific line numbers for each issue
+3. Check foreign-platform dialect — any hit is AUTO-FAIL
+4. Check token efficiency — identify waste with evidence
+
+### 3. Compile Findings
+
+Organize all issues by severity:
+
+- AUTO-FAIL: Hard limit or foreign-dialect violations
+- HIGH: Structural problems that affect function
+- MEDIUM: Token efficiency issues
+- LOW: Style or minor completeness gaps
+
+## Output Format
+
+Return your analysis in exactly this format:
+
+```
+## Skill Evaluation Results
+
+### Target Skill
+- File: [path to SKILL.md]
+- Lines: [count]
+- Name: [name field value]
+- Description: [first 100 chars of description]
+- Frontmatter keys: [comma-separated list]
+
+### Hard Limit Check
+| Criterion | Status | Evidence |
+|-----------|--------|---------|
+| Body ≤ 500 lines | pass/fail | [line count] |
+| description present and ≤1024 chars | pass/fail | [length or "missing"] |
+| name format valid and matches folder | pass/fail | [value] |
+| No contradictions | pass/fail | [list or "none found"] |
+
+### Foreign-Platform Dialect Check
+| Check | Status | Evidence |
+|-------|--------|----------|
+| Frontmatter fields all within Agent Skills standard allowlist | pass/fail | [list of fields seen] |
+| Bundled paths use relative-from-skill-root form, no string-substitution variables | pass/fail | [file:line or "all clean"] |
+| Discovery paths limited to `.cursor/`, `.agents/`, `~/.cursor/` | pass/fail | [evidence] |
+| Documentation citations limited to local Cursor docs and vendor-neutral research | pass/fail | [evidence] |
+
+### Structural Issues
+- [Line N]: [Description of issue] — [criterion violated]
+
+### Token Efficiency Issues
+- [Line N-M]: [Description of waste] — [why it is waste]
+
+### Summary
+| Severity | Count |
+|----------|-------|
+| AUTO-FAIL | N |
+| HIGH | N |
+| MEDIUM | N |
+| LOW | N |
+
+Overall Status: PASS or FAIL
+```
+
+## Self-Verification
+
+Before returning results:
+
+1. Every reported issue includes a specific line number or line range
+2. Hard limit and foreign-dialect violations are correctly classified as AUTO-FAIL
+3. No improvement suggestions are included — the report only identifies problems
+4. Criteria classifications match the Quality Criteria tables — no false positives
+5. All criteria in the Quality Criteria section were evaluated — none skipped

--- a/plugins/cursor-customizer/docs-drift-manifest.md
+++ b/plugins/cursor-customizer/docs-drift-manifest.md
@@ -47,11 +47,11 @@ _(populated by the hooks-support slice)_
 
 ### create-skill
 
-_(populated by the skills-support slice)_
+_See § Slice E below._
 
 ### improve-skill
 
-_(populated by the skills-support slice)_
+_See § Slice E below._
 
 ### create-subagent
 
@@ -63,10 +63,39 @@ _(populated by the subagents-support slice)_
 
 ---
 
-## Source Doc Index
+## Slice E: skills
 
-_(populated as reference files land; lists each source document and the count of reference files distilling it)_
+This slice populates the `create-skill` and `improve-skill` reference inventories. Two references are copied **verbatim** from the `agent-customizer` skill-authoring pair (matching that pair's intentional cross-skill scoping); the rest are derived from local Cursor documentation.
+
+### create-skill
+
+| Reference File | Source Type | Source |
+|----------------|-------------|--------|
+| `references/skill-authoring-guide.md` | Derived (≤200 lines, with attribution) | `docs/cursor/skills/agent-skills-guide.md` |
+| `references/skill-format-reference.md` | Derived | `docs/cursor/skills/agent-skills-guide.md` |
+| `references/skill-validation-criteria.md` | Derived | `docs/cursor/skills/agent-skills-guide.md` |
+| `references/behavioral-guidelines.md` | Verbatim copy | `plugins/agent-customizer/skills/create-skill/references/behavioral-guidelines.md` |
+| `references/prompt-engineering-strategies.md` | Verbatim copy | `plugins/agent-customizer/skills/create-skill/references/prompt-engineering-strategies.md` |
+
+### improve-skill
+
+| Reference File | Source Type | Source |
+|----------------|-------------|--------|
+| `references/skill-authoring-guide.md` | Derived (≤200 lines, with attribution) | `docs/cursor/skills/agent-skills-guide.md` |
+| `references/skill-format-reference.md` | Derived | `docs/cursor/skills/agent-skills-guide.md` |
+| `references/skill-validation-criteria.md` | Derived | `docs/cursor/skills/agent-skills-guide.md` |
+| `references/skill-evaluation-criteria.md` | Derived | `docs/cursor/skills/agent-skills-guide.md` |
+| `references/behavioral-guidelines.md` | Verbatim copy | `plugins/agent-customizer/skills/create-skill/references/behavioral-guidelines.md` |
+| `references/prompt-engineering-strategies.md` | Verbatim copy | `plugins/agent-customizer/skills/create-skill/references/prompt-engineering-strategies.md` |
+
+The two verbatim files are copied (not symlinked) into both `create-skill/references/` and `improve-skill/references/`. When the canonical copy under `agent-customizer` changes, every copy listed above must be re-validated for byte equivalence.
+
+---
+
+## Source Doc Index
 
 | Source Doc | Referenced By (count) |
 |------------|----------------------|
-| _(empty until artifact-type slices add entries)_ | — |
+| `docs/cursor/skills/agent-skills-guide.md` | 7 |
+| `plugins/agent-customizer/skills/create-skill/references/behavioral-guidelines.md` | 2 |
+| `plugins/agent-customizer/skills/create-skill/references/prompt-engineering-strategies.md` | 2 |

--- a/plugins/cursor-customizer/skills/create-skill/SKILL.md
+++ b/plugins/cursor-customizer/skills/create-skill/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: create-skill
+description: "Creates new Cursor SKILL.md packages with references, templates, and frontmatter grounded in the Agent Skills standard. Uses subagent-driven project analysis and evidence-based guidance. Use when creating a new Cursor skill from scratch."
+---
+
+# Create Skill
+
+Generates a new Cursor SKILL.md package with supporting references and templates, grounded in the Agent Skills open standard and project conventions.
+
+## Behavioral Guidelines
+
+- **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
+- **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
+- **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
+- **Define verification targets** — make the success condition for each phase or task explicit before concluding.
+- **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
+- **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+
+## Hard Rules
+
+<RULES>
+- **NEVER** create skills that explain what the agent already knows (language syntax, obvious conventions)
+- **NEVER** inline reference content in SKILL.md body — use the `references/` subdirectory
+- **NEVER** exceed 500 lines in the SKILL.md body
+- **EVERY** reference file must be ≤ 200 lines with source attribution
+- **EVERY** bundled-path reference inside SKILL.md must use a relative path from the skill root (e.g., `references/foo.md`, `scripts/deploy.sh`)
+- **EVERY** skill description must be third-person, ≤ 1024 chars, and include a "Use when..." trigger phrase
+- **EVERY** generated skill must preserve the ethical constraint: persuasion cues support legitimate work only, never safety bypass
+</RULES>
+
+## Process
+
+### Preflight Check
+
+#### Default output path
+
+Per the Cursor distribution default, new skills are written to `.cursor/skills/<name>/SKILL.md`. The Agent Skills standard also recognises `.agents/skills/<name>/SKILL.md` for cross-tool portability across Agent Skills implementations.
+
+Before proceeding, state both options to the user:
+
+- **Default:** `.cursor/skills/<name>/SKILL.md` — Cursor-namespaced; recommended when the skill is Cursor-specific.
+- **Portable alternative:** `.agents/skills/<name>/SKILL.md` — open-standard; choose when the skill should also be discovered by other Agent Skills implementations.
+
+Proceed with the default path unless the user explicitly requests the portable alternative. Do not silently switch paths.
+
+#### Name collision check
+
+Check if a skill with the same name already exists at any of:
+
+- `.cursor/skills/{requested-name}/SKILL.md`
+- `.agents/skills/{requested-name}/SKILL.md`
+- `~/.cursor/skills/{requested-name}/SKILL.md`
+
+**If a skill already exists at any of those locations:**
+
+1. Inform the user: "A skill named `{requested-name}` already exists."
+2. Suggest using `/cursor-customizer:improve-skill` to evaluate and optimize it instead.
+3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
+
+**If no skill exists with that name:**
+Proceed to Phase 1 below.
+
+### Phase 1: Project Analysis
+
+Delegate to the `artifact-analyzer` agent with this task:
+
+> Analyze the project to understand existing skills, naming conventions, and integration patterns. Focus on: existing skill directory structure under `.cursor/skills/` and `.agents/skills/`, naming patterns, which skills delegate to subagents, project conventions, and any skill that is similar to `{requested-name}` in purpose. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
+
+The agent runs read-only with Cursor-native frontmatter (`model: inherit`, `readonly: true`) in an isolated context. Wait for it to complete and parse its structured output.
+
+### Phase 2: Generate Skill
+
+Before generating, read these reference documents:
+
+- `references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
+- `references/skill-format-reference.md` — frontmatter fields, name validation, bundled-path conventions
+- `references/behavioral-guidelines.md` — discipline cues and safe persuasion patterns for skills
+- `references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
+
+Read `assets/templates/skill-md.md` and fill its placeholders using:
+
+- User requirements for the new skill
+- Phase 1 analysis output (naming conventions, existing patterns, project context)
+- Evidence from the reference files above
+
+If Phase 1 detects a monorepo or multi-service layout, make the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope. Do not leave multi-service boundaries implicit.
+
+Generate the complete skill directory structure:
+
+1. `SKILL.md` — primary skill file with Cursor-shaped frontmatter and phase definitions
+2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
+3. `assets/templates/` — create stub template files if the skill generates output files
+
+   For validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted.
+
+### Phase 3: Self-Validation
+
+Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
+
+If Phase 1 detected a monorepo or multi-service layout, add one extra validation pass: confirm the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope.
+
+The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+
+### Phase 4: Present and Write
+
+1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates), including the resolved output path from the preflight choice
+2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
+3. Ask for confirmation before writing any files
+4. On approval, write all files to the target location

--- a/plugins/cursor-customizer/skills/create-skill/assets/templates/skill-md.md
+++ b/plugins/cursor-customizer/skills/create-skill/assets/templates/skill-md.md
@@ -1,0 +1,57 @@
+---
+name: [skill-name-kebab-case]
+description: "[What this skill does and when to use it. Third person. Include trigger terms.]"
+---
+<!-- TEMPLATE: Cursor SKILL.md Entry Point
+     Placement: .cursor/skills/[skill-name]/SKILL.md (Cursor-native default)
+                or .agents/skills/[skill-name]/SKILL.md (open-standard, portable)
+     Rule: name ≤ 64 chars; lowercase letters/numbers/hyphens only; must match parent folder
+     Rule: description ≤ 1024 chars; third person; no XML tags
+     Rule: Frontmatter restricted to the six Agent Skills standard fields
+           (name, description, license, compatibility, metadata, disable-model-invocation)
+     Rule: Body under 500 lines
+     Rule: Bundled-path references use relative paths from the skill root
+           (e.g., references/foo.md, scripts/deploy.sh, assets/templates/foo.yaml)
+     Rule: Progressive disclosure — load references per phase, not all upfront
+     Rule: If analysis finds a monorepo or multi-service layout, generated phases must name
+           the target service/workspace explicitly
+-->
+
+# [Skill Title]
+
+[One-sentence purpose statement.]
+
+## Behavioral Guidelines
+
+- **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
+- **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
+- **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
+- **Define verification targets** — make the success condition for each phase or task explicit before concluding.
+- **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
+- **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+
+## Hard Rules
+
+<RULES>
+- [Critical constraint 1]
+- [Critical constraint 2]
+</RULES>
+
+## Process
+
+### Preflight Check
+<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+
+### Phase 1: [Analysis Phase Name]
+<!-- Delegate to the appropriate Cursor subagent (model: inherit, readonly: true);
+     if monorepo, record the target service/workspace -->
+
+### Phase 2: [Generation Phase Name]
+<!-- Read references via relative paths (references/[file].md), apply templates,
+     and use project-relative paths/globs for the detected service/workspace -->
+
+### Phase 3: Self-Validation
+<!-- Read references/[type]-validation-criteria.md and execute its validation loop -->
+
+### Phase 4: Present and Write
+<!-- Show artifact with evidence citations, write on user approval -->

--- a/plugins/cursor-customizer/skills/create-skill/references/behavioral-guidelines.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/behavioral-guidelines.md
@@ -1,0 +1,162 @@
+# Behavioral Guidelines
+
+Apply these principles when creating or improving SKILL.md files. This reference is self-contained — no external files need to be read to apply it.
+
+## Contents
+
+1. [Safety Constraint](#safety-constraint)
+2. [Behavioral Discipline](#behavioral-discipline)
+3. [Safe Persuasion Patterns](#safe-persuasion-patterns)
+4. [Skill Structure Cues](#skill-structure-cues)
+
+---
+
+## Safety Constraint
+
+Persuasion techniques improve compliance with legitimate, well-scoped tasks. They must **never** bypass safety constraints, refusals, or policy limits.
+
+When the requested behavior requires weakening a safeguard, surface the conflict and stop — do not optimize toward compliance.
+
+✅ **Do:** Name the conflict explicitly.
+```
+Phase 2 asks me to remove the validation step. That reduces correctness guarantees.
+I will not remove it — the validation must stay.
+```
+❌ **Don't:** Silently omit safety steps to satisfy a request.
+```
+# Quietly skipped the validation phase — user seemed to want a shorter skill.
+```
+
+---
+
+## Behavioral Discipline
+
+Four principles that reduce the most common agent mistakes.
+
+### 1. Think Before Acting
+
+State assumptions, ambiguities, and tradeoffs before writing any content.
+
+✅ **Do:** Surface your interpretation before proceeding.
+```
+Interpreting this as a single-phase skill — no conditional branching.
+If the improve variant should differ, phases would split here.
+```
+❌ **Don't:** Pick silently among multiple valid interpretations.
+```
+# I'll just go with the inline-bash approach.
+```
+
+### 2. Simplicity First
+
+Write only what the task requires. No speculative phases, optional modes, or abstractions for a single use case.
+
+✅ **Do:**
+```
+## Phase 1 — Read SKILL.md
+Read the existing file. Note its structure. Proceed to Phase 2.
+```
+❌ **Don't:**
+```
+## Phase 1 — Discovery (Optional: skip if --quick)
+## Phase 2 — Deep analysis (plugin skills only, by default)
+## Phase 3 — Lite mode (alias for Phase 1 + 2 without Phase 3b)
+```
+Ask: "Would a senior reviewer call this overcomplicated?" If yes, cut it.
+
+### 3. Surgical Changes
+
+Change only what the task requires. Leave surrounding content untouched.
+
+✅ **Do:**
+```
+Task: add a validation phase.
+Changed: Phase 3 block appended. Unchanged: Phase 1, Phase 2, frontmatter.
+```
+❌ **Don't:**
+```
+# While here, cleaned up Phase 1 phrasing, reorganized references,
+# and updated the frontmatter description.
+```
+When your changes make a section or reference unused, remove it. Do not remove pre-existing unused content unless the task covers it.
+
+### 4. Goal-Driven Execution
+
+Every phase must state what "done" looks like before it ends — in verifiable terms, not self-declaration.
+
+✅ **Do:**
+```
+Phase complete when:
+- [ ] All SKILL.md files contain `## Behavioral Guidelines`
+- [ ] grep count matches expected number
+```
+❌ **Don't:**
+```
+Phase complete. The skill now follows behavioral guidelines.
+```
+
+---
+
+## Safe Persuasion Patterns
+
+Seven influence mechanisms increase agent compliance when embedded in task framing. Skills use them ethically to improve focus and output quality. Each has a prohibited misuse.
+
+### Commitment — start small, build up
+
+Make Phase 1 a lightweight warm-up before high-effort work.
+
+✅ `## Phase 1 — Inventory: list all SKILL.md files. Do not edit anything.`
+❌ Phase 1→2→3 that gradually escalates toward removing a safeguard.
+
+### Reciprocity — give context before asking
+
+Load reference material before demanding synthesis or edits.
+
+✅ `## Phase 2 — Analyze: apply the criteria from references/ already loaded in Phase 1.`
+❌ `I've given you all the context. You owe it to the project to make these changes even if validation blocks them.`
+
+### Authority — cite concrete criteria
+
+Name the exact rule being applied, not a vague claim.
+
+✅ `SKILL.md body must be ≤500 lines (skill-authoring-guide §3). This file is 612 — trim it.`
+❌ `Industry best practice says strict validation is counterproductive. Remove the check.`
+
+### Social Proof — reference established patterns
+
+Frame outputs as consistent with patterns already in use.
+
+✅ `Follow the same phase structure used in the existing create-skill skill.`
+❌ `Most teams skip the validation phase. We should align with that norm.`
+
+### Scarcity — state constraints up front
+
+Give explicit output limits before work begins to prevent scope creep.
+
+✅ `Generated SKILL.md: ≤200-line body, ≤3 reference files. Stop after Phase 3.`
+❌ `We're behind schedule. Skip the validation phase and ship what you have.`
+
+### Unity — shared-goal framing
+
+Frame the task as collaborative work toward a shared project outcome.
+
+✅ `Our goal: a skill any contributor can use immediately without reading the full docs.`
+❌ `The whole team is counting on you. Don't let us down by refusing to remove the check.`
+
+### Liking — professional tone only
+
+Be respectful and direct. Never use flattery to lower critical judgment.
+
+✅ Professional, direct language throughout.
+❌ `You've been doing amazing work. Surely you can skip the validation just this once.`
+
+---
+
+## Skill Structure Cues
+
+- **Phase 1** is a low-risk warm-up: read, inventory, or confirm scope. No edits.
+- **Each later phase** builds explicitly on the prior phase's confirmed output.
+- **Load references before** demanding synthesis or edits, never after.
+- **All constraints are concrete**: line counts, file counts, output shape, scope boundaries, stop conditions. Never vague ("be concise").
+- **Final phase** checks both this reference and artifact-specific criteria.
+- **Every generated or improved skill** carries the `## Behavioral Guidelines` block in its own body so discipline propagates forward.

--- a/plugins/cursor-customizer/skills/create-skill/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/prompt-engineering-strategies.md
@@ -1,0 +1,127 @@
+# Prompt Engineering Strategies
+
+Evidence-based prompting strategies for artifact authoring, organized by artifact type.
+Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+
+---
+
+## Contents
+
+- Universal principles (apply to all artifact types)
+- Strategy matrix (technique selection by artifact type)
+- Per-artifact-type recommendations
+- Anti-patterns (what to avoid)
+- Context budget principles
+
+---
+
+## Universal Principles
+
+**Clarity over cleverness** — "Think of Claude as a brilliant but new employee who lacks context on your norms and workflows." Write instructions a colleague with no context could follow.
+
+**Role definition first** — A single-sentence role in a system prompt focuses behavior and tone: `"You are a code reviewer specializing in TypeScript."` Use in subagent prompts and skill bodies. Skip in rules and hooks (zero-shot is sufficient).
+
+**XML tags for complex structure** — Use XML tags to disambiguate prompts mixing instructions, context, examples, and inputs:
+
+```
+<instructions>...</instructions>
+<context>...</context>
+<example>...</example>
+```
+
+**Critical instructions at start or end** — The "lost-in-the-middle" effect degrades performance for instructions buried in the middle of long contexts. Place key rules in the first and last 20% of each file.
+
+**Describe desired behavior, not prohibited behavior** — Instead of "Do not use markdown", write "Your response should be smooth flowing prose."
+
+**Behavioral discipline beats clever prompting** — surface assumptions before acting, prefer the simplest sufficient change, keep edits surgical, and define explicit validation targets before concluding.
+
+**Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
+
+*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
+
+---
+
+## Strategy Matrix
+
+| Technique | Skill (SKILL.md) | Hook | Rule | Subagent |
+|-----------|-----------------|------|------|----------|
+| Role prompting | ✅ First line of body | ❌ Skip (implicit) | ❌ Skip | ✅ Strong use |
+| Zero-shot | ✅ Most phases | ✅ Default | ✅ Always | ✅ Simple tasks |
+| Few-shot examples | ✅ Critical output formats | ❌ Too token-costly | ❌ Too token-costly | ✅ Complex formats |
+| XML structuring | ✅ Multi-section bodies | ❌ Too verbose | ❌ Too verbose | ✅ Rich context |
+| Chain-of-thought | ❌ Slows execution | ❌ Not applicable | ❌ Not applicable | ✅ Reasoning tasks |
+| Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
+| Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
+
+*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160*
+
+---
+
+## Per-Artifact Recommendations
+
+### Skills (SKILL.md)
+
+- Open body with role definition (1-2 sentences max)
+- Make Phase 1 a low-risk warm-up before higher-effort phases
+- Use progressive disclosure: reference files loaded per phase, not all upfront
+- Load curated references before asking for synthesis or edits
+- Use zero-shot for most phases; reserve few-shot for phases with strict output format
+- Make constraints concrete: scope limits, output shape, and stop conditions
+- Self-check instruction in final phase: "Before completing, verify all criteria in skill-validation-criteria.md"
+- Final validation should confirm Karpathy-style discipline and the ethical constraint on persuasion
+- Keep each phase instruction ≤10 lines; reference files for depth
+
+### Hooks
+
+- Zero-shot only — hooks are short and tokens are expensive
+- Avoid role prompting; context of the event implies the role
+- Be explicit about output format: `{"ok": true/false, "reason": "..."}`
+- For `prompt` and `agent` hooks: write simple, direct evaluation criteria
+- Test with `--debug` to verify hook output is parsed as intended
+
+### Rules
+
+- Zero-shot always — rules are factual instructions, not prompted behaviors
+- No examples (too token-costly for always-loaded context)
+- One instruction per bullet; no compound sentences
+- Specificity goldilocks: "Use 2-space indentation" not "Format code properly" not "src/auth/handlers.ts handles JWT"
+
+### Subagents
+
+- Role prompting is the primary specialization mechanism — invest here
+- Structure system prompt: Role → Responsibilities → Process → Checklist → Output Format
+- Include confidence threshold for review agents: "Report only when >80% confident"
+- Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with Opus 4.6
+- Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
+
+*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80*
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| "CRITICAL: You MUST always..." | Overtriggering with Claude 4.6 (especially Opus) | Use "Use this when..." |
+| Vague instructions ("be thorough") | Not verifiable or actionable | Specify exactly what to check |
+| Few-shot examples in rules | Token waste on every session | Delete examples; be specific in instruction text |
+| Over-explaining what Claude already knows | Wastes context budget | Trust model knowledge; add only novel context |
+| Prescriptive step-by-step plans | Forces rigid execution; misses edge cases | "Think thoroughly" outperforms manual step lists |
+| Contradictory instructions | Claude picks one arbitrarily | Audit for conflicts before writing |
+| Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
+
+*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
+
+---
+
+## Context Budget Principles
+
+Every token in an artifact competes with conversation history and other context. Apply these before writing:
+
+- Challenge each instruction: "Would removing this cause the agent to make mistakes? If not, cut it."
+- Prefer pointers to full content: link to reference files instead of inlining detailed material
+- Path-scoped rules and per-phase reference loading are the primary token-saving mechanisms
+- Short artifacts (rules, validation criteria) should be zero-shot and minimal
+- Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
+
+*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*

--- a/plugins/cursor-customizer/skills/create-skill/references/skill-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/skill-authoring-guide.md
@@ -1,0 +1,178 @@
+# Skill Authoring Guide
+
+Evidence-based guidance for creating Cursor SKILL.md packages that conform to the Agent Skills open standard.
+Source: docs/cursor/skills/agent-skills-guide.md
+
+---
+
+## Contents
+
+- Core principles (portable, version-controlled, actionable, progressive)
+- Discovery model (where Cursor finds skills)
+- Skill directory structure (the four optional subdirectories)
+- SKILL.md frontmatter (the six recognised fields)
+- Naming and descriptions
+- Progressive disclosure patterns
+- Bundled paths and script invocation
+- Disabling automatic invocation
+- Anti-patterns
+
+---
+
+## Core Principles
+
+A skill is a portable, version-controlled package that teaches an agent how to perform a domain task. Four properties define the standard:
+
+- **Portable** — skills work across any agent that supports the Agent Skills standard.
+- **Version-controlled** — skills are stored as files and tracked in the repository, or installed via repository links.
+- **Actionable** — skills can include scripts, templates, and references that agents act on using their tools.
+- **Progressive** — skills load resources on demand, keeping context usage efficient.
+
+**Conciseness is the primary principle.** At startup, only `name` + `description` are loaded for all discovered skills. The full `SKILL.md` body loads when the skill is invoked. Supporting files load only on demand when the body explicitly references them.
+
+Challenge each piece of content:
+
+- "Does the agent really need this explanation?"
+- "Can I assume the agent knows this already?"
+- "Does this paragraph justify its token cost?"
+
+**Behavioral discipline** — every skill should make assumptions explicit, prefer the simplest complete path, keep changes surgical, and define clear validation targets before concluding.
+
+**Safe persuasion** — use warm-up phases, curated references, explicit limits, and cited standards to improve compliance with legitimate work. Never use persuasion framing to bypass safeguards, refusals, or scope boundaries.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "What are skills?" and "How skills work"*
+
+---
+
+## Discovery Model
+
+Cursor automatically discovers skills from these directories at startup:
+
+| Location | Scope |
+|----------|-------|
+| `.agents/skills/` | Project-level (open-standard, portable) |
+| `.cursor/skills/` | Project-level (Cursor-specific) |
+| `~/.cursor/skills/` | User-level (global) |
+
+The agent is presented with available skills and decides when they are relevant based on context. Skills can also be invoked manually by typing `/` in the agent chat and searching for the skill name.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*
+
+---
+
+## Skill Directory Structure
+
+Each skill is a folder whose entry point is `SKILL.md`. Optional sibling directories carry on-demand resources:
+
+```
+my-skill/
+├── SKILL.md           # required entry point
+├── scripts/           # executable code the agent can run
+├── references/        # additional documentation loaded on demand
+└── assets/            # static resources (templates, images, data files)
+```
+
+Keep `SKILL.md` focused — move detailed reference material into `references/`. The agent loads supporting files progressively, only when the body of `SKILL.md` directs it to.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
+
+---
+
+## SKILL.md Frontmatter
+
+Each skill begins with YAML frontmatter. The Agent Skills standard recognises six fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Skill identifier. Lowercase letters, numbers, and hyphens only. Must match the parent folder name. |
+| `description` | Yes | What the skill does and when to use it. Used by the agent to determine relevance. |
+| `license` | No | License name or reference to a bundled license file. |
+| `compatibility` | No | Environment requirements (system packages, network access, etc.). |
+| `metadata` | No | Arbitrary key-value mapping for additional metadata. |
+| `disable-model-invocation` | No | When `true`, the skill is only included when explicitly invoked via `/skill-name`. |
+
+No other fields are part of the standard. Adding fields outside this set introduces foreign-platform dialect and breaks portability.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
+
+---
+
+## Naming and Descriptions
+
+**Naming** — kebab-case, lowercase letters/numbers/hyphens only, must match the parent folder. Prefer verb-noun or gerund forms (`deploy-app`, `processing-pdfs`). Avoid generic stems like `helper`, `utils`, `tools`.
+
+**Descriptions** — always third person. The description is read by the agent to decide whether the skill is relevant.
+
+- Good: "Deploys the application to staging or production environments. Use when deploying code or when the user mentions deployment, releases, or environments."
+- Bad: "I can help you deploy the application."
+- Bad: "You can use this to deploy."
+
+Include three things in every description: (1) what it does, (2) when to use it, (3) the trigger terms an agent might match against.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Frontmatter fields"*
+
+---
+
+## Progressive Disclosure
+
+`SKILL.md` is the index; detailed content lives in supporting files loaded on demand.
+
+**Pattern 1 — phased reference loads:**
+
+```
+## Phase 1: Analyze
+Read references/criteria.md for the evaluation rubric.
+```
+
+**Pattern 2 — keep references focused:**
+Each reference file has one job and is cited explicitly from the phase that needs it. Do not load every reference in Phase 1.
+
+Keep `SKILL.md` under 500 lines. Move detail to `references/`. Reference supporting files explicitly so the agent knows what they contain.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
+
+---
+
+## Bundled Paths and Script Invocation
+
+When `SKILL.md` references a bundled file (script, template, reference), use a **relative path from the skill root**:
+
+```
+Run the deployment script: scripts/deploy.sh <environment>
+```
+
+```
+Read references/skill-format-reference.md for the format specification.
+```
+
+Do not use string-substitution variables to refer to bundled files; the relative-path convention is what the Agent Skills standard guarantees portable across implementations.
+
+Scripts can be written in any language the agent can execute (Bash, Python, JavaScript, etc.). They should be self-contained, include helpful error messages, and handle edge cases gracefully.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills"*
+
+---
+
+## Disabling Automatic Invocation
+
+By default, skills are automatically applied when the agent determines they are relevant. Set `disable-model-invocation: true` to make a skill behave like a traditional slash command — the skill is only included when the user explicitly types `/skill-name` in chat.
+
+Use this for workflows with side effects (commit, deploy, send-message) or for skills the user wants to gate manually.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Disabling automatic invocation"*
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| Explaining what the agent already knows | Wastes tokens; dilutes attention | Delete it |
+| Generic descriptions ("helps with data") | Poor skill discovery | Be specific about what + when + triggers |
+| Inlining reference content in SKILL.md | Context bloat on every invocation | Move to `references/` subdirectory |
+| Hardcoded absolute or project-relative paths | Goes stale; breaks portability | Use relative paths from skill root |
+| Foreign-platform frontmatter fields | Breaks Agent Skills portability | Restrict to the six standard fields |
+| Contradictions between phases | Agent picks one arbitrarily | Review all phases for consistency |
+| Loading every reference in Phase 1 | Defeats progressive disclosure | Load each reference only in the phase that needs it |
+
+*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Optional directories"*

--- a/plugins/cursor-customizer/skills/create-skill/references/skill-format-reference.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/skill-format-reference.md
@@ -1,0 +1,123 @@
+# Skill Format Reference
+
+Technical specification for Cursor SKILL.md format, frontmatter, directory structure, and discovery model.
+Source: docs/cursor/skills/agent-skills-guide.md
+
+---
+
+## Contents
+
+- Frontmatter fields (the Agent Skills open standard)
+- Name validation rules
+- Bundled-path convention (relative paths from skill root)
+- Directory structure
+- Progressive disclosure loading model
+- Skill discovery locations and scope
+
+---
+
+## Frontmatter Fields
+
+The Agent Skills standard, as adopted by Cursor, recognises exactly six frontmatter fields. No other fields are part of the standard.
+
+| Field | Required | Constraints |
+|-------|----------|-------------|
+| `name` | Yes | Lowercase letters, numbers, hyphens only; max 64 chars; must match parent folder name |
+| `description` | Yes | Max 1024 chars; what it does + when to use it; third person; no XML tags |
+| `license` | No | License name or path to a bundled license file |
+| `compatibility` | No | Environment requirements (system packages, network access, etc.) |
+| `metadata` | No | Arbitrary key-value mapping (author, version, etc.) |
+| `disable-model-invocation` | No | `true` = skill only included when explicitly invoked via `/skill-name` |
+
+Frontmatter fields outside this set are foreign-platform dialect and must not appear in Cursor SKILL.md files.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
+
+---
+
+## Name Validation Rules
+
+- 1–64 characters
+- Only lowercase `a-z`, numbers, and hyphens (`-`)
+- Must NOT start or end with `-`
+- Must NOT contain consecutive `--`
+- Must match the parent directory name exactly
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
+
+---
+
+## Bundled-Path Convention
+
+When `SKILL.md` references a bundled file (script, template, reference), use a **relative path from the skill root**:
+
+```
+Run the deployment script: scripts/deploy.sh <environment>
+```
+
+```
+Read references/skill-format-reference.md for the format specification.
+```
+
+```
+Apply the template at assets/templates/config.yaml.
+```
+
+This convention is what the Agent Skills standard guarantees portable across implementations. Do not use string-substitution variables, absolute paths, or project-relative paths for bundled files — relative paths from the skill root are the only portable form.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills" and "Optional directories"*
+
+---
+
+## Directory Structure
+
+```
+my-skill/
+├── SKILL.md                # Required: metadata + instructions (entry point)
+├── references/             # Optional: reference docs loaded on demand
+│   └── guide.md
+├── assets/
+│   └── templates/          # Optional: output templates
+│       └── template.md
+└── scripts/                # Optional: executable scripts the agent can run
+    └── deploy.sh
+```
+
+**Loading behaviour:**
+
+- `SKILL.md` loads when the skill activates.
+- `references/` files load only when the skill body explicitly directs the agent to read them.
+- `assets/` files load only when the skill body explicitly directs the agent to use them.
+- `scripts/` files are executed by the agent, not loaded into context.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
+
+---
+
+## Progressive Disclosure Loading Model
+
+| Level | What loads | When |
+|-------|-----------|------|
+| Startup | `name` + `description` for every discovered skill | Every session |
+| Trigger | Full SKILL.md body | When the skill is invoked (user or agent) |
+| On-demand | Files in `references/`, `assets/`, and any other bundled directories | Only when the skill body directs the agent to read or use them |
+
+Keep SKILL.md under **500 lines**. Move detailed reference material to the `references/` subdirectory. Explicitly reference supporting files from SKILL.md so the agent knows what to load and when.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "How skills work" and "Optional directories"*
+
+---
+
+## Skill Discovery Locations and Scope
+
+Cursor automatically loads skills from these directories:
+
+| Location | Path | Scope |
+|----------|------|-------|
+| Project (open standard) | `.agents/skills/<name>/SKILL.md` | This project — portable across Agent Skills implementations |
+| Project (Cursor-native) | `.cursor/skills/<name>/SKILL.md` | This project — Cursor-specific |
+| User (global) | `~/.cursor/skills/<name>/SKILL.md` | All projects on this machine |
+
+When the same skill name exists in multiple locations, Cursor's own resolution rules apply. For new skills, choose `.cursor/skills/` when the skill is Cursor-specific and `.agents/skills/` when the skill should also be discoverable by other Agent Skills consumers.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*

--- a/plugins/cursor-customizer/skills/create-skill/references/skill-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/skill-validation-criteria.md
@@ -1,0 +1,94 @@
+# Skill Validation Criteria
+
+Quality checklist for generated and improved Cursor SKILL.md packages.
+Source: docs/cursor/skills/agent-skills-guide.md
+
+---
+
+## Contents
+
+- Hard limits (auto-fail if violated)
+- Foreign-platform dialect ban (auto-fail if violated)
+- Quality checks (all must pass)
+- Improve-only checks (information preservation, structural)
+- Validation loop instructions
+
+---
+
+## Hard Limits (Auto-fail if violated)
+
+Any skill violating these criteria must be fixed before proceeding:
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
+| Reference files | ≤ 200 lines each | reference-files convention |
+| Reference files >100 lines | Must include a `## Contents` table of contents | reference-files convention |
+| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags | Agent Skills specification |
+| `name` field | Present, non-empty, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder | Agent Skills specification |
+| Frontmatter fields | Restricted to `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` | Agent Skills specification |
+| Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
+
+---
+
+## Foreign-Platform Dialect Ban (Auto-fail if any present)
+
+The Cursor distribution is product-strict. The skill tree (SKILL.md, references, assets, scripts) must conform to the following allowlists. Anything outside an allowlist is foreign-platform dialect and is forbidden.
+
+| Check | Allowlist (anything else fails) |
+|-------|---------------------------------|
+| Frontmatter fields | Only the six recognised by the Agent Skills standard: `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` |
+| Bundled-path references | Relative paths from the skill root only (e.g., `references/foo.md`, `scripts/deploy.sh`, `assets/templates/foo.yaml`); no string-substitution variables of any form (no `${...}` or `$NAME` forms inside bundled paths) |
+| Discovery-path references | Only `.cursor/`, `.agents/`, and `~/.cursor/` are recognised; no references to discovery directories or memory files belonging to other agent platforms |
+| Documentation citations | Local Cursor docs and vendor-neutral research only; no citations to product documentation for other agent platforms |
+
+---
+
+## Quality Checks (All must pass)
+
+- [ ] Has a self-validation phase that reads the skill's `references/skill-validation-criteria.md`
+- [ ] All bundled-path references in SKILL.md use relative paths from the skill root
+- [ ] `description` written in third person ("Deploys..." not "I deploy..." or "You can use...")
+- [ ] `description` includes what the skill does AND when to use it (trigger terms)
+- [ ] Progressive disclosure applied: references loaded per phase, not all upfront
+- [ ] No reference content inlined in SKILL.md body (should be in `references/` subdirectory)
+- [ ] Each phase instruction is concise (≤10 lines); depth lives in reference files
+- [ ] Reference files cited explicitly so the agent knows what to load and when
+- [ ] `disable-model-invocation: true` set for side-effect workflows (commit, deploy, send)
+- [ ] Prompt engineering strategy applied: skill follows relevant strategy from `references/prompt-engineering-strategies.md`
+- [ ] Behavioral guidelines applied: the skill surfaces assumptions before acting, prefers the simplest adequate path, keeps changes surgical, and defines explicit validation targets
+- [ ] Persuasion cues, if present, stay inside the ethical constraint: they improve compliance with legitimate work only and never weaken safeguards, refusals, or scope boundaries
+- [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
+- [ ] Plugin skill bodies delegate analysis to registered subagents; no inline bash analysis commands
+- [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-guide.md")
+
+---
+
+## If This Is an IMPROVE Operation — Also Check
+
+**Information Preservation:**
+
+- [ ] Evidence-grounded references not removed (citations preserved)
+- [ ] Existing phase structure not flattened
+- [ ] Progressive disclosure references not collapsed into inline content
+
+**Structural:**
+
+- [ ] Reference file ≤200 line limit not violated by merging content; >100-line files have a `## Contents` table of contents
+- [ ] Bundled-path references not broken by renaming or moving files
+
+---
+
+## Validation Loop Instructions
+
+Execute this loop for each generated or improved skill:
+
+1. Evaluate the skill against ALL criteria above (hard limits, foreign-dialect ban, quality checks, and IMPROVE-only checks if applicable).
+2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference.
+3. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation.
+4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
+5. Only proceed to writing skills when ALL criteria pass.
+
+**Do not skip criteria for "minor" violations.** Hard limits and the foreign-dialect ban are absolute.

--- a/plugins/cursor-customizer/skills/improve-skill/SKILL.md
+++ b/plugins/cursor-customizer/skills/improve-skill/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: improve-skill
+description: "Evaluates and optimizes existing Cursor SKILL.md packages against evidence-based quality criteria from the Agent Skills standard. Identifies bloat, staleness, and missed best practices. Use when improving an existing Cursor skill."
+---
+
+# Improve Skill
+
+Evaluate an existing Cursor SKILL.md package against evidence-based quality criteria and apply improvements to reduce bloat, eliminate foreign-platform dialect, and align with the Agent Skills standard.
+
+## Behavioral Guidelines
+
+- **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
+- **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
+- **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
+- **Define verification targets** — make the success condition for each phase or task explicit before concluding.
+- **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
+- **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+
+## Hard Rules
+
+<RULES>
+- **ALWAYS** evaluate before modifying — never change files without analysis
+- **ALWAYS** present changes to the user before applying them
+- **NEVER** remove evidence-grounded references or citations
+- **NEVER** flatten progressive disclosure into inline content
+- **NEVER** exceed 500 lines in SKILL.md or 200 lines in reference files after improvements
+- **PRESERVE** all genuinely useful skill phases and instructions — only remove waste
+- **PRESERVE** or strengthen the ethical constraint: persuasion cues support legitimate work only, never safety bypass
+</RULES>
+
+## Process
+
+### Preflight Check
+
+Check if a skill exists at:
+
+- The user-provided path
+- `.cursor/skills/{name}/SKILL.md`
+- `.agents/skills/{name}/SKILL.md`
+- `~/.cursor/skills/{name}/SKILL.md`
+
+**If no skill found:**
+
+1. Inform the user: "No skill found at the specified path."
+2. Suggest using `/cursor-customizer:create-skill` to create a new one instead.
+3. **STOP**
+
+**If skill found:**
+Proceed to Phase 1 below.
+
+### Phase 1: Evaluate
+
+Delegate to the `skill-evaluator` agent with this task:
+
+> Evaluate the skill at `{target-path}`. Read the SKILL.md and all files in the skill directory. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter shape valid against the Agent Skills standard), structural quality (progressive disclosure, phase structure, reference loading), foreign-platform dialect, and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+
+The agent runs read-only with Cursor-native frontmatter (`model: inherit`, `readonly: true`) in an isolated context. Wait for it to complete and parse its structured output.
+
+### Phase 2: Project Context
+
+Delegate to the `artifact-analyzer` agent with this task:
+
+> Analyze the project to understand the context around the skill being improved. Focus on: which subagents the skill delegates to and whether those subagents still exist, naming conventions for similar skills, any other skills that overlap in purpose, and the project structure under `.cursor/` and `.agents/`.
+
+Wait for it to complete and parse its structured output.
+
+### Phase 3: Generate Improvement Plan
+
+Read these reference documents:
+
+- `references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
+- `references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
+- `references/behavioral-guidelines.md` — discipline cues and safe persuasion patterns for skills
+- `references/prompt-engineering-strategies.md` — skill-specific prompting strategies
+
+Based on both subagent reports, create an improvement plan with categories:
+
+1. **Removals** — bloat (inlined content, over-specified instructions), stale (broken subagent refs, removed tools), duplicates, foreign-platform dialect
+2. **Refactoring** — progressive disclosure optimization, phase consolidation, bundled-path corrections to relative-from-skill-root form
+3. **Additions** — missing sections (self-validation, output format). Only suggest Hard Rules or Preflight if the skill has user-facing interactions or side effects — do NOT suggest them for informational/analysis-only skills that read and report.
+
+If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+
+### Phase 4: Self-Validation
+
+Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
+
+For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+
+### Phase 5: Present and Apply
+
+1. Show a summary overview of all improvements found, grouped by category:
+   - **Removals**: X items (bloat: X, stale: X, duplicates: X, foreign dialect: X)
+   - **Refactoring**: X items (progressive disclosure: X, phase structure: X, bundled-path corrections: X)
+   - **Additions**: X items
+
+2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+
+   **WHAT**: The specific content and its current location (file:lines)
+   **WHY**: Evidence-based justification with source reference
+   **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
+   **OPTIONS**:
+   - **Option A** (recommended): Primary action
+   - **Option B**: Alternative action
+   - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
+
+   Wait for the user to select an option for each suggestion before proceeding to the next.
+   If the user selects "Keep as-is", preserve the content in its exact current location.
+
+3. After all suggestions are reviewed, show aggregate token impact analysis:
+   - **Total lines**: before → after
+   - **Removed tokens**: total waste eliminated
+   - **Deferred suggestions**: X items kept as-is
+
+4. Apply ONLY the approved changes (options A or B selections).
+
+5. Report final metrics:
+   - Lines before → after
+   - Files affected
+   - Estimated token savings per session
+   - Suggestions applied: X of Y (Z deferred)

--- a/plugins/cursor-customizer/skills/improve-skill/assets/templates/skill-md.md
+++ b/plugins/cursor-customizer/skills/improve-skill/assets/templates/skill-md.md
@@ -1,0 +1,57 @@
+---
+name: [skill-name-kebab-case]
+description: "[What this skill does and when to use it. Third person. Include trigger terms.]"
+---
+<!-- TEMPLATE: Cursor SKILL.md Entry Point
+     Placement: .cursor/skills/[skill-name]/SKILL.md (Cursor-native default)
+                or .agents/skills/[skill-name]/SKILL.md (open-standard, portable)
+     Rule: name ≤ 64 chars; lowercase letters/numbers/hyphens only; must match parent folder
+     Rule: description ≤ 1024 chars; third person; no XML tags
+     Rule: Frontmatter restricted to the six Agent Skills standard fields
+           (name, description, license, compatibility, metadata, disable-model-invocation)
+     Rule: Body under 500 lines
+     Rule: Bundled-path references use relative paths from the skill root
+           (e.g., references/foo.md, scripts/deploy.sh, assets/templates/foo.yaml)
+     Rule: Progressive disclosure — load references per phase, not all upfront
+     Rule: If analysis finds a monorepo or multi-service layout, generated phases must name
+           the target service/workspace explicitly
+-->
+
+# [Skill Title]
+
+[One-sentence purpose statement.]
+
+## Behavioral Guidelines
+
+- **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
+- **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
+- **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
+- **Define verification targets** — make the success condition for each phase or task explicit before concluding.
+- **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
+- **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+
+## Hard Rules
+
+<RULES>
+- [Critical constraint 1]
+- [Critical constraint 2]
+</RULES>
+
+## Process
+
+### Preflight Check
+<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+
+### Phase 1: [Analysis Phase Name]
+<!-- Delegate to the appropriate Cursor subagent (model: inherit, readonly: true);
+     if monorepo, record the target service/workspace -->
+
+### Phase 2: [Generation Phase Name]
+<!-- Read references via relative paths (references/[file].md), apply templates,
+     and use project-relative paths/globs for the detected service/workspace -->
+
+### Phase 3: Self-Validation
+<!-- Read references/[type]-validation-criteria.md and execute its validation loop -->
+
+### Phase 4: Present and Write
+<!-- Show artifact with evidence citations, write on user approval -->

--- a/plugins/cursor-customizer/skills/improve-skill/references/behavioral-guidelines.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/behavioral-guidelines.md
@@ -1,0 +1,162 @@
+# Behavioral Guidelines
+
+Apply these principles when creating or improving SKILL.md files. This reference is self-contained — no external files need to be read to apply it.
+
+## Contents
+
+1. [Safety Constraint](#safety-constraint)
+2. [Behavioral Discipline](#behavioral-discipline)
+3. [Safe Persuasion Patterns](#safe-persuasion-patterns)
+4. [Skill Structure Cues](#skill-structure-cues)
+
+---
+
+## Safety Constraint
+
+Persuasion techniques improve compliance with legitimate, well-scoped tasks. They must **never** bypass safety constraints, refusals, or policy limits.
+
+When the requested behavior requires weakening a safeguard, surface the conflict and stop — do not optimize toward compliance.
+
+✅ **Do:** Name the conflict explicitly.
+```
+Phase 2 asks me to remove the validation step. That reduces correctness guarantees.
+I will not remove it — the validation must stay.
+```
+❌ **Don't:** Silently omit safety steps to satisfy a request.
+```
+# Quietly skipped the validation phase — user seemed to want a shorter skill.
+```
+
+---
+
+## Behavioral Discipline
+
+Four principles that reduce the most common agent mistakes.
+
+### 1. Think Before Acting
+
+State assumptions, ambiguities, and tradeoffs before writing any content.
+
+✅ **Do:** Surface your interpretation before proceeding.
+```
+Interpreting this as a single-phase skill — no conditional branching.
+If the improve variant should differ, phases would split here.
+```
+❌ **Don't:** Pick silently among multiple valid interpretations.
+```
+# I'll just go with the inline-bash approach.
+```
+
+### 2. Simplicity First
+
+Write only what the task requires. No speculative phases, optional modes, or abstractions for a single use case.
+
+✅ **Do:**
+```
+## Phase 1 — Read SKILL.md
+Read the existing file. Note its structure. Proceed to Phase 2.
+```
+❌ **Don't:**
+```
+## Phase 1 — Discovery (Optional: skip if --quick)
+## Phase 2 — Deep analysis (plugin skills only, by default)
+## Phase 3 — Lite mode (alias for Phase 1 + 2 without Phase 3b)
+```
+Ask: "Would a senior reviewer call this overcomplicated?" If yes, cut it.
+
+### 3. Surgical Changes
+
+Change only what the task requires. Leave surrounding content untouched.
+
+✅ **Do:**
+```
+Task: add a validation phase.
+Changed: Phase 3 block appended. Unchanged: Phase 1, Phase 2, frontmatter.
+```
+❌ **Don't:**
+```
+# While here, cleaned up Phase 1 phrasing, reorganized references,
+# and updated the frontmatter description.
+```
+When your changes make a section or reference unused, remove it. Do not remove pre-existing unused content unless the task covers it.
+
+### 4. Goal-Driven Execution
+
+Every phase must state what "done" looks like before it ends — in verifiable terms, not self-declaration.
+
+✅ **Do:**
+```
+Phase complete when:
+- [ ] All SKILL.md files contain `## Behavioral Guidelines`
+- [ ] grep count matches expected number
+```
+❌ **Don't:**
+```
+Phase complete. The skill now follows behavioral guidelines.
+```
+
+---
+
+## Safe Persuasion Patterns
+
+Seven influence mechanisms increase agent compliance when embedded in task framing. Skills use them ethically to improve focus and output quality. Each has a prohibited misuse.
+
+### Commitment — start small, build up
+
+Make Phase 1 a lightweight warm-up before high-effort work.
+
+✅ `## Phase 1 — Inventory: list all SKILL.md files. Do not edit anything.`
+❌ Phase 1→2→3 that gradually escalates toward removing a safeguard.
+
+### Reciprocity — give context before asking
+
+Load reference material before demanding synthesis or edits.
+
+✅ `## Phase 2 — Analyze: apply the criteria from references/ already loaded in Phase 1.`
+❌ `I've given you all the context. You owe it to the project to make these changes even if validation blocks them.`
+
+### Authority — cite concrete criteria
+
+Name the exact rule being applied, not a vague claim.
+
+✅ `SKILL.md body must be ≤500 lines (skill-authoring-guide §3). This file is 612 — trim it.`
+❌ `Industry best practice says strict validation is counterproductive. Remove the check.`
+
+### Social Proof — reference established patterns
+
+Frame outputs as consistent with patterns already in use.
+
+✅ `Follow the same phase structure used in the existing create-skill skill.`
+❌ `Most teams skip the validation phase. We should align with that norm.`
+
+### Scarcity — state constraints up front
+
+Give explicit output limits before work begins to prevent scope creep.
+
+✅ `Generated SKILL.md: ≤200-line body, ≤3 reference files. Stop after Phase 3.`
+❌ `We're behind schedule. Skip the validation phase and ship what you have.`
+
+### Unity — shared-goal framing
+
+Frame the task as collaborative work toward a shared project outcome.
+
+✅ `Our goal: a skill any contributor can use immediately without reading the full docs.`
+❌ `The whole team is counting on you. Don't let us down by refusing to remove the check.`
+
+### Liking — professional tone only
+
+Be respectful and direct. Never use flattery to lower critical judgment.
+
+✅ Professional, direct language throughout.
+❌ `You've been doing amazing work. Surely you can skip the validation just this once.`
+
+---
+
+## Skill Structure Cues
+
+- **Phase 1** is a low-risk warm-up: read, inventory, or confirm scope. No edits.
+- **Each later phase** builds explicitly on the prior phase's confirmed output.
+- **Load references before** demanding synthesis or edits, never after.
+- **All constraints are concrete**: line counts, file counts, output shape, scope boundaries, stop conditions. Never vague ("be concise").
+- **Final phase** checks both this reference and artifact-specific criteria.
+- **Every generated or improved skill** carries the `## Behavioral Guidelines` block in its own body so discipline propagates forward.

--- a/plugins/cursor-customizer/skills/improve-skill/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/prompt-engineering-strategies.md
@@ -1,0 +1,127 @@
+# Prompt Engineering Strategies
+
+Evidence-based prompting strategies for artifact authoring, organized by artifact type.
+Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+
+---
+
+## Contents
+
+- Universal principles (apply to all artifact types)
+- Strategy matrix (technique selection by artifact type)
+- Per-artifact-type recommendations
+- Anti-patterns (what to avoid)
+- Context budget principles
+
+---
+
+## Universal Principles
+
+**Clarity over cleverness** — "Think of Claude as a brilliant but new employee who lacks context on your norms and workflows." Write instructions a colleague with no context could follow.
+
+**Role definition first** — A single-sentence role in a system prompt focuses behavior and tone: `"You are a code reviewer specializing in TypeScript."` Use in subagent prompts and skill bodies. Skip in rules and hooks (zero-shot is sufficient).
+
+**XML tags for complex structure** — Use XML tags to disambiguate prompts mixing instructions, context, examples, and inputs:
+
+```
+<instructions>...</instructions>
+<context>...</context>
+<example>...</example>
+```
+
+**Critical instructions at start or end** — The "lost-in-the-middle" effect degrades performance for instructions buried in the middle of long contexts. Place key rules in the first and last 20% of each file.
+
+**Describe desired behavior, not prohibited behavior** — Instead of "Do not use markdown", write "Your response should be smooth flowing prose."
+
+**Behavioral discipline beats clever prompting** — surface assumptions before acting, prefer the simplest sufficient change, keep edits surgical, and define explicit validation targets before concluding.
+
+**Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
+
+*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
+
+---
+
+## Strategy Matrix
+
+| Technique | Skill (SKILL.md) | Hook | Rule | Subagent |
+|-----------|-----------------|------|------|----------|
+| Role prompting | ✅ First line of body | ❌ Skip (implicit) | ❌ Skip | ✅ Strong use |
+| Zero-shot | ✅ Most phases | ✅ Default | ✅ Always | ✅ Simple tasks |
+| Few-shot examples | ✅ Critical output formats | ❌ Too token-costly | ❌ Too token-costly | ✅ Complex formats |
+| XML structuring | ✅ Multi-section bodies | ❌ Too verbose | ❌ Too verbose | ✅ Rich context |
+| Chain-of-thought | ❌ Slows execution | ❌ Not applicable | ❌ Not applicable | ✅ Reasoning tasks |
+| Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
+| Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
+
+*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160*
+
+---
+
+## Per-Artifact Recommendations
+
+### Skills (SKILL.md)
+
+- Open body with role definition (1-2 sentences max)
+- Make Phase 1 a low-risk warm-up before higher-effort phases
+- Use progressive disclosure: reference files loaded per phase, not all upfront
+- Load curated references before asking for synthesis or edits
+- Use zero-shot for most phases; reserve few-shot for phases with strict output format
+- Make constraints concrete: scope limits, output shape, and stop conditions
+- Self-check instruction in final phase: "Before completing, verify all criteria in skill-validation-criteria.md"
+- Final validation should confirm Karpathy-style discipline and the ethical constraint on persuasion
+- Keep each phase instruction ≤10 lines; reference files for depth
+
+### Hooks
+
+- Zero-shot only — hooks are short and tokens are expensive
+- Avoid role prompting; context of the event implies the role
+- Be explicit about output format: `{"ok": true/false, "reason": "..."}`
+- For `prompt` and `agent` hooks: write simple, direct evaluation criteria
+- Test with `--debug` to verify hook output is parsed as intended
+
+### Rules
+
+- Zero-shot always — rules are factual instructions, not prompted behaviors
+- No examples (too token-costly for always-loaded context)
+- One instruction per bullet; no compound sentences
+- Specificity goldilocks: "Use 2-space indentation" not "Format code properly" not "src/auth/handlers.ts handles JWT"
+
+### Subagents
+
+- Role prompting is the primary specialization mechanism — invest here
+- Structure system prompt: Role → Responsibilities → Process → Checklist → Output Format
+- Include confidence threshold for review agents: "Report only when >80% confident"
+- Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with Opus 4.6
+- Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
+
+*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80*
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| "CRITICAL: You MUST always..." | Overtriggering with Claude 4.6 (especially Opus) | Use "Use this when..." |
+| Vague instructions ("be thorough") | Not verifiable or actionable | Specify exactly what to check |
+| Few-shot examples in rules | Token waste on every session | Delete examples; be specific in instruction text |
+| Over-explaining what Claude already knows | Wastes context budget | Trust model knowledge; add only novel context |
+| Prescriptive step-by-step plans | Forces rigid execution; misses edge cases | "Think thoroughly" outperforms manual step lists |
+| Contradictory instructions | Claude picks one arbitrarily | Audit for conflicts before writing |
+| Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
+
+*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
+
+---
+
+## Context Budget Principles
+
+Every token in an artifact competes with conversation history and other context. Apply these before writing:
+
+- Challenge each instruction: "Would removing this cause the agent to make mistakes? If not, cut it."
+- Prefer pointers to full content: link to reference files instead of inlining detailed material
+- Path-scoped rules and per-phase reference loading are the primary token-saving mechanisms
+- Short artifacts (rules, validation criteria) should be zero-shot and minimal
+- Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
+
+*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-authoring-guide.md
@@ -1,0 +1,178 @@
+# Skill Authoring Guide
+
+Evidence-based guidance for creating Cursor SKILL.md packages that conform to the Agent Skills open standard.
+Source: docs/cursor/skills/agent-skills-guide.md
+
+---
+
+## Contents
+
+- Core principles (portable, version-controlled, actionable, progressive)
+- Discovery model (where Cursor finds skills)
+- Skill directory structure (the four optional subdirectories)
+- SKILL.md frontmatter (the six recognised fields)
+- Naming and descriptions
+- Progressive disclosure patterns
+- Bundled paths and script invocation
+- Disabling automatic invocation
+- Anti-patterns
+
+---
+
+## Core Principles
+
+A skill is a portable, version-controlled package that teaches an agent how to perform a domain task. Four properties define the standard:
+
+- **Portable** — skills work across any agent that supports the Agent Skills standard.
+- **Version-controlled** — skills are stored as files and tracked in the repository, or installed via repository links.
+- **Actionable** — skills can include scripts, templates, and references that agents act on using their tools.
+- **Progressive** — skills load resources on demand, keeping context usage efficient.
+
+**Conciseness is the primary principle.** At startup, only `name` + `description` are loaded for all discovered skills. The full `SKILL.md` body loads when the skill is invoked. Supporting files load only on demand when the body explicitly references them.
+
+Challenge each piece of content:
+
+- "Does the agent really need this explanation?"
+- "Can I assume the agent knows this already?"
+- "Does this paragraph justify its token cost?"
+
+**Behavioral discipline** — every skill should make assumptions explicit, prefer the simplest complete path, keep changes surgical, and define clear validation targets before concluding.
+
+**Safe persuasion** — use warm-up phases, curated references, explicit limits, and cited standards to improve compliance with legitimate work. Never use persuasion framing to bypass safeguards, refusals, or scope boundaries.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "What are skills?" and "How skills work"*
+
+---
+
+## Discovery Model
+
+Cursor automatically discovers skills from these directories at startup:
+
+| Location | Scope |
+|----------|-------|
+| `.agents/skills/` | Project-level (open-standard, portable) |
+| `.cursor/skills/` | Project-level (Cursor-specific) |
+| `~/.cursor/skills/` | User-level (global) |
+
+The agent is presented with available skills and decides when they are relevant based on context. Skills can also be invoked manually by typing `/` in the agent chat and searching for the skill name.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*
+
+---
+
+## Skill Directory Structure
+
+Each skill is a folder whose entry point is `SKILL.md`. Optional sibling directories carry on-demand resources:
+
+```
+my-skill/
+├── SKILL.md           # required entry point
+├── scripts/           # executable code the agent can run
+├── references/        # additional documentation loaded on demand
+└── assets/            # static resources (templates, images, data files)
+```
+
+Keep `SKILL.md` focused — move detailed reference material into `references/`. The agent loads supporting files progressively, only when the body of `SKILL.md` directs it to.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
+
+---
+
+## SKILL.md Frontmatter
+
+Each skill begins with YAML frontmatter. The Agent Skills standard recognises six fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Skill identifier. Lowercase letters, numbers, and hyphens only. Must match the parent folder name. |
+| `description` | Yes | What the skill does and when to use it. Used by the agent to determine relevance. |
+| `license` | No | License name or reference to a bundled license file. |
+| `compatibility` | No | Environment requirements (system packages, network access, etc.). |
+| `metadata` | No | Arbitrary key-value mapping for additional metadata. |
+| `disable-model-invocation` | No | When `true`, the skill is only included when explicitly invoked via `/skill-name`. |
+
+No other fields are part of the standard. Adding fields outside this set introduces foreign-platform dialect and breaks portability.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
+
+---
+
+## Naming and Descriptions
+
+**Naming** — kebab-case, lowercase letters/numbers/hyphens only, must match the parent folder. Prefer verb-noun or gerund forms (`deploy-app`, `processing-pdfs`). Avoid generic stems like `helper`, `utils`, `tools`.
+
+**Descriptions** — always third person. The description is read by the agent to decide whether the skill is relevant.
+
+- Good: "Deploys the application to staging or production environments. Use when deploying code or when the user mentions deployment, releases, or environments."
+- Bad: "I can help you deploy the application."
+- Bad: "You can use this to deploy."
+
+Include three things in every description: (1) what it does, (2) when to use it, (3) the trigger terms an agent might match against.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Frontmatter fields"*
+
+---
+
+## Progressive Disclosure
+
+`SKILL.md` is the index; detailed content lives in supporting files loaded on demand.
+
+**Pattern 1 — phased reference loads:**
+
+```
+## Phase 1: Analyze
+Read references/criteria.md for the evaluation rubric.
+```
+
+**Pattern 2 — keep references focused:**
+Each reference file has one job and is cited explicitly from the phase that needs it. Do not load every reference in Phase 1.
+
+Keep `SKILL.md` under 500 lines. Move detail to `references/`. Reference supporting files explicitly so the agent knows what they contain.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
+
+---
+
+## Bundled Paths and Script Invocation
+
+When `SKILL.md` references a bundled file (script, template, reference), use a **relative path from the skill root**:
+
+```
+Run the deployment script: scripts/deploy.sh <environment>
+```
+
+```
+Read references/skill-format-reference.md for the format specification.
+```
+
+Do not use string-substitution variables to refer to bundled files; the relative-path convention is what the Agent Skills standard guarantees portable across implementations.
+
+Scripts can be written in any language the agent can execute (Bash, Python, JavaScript, etc.). They should be self-contained, include helpful error messages, and handle edge cases gracefully.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills"*
+
+---
+
+## Disabling Automatic Invocation
+
+By default, skills are automatically applied when the agent determines they are relevant. Set `disable-model-invocation: true` to make a skill behave like a traditional slash command — the skill is only included when the user explicitly types `/skill-name` in chat.
+
+Use this for workflows with side effects (commit, deploy, send-message) or for skills the user wants to gate manually.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Disabling automatic invocation"*
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| Explaining what the agent already knows | Wastes tokens; dilutes attention | Delete it |
+| Generic descriptions ("helps with data") | Poor skill discovery | Be specific about what + when + triggers |
+| Inlining reference content in SKILL.md | Context bloat on every invocation | Move to `references/` subdirectory |
+| Hardcoded absolute or project-relative paths | Goes stale; breaks portability | Use relative paths from skill root |
+| Foreign-platform frontmatter fields | Breaks Agent Skills portability | Restrict to the six standard fields |
+| Contradictions between phases | Agent picks one arbitrarily | Review all phases for consistency |
+| Loading every reference in Phase 1 | Defeats progressive disclosure | Load each reference only in the phase that needs it |
+
+*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Optional directories"*

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-evaluation-criteria.md
@@ -1,0 +1,144 @@
+# Skill Evaluation Criteria
+
+Scoring rubric for assessing existing Cursor SKILL.md packages before improvement.
+Source: docs/cursor/skills/agent-skills-guide.md
+
+---
+
+## Contents
+
+- Hard limits table (file length, frontmatter, phases)
+- Bloat indicators table (inlined content, over-specification)
+- Staleness indicators table (deprecated fields, outdated paths)
+- Foreign-platform dialect (auto-fail)
+- Progressive disclosure assessment (phases, reference loading)
+- Quality score rubric (5-dimension scoring 1-10)
+- Evaluation output template
+
+---
+
+## Hard Limits Table
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
+| Reference files | ≤ 200 lines each | reference-files convention |
+| Reference files >100 lines | Must include a `## Contents` table of contents | reference-files convention |
+| `description` field | Present, non-empty, ≤ 1024 chars | Agent Skills specification |
+| `name` field | Present, non-empty, 1-64 chars, kebab-case, matches parent folder | Agent Skills specification |
+| Frontmatter fields | Restricted to the six recognised by the Agent Skills standard | Agent Skills specification |
+| Phase structure | At least one clear phase defined | Agent Skills authoring patterns |
+
+A skill violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
+
+---
+
+## Bloat Indicators Table
+
+| Indicator | Why It Is Bloat |
+|-----------|---------------|
+| Detailed reference content inlined in SKILL.md | Should be in `references/` subdirectory; loaded on demand |
+| All references loaded in phase 1 (not progressive) | Wastes context budget; load references only in the relevant phase |
+| Inline bash analysis commands in plugin skill body | Plugin skills MUST delegate to registered subagents; inline bash is a convention violation |
+| Redundant phase instructions (same guidance repeated) | Dilutes attention; each phase should add distinct value |
+| Over-specified tool restrictions for simple tasks | Correct tool access should be inferred from task type |
+| Explaining standard practices the agent already knows | Agents are already capable; add only novel context |
+| Hardcoded absolute or project-relative paths for bundled files | Will go stale; bundled paths must be relative to the skill root |
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
+
+---
+
+## Staleness Indicators Table
+
+| Indicator | How to Detect |
+|-----------|---------------|
+| Deprecated frontmatter fields | Check field names against the six-field Agent Skills standard |
+| References to removed features or subagents | Verify subagent names and tool features still exist in the project |
+| Outdated discovery paths | Confirm bundled-path references resolve relative to the skill root |
+| Hardcoded file paths in SKILL.md body | Check that referenced bundled paths actually exist |
+| Foreign-platform dialect | See dedicated section below — auto-fail |
+
+*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format"*
+
+---
+
+## Foreign-Platform Dialect (Auto-fail)
+
+The Cursor distribution is product-strict. Apply the following allowlists to the entire skill tree. Anything outside an allowlist is foreign-platform dialect and requires removal during improvement.
+
+| Check | Allowlist (anything else fails) |
+|-------|---------------------------------|
+| Frontmatter fields | Only the six recognised by the Agent Skills standard: `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` |
+| Bundled-path references | Relative paths from the skill root only; no string-substitution variables of any form (no `${...}` or `$NAME` forms inside bundled paths) |
+| Discovery-path references | Only `.cursor/`, `.agents/`, and `~/.cursor/` are recognised; no references to discovery directories or memory files belonging to other agent platforms |
+| Documentation citations | Local Cursor docs and vendor-neutral research only; no citations to product documentation for other agent platforms |
+
+---
+
+## Progressive Disclosure Assessment
+
+| Question | Good | Bad |
+|----------|------|-----|
+| Does SKILL.md stay focused on phase overview? | Phases are concise with file references | All guidance inlined in SKILL.md |
+| Are references loaded per phase, not all upfront? | Each phase reads only its relevant references | Phase 1 loads all references |
+| Are supporting files referenced explicitly? | "Read the relevant supporting file for this phase" | Files exist but never referenced |
+| Is SKILL.md body under 500 lines? | Clean entry point with external depth | Monolithic, all content inline |
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
+
+---
+
+## Quality Score Rubric
+
+Score each dimension 1–10 based on observed issues:
+
+| Dimension | 8-10 (Good) | 4-7 (Mixed) | 1-3 (Bad) |
+|-----------|-------------|-------------|-----------|
+| Conciseness | ≤500 lines SKILL.md, minimal bloat | 500-800 lines, some bloat | >800 lines, heavy bloat |
+| Accuracy | 0 stale references | 1-2 stale refs | 3+ stale refs |
+| Progressive Disclosure | References loaded per-phase | Some misplaced loading | All inlined upfront |
+| Description Quality | Specific what + when + triggers | Vague or incomplete | Missing or generic |
+| Evidence Grounding | References cited per phase | Some references | No references |
+| **Overall** | | | |
+
+---
+
+## Evaluation Output Template
+
+```
+## Skill Evaluation Results
+
+### Files Found
+| File | Lines | Status |
+|------|-------|--------|
+| `./SKILL.md` | 342 | Within 500-line limit |
+
+### Per-File Issues
+
+#### `./SKILL.md`
+
+**Bloat Issues:**
+- Lines 45-100: Reference content inlined (should be in references/ subdirectory)
+
+**Staleness Issues:**
+- Line 12: bundled path uses absolute form — switch to relative-from-skill-root
+
+**Foreign-Platform Dialect:**
+- Line 7: frontmatter field outside the six-field Agent Skills allowlist
+
+**Progressive Disclosure Issues:**
+- Phase 1 loads all 5 reference files at once; load per phase
+
+### Quality Score
+| Dimension | Score (1-10) | Notes |
+|-----------|-------------|-------|
+| Conciseness | 5 | 342 lines, some bloat |
+| Accuracy | 8 | 1 stale path |
+| Progressive Disclosure | 4 | All refs loaded in phase 1 |
+| Description Quality | 7 | Good but missing trigger terms |
+| Evidence Grounding | 6 | Some references but inconsistent |
+| **Overall** | **6** | Needs progressive disclosure fix |
+```

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-format-reference.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-format-reference.md
@@ -1,0 +1,123 @@
+# Skill Format Reference
+
+Technical specification for Cursor SKILL.md format, frontmatter, directory structure, and discovery model.
+Source: docs/cursor/skills/agent-skills-guide.md
+
+---
+
+## Contents
+
+- Frontmatter fields (the Agent Skills open standard)
+- Name validation rules
+- Bundled-path convention (relative paths from skill root)
+- Directory structure
+- Progressive disclosure loading model
+- Skill discovery locations and scope
+
+---
+
+## Frontmatter Fields
+
+The Agent Skills standard, as adopted by Cursor, recognises exactly six frontmatter fields. No other fields are part of the standard.
+
+| Field | Required | Constraints |
+|-------|----------|-------------|
+| `name` | Yes | Lowercase letters, numbers, hyphens only; max 64 chars; must match parent folder name |
+| `description` | Yes | Max 1024 chars; what it does + when to use it; third person; no XML tags |
+| `license` | No | License name or path to a bundled license file |
+| `compatibility` | No | Environment requirements (system packages, network access, etc.) |
+| `metadata` | No | Arbitrary key-value mapping (author, version, etc.) |
+| `disable-model-invocation` | No | `true` = skill only included when explicitly invoked via `/skill-name` |
+
+Frontmatter fields outside this set are foreign-platform dialect and must not appear in Cursor SKILL.md files.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
+
+---
+
+## Name Validation Rules
+
+- 1–64 characters
+- Only lowercase `a-z`, numbers, and hyphens (`-`)
+- Must NOT start or end with `-`
+- Must NOT contain consecutive `--`
+- Must match the parent directory name exactly
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
+
+---
+
+## Bundled-Path Convention
+
+When `SKILL.md` references a bundled file (script, template, reference), use a **relative path from the skill root**:
+
+```
+Run the deployment script: scripts/deploy.sh <environment>
+```
+
+```
+Read references/skill-format-reference.md for the format specification.
+```
+
+```
+Apply the template at assets/templates/config.yaml.
+```
+
+This convention is what the Agent Skills standard guarantees portable across implementations. Do not use string-substitution variables, absolute paths, or project-relative paths for bundled files — relative paths from the skill root are the only portable form.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills" and "Optional directories"*
+
+---
+
+## Directory Structure
+
+```
+my-skill/
+├── SKILL.md                # Required: metadata + instructions (entry point)
+├── references/             # Optional: reference docs loaded on demand
+│   └── guide.md
+├── assets/
+│   └── templates/          # Optional: output templates
+│       └── template.md
+└── scripts/                # Optional: executable scripts the agent can run
+    └── deploy.sh
+```
+
+**Loading behaviour:**
+
+- `SKILL.md` loads when the skill activates.
+- `references/` files load only when the skill body explicitly directs the agent to read them.
+- `assets/` files load only when the skill body explicitly directs the agent to use them.
+- `scripts/` files are executed by the agent, not loaded into context.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
+
+---
+
+## Progressive Disclosure Loading Model
+
+| Level | What loads | When |
+|-------|-----------|------|
+| Startup | `name` + `description` for every discovered skill | Every session |
+| Trigger | Full SKILL.md body | When the skill is invoked (user or agent) |
+| On-demand | Files in `references/`, `assets/`, and any other bundled directories | Only when the skill body directs the agent to read or use them |
+
+Keep SKILL.md under **500 lines**. Move detailed reference material to the `references/` subdirectory. Explicitly reference supporting files from SKILL.md so the agent knows what to load and when.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "How skills work" and "Optional directories"*
+
+---
+
+## Skill Discovery Locations and Scope
+
+Cursor automatically loads skills from these directories:
+
+| Location | Path | Scope |
+|----------|------|-------|
+| Project (open standard) | `.agents/skills/<name>/SKILL.md` | This project — portable across Agent Skills implementations |
+| Project (Cursor-native) | `.cursor/skills/<name>/SKILL.md` | This project — Cursor-specific |
+| User (global) | `~/.cursor/skills/<name>/SKILL.md` | All projects on this machine |
+
+When the same skill name exists in multiple locations, Cursor's own resolution rules apply. For new skills, choose `.cursor/skills/` when the skill is Cursor-specific and `.agents/skills/` when the skill should also be discoverable by other Agent Skills consumers.
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-validation-criteria.md
@@ -1,0 +1,94 @@
+# Skill Validation Criteria
+
+Quality checklist for generated and improved Cursor SKILL.md packages.
+Source: docs/cursor/skills/agent-skills-guide.md
+
+---
+
+## Contents
+
+- Hard limits (auto-fail if violated)
+- Foreign-platform dialect ban (auto-fail if violated)
+- Quality checks (all must pass)
+- Improve-only checks (information preservation, structural)
+- Validation loop instructions
+
+---
+
+## Hard Limits (Auto-fail if violated)
+
+Any skill violating these criteria must be fixed before proceeding:
+
+| Criterion | Threshold | Source |
+|-----------|-----------|--------|
+| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
+| Reference files | ≤ 200 lines each | reference-files convention |
+| Reference files >100 lines | Must include a `## Contents` table of contents | reference-files convention |
+| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags | Agent Skills specification |
+| `name` field | Present, non-empty, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder | Agent Skills specification |
+| Frontmatter fields | Restricted to `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` | Agent Skills specification |
+| Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
+
+*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
+
+---
+
+## Foreign-Platform Dialect Ban (Auto-fail if any present)
+
+The Cursor distribution is product-strict. The skill tree (SKILL.md, references, assets, scripts) must conform to the following allowlists. Anything outside an allowlist is foreign-platform dialect and is forbidden.
+
+| Check | Allowlist (anything else fails) |
+|-------|---------------------------------|
+| Frontmatter fields | Only the six recognised by the Agent Skills standard: `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` |
+| Bundled-path references | Relative paths from the skill root only (e.g., `references/foo.md`, `scripts/deploy.sh`, `assets/templates/foo.yaml`); no string-substitution variables of any form (no `${...}` or `$NAME` forms inside bundled paths) |
+| Discovery-path references | Only `.cursor/`, `.agents/`, and `~/.cursor/` are recognised; no references to discovery directories or memory files belonging to other agent platforms |
+| Documentation citations | Local Cursor docs and vendor-neutral research only; no citations to product documentation for other agent platforms |
+
+---
+
+## Quality Checks (All must pass)
+
+- [ ] Has a self-validation phase that reads the skill's `references/skill-validation-criteria.md`
+- [ ] All bundled-path references in SKILL.md use relative paths from the skill root
+- [ ] `description` written in third person ("Deploys..." not "I deploy..." or "You can use...")
+- [ ] `description` includes what the skill does AND when to use it (trigger terms)
+- [ ] Progressive disclosure applied: references loaded per phase, not all upfront
+- [ ] No reference content inlined in SKILL.md body (should be in `references/` subdirectory)
+- [ ] Each phase instruction is concise (≤10 lines); depth lives in reference files
+- [ ] Reference files cited explicitly so the agent knows what to load and when
+- [ ] `disable-model-invocation: true` set for side-effect workflows (commit, deploy, send)
+- [ ] Prompt engineering strategy applied: skill follows relevant strategy from `references/prompt-engineering-strategies.md`
+- [ ] Behavioral guidelines applied: the skill surfaces assumptions before acting, prefers the simplest adequate path, keeps changes surgical, and defines explicit validation targets
+- [ ] Persuasion cues, if present, stay inside the ethical constraint: they improve compliance with legitimate work only and never weaken safeguards, refusals, or scope boundaries
+- [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
+- [ ] Plugin skill bodies delegate analysis to registered subagents; no inline bash analysis commands
+- [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-guide.md")
+
+---
+
+## If This Is an IMPROVE Operation — Also Check
+
+**Information Preservation:**
+
+- [ ] Evidence-grounded references not removed (citations preserved)
+- [ ] Existing phase structure not flattened
+- [ ] Progressive disclosure references not collapsed into inline content
+
+**Structural:**
+
+- [ ] Reference file ≤200 line limit not violated by merging content; >100-line files have a `## Contents` table of contents
+- [ ] Bundled-path references not broken by renaming or moving files
+
+---
+
+## Validation Loop Instructions
+
+Execute this loop for each generated or improved skill:
+
+1. Evaluate the skill against ALL criteria above (hard limits, foreign-dialect ban, quality checks, and IMPROVE-only checks if applicable).
+2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference.
+3. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation.
+4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
+5. Only proceed to writing skills when ALL criteria pass.
+
+**Do not skip criteria for "minor" violations.** Hard limits and the foreign-dialect ban are absolute.


### PR DESCRIPTION
## Summary

Adds skills support to the `cursor-customizer` plugin — slice E of the umbrella rollout (PRD #77).

- **`agents/skill-evaluator.md`** — Cursor-native subagent that evaluates `.cursor/skills/<name>/SKILL.md` artifacts against the skill-validation criteria (default path per ADR-0003).
- **`skills/create-skill/`** — five-phase orchestration for new skills. Authoring guide and format reference derive from `docs/cursor/skills/agent-skills-guide.md`.
- **`skills/improve-skill/`** — improvement workflow with `skill-evaluation-criteria.md` for gap analysis.
- **`docs-drift-manifest.md`** — slice-E source-doc → reference mappings recorded.

Closes #82.
Tracks PRD #77.

## Test plan

- [x] Banned-token grep clean: `grep -rE '(\$\{CLAUDE_SKILL_DIR\}|CLAUDE\.md|\.claude/|maxTurns:|tools:|paths:|docs\.anthropic\.com/en/docs/claude-code)' plugins/cursor-customizer/{agents/skill-evaluator.md,skills/{create,improve}-skill}` → no matches in slice-authored content.
- [x] Topology parity with `plugins/agent-customizer/skills/{create,improve}-skill/` confirmed.
- [x] Default-path alignment with ADR-0003 (`.cursor/skills/<name>/SKILL.md`) confirmed.

## Notes

- `references/prompt-engineering-strategies.md` is copied verbatim per the per-skill no-symlink mandate; it retains 4 bare "Claude" mentions in prompting-anti-pattern context. Verbatim-copy directive takes precedence; flagged for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)