### PR TITLE
feat(cursor): governance + repo-level integration of cursor-customizer

### DIFF
--- a/.claude/rules/cursor-agent-files.md
+++ b/.claude/rules/cursor-agent-files.md
@@ -1,8 +1,9 @@
 ---
 paths:
   - "plugins/cursor-initializer/agents/*.md"
+  - "plugins/cursor-customizer/agents/*.md"
 ---
-# Cursor Agent File Conventions
+# Cursor-distribution Agent File Conventions
 
 - YAML frontmatter required: `name`, `description`, `model`, `readonly`
 - `model: inherit` — Cursor agents inherit model from parent context

--- a/.claude/rules/cursor-plugin-skills.md
+++ b/.claude/rules/cursor-plugin-skills.md
@@ -1,19 +1,20 @@
 ---
 paths:
   - "plugins/cursor-initializer/skills/*/SKILL.md"
+  - "plugins/cursor-customizer/skills/*/SKILL.md"
 ---
 # Cursor Plugin Skill Conventions
 
-- Analysis phases MUST delegate to agents registered in the plugin's `agents/` directory (currently: `codebase-analyzer`, `rule-domain-detector`, `file-evaluator`)
+- Analysis phases MUST delegate to agents registered in the plugin's `agents/` directory (the registered set varies by plugin — e.g., cursor-initializer uses `codebase-analyzer`, `rule-domain-detector`, `file-evaluator`; cursor-customizer uses `artifact-analyzer` plus per-artifact-type evaluators)
 - Never add inline bash analysis here — subagent delegation keeps the orchestrator context clean
-- Reference agents by registered name (e.g., "Delegate to the `codebase-analyzer` agent with this task:")
+- Reference agents by registered name (e.g., "Delegate to the `artifact-analyzer` agent with this task:")
 - `references/` directory MUST exist alongside SKILL.md and contain evidence-based guidance files
 - `assets/templates/` directory MUST exist alongside SKILL.md and contain output templates
 - Bundled files in Cursor SKILL.md files MUST be referenced with relative paths from the skill root (`references/...`, `assets/templates/...`), not `${CLAUDE_SKILL_DIR}`
 - Self-validation phase MUST read `references/validation-criteria.md` and loop until all checks pass
 - Reference files must be one level deep from SKILL.md — no nested `references/references/` paths
 - Conditional reference loading pattern: "read X only if project uses Y"
-- Currently, init-cursor generates only `.cursor/rules/*.mdc` files; improve-cursor migrates AGENTS.md non-destructively into modular rules when the target project has it (the original AGENTS.md is left intact and the user removes it manually after validation)
+- In `cursor-initializer`: `init-cursor` generates only `.cursor/rules/*.mdc` files; `improve-cursor` migrates AGENTS.md non-destructively into modular rules when the target project has it (the original AGENTS.md is left intact and the user removes it manually after validation). `cursor-customizer` skills do not generate `.cursor/rules/` hierarchies — they CRUD individual artifacts (rules, hooks, skills, subagents) inside an already-initialized project
 - Subagent definitions use `readonly: true`, NOT `tools:` whitelists or `maxTurns:`
 - .mdc frontmatter allows ONLY: `description` (string), `alwaysApply` (boolean), `globs` (string|array)
 - Never use `paths:` in .mdc frontmatter — that is Claude Code specific

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "rodrigo_rjsf@hotmail.com"
   },
   "metadata": {
-    "description": "Multi-plugin marketplace for evidence-based Cursor artifact engineering. Provides plugins for configuration initialization (AGENTS.md, .cursor/rules/) based on academic research and Cursor best practices.",
+    "description": "Multi-plugin marketplace for evidence-based Cursor artifact engineering. Ships the rules-first Cursor distribution as an Initializer/Customizer pair: cursor-initializer bootstraps minimal, scoped .cursor/rules/*.mdc hierarchies; cursor-customizer creates and improves individual Cursor artifacts (rules, hooks, skills, subagents) inside an already-initialized project.",
     "version": "1.0.0",
     "pluginRoot": "plugins"
   },
@@ -13,7 +13,12 @@
     {
       "name": "cursor-initializer",
       "source": "cursor-initializer",
-      "description": "Generate and optimize minimal, scoped AGENTS.md and .cursor/rules/*.mdc configuration files based on academic research and Cursor best practices. Uses subagent-driven analysis for context-efficient file generation."
+      "description": "Evidence-based rules-first initializer and optimizer for Cursor projects. Generates minimal .cursor/rules/*.mdc hierarchies with the right activation mode per rule; non-destructively migrates legacy AGENTS.md when present."
+    },
+    {
+      "name": "cursor-customizer",
+      "source": "cursor-customizer",
+      "description": "Rules-first, product-strict customizer for the Cursor distribution: creates and improves individual Cursor artifacts (rules, hooks, skills, subagents) inside an already-initialized project. Sibling of cursor-initializer."
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ Multi-plugin marketplace for evidence-based agent artifact engineering.
 Multiple plugin distributions and one standalone distribution — each follows its own platform conventions:
 
 - `plugins/agents-initializer/skills/` — Claude Code plugin; delegates analysis to subagents
-- `plugins/cursor-initializer/skills/` — Cursor IDE plugin; delegates analysis to subagents (Cursor-native format)
+- `plugins/cursor-initializer/skills/` — Cursor IDE plugin; rules-first `.cursor/rules/*.mdc` initializer; delegates analysis to subagents (Cursor-native format)
+- `plugins/cursor-customizer/skills/` — Cursor IDE plugin; single-artifact CRUD (rules, hooks, skills, subagents); delegates analysis to subagents (Cursor-native format)
 - `plugins/agent-customizer/skills/` — Claude Code plugin; artifact creation/improvement
 - `skills/` — npx skills add; standalone inline analysis, no agent delegation
 
@@ -28,6 +29,7 @@ Each skill directory contains:
 
 See `plugins/agents-initializer/CLAUDE.md` for plugin-specific conventions.
 See `plugins/cursor-initializer/CLAUDE.md` for cursor-initializer plugin conventions.
+See `plugins/cursor-customizer/CLAUDE.md` for cursor-customizer plugin conventions.
 See `plugins/agent-customizer/CLAUDE.md` for agent-customizer plugin conventions.
 
 ## Knowledge Lookup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Engineering Toolkit
 
-A multi-plugin marketplace providing evidence-based agent artifact engineering. Instead of auto-generating one bloated configuration file, this toolkit creates **minimal, scoped files** following progressive disclosure principles — proven by research to outperform comprehensive auto-generated configurations. Ships as three distributions: a Claude Code plugin (`agents-initializer`), a Cursor IDE plugin (`cursor-initializer`), and a standalone distribution compatible with any AI coding tool.
+A multi-plugin marketplace providing evidence-based agent artifact engineering. Instead of auto-generating one bloated configuration file, this toolkit creates **minimal, scoped files** following progressive disclosure principles — proven by research to outperform comprehensive auto-generated configurations. Ships as Claude Code and Cursor distributions — each an Initializer/Customizer pair — plus a standalone distribution compatible with any AI coding tool.
 
 ## Cost and Model Guidance
 
@@ -21,8 +21,9 @@ the generated files are in place. Treat the first execution as a one-time invest
 | Distribution | Platform | Install Path | Full Documentation |
 |---|---|---|---|
 | `agents-initializer` | Claude Code | Native plugin system | [plugins/agents-initializer/README.md](plugins/agents-initializer/README.md) |
-| `cursor-initializer` | Cursor IDE | Native plugin system | [plugins/cursor-initializer/README.md](plugins/cursor-initializer/README.md) |
 | `agent-customizer` | Claude Code | Native plugin system | [plugins/agent-customizer/README.md](plugins/agent-customizer/README.md) |
+| `cursor-initializer` | Cursor IDE | Native plugin system | [plugins/cursor-initializer/README.md](plugins/cursor-initializer/README.md) |
+| `cursor-customizer` | Cursor IDE | Native plugin system | [plugins/cursor-customizer/README.md](plugins/cursor-customizer/README.md) |
 | Standalone | Any AI tool | `npx skills add` / manual | [skills/README.md](skills/README.md) |
 
 ## Research Foundation
@@ -74,6 +75,16 @@ ln -s ~/src/agent-engineering-toolkit ~/.cursor/plugins/local/agent-engineering-
 
 → See [plugins/cursor-initializer/README.md](plugins/cursor-initializer/README.md) for full setup instructions.
 
+### Cursor IDE — cursor-customizer
+
+```bash
+git clone https://github.com/rodrigorjsf/agent-engineering-toolkit.git ~/src/agent-engineering-toolkit
+mkdir -p ~/.cursor/plugins/local
+ln -s ~/src/agent-engineering-toolkit ~/.cursor/plugins/local/agent-engineering-toolkit
+```
+
+→ See [plugins/cursor-customizer/README.md](plugins/cursor-customizer/README.md) for full setup instructions.
+
 ### npx skills add — Standalone
 
 ```bash
@@ -96,11 +107,17 @@ agent-engineering-toolkit/
 │   │   ├── README.md                # Full plugin documentation
 │   │   ├── skills/                  # 4 skills: init-agents, init-claude, improve-agents, improve-claude
 │   │   └── agents/                  # 3 subagents: codebase-analyzer, scope-detector, file-evaluator
-│   ├── cursor-initializer/          # Cursor IDE plugin — .cursor/rules/*.mdc + AGENTS.md init/improve
+│   ├── cursor-initializer/          # Cursor IDE plugin — rules-first .cursor/rules/*.mdc init/improve (legacy AGENTS.md migration only)
 │   │   ├── .cursor-plugin/plugin.json
 │   │   ├── README.md                # Full plugin documentation
 │   │   ├── skills/                  # 2 skills: init-cursor, improve-cursor
 │   │   └── agents/                  # 3 subagents (Cursor-native format)
+│   ├── cursor-customizer/           # Cursor IDE plugin — single-artifact CRUD (rules, hooks, skills, subagents)
+│   │   ├── .cursor-plugin/plugin.json
+│   │   ├── README.md                # Full plugin documentation
+│   │   ├── docs-drift-manifest.md   # Registry: reference files → source docs
+│   │   ├── agents/                  # artifact-analyzer + per-type evaluators (Cursor-native format)
+│   │   └── skills/                  # 8 skills: create-{type} and improve-{type}
 │   └── agent-customizer/            # Claude Code plugin — artifact creation and improvement
 │       ├── .claude-plugin/plugin.json
 │       ├── README.md                # Full plugin documentation


### PR DESCRIPTION
## Summary

Slice H of the cursor-customizer rollout (PRD #77). Completes the Cursor distribution as the Initializer/Customizer pair at the repo level — four atomic commits, each scoped to one concern.

- **Governance** (`.claude/rules/cursor-*.md`): extends `cursor-agent-files.md` and `cursor-plugin-skills.md` `paths:` globs to cover `plugins/cursor-customizer/`. No new `cursor-customizer-*.md` rules created (constraint: avoid duplication; expand existing rules instead).
- **Cursor marketplace** (`.cursor-plugin/marketplace.json`): advertises `cursor-customizer` alongside `cursor-initializer`; rewrites `metadata.description` to drop "AGENTS.md" wording and reflect the rules-first posture set by ADR-0001 + slice B (#79). Also synced the stale `cursor-initializer` entry description.
- **Root `README.md`**: adds installation entry for `cursor-customizer`; reframes the Cursor distribution as the Initializer/Customizer pair, matching the Claude Code distribution presentation.
- **Root `CLAUDE.md`**: adds `plugins/cursor-customizer/skills/` to the Structure section; adds a one-line pointer to `plugins/cursor-customizer/CLAUDE.md`.
- `.claude-plugin/marketplace.json` (Claude Code marketplace) intentionally untouched — `cursor-customizer` is a Cursor plugin only.

Closes #85.
Tracks PRD #77.

## Test plan

- [x] Governance globs cover cursor-customizer: `grep -E 'plugins/cursor-customizer/' .claude/rules/cursor-agent-files.md .claude/rules/cursor-plugin-skills.md` → matched in both.
- [x] Cursor marketplace lists both plugins: `jq -r '.plugins[].name' .cursor-plugin/marketplace.json` → `cursor-initializer`, `cursor-customizer`.
- [x] `metadata.description` no longer contains "AGENTS.md".
- [x] Claude Code marketplace untouched: `git diff origin/development -- .claude-plugin/marketplace.json` → empty.
- [x] Banned-token grep clean across `plugins/cursor-initializer/` + `plugins/cursor-customizer/`.
- [x] Atomic shape: exactly 4 commits (`rules` / `marketplace` / `readme` / `claude`).

## Notes

- README install block for `cursor-customizer` is identical to `cursor-initializer`'s (single clone + symlink to `~/.cursor/plugins/local/`) — both plugins ship in the same repo, so one clone makes both available. Pattern matches the Claude Code distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)