### PR TITLE
docs(adr): XC-12 establish ADR-0006 distribution-content boundary

### DIFF
--- a/.claude/rules/standalone-skills.md
+++ b/.claude/rules/standalone-skills.md
@@ -12,7 +12,7 @@ paths:
 - Reference docs in `references/` are "follow these instructions" content — not executable scripts
 - `references/` directory MUST exist alongside SKILL.md and contain evidence-based guidance files
 - `assets/templates/` directory MUST exist alongside SKILL.md and contain output templates; validator-type or report-only standalone skills that do not generate templated artifacts MAY omit it
-- Templates in `assets/templates/` MAY embed platform-specific format only if the skill's `name` declares that platform target. The skill's `name` field is the canonical platform-target declaration — aliasing to escape this scoping is itself a violation.
+- Templates in `assets/templates/` MAY embed platform-specific format only if the skill's `name` declares that platform target. The skill's `name` field is the canonical platform-target declaration — aliasing to escape this scoping is itself a violation. See ADR-0006.
 - Skills MUST encode the behavioral discipline defined in `.github/instructions/karpathy-guidelines.instructions.md` (assumptions-first, simplest path, surgical changes, validation targets).
 - If standalone skills use persuasion patterns, they MUST state the ethical constraint that those patterns support legitimate work only and never bypass safeguards or refusals
 - Self-validation phase MUST read `references/validation-criteria.md` and loop until all checks pass
@@ -20,8 +20,7 @@ paths:
 - Each skill bundles its own copies of shared references — no symlinks, no cross-directory references
 - Standalone bundled-file references MUST use relative `references/...` and `assets/templates/...` paths — NEVER `${CLAUDE_SKILL_DIR}`
 - When an intentionally shared reference is updated, update all intended copies in sync
-- Standalone improve skills MUST suggest only skills and path-scoped rules as migration targets — NEVER hooks or subagents (these require Claude Code plugin architecture)
-- When shared references mention hooks or subagents, standalone SKILL.md MUST instruct to substitute with the closest available mechanism (rule or skill)
+- Standalone skills MUST NOT author hooks, subagents, path-scoped rules, or CLAUDE.md hierarchy. The standalone bundle authors only **skills** (SKILL.md packages) and **AGENTS.md**. See ADR-0006.
 - SKILL.md `name` field: ≤64 chars, lowercase letters/numbers/hyphens only, no XML tags
 - SKILL.md `description` field: non-empty, ≤1024 chars, third person, no XML tags
 - SKILL.md body: under 500 lines

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,6 +83,7 @@ _Avoid_: layered scope (too generic), output exception (misses that the split is
 - The **Claude Code distribution** and the **Cursor distribution** are siblings — same conceptual roles, different platform formats and conventions.
 - A **Source document** in `docs/` is summarized into one **Wiki page** in `wiki/knowledge/`; one Source document may also seed multiple concept Wiki pages with `[[wiki-link]]` cross-references.
 - The **Wiki** is the canonical knowledge surface for agents; **Source documents** are searched only when the wiki lacks coverage.
+- The **Standalone distribution** sources from the cross-platform standard alone (platform-agnostic docs, filtered to skills and AGENTS.md authoring); plugin distributions source from their platform's docs plus the standard. See ADR-0006.
 
 ## Example dialogue
 

--- a/docs/adr/0005-standalone-two-layer-scope.md
+++ b/docs/adr/0005-standalone-two-layer-scope.md
@@ -2,6 +2,8 @@
 
 The standalone distribution (`skills/`) hosts skills like `init-claude` and `improve-claude` whose explicit purpose is to generate Claude Code-format artifacts (`.claude/rules/*.md` with `paths:` frontmatter, `CLAUDE.md` hierarchy). The previous wording in `wiki/knowledge/validation-routing-standalone.md` listed `paths:` in any generated rule file and references to platform-specific files as forbidden contamination signals — under a literal reading those skills failed compliance by definition, contradicting the explicit catalog in `skills/README.md`. We resolve the contradiction by formally splitting the standalone-bundle into two compliance layers: the **skill body** (SKILL.md prose, references) must remain platform-agnostic and source only from `SHARED-*` and `GENERAL-*` IDs; the **templates** (`assets/templates/`) MAY embed platform-specific format **iff** the skill's `name` declares the target platform (e.g. `init-claude` is allowed `CLAUDE-*` template content, `init-agents` is allowed cross-platform AGENTS.md format, a hypothetical platform-neutral skill must keep its templates platform-neutral too).
 
+**Status: superseded by ADR-0006 (2026-05-04)**
+
 ## Why two layers, not one
 
 We considered three readings:
@@ -42,3 +44,13 @@ The contradiction was latent until the Q1 grilling round of the May 2026 alignme
 **Rationale for the split.** Reframing is only faithful when the underlying concept survives stripping platform-specific mechanics. Rules pass this test; hooks and subagents do not. Deprecating the latter preserves the override doctrine (no rename) while avoiding hollow content.
 
 **Execution.** The per-skill SKILL.md changes (reframe prose for rule skills; add deprecation notes for hook and subagent skills) are deferred to a future Slice 5 issue. This follow-up records only the decision. Full discussion: issue #113. Parent context: issue #108.
+
+## Supersession (2026-05-04)
+
+The two-layer split recorded in this ADR was an attempt to preserve `init-claude` and `improve-claude` in the standalone bundle. By naming the template layer separately from the skill body, the ADR allowed those two skills to source `CLAUDE-*` platform documentation for their templates while keeping their prose platform-agnostic. This preservation was pragmatic — it resolved the immediate compliance contradiction without removing user-facing skills.
+
+ADR-0006 identifies why that preservation is itself a problem. `init-claude` and `improve-claude` generate platform-attached output forms — `CLAUDE.md` hierarchy and `.claude/rules/` with `paths:` frontmatter — which are not in the cross-platform standard that defines the standalone bundle's content sources. The two-layer split allowed the template layer to import platform knowledge that the standalone bundle's source constraint excludes. Naming the import as "template-layer authority" did not change what was being imported.
+
+The per-family disposition in § Follow-up — rules → reframe, hooks/subagents → deprecate — was derived by applying the two-layer logic to each skill family. ADR-0006 replaces that per-family analysis with a single principle-level test: does the skill's output form require platform-attached knowledge? All six skills named in § Follow-up fail this test, as do `init-claude` and `improve-claude`. The boundary applies uniformly; no template-layer exception survives it.
+
+See ADR-0006 for the new boundary and its full consequences.

--- a/docs/adr/0006-distribution-content-boundary.md
+++ b/docs/adr/0006-distribution-content-boundary.md
@@ -1,0 +1,59 @@
+# Distribution-content boundary
+
+**Status:** accepted (2026-05-04)
+
+A plugin distribution sources from its target platform's docs plus the cross-platform standard; the standalone distribution sources from the standard alone.
+
+The "cross-platform standard" is platform-agnostic documentation (context engineering, general harness, general-LLM filtered) — the subset that fits for **skills** (open Agent Skills format) and **AGENTS.md** as the supported output forms.
+
+Concepts whose output forms are platform-attached — Hooks, Subagents, path-scoped Rules with platform-specific frontmatter, CLAUDE.md hierarchy — are not in the standard. Standalone skills must not author them.
+
+## Context
+
+The toolkit ships three distributions (see `CONTEXT.md` for canonical definitions):
+
+- **Claude Code distribution** — the `agents-initializer` + `agent-customizer` plugin pair, targeting the Claude Code platform. Artifacts live under `.claude/`.
+- **Cursor distribution** — the `cursor-initializer` + `cursor-customizer` plugin pair, targeting Cursor IDE. Artifacts live under `.cursor/`.
+- **Standalone distribution** — the npx-installable `skills/` bundle. Performs inline analysis without subagent delegation; no initializer/customizer split.
+
+Each distribution draws on a different content source. Plugin distributions are justified in consuming platform-specific documentation because their output is intentionally platform-attached. The standalone bundle has no such justification: it claims to be portable, yet several of its skills were generating Claude Code-native output forms (`CLAUDE.md` hierarchy, `.claude/rules/*.md` with `paths:` frontmatter). ADR-0005 attempted to resolve the resulting compliance contradiction by splitting standalone scope into two layers (agnostic prose, platform-targeted templates). That two-layer reading preserved `init-claude` and `improve-claude` in the bundle. This ADR supersedes that preservation by articulating the upstream principle: the standalone bundle's content sources do not include platform-specific documentation, and therefore no standalone skill may author platform-attached output forms, regardless of how the template layer is named.
+
+## The boundary
+
+| Distribution | Sources from | Output forms |
+|---|---|---|
+| Claude Code plugin (`agents-initializer`, `agent-customizer`) | Claude Code platform docs + cross-platform standard | Skills, AGENTS.md, Hooks, Subagents, Rules (`.claude/rules/`), CLAUDE.md hierarchy |
+| Cursor plugin (`cursor-initializer`, `cursor-customizer`) | Cursor platform docs + cross-platform standard | Skills, Hooks, Rules (`.cursor/rules/*.mdc`), Subagents |
+| Standalone bundle (`skills/`) | Cross-platform standard only | Skills (SKILL.md packages), AGENTS.md |
+
+## Consequences
+
+Every standalone skill that generates a platform-attached output form fails the test under this boundary. Eight skills are affected:
+
+**Six deleted in issue #117:**
+
+- `create-rule` — generated `.claude/rules/*.md` with `paths:` frontmatter. Plugin equivalent: `plugins/agent-customizer/skills/create-rule/`.
+- `improve-rule` — evaluated and rewrote Claude Code path-scoped rules. Plugin equivalent: `plugins/agent-customizer/skills/improve-rule/`.
+- `create-hook` — generated Claude Code hook configurations (`settings.json` entries). Plugin equivalent: `plugins/agent-customizer/skills/create-hook/`.
+- `improve-hook` — evaluated and rewrote Claude Code hooks. Plugin equivalent: `plugins/agent-customizer/skills/improve-hook/`.
+- `create-subagent` — generated `.claude/agents/*.md` subagent definitions. Plugin equivalent: `plugins/agent-customizer/skills/create-subagent/`.
+- `improve-subagent` — evaluated and rewrote Claude Code subagent definitions. Plugin equivalent: `plugins/agent-customizer/skills/improve-subagent/`.
+
+**Two deferred to XC-12/Final:**
+
+- `init-claude` — bootstraps `CLAUDE.md` hierarchy and `.claude/rules/` for a project. Plugin equivalent: `plugins/agents-initializer/skills/init-claude/`.
+- `improve-claude` — evaluates and improves existing `CLAUDE.md` and `.claude/rules/`. Plugin equivalent: `plugins/agents-initializer/skills/improve-claude/`.
+
+The surviving standalone skills — `init-agents`, `improve-agents`, `create-skill`, `improve-skill` — author only cross-platform output forms (AGENTS.md and SKILL.md packages) and are unaffected by this boundary.
+
+## Considered options (rejected)
+
+**Union-of-platforms** — the standalone bundle could include any platform's concepts under generic names (e.g., "init-project" covering CLAUDE.md and AGENTS.md and `.cursor/rules/` setup). Rejected because the output forms remain platform-attached regardless of what the skill is called. A skill that generates `CLAUDE.md` hierarchy is a Claude Code skill, independent of its name.
+
+**Claude-as-default** — the standalone bundle covers Claude Code natively (on the grounds that Claude Code is the reference runtime for this repo). Rejected because it makes Cursor and other platforms second-class citizens inside the nominally "portable" bundle. The standalone bundle's portability claim is its purpose; privileging one platform hollows that claim.
+
+**Output-form-only skills** — allow platform-attached concepts if the output is wrapped generically (e.g., a skill that authors "project memory" which happens to be `CLAUDE.md`). Rejected because rename without reframe still produces hollow content. The skill body must teach to the output form, and once the output form is platform-attached the body inevitably imports platform-specific knowledge. This is the lesson from ADR-0005: the two-layer split attempted exactly this wrapping and still required knowledge sources (`CLAUDE-*` IDs) that are not in the cross-platform standard.
+
+## Why now
+
+ADR-0005 recorded the two-layer split as a pragmatic resolution to a compliance contradiction surfaced during the May 2026 alignment audit. The § Follow-up section of that ADR then documented per-family disposition decisions (rules: reframe; hooks/subagents: deprecate) as effects of applying the split. This ADR identifies the underlying cause: the standalone bundle's content-source constraint was never formally stated. The per-family outcomes in ADR-0005 § Follow-up are effects of this boundary, not independent decisions. Locking the principle here prevents future skills from being added to the standalone bundle without a clear test to apply.


### PR DESCRIPTION
## Summary

- Creates `docs/adr/0006-distribution-content-boundary.md` with the upstream principle that supersedes ADR-0005's per-family disposition: a plugin distribution sources from its target platform's docs plus the cross-platform standard; the standalone distribution sources from the standard alone.
- Marks ADR-0005 superseded with a header note and appends a `## Supersession (2026-05-04)` section that explains why the two-layer split was insufficient (the body of ADR-0005 is preserved verbatim as historical record).
- Adds the boundary to `CONTEXT.md` § Relationships and replaces the migration-targets rule in `.claude/rules/standalone-skills.md` with the ADR-0006-aligned must-not-author rule.

## The principle (ADR-0006 wording)

> A plugin distribution sources from its target platform's docs plus the cross-platform standard; the standalone distribution sources from the standard alone. The "cross-platform standard" is platform-agnostic documentation (context engineering, general harness, general-LLM filtered) — the subset that fits for **skills** (open Agent Skills format) and **AGENTS.md** as the supported output forms. Concepts whose output forms are platform-attached — Hooks, Subagents, path-scoped Rules with platform-specific frontmatter, CLAUDE.md hierarchy — are not in the standard. Standalone skills must not author them.

## Files changed (1 atomic commit)

| File | Change |
|---|---|
| `docs/adr/0006-distribution-content-boundary.md` | **Created.** All required sections: Context, The boundary (table), Consequences (8 affected skills with plugin-equivalent migration pointers), Considered options (3 rejected), Why now. |
| `docs/adr/0005-standalone-two-layer-scope.md` | Status header inserted after intro; body preserved verbatim; `## Supersession (2026-05-04)` appended after § Follow-up. |
| `CONTEXT.md` | New bullet appended to § Relationships citing the boundary. |
| `.claude/rules/standalone-skills.md` | Templates rule (line 15) appended ` See ADR-0006.`; migration-targets rule (lines 23–24) replaced with the must-not-author rule. |

## Out of scope

- **Skill deletions** — handled by #117 (in parallel, depends on this PR landing first).
- **`init-claude` / `improve-claude` removal** — deferred to XC-12/Final (will be filed after #117 merges).
- **`CONTEXT.md` "Two-layer standalone scope" term entry removal** — deferred to XC-12/Final.
- **Wiki updates** — separate sweep.

## Test plan

- [ ] `docs/adr/0006-distribution-content-boundary.md` renders correctly on GitHub.
- [ ] `docs/adr/0005-standalone-two-layer-scope.md` original body is byte-identical to pre-PR (verified via `git diff` against base).
- [ ] `grep -n "ADR-0006" docs/adr/0006-distribution-content-boundary.md CONTEXT.md docs/adr/0005-standalone-two-layer-scope.md .claude/rules/standalone-skills.md` returns matches in all four files.
- [ ] `.claude/rules/standalone-skills.md` line 23 contains the locked must-not-author wording.

Closes #130
Parent: #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)