### PR TITLE
refactor(skills/init-agents): strip Claude-Code leakage end-to-end (#115)

### DIFF
--- a/skills/docs-drift-manifest.md
+++ b/skills/docs-drift-manifest.md
@@ -24,11 +24,11 @@ or manually.
 | Reference File | Source Docs | Status |
 |----------------|-------------|--------|
 | `init-agents/references/codebase-analyzer.md` | `plugins/agents-initializer/agents/codebase-analyzer.md` | baseline |
-| `init-agents/references/context-optimization.md` | `docs/general-llm/research-context-engineering-comprehensive.md` | baseline |
-| `init-agents/references/progressive-disclosure-guide.md` | `docs/general-llm/a-guide-to-agents.md`, `docs/general-llm/research-context-engineering-comprehensive.md` (inline citations) | baseline |
+| `init-agents/references/context-optimization.md` | `docs/general-llm/research-context-engineering-comprehensive.md` | diverged-from-init-claude — hook phrasing replaced with "rely on tooling enforcement" (XC-11/#115) |
+| `init-agents/references/progressive-disclosure-guide.md` | `docs/general-llm/a-guide-to-agents.md`, `docs/general-llm/research-context-engineering-comprehensive.md` (inline citations) | diverged-from-init-claude — CLAUDE.md-specific hierarchy section removed, claudeMdExcludes block removed, .claude/rules/ row removed from hierarchy table (XC-11/#115) |
 | `init-agents/references/scope-detector.md` | `plugins/agents-initializer/agents/scope-detector.md` | baseline |
-| `init-agents/references/validation-criteria.md` | `plugins/agents-initializer/agents/file-evaluator.md` (lines 23-59) | baseline |
-| `init-agents/references/what-not-to-include.md` | `docs/general-llm/research-context-engineering-comprehensive.md` (lines 112-121), `docs/general-llm/Evaluating-AGENTS-paper.md` (abstract) | baseline |
+| `init-agents/references/validation-criteria.md` | `plugins/agents-initializer/agents/file-evaluator.md` (lines 23-59) | diverged-from-init-claude — CLAUDE.md-specific rows deleted, hook phrasing replaced with "rely on tooling enforcement", improve-claude source ref removed (XC-11/#115) |
+| `init-agents/references/what-not-to-include.md` | `docs/general-llm/research-context-engineering-comprehensive.md` (lines 112-121), `docs/general-llm/Evaluating-AGENTS-paper.md` (abstract) | diverged-from-init-claude — Hook row removed from exclusion table, migration table rewritten to AGENTS.md-only targets (subdirectory AGENTS.md, docs/), hooks/automate-workflow-with-hooks.md source removed (XC-11/#115) |
 | `init-claude/references/claude-rules-system.md` | `docs/claude-code/memory/how-claude-remembers-a-project.md`, `docs/general-llm/research-context-engineering-comprehensive.md` (inline citations) | baseline |
 | `init-claude/references/codebase-analyzer.md` | `plugins/agents-initializer/agents/codebase-analyzer.md` | baseline |
 | `init-claude/references/context-optimization.md` | `docs/general-llm/research-context-engineering-comprehensive.md` | baseline |

--- a/skills/init-agents/references/context-optimization.md
+++ b/skills/init-agents/references/context-optimization.md
@@ -91,7 +91,7 @@ Detect and remove these before generating or improving configuration files:
 |---------------|-----------|-----|
 | Stale file paths | Check if referenced paths actually exist | Remove or update |
 | Contradictions | Compare instructions across all files | Remove the weaker/older rule |
-| Over-specification | Count lines; check if agent already follows rule | Delete or convert to hook |
+| Over-specification | Count lines; check if agent already follows rule | Delete or rely on tooling enforcement |
 | Failed approach accumulation | Look for rules added defensively after incidents | Remove rules that shouldn't be needed |
 | High-churn information | Look for version numbers, file counts, team names | Remove or move to a pointer |
 

--- a/skills/init-agents/references/progressive-disclosure-guide.md
+++ b/skills/init-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,7 @@
 # Progressive Disclosure Guide
 
-Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
+Evidence-based instructions for structuring AGENTS.md hierarchies.
+Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md
 
 ---
 
@@ -9,10 +9,9 @@ Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, me
 
 - File hierarchy decision table (where to place content)
 - Root file requirements (minimal elements only)
-- Monorepo: what goes where (root vs package level, claudeMdExcludes)
+- Monorepo: what goes where (root vs package level)
 - Progressive disclosure patterns (domain files, nested docs, skills)
-- CLAUDE.md-specific hierarchy (5 scopes, @import, load order)
-- AGENTS.md-specific notes (open standard, symlinks, merging)
+- AGENTS.md-specific notes (open standard, merging)
 - Anti-patterns to detect and remove
 - Validation checklist
 
@@ -24,10 +23,9 @@ When deciding where to place content, use this table:
 
 | Location | Use when content is... | Load timing |
 |----------|------------------------|-------------|
-| Root AGENTS.md / CLAUDE.md | Relevant to **every single task** in the repo | Always (every request) |
+| Root AGENTS.md | Relevant to **every single task** in the repo | Always (every request) |
 | Separate domain file | Relevant to one domain (TypeScript, testing, API design) | On-demand |
-| Subdirectory AGENTS.md / CLAUDE.md | Specific to one package or area | On-demand when working there |
-| `.claude/rules/` (path-scoped) | Specific to certain file patterns | On-demand when files match |
+| Subdirectory AGENTS.md | Specific to one package or area | On-demand when working there |
 | Skill | A workflow the agent should invoke explicitly | On-demand when invoked |
 
 *Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
@@ -66,16 +64,6 @@ See each package's AGENTS.md for specific guidelines.
 > "Don't overload any level. The agent sees all merged files in its context."
 > — a-guide-to-agents.md lines 164-193
 
-**`claudeMdExcludes`**: In large monorepos, skip irrelevant ancestor CLAUDE.md files via `.claude/settings.local.json`:
-
-```json
-{ "claudeMdExcludes": ["**/other-team/CLAUDE.md", "**/other-team/.claude/rules/**"] }
-```
-
-Patterns match absolute paths with glob syntax. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded.
-
-*Source: memory/how-claude-remembers-a-project.md lines 243-260*
-
 ---
 
 ## Progressive Disclosure Patterns
@@ -109,32 +97,11 @@ docs/
 
 ---
 
-## CLAUDE.md-Specific Hierarchy
-
-| Scope | Location | Loads when |
-|-------|----------|------------|
-| Org-wide | Managed policy (MDM) | Always |
-| Project | `./CLAUDE.md` or `./.claude/CLAUDE.md` | Session start (always) |
-| Personal | `~/.claude/CLAUDE.md` | Session start (always) |
-| Subdirectory | `./subdir/CLAUDE.md` | When reading files in that dir |
-| Path-scoped rules | `.claude/rules/*.md` with `paths:` | When matching files are read |
-
-**Priority rule**: Minimize content in always-loaded locations. Move to on-demand locations wherever possible.
-
-**@import syntax**: CLAUDE.md files can import additional files with `@path/to/file`. Imports expand at launch alongside the importing CLAUDE.md. Relative paths resolve relative to the importing file, not CWD. Max recursion depth: 5 hops. Requires one-time user approval per project.
-
-**Load order**: Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory CLAUDE.md files load on-demand only when Claude reads files in that directory — not at launch.
-
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
-
----
-
 ## AGENTS.md-Specific Notes
 
-- AGENTS.md is an **open standard** supported by most agent frameworks (not Claude Code)
-- Claude Code uses CLAUDE.md; create a symlink for cross-tool compatibility: `ln -s AGENTS.md CLAUDE.md`
-- AGENTS.md has **no `.claude/rules/` equivalent** — use subdirectory AGENTS.md files for scoped rules
+- AGENTS.md is an **open standard** supported by most agent frameworks
 - Subdirectory AGENTS.md files **merge with root** (not replace)
+- Use subdirectory AGENTS.md files for scoped, package-level rules
 
 ---
 

--- a/skills/init-agents/references/validation-criteria.md
+++ b/skills/init-agents/references/validation-criteria.md
@@ -1,7 +1,7 @@
 # Validation Criteria
 
-Quality checklist for generated and improved AGENTS.md / CLAUDE.md files.
-Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
+Quality checklist for generated and improved AGENTS.md files.
+Source: improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
 
 ---
 
@@ -36,7 +36,7 @@ Directional goals — not auto-fail triggers. Apply during IMPROVE operations wh
 - [ ] Non-standard configuration values documented (e.g., `addopts = "--cov=src"`, `strict = true`, line-length overrides)
 - [ ] Cross-scope build prerequisites at root level (e.g., WASM must build before web — document ordering at root)
 - [ ] Progressive disclosure applied: domain docs referenced, not inlined
-- [ ] No information that tools can enforce (linting, formatting rules → use hooks instead)
+- [ ] No information that tools can enforce (linting, formatting rules → rely on tooling enforcement)
 - [ ] No duplication of content across files in the hierarchy
 - [ ] No directory/file structure listings
 - [ ] No standard language conventions the model already knows
@@ -67,9 +67,7 @@ Directional goals — not auto-fail triggers. Apply during IMPROVE operations wh
 - [ ] Root file: one-liner + package manager (if non-standard) + build commands (if non-standard) + pointers
 - [ ] Domain content lives in separate files, not inline
 - [ ] Progressive disclosure pointers point to files that actually exist
-- [ ] **CLAUDE.md-specific**: `.claude/rules/` files have path-scoping (`paths:` frontmatter) when they apply to specific file patterns
-- [ ] **CLAUDE.md-specific**: Minimal content in always-loaded locations (`./CLAUDE.md`, `.claude/rules/*.md` without paths)
-- [ ] **AGENTS.md-specific**: Subdirectory AGENTS.md files used for monorepo package scoping (no `.claude/rules/` equivalent)
+- [ ] **AGENTS.md-specific**: Subdirectory AGENTS.md files used for monorepo package scoping
 
 ---
 

--- a/skills/init-agents/references/what-not-to-include.md
+++ b/skills/init-agents/references/what-not-to-include.md
@@ -1,7 +1,7 @@
 # What NOT to Include
 
-Evidence-based exclusion table for AGENTS.md and CLAUDE.md content.
-Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md, hooks/automate-workflow-with-hooks.md
+Evidence-based exclusion table for AGENTS.md content.
+Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md
 
 ---
 
@@ -21,7 +21,6 @@ Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-gu
 | Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
 | Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
 | Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" | Anthropic Best Practices |
-| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; config file instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | "Hooks provide deterministic control over Claude Code's behavior, ensuring certain actions always happen rather than relying on the LLM" | Anthropic Hooks Guide |
 
 *Source: init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
@@ -31,21 +30,8 @@ Not all excluded content should be deleted — some should migrate to on-demand 
 
 | Exclusion Category | Action | Mechanism |
 |-------------------|--------|-----------|
-| Hook-enforced behaviors | **Migrate** | Hook (zero context cost, deterministic enforcement) |
-| Path-specific conventions | **Migrate** | `.claude/rules/` with `paths:` (loads on file match only) |
-| Domain knowledge blocks >50 lines | **Migrate** | Skill `user-invocable: false` (~100 token startup cost) |
-| Agent-inferable content | **Delete** | No migration — agents discover via tools |
-| Stale, vague, or duplicate content | **Delete** | No migration value |
-
-### Exclusion Actions
-
-Not all excluded content should be deleted — some should migrate to on-demand mechanisms:
-
-| Exclusion Category | Action | Mechanism |
-|-------------------|--------|-----------|
-| Hook-enforced behaviors | **Migrate** | Hook (zero context cost, deterministic enforcement) |
-| Path-specific conventions | **Migrate** | `.claude/rules/` with `paths:` (loads on file match only) |
-| Domain knowledge blocks >50 lines | **Migrate** | Skill `user-invocable: false` (~100 token startup cost) |
+| Path-specific conventions | **Migrate** | Subdirectory AGENTS.md (scoped to that area) |
+| Domain knowledge blocks >50 lines | **Migrate** | Separate domain doc in `docs/` (referenced by pointer) |
 | Agent-inferable content | **Delete** | No migration — agents discover via tools |
 | Stale, vague, or duplicate content | **Delete** | No migration value |
 


### PR DESCRIPTION
## Summary

- Removes all Claude-Code-specific mechanisms from `skills/init-agents/references/` so the cross-platform AGENTS.md initialization flow contains zero Claude-only patterns
- Fixes findings CF-STANDALONE-003 (Hook row in exclusion table) and CF-STANDALONE-008 (CLAUDE.md-specific rows in validation criteria)
- Records reference divergence between `init-agents` (cross-platform) and `init-claude` (Claude-aware) in `skills/docs-drift-manifest.md`

## Changes

### `skills/init-agents/references/what-not-to-include.md`
- Removed Hook-enforced-behaviors row from the Exclusion Evidence Table
- Rewrote migration mechanism table to AGENTS.md-compatible targets only (subdirectory AGENTS.md, domain docs in `docs/`); removed `.claude/rules/` and Hook rows
- Removed duplicate Exclusion Actions section
- Updated source attribution to remove `hooks/automate-workflow-with-hooks.md`

### `skills/init-agents/references/validation-criteria.md`
- Replaced `→ use hooks instead` with `→ rely on tooling enforcement` in quality checklist
- Deleted two `**CLAUDE.md-specific**` structural check rows (`.claude/rules/` path-scoping and always-loaded locations)
- Updated file header to scope to AGENTS.md only

### `skills/init-agents/references/progressive-disclosure-guide.md`
- Removed entire `## CLAUDE.md-Specific Hierarchy` section (5-scope table, @import syntax, load order)
- Removed `claudeMdExcludes` block from monorepo section
- Removed `.claude/rules/` row from file hierarchy decision table
- Rewrote AGENTS.md-Specific Notes (removed symlink-to-CLAUDE.md guidance)
- Updated header/sources to remove Claude-Code-specific references

### `skills/init-agents/references/context-optimization.md`
- Replaced `Delete or convert to hook` with `Delete or rely on tooling enforcement`

### `skills/docs-drift-manifest.md`
- Updated 4 `init-agents/references/` rows to status `diverged-from-init-claude` with change notes

## Grep verification

```
grep -rE '\$\{CLAUDE_SKILL_DIR\}|paths:|\.claude/|hook|subagent|CLAUDE\.md-specific' skills/init-agents/references/
```
Returns zero matches.

## Context

- Parent issue: #108 (XC-11)
- Maintainer scope override: standalone bundle stays AGENTS.md target; strip Claude-specific content
- ADR-0005 (cross-platform conventions)

Closes #115