### PR TITLE
feat(cursor-customizer): quality gate (drift-checker + meta-skill)

### DIFF
--- a/.claude/skills/cursor-customizer-quality-gate/SKILL.md
+++ b/.claude/skills/cursor-customizer-quality-gate/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: cursor-customizer-quality-gate
+description: "Performs a complete quality gate analysis of the cursor-customizer plugin. Validates all artifacts against documented Cursor-platform conventions, checks intra-plugin shared-copy parity, runs docs drift detection, evaluates red-green test scenarios, and generates a structured findings report compatible with /prp-core:prp-prd when issues are found."
+---
+
+# Cursor-Customizer Quality Gate Analysis
+
+Perform a complete quality gate of the cursor-customizer plugin. This meta-skill validates every
+artifact against documented Cursor-platform conventions, verifies intra-plugin shared-copy
+consistency, detects docs drift via the plugin's own `docs-drift-checker` subagent, and evaluates
+whether all 8 skills are structurally capable of passing all test scenarios.
+
+**Scope:** `plugins/cursor-customizer/` — 8 SKILL.md files, 6 Cursor-native subagent files,
+30+ reference files, 8 template directories, plugin manifest, and the docs drift manifest.
+
+**Convention sources:**
+`.claude/rules/cursor-plugin-skills.md`, `.claude/rules/reference-files.md`,
+`plugins/cursor-customizer/CLAUDE.md`, `docs/adr/0001-cursor-distribution-rules-first.md`,
+`docs/adr/0002-product-strict-research-foundation.md`,
+`docs/adr/0003-cursor-skills-default-path.md`.
+
+**Test scenarios:** `.claude/PRPs/tests/scenarios/` — `create-simple-artifact.md`,
+`create-complex-artifact.md`, `improve-bloated-artifact.md`, `improve-reasonable-artifact.md`
+(four families × four artifact types each).
+
+**Report output:** `.specs/reports/cursor-customizer-quality-gate-[YYYY-MM-DD]-findings.md`
+(only generated when issues are found).
+
+---
+
+## Phase 1: Static Artifact Inspection
+
+Read `.claude/skills/cursor-customizer-quality-gate/agents/artifact-inspector.md`. Skip the YAML
+frontmatter block (the content between the first and second `---` delimiters) — it is documentation
+metadata only. Pass the remaining content as the task to a general-purpose agent via the Task tool.
+
+**Wait for completion.** Collect structured output as `artifact_report`, which contains:
+- Compliance matrix per category (Plugin SKILL.md × 8, Cursor Subagents × 6, Reference Files,
+  Templates × 8 dirs, Plugin Manifest, Drift Manifest)
+- Violation list: file path, rule violated, rule source, severity (CRITICAL/MAJOR/MINOR), evidence
+
+---
+
+## Phase 2: Intra-Plugin Shared-Copy Parity
+
+Read `.claude/skills/cursor-customizer-quality-gate/agents/parity-checker.md`. Skip the YAML
+frontmatter block. Pass the remaining content as the task to a general-purpose agent via the Task tool.
+
+**Wait for completion.** Collect structured output as `parity_report`, which contains:
+- Parity matrix: 19 shared file groups with MATCH/MISMATCH status
+- Divergence list: file pair, nature of difference, diff excerpt
+
+---
+
+## Phase 3: Docs Drift Detection
+
+Delegate to the existing `docs-drift-checker` subagent registered in the cursor-customizer plugin:
+`plugins/cursor-customizer/agents/docs-drift-checker.md`.
+
+The subagent's frontmatter is Cursor-native and forbids spawning other agents. Skip the YAML
+frontmatter block. Pass the remaining content as the task to a general-purpose agent via the
+Task tool, with this appended instruction:
+
+> **Manifest to check:** Read `plugins/cursor-customizer/docs-drift-manifest.md` and verify all
+> source documents and section attributions it cites for every reference file under
+> `plugins/cursor-customizer/skills/*/references/`.
+
+**Wait for completion.** Collect structured output as `drift_report`, which contains:
+- Per-row drift status: `{reference_file, source_doc, cited_range, drift_status, evidence}`
+- Inventory audit: any `UNREGISTERED` or `MISSING_FILE` entries
+- Overall status: `CLEAN` or `DRIFT_DETECTED`
+
+---
+
+## Phase 4: Red-Green Scenario Evaluation
+
+Read `.claude/skills/cursor-customizer-quality-gate/agents/scenario-evaluator.md`. Skip the YAML
+frontmatter block. Use the remaining content as base evaluator instructions.
+
+**Spawn all 4 agents simultaneously in a single response** using the Task tool (one call per scenario
+— do not wait between them). For each agent, combine the scenario-evaluator instructions with this
+appended instruction:
+
+> **Your scenario to evaluate:** Read the scenario file at `[SCENARIO_PATH]` and evaluate the
+> cursor-customizer plugin version of all 4 artifact types covered by it.
+
+| Agent | Scenario Path |
+|-------|--------------|
+| Agent 1 | `.claude/PRPs/tests/scenarios/create-simple-artifact.md` |
+| Agent 2 | `.claude/PRPs/tests/scenarios/create-complex-artifact.md` |
+| Agent 3 | `.claude/PRPs/tests/scenarios/improve-bloated-artifact.md` |
+| Agent 4 | `.claude/PRPs/tests/scenarios/improve-reasonable-artifact.md` |
+
+**Wait for all 4 to complete.** Collect outputs as `scenario_reports[1..4]`. Each contains:
+- Scenario ID, target skills, RED baseline description
+- GREEN assessment per artifact type: PASS / FAIL / PARTIAL
+- Gap list: guidance missing from skill that would cause a failure
+
+---
+
+## Phase 5: Findings Synthesis
+
+Aggregate all outputs from Phases 1–4.
+
+Read `.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md` Sections
+`## Plugin SKILL.md Checks`, `## Cursor Subagent Checks`, `## Reference File Checks`,
+`## Template File Checks`, `## Intra-Plugin Parity Checks`, `## Docs Drift Checks`,
+`## Red-Green Scenario Checks`, `## Plugin Manifest Checks`, and
+`## Known-Accepted Exceptions`. Cross-reference those category headings against Phase 1–4 results
+to confirm full coverage. Apply the documented known-accepted exceptions before classifying
+findings — those exceptions must NOT appear as violations in the final report.
+
+Compute and display the **Quality Gate Dashboard**:
+
+```
+Quality Gate Dashboard — cursor-customizer [DATE]
+═══════════════════════════════════════════════════════════
+Category                         Checks  Passed  Failed  Status
+─────────────────────────────────────────────────────────────
+Static Artifact Compliance          [N]    [N]     [N]   [PASS/FAIL]
+Intra-Plugin Parity                  19    [N]     [N]   [PASS/FAIL]
+Docs Drift                          [N]    [N]     [N]   [PASS/FAIL]
+Red-Green Scenario Coverage          16    [N]     [N]   [PASS/FAIL]
+Plugin Manifest                       3    [N]     [N]   [PASS/FAIL]
+─────────────────────────────────────────────────────────────
+OVERALL                             [N]    [N]     [N]   [PASS/FAIL]
+═══════════════════════════════════════════════════════════
+```
+
+**If all checks pass:**
+> Quality Gate PASSED — All [N] checks passed. All artifacts comply with documented
+> cursor-customizer conventions and all test scenarios evaluate as GREEN.
+
+**Stop here. Do NOT write any report file.**
+
+**If any checks fail:** generate
+`.specs/reports/cursor-customizer-quality-gate-[YYYY-MM-DD]-findings.md`.
+
+Read the `## Report Template` section from the criteria reference for the exact document structure.
+
+For each finding, document: Artifact, Rule Violated, Rule Source, Current State, Expected State,
+Impact, Proposed Fix. Group findings into Improvement Areas. Close with a PRD Brief section
+pre-formatted for `/prp-core:prp-prd`.
+
+After writing the file, report:
+> Quality Gate FAILED — [N] finding(s) across [N] category(ies).
+> Findings report: `.specs/reports/cursor-customizer-quality-gate-[DATE]-findings.md`
+> Next step: Run `/prp-core:prp-prd` with this findings file to create a remediation PRD.
+
+---
+
+## Regression Checkpoint
+
+Before declaring the gate complete, confirm the following against
+`docs/compliance/regression-prevention-workflow.md` (where applicable):
+
+1. **Drift manifest current** — if any cursor-customizer reference file was modified during this
+   session, verify its row in `plugins/cursor-customizer/docs-drift-manifest.md` still reflects
+   the correct source path and cited section/range.
+2. **Parity families intact** — if any shared-copy reference or template was changed, verify all
+   copies in the parity family remain in sync per the parity matrix in Phase 2.
+3. **Cursor frontmatter posture intact** — every file in `plugins/cursor-customizer/agents/`
+   still uses Cursor-native frontmatter exclusively (`name`, `description`, `model: inherit`,
+   `readonly: true`); none has been promoted to include `tools:`, `maxTurns:`, or `paths:`.
+4. **No Claude-Code contamination** — no slice-authored cursor-customizer artifact contains
+   banned tokens (see `## Product-Strict Textual Compliance` in the criteria reference), with
+   the documented known-accepted exceptions applied.
+
+If any item above is unresolved, file a follow-up issue before merging.

--- a/.claude/skills/cursor-customizer-quality-gate/agents/artifact-inspector.md
+++ b/.claude/skills/cursor-customizer-quality-gate/agents/artifact-inspector.md
@@ -1,0 +1,168 @@
+---
+name: artifact-inspector
+description: "Inspects all artifacts in the cursor-customizer plugin for static compliance against documented Cursor-platform conventions. Returns a structured compliance report with category summaries and violation details."
+tools: Read, Grep, Glob, Bash
+model: sonnet
+maxTurns: 20
+---
+
+# Artifact Inspector — cursor-customizer
+
+You are a compliance auditor for the cursor-customizer plugin. Inspect every plugin artifact
+against its documented Cursor-platform conventions and return a structured compliance report.
+Use bash commands to measure files and verify content patterns.
+
+**Convention sources to read first:**
+- `.claude/rules/cursor-plugin-skills.md`
+- `.claude/rules/reference-files.md`
+- `plugins/cursor-customizer/CLAUDE.md`
+- `docs/adr/0002-product-strict-research-foundation.md`
+- `.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md`
+
+The criteria reference enumerates every check, threshold, and severity. Follow it exactly. Apply
+the documented known-accepted exceptions before reporting violations — exceptions listed in the
+criteria reference's `## Known-Accepted Exceptions` section must NOT appear as violations.
+
+---
+
+## Inspection Checklist
+
+### 1. Plugin SKILL.md Files
+
+Inspect all 8 files in `plugins/cursor-customizer/skills/*/SKILL.md`:
+
+| Check | Rule | How to Verify |
+|-------|------|--------------|
+| YAML frontmatter has `name` and `description` | Required fields | Read file header |
+| `name` ≤ 64 chars, pattern `[a-z0-9-]+` | Naming constraint | `wc -c` on name value |
+| `description` ≤ 1024 chars, non-empty, no XML tags | Description constraint | `wc -c` on description value |
+| Body < 500 lines total | Size limit | `wc -l` on file |
+| Uses relative paths for bundled files (`references/...`, `assets/templates/...`) | Cursor path convention | `grep '\$\{CLAUDE_SKILL_DIR\}'` — must NOT match |
+| Create skills delegate to `artifact-analyzer` | Required delegation | `grep artifact-analyzer` |
+| Improve skills delegate to a Cursor-native type-specific evaluator (`skill-evaluator`, `hook-evaluator`, `rule-evaluator`, `subagent-evaluator`) | Required delegation | `grep -E 'skill-evaluator\|hook-evaluator\|rule-evaluator\|subagent-evaluator'` |
+| No inline bash analysis blocks (plugin skills must not run bash for analysis) | Prohibited | Inspect for shell code blocks performing codebase scans |
+| Self-validation phase references `*-validation-criteria.md` | Required | `grep validation-criteria` |
+| `references/` directory exists alongside | Directory required | `ls` check |
+| `assets/templates/` directory exists alongside | Directory required | `ls` check |
+| References one level deep — no nested `references/references/` paths | Required | `grep 'references/references'` |
+
+### 2. Cursor Subagent Files
+
+Inspect all files in `plugins/cursor-customizer/agents/*.md`:
+
+| Check | Rule | How to Verify |
+|-------|------|--------------|
+| YAML frontmatter present with `name` and `description` | Required | Read `---` delimiters |
+| `model` field equals `inherit` | Cursor requirement | `grep -E '^model:\s*inherit'` |
+| `readonly` field equals `true` | Cursor requirement | `grep -E '^readonly:\s*true'` |
+| NO `tools:` field present | Cursor constraint | `grep -E '^tools:'` — must have 0 matches |
+| NO `maxTurns:` field present | Cursor constraint | `grep -E '^maxTurns:'` — must have 0 matches |
+| NO `paths:` field present | Cursor constraint | `grep -E '^paths:'` — must have 0 matches |
+| `model` value is exactly `inherit` (no `sonnet`, `opus`, `haiku`, `claude-*` literals) | Cursor constraint | `grep -E '^model:\s*(sonnet|opus|haiku|claude-)'` — must have 0 matches |
+| No agent-spawning instructions in body | Cannot spawn sub-agents | Inspect for "delegate to", "spawn", "Task tool" language |
+
+### 3. Reference Files
+
+Inspect all files matching `plugins/cursor-customizer/skills/*/references/*.md`:
+
+| Check | Rule | How to Verify |
+|-------|------|--------------|
+| ≤ 200 lines | Hard limit | `wc -l` — flag any file exceeding 200 |
+| `## Contents` TOC present if file > 100 lines | Required | `grep '## Contents'` for files > 100 lines |
+| Source attribution present (`Source:` or `Sources:`) | Required | `grep -i '^Source'` |
+| Content framed as instructions ("do this", "check for"), not documentation prose | Required | Inspect framing |
+| No nested reference imports within file | Prohibited | `grep 'references/'` within file content |
+
+### 4. Template Files
+
+Verify required template files exist using `ls`:
+
+| Skill | Required Templates |
+|-------|-------------------|
+| `create-skill/assets/templates/` | `skill-md.md` |
+| `improve-skill/assets/templates/` | `skill-md.md` |
+| `create-hook/assets/templates/` | `hook-config.md` |
+| `improve-hook/assets/templates/` | `hook-config.md` |
+| `create-rule/assets/templates/` | `cursor-rule-always.mdc`, `cursor-rule-globs.mdc`, `cursor-rule-description.mdc` |
+| `improve-rule/assets/templates/` | `cursor-rule-always.mdc`, `cursor-rule-globs.mdc`, `cursor-rule-description.mdc` |
+| `create-subagent/assets/templates/` | `subagent-definition.md` |
+| `improve-subagent/assets/templates/` | `subagent-definition.md` |
+
+For each template, verify:
+
+- `.mdc` rule templates use ONLY Cursor-native frontmatter keys: `description`, `alwaysApply`, `globs`. Reject any `paths:` key as Claude-specific.
+- `subagent-definition.md` template uses ONLY Cursor-native subagent frontmatter (`name`, `description`, `model: inherit`, `readonly: true`). Reject `tools:`, `maxTurns:`, `paths:`, or any literal model alias.
+- HTML comment metadata block present (`<!-- TEMPLATE: ... -->`).
+- Bracket placeholder convention used (`[PLACEHOLDER_NAME]`).
+
+### 5. Plugin Manifest
+
+Inspect `plugins/cursor-customizer/.cursor-plugin/plugin.json`:
+
+| Check | Rule | How to Verify |
+|-------|------|--------------|
+| `name` field equals `cursor-customizer` | Name must match directory | Parse JSON |
+| `description` field non-empty | Required | Parse JSON |
+| Valid JSON | Structural validity | `python3 -m json.tool` |
+
+### 6. Drift Manifest Completeness
+
+Inspect `plugins/cursor-customizer/docs-drift-manifest.md`:
+
+| Check | Rule | How to Verify |
+|-------|------|--------------|
+| Every file under `plugins/cursor-customizer/skills/*/references/*.md` has at least one corresponding manifest entry | Required | List references with `find`, then `grep` each file basename in the manifest |
+| Every reference path mentioned in the manifest exists on disk | Required | Extract reference paths from the manifest, `ls` each |
+| Each entry declares at least one source document (Cursor source under `docs/cursor/`, Industry Research file, or a verbatim-copy upstream) | Required | Inspect entry rows |
+
+### 7. Product-Strict Textual Compliance
+
+Run a banned-token grep across slice-authored content under `plugins/cursor-customizer/`:
+
+```bash
+grep -rnE '(\$\{CLAUDE_SKILL_DIR\}|CLAUDE\.md|\.claude/|maxTurns:|tools:|paths:|docs\.anthropic\.com/en/docs/claude-code)' plugins/cursor-customizer/agents/ plugins/cursor-customizer/skills/
+```
+
+Apply the `## Known-Accepted Exceptions` from the criteria reference before reporting hits — those
+specific lines are pre-approved and must NOT be flagged.
+
+After applying exceptions, the remaining hit count must be zero. Any remaining hit is a MAJOR
+violation per ADR-0002.
+
+---
+
+## Output Format
+
+Return exactly this structure:
+
+```
+## Artifact Inspection Report — cursor-customizer
+
+### Compliance Summary
+| Category | Files Checked | Checks Run | Passed | Failed |
+|----------|--------------|-----------|--------|--------|
+| Plugin SKILL.md (8 files) | 8 | [N] | [N] | [N] |
+| Cursor Subagent Files (6 files) | 6 | [N] | [N] | [N] |
+| Reference Files ([N] files) | [N] | [N] | [N] | [N] |
+| Template Files | 8 dirs | [N] | [N] | [N] |
+| Plugin Manifest | 1 | [N] | [N] | [N] |
+| Drift Manifest | 1 | [N] | [N] | [N] |
+| Product-Strict Compliance | [N] paths | [N] | [N] | [N] |
+| **TOTAL** | | [N] | [N] | [N] |
+
+### Violations Found
+[If none: "No violations — all artifacts comply."]
+
+For each violation:
+**V[NNN]** | Severity: [CRITICAL/MAJOR/MINOR]
+- File: [path]
+- Rule: [exact rule text]
+- Source: [rule file and section]
+- Evidence: [measurement or quote showing the violation]
+- Fix: [specific corrective action]
+```
+
+**Severity guide:**
+- CRITICAL: hard limit violation (file > 200 lines, `tools:` or `maxTurns:` or `paths:` in a Cursor subagent, missing required directory, wrong delegation, manifest entry missing for an existing reference file)
+- MAJOR: structural convention violated (`${CLAUDE_SKILL_DIR}` in a cursor skill, `paths:` in a `.mdc` template, banned token in slice-authored content after exceptions applied, parity-eligible file not present in both copies)
+- MINOR: quality convention violated (missing source attribution, missing TOC on long file)

--- a/.claude/skills/cursor-customizer-quality-gate/agents/parity-checker.md
+++ b/.claude/skills/cursor-customizer-quality-gate/agents/parity-checker.md
@@ -1,0 +1,221 @@
+---
+name: parity-checker
+description: "Verifies that intentionally shared reference files and templates stay byte-identical across their intended copies within the cursor-customizer plugin."
+tools: Read, Grep, Glob, Bash
+model: sonnet
+maxTurns: 15
+---
+
+# Parity Checker — cursor-customizer
+
+You are an intra-plugin consistency auditor for the cursor-customizer plugin. Verify that all
+intentionally shared files remain byte-identical across their declared copy families. Use
+`md5sum` to compare files efficiently, then `diff` only when a divergence is detected.
+
+**Rule sources:**
+- `.claude/rules/reference-files.md` — "Explicitly shared references MUST have identical content across their intended copies"
+- `plugins/cursor-customizer/CLAUDE.md` — shared references are copied (not symlinked) into each skill; copies must remain in sync
+- `plugins/cursor-customizer/docs-drift-manifest.md` — declares which references are verbatim copies and which are derived
+
+A group passes parity if all files in the `md5sum` output show the same hash. A group fails if
+any file in the group has a different hash.
+
+---
+
+## Parity Groups
+
+### Group 1: prompt-engineering-strategies.md (8 copies — verbatim-copy from agent-customizer)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-skill/references/prompt-engineering-strategies.md \
+       plugins/cursor-customizer/skills/improve-skill/references/prompt-engineering-strategies.md \
+       plugins/cursor-customizer/skills/create-hook/references/prompt-engineering-strategies.md \
+       plugins/cursor-customizer/skills/improve-hook/references/prompt-engineering-strategies.md \
+       plugins/cursor-customizer/skills/create-rule/references/prompt-engineering-strategies.md \
+       plugins/cursor-customizer/skills/improve-rule/references/prompt-engineering-strategies.md \
+       plugins/cursor-customizer/skills/create-subagent/references/prompt-engineering-strategies.md \
+       plugins/cursor-customizer/skills/improve-subagent/references/prompt-engineering-strategies.md
+```
+
+### Group 2: behavioral-guidelines.md (create-skill ↔ improve-skill)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-skill/references/behavioral-guidelines.md \
+       plugins/cursor-customizer/skills/improve-skill/references/behavioral-guidelines.md
+```
+
+### Group 3: skill-authoring-guide.md (create-skill ↔ improve-skill)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-skill/references/skill-authoring-guide.md \
+       plugins/cursor-customizer/skills/improve-skill/references/skill-authoring-guide.md
+```
+
+### Group 4: skill-format-reference.md (create-skill ↔ improve-skill)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-skill/references/skill-format-reference.md \
+       plugins/cursor-customizer/skills/improve-skill/references/skill-format-reference.md
+```
+
+### Group 5: skill-validation-criteria.md (create-skill ↔ improve-skill)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-skill/references/skill-validation-criteria.md \
+       plugins/cursor-customizer/skills/improve-skill/references/skill-validation-criteria.md
+```
+
+### Group 6: hook-authoring-guide.md (create-hook ↔ improve-hook)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-hook/references/hook-authoring-guide.md \
+       plugins/cursor-customizer/skills/improve-hook/references/hook-authoring-guide.md
+```
+
+### Group 7: hook-events-reference.md (create-hook ↔ improve-hook)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-hook/references/hook-events-reference.md \
+       plugins/cursor-customizer/skills/improve-hook/references/hook-events-reference.md
+```
+
+### Group 8: hook-validation-criteria.md (create-hook ↔ improve-hook)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-hook/references/hook-validation-criteria.md \
+       plugins/cursor-customizer/skills/improve-hook/references/hook-validation-criteria.md
+```
+
+### Group 9: rule-authoring-guide.md (create-rule ↔ improve-rule)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-rule/references/rule-authoring-guide.md \
+       plugins/cursor-customizer/skills/improve-rule/references/rule-authoring-guide.md
+```
+
+### Group 10: rule-validation-criteria.md (create-rule ↔ improve-rule)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-rule/references/rule-validation-criteria.md \
+       plugins/cursor-customizer/skills/improve-rule/references/rule-validation-criteria.md
+```
+
+### Group 11: subagent-authoring-guide.md (create-subagent ↔ improve-subagent)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-subagent/references/subagent-authoring-guide.md \
+       plugins/cursor-customizer/skills/improve-subagent/references/subagent-authoring-guide.md
+```
+
+### Group 12: subagent-config-reference.md (create-subagent ↔ improve-subagent)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-subagent/references/subagent-config-reference.md \
+       plugins/cursor-customizer/skills/improve-subagent/references/subagent-config-reference.md
+```
+
+### Group 13: subagent-validation-criteria.md (create-subagent ↔ improve-subagent)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-subagent/references/subagent-validation-criteria.md \
+       plugins/cursor-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
+```
+
+### Group 14: Template cursor-rule-always.mdc (create-rule ↔ improve-rule)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-rule/assets/templates/cursor-rule-always.mdc \
+       plugins/cursor-customizer/skills/improve-rule/assets/templates/cursor-rule-always.mdc
+```
+
+### Group 15: Template cursor-rule-globs.mdc (create-rule ↔ improve-rule)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-rule/assets/templates/cursor-rule-globs.mdc \
+       plugins/cursor-customizer/skills/improve-rule/assets/templates/cursor-rule-globs.mdc
+```
+
+### Group 16: Template cursor-rule-description.mdc (create-rule ↔ improve-rule)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-rule/assets/templates/cursor-rule-description.mdc \
+       plugins/cursor-customizer/skills/improve-rule/assets/templates/cursor-rule-description.mdc
+```
+
+### Group 17: Template hook-config.md (create-hook ↔ improve-hook)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-hook/assets/templates/hook-config.md \
+       plugins/cursor-customizer/skills/improve-hook/assets/templates/hook-config.md
+```
+
+### Group 18: Template skill-md.md (create-skill ↔ improve-skill)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-skill/assets/templates/skill-md.md \
+       plugins/cursor-customizer/skills/improve-skill/assets/templates/skill-md.md
+```
+
+### Group 19: Template subagent-definition.md (create-subagent ↔ improve-subagent)
+
+```bash
+md5sum plugins/cursor-customizer/skills/create-subagent/assets/templates/subagent-definition.md \
+       plugins/cursor-customizer/skills/improve-subagent/assets/templates/subagent-definition.md
+```
+
+---
+
+## Interpreting Results
+
+For each group, all `md5sum` output rows must show the **same** hash. If any hash differs:
+
+1. Run `diff [file1] [file2]` for the diverging files.
+2. Classify severity:
+   - **MAJOR** — content divergence; affects analysis accuracy or output quality.
+   - **MINOR** — whitespace-only or trailing-newline difference.
+3. Identify which copy is canonical (per the manifest's "verbatim copy" / "identical to" notes —
+   the upstream `agent-customizer` copy is canonical for `prompt-engineering-strategies.md` and
+   `behavioral-guidelines.md`; otherwise the create-* copy is canonical for create/improve pairs).
+
+---
+
+## Output Format
+
+Return exactly this structure:
+
+```
+## Parity Check Report — cursor-customizer
+
+### Parity Matrix
+| Group | File | Copies | Status |
+|-------|------|--------|--------|
+| 1 | prompt-engineering-strategies.md | 8 | MATCH/MISMATCH |
+| 2 | behavioral-guidelines.md | 2 | MATCH/MISMATCH |
+| 3 | skill-authoring-guide.md | 2 | MATCH/MISMATCH |
+| 4 | skill-format-reference.md | 2 | MATCH/MISMATCH |
+| 5 | skill-validation-criteria.md | 2 | MATCH/MISMATCH |
+| 6 | hook-authoring-guide.md | 2 | MATCH/MISMATCH |
+| 7 | hook-events-reference.md | 2 | MATCH/MISMATCH |
+| 8 | hook-validation-criteria.md | 2 | MATCH/MISMATCH |
+| 9 | rule-authoring-guide.md | 2 | MATCH/MISMATCH |
+| 10 | rule-validation-criteria.md | 2 | MATCH/MISMATCH |
+| 11 | subagent-authoring-guide.md | 2 | MATCH/MISMATCH |
+| 12 | subagent-config-reference.md | 2 | MATCH/MISMATCH |
+| 13 | subagent-validation-criteria.md | 2 | MATCH/MISMATCH |
+| 14 | template cursor-rule-always.mdc | 2 | MATCH/MISMATCH |
+| 15 | template cursor-rule-globs.mdc | 2 | MATCH/MISMATCH |
+| 16 | template cursor-rule-description.mdc | 2 | MATCH/MISMATCH |
+| 17 | template hook-config.md | 2 | MATCH/MISMATCH |
+| 18 | template skill-md.md | 2 | MATCH/MISMATCH |
+| 19 | template subagent-definition.md | 2 | MATCH/MISMATCH |
+
+### Divergences Found
+[If none: "No divergences — all shared files are byte-identical across their intended copies."]
+
+For each divergence:
+**P[NNN]** | Severity: [MAJOR/MINOR]
+- Files: [list of diverging paths]
+- Nature: [content, whitespace, structure]
+- Diff excerpt: [key lines that differ]
+- Fix: [which copy is canonical and what update is needed]
+```

--- a/.claude/skills/cursor-customizer-quality-gate/agents/scenario-evaluator.md
+++ b/.claude/skills/cursor-customizer-quality-gate/agents/scenario-evaluator.md
@@ -1,0 +1,143 @@
+---
+name: scenario-evaluator
+description: "Evaluates a test scenario against cursor-customizer skill instructions to determine if the skill is structurally capable of producing a passing output across all 4 artifact types (skill, hook, rule, subagent)."
+tools: Read, Grep, Glob, Bash
+model: sonnet
+maxTurns: 15
+---
+
+# Scenario Evaluator — cursor-customizer
+
+You are a test analyst for the cursor-customizer plugin. Evaluate a specific test scenario to
+determine whether the current skill instructions and references are sufficient to produce output
+that passes all criteria — across all 4 artifact types (skill, hook, rule, subagent) at the
+Cursor-native target.
+
+This is a **structural dry-run**: trace through skill phases and assess whether guidance would
+lead to correct output, without actually executing the skill.
+
+**Cursor-specific output expectations:**
+- Generated skills land at `.cursor/skills/` by default per ADR-0003 (or `.agents/skills/` for projects that opt in to portability).
+- Generated subagents use the four-key Cursor-native frontmatter only: `name`, `description`, `model: inherit`, `readonly: true`. Foreign-platform keys (`tools:`, `maxTurns:`, `paths:`, literal model aliases such as `sonnet`/`opus`/`haiku` or specific model IDs) are explicitly rejected per ADR-0002.
+- Generated rules are `.cursor/rules/*.mdc` files with frontmatter limited to `description`, `alwaysApply`, `globs`. The Claude-specific `paths:` key is rejected.
+- Generated hooks target Cursor's native event vocabulary and configuration shape per `docs/cursor/hooks/hooks-guide.md`.
+- No artifact may contain references to `${CLAUDE_SKILL_DIR}`, `CLAUDE.md`, `.claude/`, or `docs.anthropic.com/en/docs/claude-code` (per ADR-0002 product-strict posture).
+
+---
+
+## Evaluation Process
+
+### Step 1: Load the Scenario
+
+Read the scenario file at the path provided in your instructions. Extract:
+- Scenario ID
+- Skills under test (which `create-*` or `improve-*` variants of cursor-customizer)
+- Scenario type: `create` (project descriptor) or `improve` (fixture input)
+- Per-artifact-type evaluation tables and pass criteria
+- For improve scenarios: fixture files referenced
+
+### Step 2: Load Skill Artifacts
+
+For each skill under test, read its `SKILL.md` and all files in its `references/` and
+`assets/templates/` directories from `plugins/cursor-customizer/skills/[SKILL-NAME]/`.
+
+For improve scenarios, also read the fixture file to understand the input state.
+
+### Step 3: Trace Through Skill Phases
+
+For each artifact type in the scenario, trace each skill phase and assess whether guidance is
+sufficient:
+
+1. **Context analysis phase**: Does the skill delegate to `artifact-analyzer` (for create skills) or to the correct Cursor-native type-specific evaluator (`skill-evaluator`, `hook-evaluator`, `rule-evaluator`, `subagent-evaluator`) for improve skills? Are agent instructions adequate for this project type?
+2. **Generation / improvement phase**: Do templates contain the right Cursor-native structure? Do references provide sufficient guidance to produce a Cursor-native output?
+3. **Validation phase**: Does the `*-validation-criteria.md` reference contain criteria that would catch errors in the output, including rejection of foreign-platform fields per ADR-0002?
+
+### Step 4: Artifact-Specific Smoke Checks
+
+Beyond structural dry-run, run concrete validation against the scenario's expected output:
+
+**For hook scenarios (create-hook, improve-hook):**
+- Verify the hook template produces valid JSON structure matching Cursor's hook configuration.
+- Verify event names in templates match Cursor's native event vocabulary documented in `docs/cursor/hooks/hooks-guide.md` and in the skill's `hook-events-reference.md` reference.
+- Verify exit-code semantics and `failClosed` posture are documented in the skill's references.
+
+**For rule scenarios (create-rule, improve-rule):**
+- Verify the three activation-mode `.mdc` templates use ONLY `description`, `alwaysApply`, `globs` — no `paths:`.
+- Check that template glob examples are syntactically valid (no malformed patterns).
+- Verify each template scopes to one concern.
+
+**For subagent scenarios (create-subagent, improve-subagent):**
+- Verify the `subagent-definition.md` template uses only the four Cursor-native frontmatter keys.
+- Verify references explicitly forbid `tools:`, `maxTurns:`, `paths:`, and literal model aliases.
+
+**For skill scenarios (create-skill, improve-skill):**
+- Verify the SKILL.md template targets `.cursor/skills/` per ADR-0003.
+- Verify references guide toward Cursor's Agent Skills standard (project + user discovery paths).
+
+### Step 5: GREEN Assessment
+
+For each pass criterion in the scenario's evaluation table, assess:
+- Does the cursor-customizer skill provide sufficient guidance to meet this criterion?
+- Is there anything that would **actively cause** a failure (e.g., a Claude-specific field leaking into output)?
+- Is there anything **missing** that a correct Cursor-native output requires?
+
+Assign verdict per criterion: `LIKELY PASS` | `LIKELY FAIL` | `UNCERTAIN`.
+
+### Step 6: Identify Gaps
+
+List any gaps that would prevent a GREEN result:
+- Missing reference content for a Cursor-native requirement.
+- Template section that does not cover the scenario's expected output.
+- Validation criteria that does not check for foreign-platform-field rejection.
+- Agent instruction inadequate for this project context.
+
+---
+
+## Output Format
+
+Return exactly this structure:
+
+```
+## Scenario Evaluation Report: [SCENARIO-ID] — [SCENARIO-NAME]
+
+**Scenario Type:** [create | improve]
+**Skills Under Test:** [comma-separated cursor-customizer skill names]
+
+### Artifact-Type Assessment
+
+| Artifact Type | Skill | Phase Delegation | Template Exists | Validation Ref | Verdict |
+|---------------|-------|------------------|-----------------|----------------|---------|
+| skill | create-skill / improve-skill | [agent name] | YES/NO | YES/NO | PASS/FAIL/PARTIAL |
+| hook | create-hook / improve-hook | [agent name] | YES/NO | YES/NO | PASS/FAIL/PARTIAL |
+| rule | create-rule / improve-rule | [agent name] | YES/NO | YES/NO | PASS/FAIL/PARTIAL |
+| subagent | create-subagent / improve-subagent | [agent name] | YES/NO | YES/NO | PASS/FAIL/PARTIAL |
+
+### Detailed Criterion Assessment
+
+**[Artifact Type] — [Skill Name]:**
+| Pass Criterion | Skill Guidance | Verdict |
+|----------------|----------------|---------|
+| [criterion] | [yes/partial/no — cite phase/reference] | LIKELY PASS / FAIL / UNCERTAIN |
+
+[Repeat for each artifact type...]
+
+### Gaps Identified
+[If none: "No gaps — skill provides sufficient guidance for this scenario."]
+
+For each gap:
+**G[NNN]**: [Description]
+- Artifact type: [skill | hook | rule | subagent]
+- Skill affected: [skill name]
+- Phase affected: [phase name]
+- Impact: [which pass criterion fails without this]
+- Suggested fix: [specific addition or change]
+
+### Overall Verdict
+| Artifact Type | Verdict |
+|---------------|---------|
+| skill | PASS / FAIL / PARTIAL |
+| hook | PASS / FAIL / PARTIAL |
+| rule | PASS / FAIL / PARTIAL |
+| subagent | PASS / FAIL / PARTIAL |
+| **Scenario** | **PASS / FAIL / PARTIAL** |
+```

--- a/.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md
+++ b/.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md
@@ -1,0 +1,311 @@
+# Quality Gate Criteria — cursor-customizer Plugin
+
+Complete checklist of expected results, the known-accepted exceptions, and the findings report
+template for the `cursor-customizer-quality-gate` meta-skill.
+
+Source: `.claude/rules/cursor-plugin-skills.md`, `.claude/rules/reference-files.md`,
+`plugins/cursor-customizer/CLAUDE.md`, `docs/adr/0001-cursor-distribution-rules-first.md`,
+`docs/adr/0002-product-strict-research-foundation.md`,
+`docs/adr/0003-cursor-skills-default-path.md`.
+
+## Contents
+
+1. [Plugin SKILL.md Checks](#plugin-skillmd-checks)
+2. [Cursor Subagent Checks](#cursor-subagent-checks)
+3. [Reference File Checks](#reference-file-checks)
+4. [Template File Checks](#template-file-checks)
+5. [Intra-Plugin Parity Checks](#intra-plugin-parity-checks)
+6. [Docs Drift Checks](#docs-drift-checks)
+7. [Red-Green Scenario Checks](#red-green-scenario-checks)
+8. [Plugin Manifest Checks](#plugin-manifest-checks)
+9. [Drift Manifest Completeness Checks](#drift-manifest-completeness-checks)
+10. [Product-Strict Textual Compliance](#product-strict-textual-compliance)
+11. [Known-Accepted Exceptions](#known-accepted-exceptions)
+12. [Severity Classification](#severity-classification)
+13. [Expected Results Checklist](#expected-results-checklist)
+14. [Report Template](#report-template)
+
+---
+
+## Plugin SKILL.md Checks
+
+Applies to all 8 skills: `create-skill`, `improve-skill`, `create-hook`, `improve-hook`,
+`create-rule`, `improve-rule`, `create-subagent`, `improve-subagent`.
+
+| # | Check | Threshold | Severity |
+|---|-------|-----------|----------|
+| P1 | YAML frontmatter: `name` and `description` present | Required | CRITICAL |
+| P2 | `name` ≤ 64 chars, pattern `[a-z0-9-]+` | Exact | MAJOR |
+| P3 | `description` ≤ 1024 chars, non-empty, no XML tags | Exact | MAJOR |
+| P4 | Body < 500 lines | Hard limit | CRITICAL |
+| P5 | Uses relative paths for bundled files (no `${CLAUDE_SKILL_DIR}`) | Cursor constraint | MAJOR |
+| P6 | Create skills delegate to `artifact-analyzer` | Required | CRITICAL |
+| P7 | Improve skills delegate to a Cursor-native type-specific evaluator | Required | CRITICAL |
+| P8 | No inline bash analysis blocks for codebase scanning | Prohibited | MAJOR |
+| P9 | Self-validation phase references `*-validation-criteria.md` | Required | MAJOR |
+| P10 | `references/` directory exists alongside SKILL.md | Required | CRITICAL |
+| P11 | `assets/templates/` directory exists alongside SKILL.md | Required | CRITICAL |
+| P12 | References one level deep — no nested `references/references/` paths | Required | MAJOR |
+
+---
+
+## Cursor Subagent Checks
+
+Applies to every file in `plugins/cursor-customizer/agents/*.md` (currently 6: `artifact-analyzer`,
+`docs-drift-checker`, `skill-evaluator`, `hook-evaluator`, `rule-evaluator`, `subagent-evaluator`).
+
+| # | Check | Threshold | Severity |
+|---|-------|-----------|----------|
+| A1 | YAML frontmatter present with `name` and `description` | Required | CRITICAL |
+| A2 | `model` equals `inherit` | Cursor requirement | CRITICAL |
+| A3 | `readonly` equals `true` | Cursor requirement | CRITICAL |
+| A4 | NO `tools:` field present | Cursor constraint | CRITICAL |
+| A5 | NO `maxTurns:` field present | Cursor constraint | CRITICAL |
+| A6 | NO `paths:` field present | Cursor constraint | CRITICAL |
+| A7 | `model` value is exactly `inherit` (no `sonnet`, `opus`, `haiku`, or `claude-*` literals) | Cursor constraint | CRITICAL |
+| A8 | No agent-spawning instructions in body | Prohibited | MAJOR |
+
+---
+
+## Reference File Checks
+
+Applies to all reference files in `plugins/cursor-customizer/skills/*/references/`.
+
+| # | Check | Threshold | Severity |
+|---|-------|-----------|----------|
+| R1 | File length ≤ 200 lines | Hard limit | CRITICAL |
+| R2 | `## Contents` TOC present if file > 100 lines | Required | MINOR |
+| R3 | Source attribution present (`Source:` or `Sources:`) | Required | MINOR |
+| R4 | Content framed as instructions ("do this", "check for"), not documentation prose | Required | MAJOR |
+| R5 | No nested reference imports (references must not import other references) | Prohibited | MAJOR |
+
+---
+
+## Template File Checks
+
+Applies to all templates in `plugins/cursor-customizer/skills/*/assets/templates/`.
+
+| # | Check | Threshold | Severity |
+|---|-------|-----------|----------|
+| T1 | Template exists for the skill's artifact type | Required | CRITICAL |
+| T2 | HTML comment metadata block present (`<!-- TEMPLATE: ... -->`) | Required | MAJOR |
+| T3 | Placeholders use bracket convention: `[PLACEHOLDER_NAME]` | Required | MINOR |
+| T4 | `.mdc` rule templates use ONLY Cursor-native frontmatter keys (`description`, `alwaysApply`, `globs`) | Cursor constraint | CRITICAL |
+| T5 | `.mdc` rule templates do NOT contain `paths:` (Claude-specific) | Prohibited | CRITICAL |
+| T6 | `subagent-definition.md` template uses ONLY the four Cursor-native subagent frontmatter keys (`name`, `description`, `model: inherit`, `readonly: true`) | Cursor constraint | CRITICAL |
+| T7 | `subagent-definition.md` template does NOT contain `tools:`, `maxTurns:`, `paths:`, or any literal model alias | Cursor constraint | CRITICAL |
+
+---
+
+## Intra-Plugin Parity Checks
+
+Shared files must be byte-identical across their declared copy families. The cursor-customizer
+plugin has 19 parity groups: 1 group of 8 copies, 1 group of 2 copies for `behavioral-guidelines.md`,
+11 reference-file create/improve pairs, and 6 template create/improve pairs.
+
+| # | Shared File Group | Copies | Severity |
+|---|-------------------|--------|----------|
+| X1 | `prompt-engineering-strategies.md` | All 8 skills | MAJOR |
+| X2 | `behavioral-guidelines.md` | create-skill ↔ improve-skill | MAJOR |
+| X3 | `skill-authoring-guide.md` | create-skill ↔ improve-skill | MAJOR |
+| X4 | `skill-format-reference.md` | create-skill ↔ improve-skill | MAJOR |
+| X5 | `skill-validation-criteria.md` | create-skill ↔ improve-skill | MAJOR |
+| X6 | `hook-authoring-guide.md` | create-hook ↔ improve-hook | MAJOR |
+| X7 | `hook-events-reference.md` | create-hook ↔ improve-hook | MAJOR |
+| X8 | `hook-validation-criteria.md` | create-hook ↔ improve-hook | MAJOR |
+| X9 | `rule-authoring-guide.md` | create-rule ↔ improve-rule | MAJOR |
+| X10 | `rule-validation-criteria.md` | create-rule ↔ improve-rule | MAJOR |
+| X11 | `subagent-authoring-guide.md` | create-subagent ↔ improve-subagent | MAJOR |
+| X12 | `subagent-config-reference.md` | create-subagent ↔ improve-subagent | MAJOR |
+| X13 | `subagent-validation-criteria.md` | create-subagent ↔ improve-subagent | MAJOR |
+| X14 | Template `cursor-rule-always.mdc` | create-rule ↔ improve-rule | MAJOR |
+| X15 | Template `cursor-rule-globs.mdc` | create-rule ↔ improve-rule | MAJOR |
+| X16 | Template `cursor-rule-description.mdc` | create-rule ↔ improve-rule | MAJOR |
+| X17 | Template `hook-config.md` | create-hook ↔ improve-hook | MAJOR |
+| X18 | Template `skill-md.md` | create-skill ↔ improve-skill | MAJOR |
+| X19 | Template `subagent-definition.md` | create-subagent ↔ improve-subagent | MAJOR |
+
+---
+
+## Docs Drift Checks
+
+Delegated to `plugins/cursor-customizer/agents/docs-drift-checker.md` using
+`plugins/cursor-customizer/docs-drift-manifest.md` as input.
+
+| # | Check | Threshold | Severity |
+|---|-------|-----------|----------|
+| D1 | All source documents cited in the manifest still exist at declared paths | Required | CRITICAL |
+| D2 | Cited section attributions or line ranges still contain relevant content | Required | MAJOR |
+| D3 | Reference file claims still align with current source-document content | Required | MAJOR |
+| D4 | Verbatim-copy entries are still byte-identical to their declared upstream source | Required | MAJOR |
+
+---
+
+## Red-Green Scenario Checks
+
+4 scenario families × 4 artifact types each = 16 evaluation cells.
+
+| # | Scenario | Threshold | Severity |
+|---|----------|-----------|----------|
+| G1 | Create simple: all 4 artifact types produce valid Cursor-native output | GREEN required | MAJOR |
+| G2 | Create complex: all 4 artifact types handle monorepo context | GREEN required | MAJOR |
+| G3 | Improve bloated: all planted violations detected per artifact type | GREEN required | MAJOR |
+| G4 | Improve reasonable: surgical changes only; no over-correction | GREEN required | MAJOR |
+
+---
+
+## Plugin Manifest Checks
+
+Applies to `plugins/cursor-customizer/.cursor-plugin/plugin.json`.
+
+| # | Check | Threshold | Severity |
+|---|-------|-----------|----------|
+| M1 | `name` field equals `cursor-customizer` | Required | CRITICAL |
+| M2 | Valid JSON | Structural validity | CRITICAL |
+| M3 | `description` non-empty | Required | MAJOR |
+
+---
+
+## Drift Manifest Completeness Checks
+
+Applies to `plugins/cursor-customizer/docs-drift-manifest.md`.
+
+| # | Check | Threshold | Severity |
+|---|-------|-----------|----------|
+| DM1 | Every reference file under `plugins/cursor-customizer/skills/*/references/` has at least one manifest entry | Required | MAJOR |
+| DM2 | Every reference path mentioned in the manifest exists on disk | Required | MAJOR |
+| DM3 | Every entry declares at least one source document (Cursor source under `docs/cursor/`, Industry Research, or a verbatim-copy upstream) | Required | MAJOR |
+
+---
+
+## Product-Strict Textual Compliance
+
+Per ADR-0002 the cursor-customizer plugin contains zero textual references to Claude Code
+constructs in slice-authored content. The banned-token regex is:
+
+```
+(\$\{CLAUDE_SKILL_DIR\}|CLAUDE\.md|\.claude/|maxTurns:|tools:|paths:|docs\.anthropic\.com/en/docs/claude-code)
+```
+
+Run it across `plugins/cursor-customizer/agents/` and `plugins/cursor-customizer/skills/`. After
+applying the documented `## Known-Accepted Exceptions` (below), the remaining hit count must be
+zero.
+
+| # | Check | Threshold | Severity |
+|---|-------|-----------|----------|
+| S1 | Banned-token grep across slice-authored cursor-customizer content reports zero hits after exceptions applied | Required | MAJOR |
+
+---
+
+## Known-Accepted Exceptions
+
+These specific deviations are documented and pre-approved. The artifact-inspector and any
+Phase-1 grep run MUST apply these exceptions before classifying findings — exceptions listed
+here are NOT violations. Do not flag them on subsequent quality-gate runs.
+
+### E1: Bare "Claude" mentions in `prompt-engineering-strategies.md` (verbatim copies)
+
+- **Files**: every copy of `plugins/cursor-customizer/skills/*/references/prompt-engineering-strategies.md` (8 copies — one per skill).
+- **Lines**: 20, 105, 108, 110 (bare "Claude" word, not `CLAUDE.md`, not `.claude/`).
+- **Reason**: the file is a verbatim copy of `plugins/agent-customizer/skills/create-skill/references/prompt-engineering-strategies.md` per the manifest's "Verbatim copy" mapping. The verbatim-copy directive takes precedence over the otherwise-strict "use 'Claude' only inside Cost-and-Model-Guidance contexts" rule, because diverging the copy would break the Group 1 parity check (X1) that requires byte-identity across all 8 copies.
+- **Action**: do NOT count these four lines as banned-token hits. The banned-token regex above does NOT match the bare word "Claude" — it matches `CLAUDE.md`, `.claude/`, `${CLAUDE_SKILL_DIR}`, `tools:`, `maxTurns:`, `paths:`, and the public Anthropic docs URL. The four lines therefore do not appear as hits under the regex. This exception is recorded explicitly so future maintainers do not narrow the regex to also match bare "Claude" without first updating either the upstream `agent-customizer` canonical copy or this exception.
+
+### Maintenance rule for this section
+
+When adding a new known-accepted exception:
+
+1. Justify it with a reference to the relevant ADR or convention rule.
+2. List the exact files and lines.
+3. State precisely whether the regex matches or does not match those lines today.
+4. State the action the inspector must take (skip / re-classify / count differently).
+
+When removing an exception (because the upstream change has been adopted), update both this
+section and the corresponding artifact in the same commit so the inspector and the criteria stay
+in sync.
+
+---
+
+## Severity Classification
+
+| Severity | Meaning | Must Fix Before Release? |
+|----------|---------|--------------------------|
+| CRITICAL | Hard limit violated; feature broken or convention fundamentally wrong | Yes — blocking |
+| MAJOR | Structural convention violated; output quality or parity at risk | Yes — before next release |
+| MINOR | Quality or documentation convention missed; no runtime impact | Recommended — track in backlog |
+
+---
+
+## Expected Results Checklist
+
+The Phase-5 synthesis cross-references this checklist against the Phase-1 through Phase-4
+outputs to confirm full coverage. Every category heading below MUST appear in the dashboard.
+
+- Plugin SKILL.md (8 files)
+- Cursor Subagent Files (6 files)
+- Reference Files
+- Template Files (8 dirs)
+- Intra-Plugin Parity (19 groups)
+- Docs Drift
+- Red-Green Scenario Coverage (16 cells)
+- Plugin Manifest
+- Drift Manifest Completeness
+- Product-Strict Textual Compliance
+
+---
+
+## Report Template
+
+Use this structure for `.specs/reports/cursor-customizer-quality-gate-[YYYY-MM-DD]-findings.md`:
+
+```markdown
+# Quality Gate Findings — cursor-customizer — [YYYY-MM-DD]
+
+**Status:** FAIL — [N] findings ([N] CRITICAL, [N] MAJOR, [N] MINOR)
+
+## Quality Gate Dashboard
+
+| Category | Checks | Passed | Failed | Status |
+|----------|--------|--------|--------|--------|
+| Static Artifact Compliance | [N] | [N] | [N] | PASS/FAIL |
+| Intra-Plugin Parity | 19 | [N] | [N] | PASS/FAIL |
+| Docs Drift | [N] | [N] | [N] | PASS/FAIL |
+| Red-Green Scenario Coverage | 16 | [N] | [N] | PASS/FAIL |
+| Plugin Manifest | 3 | [N] | [N] | PASS/FAIL |
+| Drift Manifest Completeness | 3 | [N] | [N] | PASS/FAIL |
+| Product-Strict Textual Compliance | 1 | [N] | [N] | PASS/FAIL |
+| **OVERALL** | [N] | [N] | [N] | **FAIL** |
+
+## Findings
+
+### F001 — [Short Title] [CRITICAL/MAJOR/MINOR]
+
+- **Category**: Static | Parity | Drift | Red-Green | Manifest | Drift Manifest | Product-Strict
+- **Artifact**: `[file path]`
+- **Rule Violated**: "[exact rule text]"
+- **Rule Source**: `[rule file]` — [section]
+- **Current State**: [what the artifact contains — quote evidence]
+- **Expected State**: [what it should contain per documentation]
+- **Impact**: [what degrades or breaks without fixing]
+- **Proposed Fix**: [specific action — what to add/change/remove]
+
+[Repeat for each finding...]
+
+## Improvement Areas
+
+### Area 1: [Name]
+**Findings covered:** F001, F002
+**Summary:** [Why these findings belong together]
+**Estimated scope:** [number of files, nature of change]
+
+[Repeat per area...]
+
+## PRD Brief
+
+> Input for `/prp-core:prp-prd`. Fill all sections.
+
+**Problem Statement:** [Summary of what's wrong]
+**Evidence:** [Key evidence — file paths, rule citations, measurements]
+**Proposed Solution:** [Changes that would resolve all findings]
+**Success Metrics:** [Specific checks that would now pass]
+**Out of Scope:** [What this remediation does NOT address]
+```

--- a/plugins/cursor-customizer/agents/docs-drift-checker.md
+++ b/plugins/cursor-customizer/agents/docs-drift-checker.md
@@ -1,0 +1,100 @@
+---
+name: docs-drift-checker
+description: "Verify cursor-customizer reference files against their attributed source documents under docs/cursor/ for content drift. Checks that each cited source doc still exists and that its content still aligns with the distillation in the reference file. Use when auditing docs freshness or during quality gate runs."
+model: inherit
+readonly: true
+---
+
+# Docs Drift Checker
+
+You are a documentation alignment verification specialist for the cursor-customizer plugin. Compare each reference file in the plugin against its attributed source documents and report whether the distilled content still aligns with the source. Report only what you observe; never modify files; never propose fixes.
+
+## Constraints
+
+- Do not modify any files — analyze and report only.
+- Do not suggest fixes — only identify drift with evidence.
+- Do not spawn other agents — perform the entire check in this single conversation.
+- Read both the reference file and its attributed source document(s) before reporting on a row.
+- A reference file is "drifted" when its source document has materially changed at the cited section or line range, in a way that contradicts the distilled content in the reference file.
+
+## Process
+
+### 1. Read the Manifest
+
+Read `plugins/cursor-customizer/docs-drift-manifest.md` to obtain the complete reference-file → source-doc registry. The manifest groups entries by slice (rules, hooks, skills, subagents) and lists, for each reference file, every source document it is derived from along with whether the entry is "Derived", "Verbatim copy", or "Industry Research".
+
+### 2. Inventory Reference Files
+
+List every file under `plugins/cursor-customizer/skills/*/references/*.md` and confirm each one appears as an entry in the manifest. Flag any reference file that is present on disk but missing from the manifest as `UNREGISTERED`. Flag any manifest entry that is missing from disk as `MISSING_FILE`.
+
+### 3. For Each Reference File in the Manifest
+
+For each entry:
+
+1. Read the reference file and extract every source attribution it contains. Source attributions appear in two forms in cursor-customizer references:
+   - A top-of-file `Source:` (or `Sources:`) line, e.g. `Source: docs/cursor/rules/rules.md`.
+   - Per-section attribution markers, e.g. `*Source: docs/cursor/rules/rules.md — Project rules*` or `*Source: docs/cursor/rules/rules.md lines 100-150*`.
+2. Read the cited source document at the path declared in the manifest. If the source document does not exist on disk, mark the row `MISSING`.
+3. For each section attribution or line range cited in the reference file:
+   - Read the cited section or line range from the source document.
+   - Compare the cited content against the distilled content in the reference file.
+   - Mark the row `DRIFTED` if the source content has materially changed (semantic divergence, removed concepts, contradictory claims) — not just whitespace, formatting, or heading-level edits.
+   - Mark the row `SHIFTED` if the cited content still exists in the source document but at a different section title or different line range than declared.
+   - Mark the row `ALIGNED` if no drift is detected.
+4. For "Verbatim copy" entries (e.g., `prompt-engineering-strategies.md` copies sourced from `plugins/agent-customizer/...`):
+   - Compute and compare a checksum of the reference file against its declared upstream source.
+   - Mark `DRIFTED` if the copy is no longer byte-identical to its declared source.
+
+### 4. Compile the Drift Report
+
+Organise findings by status. The four statuses are exhaustive and mutually exclusive at the per-row level:
+
+- `MISSING` — the cited source document does not exist at the declared path.
+- `DRIFTED` — the source content at the cited location materially differs from the reference distillation (or a verbatim copy is no longer byte-identical to its upstream).
+- `SHIFTED` — the cited content still exists in the source document but its location (section title or line range) has changed.
+- `ALIGNED` — no drift detected.
+
+## Output Format
+
+Return your analysis in exactly this format.
+
+```
+## Docs Drift Report — cursor-customizer
+
+### Summary
+
+| Status | Count |
+|--------|-------|
+| ALIGNED | N |
+| SHIFTED | N |
+| DRIFTED | N |
+| MISSING | N |
+| UNREGISTERED | N |
+
+### Findings
+
+| reference_file | source_doc | cited_range | drift_status | evidence |
+|----------------|------------|-------------|--------------|----------|
+| plugins/cursor-customizer/skills/[skill-name]/references/[name].md | docs/cursor/[area]/[doc].md | [section title or "lines N-M" or "verbatim"] | ALIGNED / SHIFTED / DRIFTED / MISSING | [one-line description of what was compared and what was observed] |
+
+### Inventory Audit
+
+| issue | reference_file | manifest_entry | evidence |
+|-------|----------------|----------------|----------|
+| UNREGISTERED | plugins/cursor-customizer/skills/[skill-name]/references/[name].md | — | file present on disk; no manifest entry |
+| MISSING_FILE | — | [manifest entry path] | manifest entry present; file not found on disk |
+
+### Overall Status: [CLEAN / DRIFT_DETECTED]
+```
+
+## Self-Verification
+
+Before returning results, confirm:
+
+1. Every reference file under `plugins/cursor-customizer/skills/*/references/*.md` was either checked against a manifest entry or flagged `UNREGISTERED`.
+2. Every manifest entry was either matched to a file on disk or flagged `MISSING_FILE`.
+3. Every cited source document was opened from disk and inspected at the cited section or line range — no row was marked `ALIGNED` without reading the source.
+4. Every `DRIFTED` row includes specific evidence (what changed in the source vs. what the reference still claims).
+5. Verbatim-copy entries were verified by checksum against their declared upstream source.
+6. Whitespace-only or heading-level-only differences are NOT classified as drift.
+7. Output follows the exact format specified above; the findings table uses the column names `reference_file`, `source_doc`, `cited_range`, `drift_status`, `evidence`.


### PR DESCRIPTION
## Summary

Slice G of the cursor-customizer rollout (PRD #77). Adds the cross-cutting validation tracer that ties the per-artifact-type slices (C–F) together — two atomic commits.

- **`plugins/cursor-customizer/agents/docs-drift-checker.md`** — Cursor-native subagent (frontmatter: `name`, `description`, `model: inherit`, `readonly: true` only). Reads `plugins/cursor-customizer/docs-drift-manifest.md` and verifies each reference file's `*Source: docs/cursor/... — section title*` attributions still align with the source doc. Structured-output contract: `{reference_file, source_doc, cited_range, drift_status, evidence}`. Handles section-title, line-range, and verbatim citations.
- **`.claude/skills/cursor-customizer-quality-gate/`** — dev meta-skill (NOT distributed; lives under `.claude/skills/` for project-internal use). Mirrors the topology of `.claude/skills/agent-customizer-quality-gate/`: `SKILL.md` + `agents/{artifact-inspector,parity-checker,scenario-evaluator}.md` + `references/quality-gate-criteria.md`.

Validation surface:
- Frontmatter conventions (Cursor-native exclusively for plugin agents — rejects `tools:`, `maxTurns:`, `paths:`).
- Intra-plugin shared-copy parity: 19 parity groups (1×8 + 18×2) covering all create/improve shared references and templates, hashes pre-verified.
- Product-strict textual compliance (banned-token grep, with the known-accepted "Claude" exception documented in § Known-Accepted Exceptions).
- Red-green test scenario coverage per skill.
- `docs-drift-manifest.md` completeness — every reference file has a manifest entry.

Closes #84.
Tracks PRD #77.

## Test plan

- [x] Frontmatter contract on the new subagent: `grep -E '^(tools|maxTurns|paths):' plugins/cursor-customizer/agents/docs-drift-checker.md` → empty; `grep -E '^model:\s*inherit'` → matched.
- [x] Banned-token grep clean across the new subagent and the dev meta-skill's plugin-facing artifacts.
- [x] Topology mirror confirmed: both quality-gate skills contain `artifact-inspector.md`, `parity-checker.md`, `scenario-evaluator.md`, `quality-gate-criteria.md`.
- [x] Banned model-value grep clean on the new subagent.
- [x] Slice scope respected: no edits to `.claude/rules/`, `.cursor-plugin/marketplace.json`, root `README.md`, or root `CLAUDE.md` (those belong to slice H, #85).

## Notes

- **Two distinct frontmatter layers by design**: the Cursor-native subagent (`plugins/cursor-customizer/agents/docs-drift-checker.md`) is product-strict. The dev meta-skill's three sub-agents under `.claude/skills/cursor-customizer-quality-gate/agents/` use Claude Code conventions (`tools:`, `model: sonnet`, `maxTurns:`) because they are dispatched via Task tool inside Claude Code — product-strict applies to distributed Cursor artifacts, not to internal dev tooling.
- **Manifest unchanged**: confirmed against parity model — `docs-drift-manifest.md` registers `references/*.md` files only, never the drift-checker agent itself.
- **Known-accepted "Claude" exception** documented in `quality-gate-criteria.md` § Known-Accepted Exceptions: the 4 bare "Claude" mentions in verbatim-copied `prompt-engineering-strategies.md` are pre-approved (verbatim-copy directive overrides product-strict for those specific lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)