### PR TITLE
refactor: XC-11 post-merge cleanup (P0/P1 review findings from #112/#114/#115/#116)

### DIFF
--- a/docs/compliance/artifact-audit-manifest.md
+++ b/docs/compliance/artifact-audit-manifest.md
@@ -736,13 +736,6 @@ Enforcement status per (scope × artifact type). Cells show active rule/instruct
 | cursor-initializer | agent | `r:ca` | `i:ad` | `ci:A` (A1–A5) | — | no |
 | cursor-initializer | reference | `r:rf` | `i:rf` | `ci:R` (R1–R5), `ci:X` (X1–X2) | — | no |
 | cursor-initializer | template | — | `i:tf` | `ci:T` (T1–T4), `ci:X` | — | no |
-| cursor-customizer | skill | `r:cp` | `i:sf` | `cc:P` (P1–P12) | `cc:D` (D1–D4) | no |
-| cursor-customizer | agent | `r:ca` | `i:ad` | `cc:A` (A1–A8) | `cc:D` (D1–D4) | no |
-| cursor-customizer | reference | `r:rf` | `i:rf` | `cc:R` (R1–R5), `cc:X` (X1–X19) | `cc:D` (D1–D4) | no |
-| cursor-customizer | template | — | `i:tf` | `cc:T` (T1–T7), `cc:X` | — | no |
-| cursor-customizer | drift-manifest | — | — | `cc:D` (D1–D4) | — | no |
-| cursor-customizer | plugin-manifest | — | `i:pc` | — | — | **yes** (no gate) |
-| cursor-customizer | config-file/readme | `r:rm` | `i:pc`, `i:rm` | — | — | **yes** (no gate) |
 | standalone | skill | `r:ss` | `i:sf` | `q:S` (S1–S11) | — | no |
 | standalone | reference | `r:rf` | `i:rf` | `q:R` (R1–R5), `q:X` (X1–X2) | — | no |
 | standalone | template | — | `i:tf` | `q:T` (T1–T2), `q:X` | — | no |
@@ -762,7 +755,6 @@ Enforcement status per (scope × artifact type). Cells show active rule/instruct
 | agent-customizer | `.claude/skills/agent-customizer-quality-gate/` | ✅ P1–P12, A1–A6, R1–R5, M1–M3 | ✅ X1–X14, T1–T3 | ✅ D1–D3 | ✅ G1–G4 | Full coverage |
 | cursor-customizer | `.claude/skills/cursor-customizer-quality-gate/` | ✅ P1–P12, A1–A8, R1–R5, T1–T7, M1–M3, DM1–DM3, S1 | ✅ X1–X19 | ✅ D1–D4 | ✅ G1–G4 | Full coverage |
 | cursor-initializer | `.claude/skills/cursor-initializer-quality-gate/` | ✅ P1–P10, A1–A5, R1–R5 | ✅ X1–X2, T1–T4 | ❌ none | ✅ G1–G4 | No drift detection |
-| cursor-customizer | `.claude/skills/cursor-customizer-quality-gate/` | ✅ P1–P12, A1–A8, R1–R5 | ✅ T1–T7, X1–X19 | ✅ D1–D4 | ✅ G1–G4 | Full coverage |
 | standalone | `.claude/skills/quality-gate/` (shared) | ✅ S1–S11, R1–R5 | ✅ X1–X2, T1–T2 | ✅ (Phase 3, via manifest) | ✅ G1–G4 | No cursor-initializer drift |
 | repository-global | **No quality gate** | ❌ | ❌ | ❌ | ❌ | **All coverage manual** |
 

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -50,7 +50,7 @@ Proceed to Phase 1 below.
 
 Read `references/artifact-analyzer.md` and follow its analysis instructions to analyze the project at the current working directory.
 
-Focus on: existing skill directory structure, naming patterns, which skills delegate to agents, plugin conventions in CLAUDE.md files, and any skill that is similar to `{requested-name}` in purpose.
+Focus on: existing skill directory structure, naming patterns, and any skill that is similar to `{requested-name}` in purpose.
 
 ### Phase 2: Generate Skill
 

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -64,7 +64,7 @@ Before generating, read these reference documents:
 Read `assets/templates/skill-md.md` and fill its placeholders using:
 
 - User requirements for the new skill
-- Phase 1 analysis output (naming conventions, existing patterns, plugin context)
+- Phase 1 analysis output (naming conventions, existing patterns)
 - Evidence from the reference files above
 
 Generate the complete skill directory structure:

--- a/skills/improve-agents/SKILL.md
+++ b/skills/improve-agents/SKILL.md
@@ -89,12 +89,11 @@ Based on both analyses, create an improvement plan. Categorize actions:
 2. **Extract domain content** into docs/TESTING.md, docs/BUILD.md, etc.
 3. **Add progressive disclosure pointers** in root file to new split files
 4. **Consolidate fragmented files** that cover the same scope
-5. **Migrate automation candidates** — for each instruction flagged in Phase 1 as `HOOK_CANDIDATE`, `RULE_CANDIDATE`, or `SKILL_CANDIDATE`:
+5. **Migrate automation candidates** — for each instruction flagged in Phase 1 as `RULE_CANDIDATE` or `SKILL_CANDIDATE`:
    - Classify using the decision flowchart in automation-migration-guide.md
-   - Select target mechanism: path-scoped rule (file-pattern convention) or skill (domain knowledge/infrequent workflow)
-   - Reclassify `HOOK_CANDIDATE` items: if the behavior is path-specific and under 50 lines → `RULE_CANDIDATE`; if it is a workflow or domain block → `SKILL_CANDIDATE`
+   - Select target mechanism: subdirectory AGENTS.md or skill (domain knowledge/infrequent workflow)
    - Estimate token savings using the token impact estimation table in automation-migration-guide.md
-   - This is the standalone distribution — suggest only skills and path-scoped rules. Do not suggest hooks or subagents (these require Claude Code). When automation-migration-guide.md references hooks or subagents, substitute with the closest available mechanism.
+   - This is the standalone distribution — suggest only skills, subdirectory AGENTS.md, and domain docs. Do not suggest hooks or subagents (these require Claude Code). When automation-migration-guide.md references hooks or subagents, substitute with the closest available mechanism.
    - In calibrated mode (overall quality score ≥ 7 with no hard-limit violations), keep migration and extraction suggestions proportional to the confirmed issues. Do not create new files or migrations unless they resolve a failing criterion, and preserve non-issue sections in place.
 
 #### Redundancy Elimination (delete what agents already know)

--- a/skills/improve-agents/references/file-evaluator.md
+++ b/skills/improve-agents/references/file-evaluator.md
@@ -157,9 +157,8 @@ Return your analysis in exactly this format:
 - Line 67: "Follow best practices for error handling" — not actionable
 
 **Automation Opportunity Issues:**
-- Lines 45-60: Formatting enforcement (HOOK_CANDIDATE — deterministic behavior)
+- Lines 45-60: Scope-specific content (RULE_CANDIDATE — move to subdirectory AGENTS.md)
 - Lines 102-130: Testing domain block, 28 lines (SKILL_CANDIDATE — domain knowledge)
-- Lines 200-210: Glob-based rule "*.test.ts" (RULE_CANDIDATE — path-specific)
 
 ### Cross-File Issues
 - [List any cross-file contradictions or duplications]

--- a/skills/improve-skill/SKILL.md
+++ b/skills/improve-skill/SKILL.md
@@ -55,7 +55,7 @@ Read `references/skill-evaluator.md` and follow its evaluation instructions to e
 
 Read `references/artifact-analyzer.md` and follow its analysis instructions.
 
-Focus on: which agents the skill delegates to and whether those agents still exist, naming conventions for similar skills, any other skills that overlap in purpose, and the plugin structure.
+Focus on: naming conventions for similar skills and any other skills that overlap in purpose.
 
 ### Phase 3: Generate Improvement Plan
 

--- a/skills/init-agents/references/context-optimization.md
+++ b/skills/init-agents/references/context-optimization.md
@@ -108,9 +108,7 @@ Use these patterns to move content from always-consumed to on-demand locations:
 | Pattern | How it works | Token impact |
 |---------|-------------|-------------|
 | Skills | Description loaded at start; full body loaded on invocation | On-demand |
-| Path-scoped rules | Trigger only when matching files are read | On-demand |
-| Subdirectory config files | Load when working in that directory | On-demand |
-| `@path/to/import` | Expands when parent file loads | Controlled |
+| Subdirectory AGENTS.md | Loads when working under that subdirectory | On-demand |
 | Domain docs (e.g., `docs/TESTING.md`) | Agent navigates when relevant | On-demand |
 
 > "Rather than pre-processing all relevant data up front, agents maintain lightweight identifiers and use these references to dynamically load data into context at runtime."


### PR DESCRIPTION
Bundled follow-up addressing P0/P1 findings from Opus reviews of the XC-11 PR batch (PRs #119/#126, #120/#125, #121/#124, #122 — all merged).

## Commits

### 1. `docs(compliance)`: Delete duplicate cursor-customizer rows from §11 and §12

**Source PR:** #112 (#126 merge)

**Problem:** PR #119/#126 was rebased on a stale base that didn't have the cursor-customizer §11 block (added by `b5417da`). The merge resolution added a fresh block instead of reconciling, leaving duplicate and contradictory rows — the stale block had `plugin-manifest | … | **yes** (no gate)` while the canonical block correctly had `cc:M (M1–M3)` Gate=`no`. §12 similarly had a stale cursor-customizer row with regressed Static enumeration `P1–P12, A1–A8, R1–R5` vs the correct full superset `M1–M3, DM1–DM3, S1`.

**Fix:** Deleted the 7-row stale §11 block (was lines 739-745) and the stale §12 cursor-customizer row (was line 765).

**Verification:**
```
grep -c 'cursor-customizer' docs/compliance/artifact-audit-manifest.md
# §11 now has exactly 7 cc rows (728-734), §12 has 1 cc row with full superset
```

---

### 2. `refactor(skills/{create,improve}-skill)`: Narrow SKILL.md analyzer focus

**Source PR:** #116 (#125 merge)

**Problem:** PR #120/#125 narrowed `references/artifact-analyzer.md` to generic SKILL.md inventory only (no `.claude/`, agents, hooks, plugins). But the SKILL.md "Focus on:" lines that call into the analyzer still demanded the removed data — caller asked for X, callee no longer returned X.

**Fix:**
- `skills/create-skill/SKILL.md` line 53: Removed "which skills delegate to agents, plugin conventions in CLAUDE.md files"
- `skills/improve-skill/SKILL.md` line 58: Removed "which agents the skill delegates to and whether those agents still exist" and "the plugin structure"

**Verification:**
```
grep -n 'delegate\|plugin\|agent' skills/create-skill/SKILL.md skills/improve-skill/SKILL.md | grep -i 'Focus on'
# zero matches
```

---

### 3. `refactor(skills/init-agents)`: Replace Claude-only JIT mechanisms with AGENTS.md-native

**Source PR:** #115 (#124 merge)

**Problem:** The JIT Documentation Patterns table in `skills/init-agents/references/context-optimization.md` still listed two Claude-only mechanisms with no AGENTS.md analog:
- "Path-scoped rules" — only exists as `.claude/rules/*.md` `paths:` frontmatter
- `` `@path/to/import` `` — `@import` is a CLAUDE.md-only feature

**Fix:** Deleted both Claude-only rows and renamed "Subdirectory config files" → "Subdirectory AGENTS.md" to match AGENTS.md-native terminology. The remaining 3 rows (Skills, Subdirectory AGENTS.md, Domain docs) are the authoritative AGENTS.md-native JIT substitutes per ADR-0005.

**Verification:**
```
grep -n 'Path-scoped\|@path\|@import\|paths:' skills/init-agents/references/context-optimization.md
# zero matches
```

---

### 4. `refactor(skills/improve-agents)`: Strip path-scoped-rule + HOOK_CANDIDATE residue

**Source PR:** #114 (#122 merge)

**Problem:** PR #122 deleted the `claude-rule.md` template AND reclassified RULE_CANDIDATE as "Subdirectory AGENTS.md candidate" in references — but:
- `SKILL.md` Phase-3 prose still mentioned `HOOK_CANDIDATE` in the flag list and the "path-scoped rule" mechanism
- `HOOK_CANDIDATE` reclassification logic was dead code (no reference emits it)
- `file-evaluator.md` output template still contained a `HOOK_CANDIDATE` example and `"*.test.ts"` glob wording tied to deleted indicators

**Fix:**
- `SKILL.md`: Removed `HOOK_CANDIDATE` from the flag list (line 92), replaced "path-scoped rule" with "subdirectory AGENTS.md" (line 94), dropped the HOOK_CANDIDATE reclassification bullet (was line 95), updated "suggest only skills and path-scoped rules" → "suggest only skills, subdirectory AGENTS.md, and domain docs" (line 97)
- `file-evaluator.md`: Replaced the 3-line Automation Opportunity Issues example (HOOK_CANDIDATE + glob) with 2 lines using only live indicators (RULE_CANDIDATE, SKILL_CANDIDATE)

**Verification:**
```
grep -n 'path-scoped\|HOOK_CANDIDATE\|hook candidate\|*\.test\.ts' skills/improve-agents/SKILL.md skills/improve-agents/references/file-evaluator.md
# zero matches

grep -n 'RULE_CANDIDATE\|SKILL_CANDIDATE' skills/improve-agents/SKILL.md
# matches on line 92 (flag list) — flow preserved
```

---

## Refs: #112, #114, #115, #116