### PR TITLE
chore: commit prototype meta-skill and orchestrate handoffs

### DIFF
--- a/.claude/skills/prototype/LOGIC.md
+++ b/.claude/skills/prototype/LOGIC.md
@@ -1,0 +1,79 @@
+# Logic Prototype
+
+A tiny interactive terminal app that lets the user drive a state model by hand. Use this when the question is about **business logic, state transitions, or data shape** — the kind of thing that looks reasonable on paper but only feels wrong once you push it through real cases.
+
+## When this is the right shape
+
+- "I'm not sure if this state machine handles the edge case where X then Y."
+- "Does this data model actually let me represent the case where..."
+- "I want to feel out what the API should look like before writing it."
+- Anything where the user wants to **press buttons and watch state change**.
+
+If the question is "what should this look like" — wrong branch. Use [UI.md](UI.md).
+
+## Process
+
+### 1. State the question
+
+Before writing code, write down what state model and what question you're prototyping. One paragraph, in the prototype's README or a comment at the top of the file. A logic prototype that answers the wrong question is pure waste — make the question explicit so it can be checked later, whether the user is watching now or returning to it AFK.
+
+### 2. Pick the language
+
+Use whatever the host project uses. If the project has no obvious runtime (e.g. a docs repo), ask.
+
+Match the project's existing conventions for tooling — don't add a new package manager or runtime just for the prototype.
+
+### 3. Isolate the logic in a portable module
+
+Put the actual logic — the bit that's answering the question — behind a small, pure interface that could be lifted out and dropped into the real codebase later. The TUI around it is throwaway; the logic module shouldn't be.
+
+The right shape depends on the question:
+
+- **A pure reducer** — `(state, action) => state`. Good when actions are discrete events and state is a single value.
+- **A state machine** — explicit states and transitions. Good when "which actions are even legal right now" is part of the question.
+- **A small set of pure functions** over a plain data type. Good when there's no implicit current state — just transformations.
+- **A class or module with a clear method surface** when the logic genuinely owns ongoing internal state.
+
+Pick whichever shape best fits the question being asked, *not* whichever is easiest to wire to a TUI. Keep it pure: no I/O, no terminal code, no `console.log` for control flow. The TUI imports it and calls into it; nothing flows the other direction.
+
+This is what makes the prototype useful past its own lifetime. When the question's been answered, the validated reducer / machine / function set can be lifted into the real module — the TUI shell gets deleted.
+
+### 4. Build the smallest TUI that exposes the state
+
+Build it as a **lightweight TUI** — on every tick, clear the screen (`console.clear()` / `print("\033[2J\033[H")` / equivalent) and re-render the whole frame. The user should always see one stable view, not an ever-growing scrollback.
+
+Each frame has two parts, in this order:
+
+1. **Current state**, pretty-printed and diff-friendly (one field per line, or formatted JSON). Use **bold** for field names or section headers and **dim** for less important context (timestamps, IDs, derived values). Native ANSI escape codes are fine — `\x1b[1m` bold, `\x1b[2m` dim, `\x1b[0m` reset. No need to pull in a styling library unless one is already in the project.
+2. **Keyboard shortcuts**, listed at the bottom: `[a] add user  [d] delete user  [t] tick clock  [q] quit`. Bold the key, dim the description, or vice-versa — whatever reads cleanly.
+
+Behaviour:
+
+1. **Initialise state** — a single in-memory object/struct. Render the first frame on start.
+2. **Read one keystroke (or one line)** at a time, dispatch to a handler that mutates state.
+3. **Re-render** the full frame after every action — don't append, replace.
+4. **Loop until quit.**
+
+The whole frame should fit on one screen.
+
+### 5. Make it runnable in one command
+
+Add a script to the project's existing task runner (`package.json` scripts, `Makefile`, `justfile`, `pyproject.toml`). The user should run `pnpm run <prototype-name>` or equivalent — never need to remember a path.
+
+If the host project has no task runner, just put the command at the top of the prototype's README.
+
+### 6. Hand it over
+
+Give the user the run command. They'll drive it themselves; the interesting moments are when they say "wait, that shouldn't be possible" or "huh, I assumed X would be different" — those are the bugs in the _idea_, which is the whole point. If they want new actions added, add them. Prototypes evolve.
+
+### 7. Capture the answer
+
+When the prototype has done its job, the answer to the question is the only thing worth keeping. If the user is around, ask what it taught them. If not, leave a `NOTES.md` next to the prototype so the answer can be filled in (or filled in by you, if you've watched the session) before the prototype gets deleted.
+
+## Anti-patterns
+
+- **Don't add tests.** A prototype that needs tests is no longer a prototype.
+- **Don't wire it to the real database.** Use an in-memory store unless the question is specifically about persistence.
+- **Don't generalise.** No "what if we wanted to support X later." The prototype answers one question.
+- **Don't blur the logic and the TUI together.** If the reducer / state machine references `console.log`, prompts, or terminal escape codes, it's no longer portable. Keep the TUI as a thin shell over a pure module.
+- **Don't ship the TUI shell into production.** The shell is optimised for being driven by hand from a terminal. The logic module behind it is the bit worth keeping.

--- a/.claude/skills/prototype/SKILL.md
+++ b/.claude/skills/prototype/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: prototype
+description: Build a throwaway prototype to flesh out a design before committing to it. Routes between two branches — a runnable terminal app for state/business-logic questions, or several radically different UI variations toggleable from one route. Use when the user wants to prototype, sanity-check a data model or state machine, mock up a UI, explore design options, or says "prototype this", "let me play with it", "try a few designs".
+---
+
+# Prototype
+
+A prototype is **throwaway code that answers a question**. The question decides the shape.
+
+## Pick a branch
+
+Identify which question is being answered — from the user's prompt, the surrounding code, or by asking if the user is around:
+
+- **"Does this logic / state model feel right?"** → [LOGIC.md](LOGIC.md). Build a tiny interactive terminal app that pushes the state machine through cases that are hard to reason about on paper.
+- **"What should this look like?"** → [UI.md](UI.md). Generate several radically different UI variations on a single route, switchable via a URL search param and a floating bottom bar.
+
+The two branches produce very different artifacts — getting this wrong wastes the whole prototype. If the question is genuinely ambiguous and the user isn't reachable, default to whichever branch better matches the surrounding code (a backend module → logic; a page or component → UI) and state the assumption at the top of the prototype.
+
+## Rules that apply to both
+
+1. **Throwaway from day one, and clearly marked as such.** Locate the prototype code close to where it will actually be used (next to the module or page it's prototyping for) so context is obvious — but name it so a casual reader can see it's a prototype, not production. For throwaway UI routes, obey whatever routing convention the project already uses; don't invent a new top-level structure.
+2. **One command to run.** Whatever the project's existing task runner supports — `pnpm <name>`, `python <path>`, `bun <path>`, etc. The user must be able to start it without thinking.
+3. **No persistence by default.** State lives in memory. Persistence is the thing the prototype is _checking_, not something it should depend on. If the question explicitly involves a database, hit a scratch DB or a local file with a clear "PROTOTYPE — wipe me" name.
+4. **Skip the polish.** No tests, no error handling beyond what makes the prototype _runnable_, no abstractions. The point is to learn something fast and then delete it.
+5. **Surface the state.** After every action (logic) or on every variant switch (UI), print or render the full relevant state so the user can see what changed.
+6. **Delete or absorb when done.** When the prototype has answered its question, either delete it or fold the validated decision into the real code — don't leave it rotting in the repo.
+
+## When done
+
+The _answer_ is the only thing worth keeping from a prototype. Capture it somewhere durable (commit message, ADR, issue, or a `NOTES.md` next to the prototype) along with the question it was answering. If the user is around, that capture is a quick conversation; if not, leave the placeholder so they (or you, on the next pass) can fill in the verdict before deleting the prototype.

--- a/.claude/skills/prototype/UI.md
+++ b/.claude/skills/prototype/UI.md
@@ -1,0 +1,112 @@
+# UI Prototype
+
+Generate **several radically different UI variations** on a single route, switchable from a floating bottom bar. The user flips between variants in the browser, picks one (or steals bits from each), then throws the rest away.
+
+If the question is about logic/state rather than what something looks like — wrong branch. Use [LOGIC.md](LOGIC.md).
+
+## When this is the right shape
+
+- "What should this page look like?"
+- "I want to see a few options for this dashboard before committing."
+- "Try a different layout for the settings screen."
+- Any time the user would otherwise spend a day picking between three vague mockups in their head.
+
+## Two sub-shapes — strongly prefer sub-shape A
+
+A UI prototype is much easier to judge when it's **butting up against the rest of the app** — real header, real sidebar, real data, real density. A throwaway route on its own is a vacuum: every variant looks fine in isolation. Default to sub-shape A whenever there's a plausible existing page to host the variants. Only reach for sub-shape B if the prototype genuinely has no nearby home.
+
+### Sub-shape A — adjustment to an existing page (preferred)
+
+The route already exists. Variants are rendered **on the same route**, gated by a `?variant=` URL search param. The existing data fetching, params, and auth all stay — only the rendering swaps. This is the default; pick it unless there's a specific reason not to.
+
+If the prototype is for something that doesn't yet have a page but *would naturally live inside one* (a new section of the dashboard, a new card on the settings screen, a new step in an existing flow) — that's still sub-shape A. Mount the variants inside the host page.
+
+### Sub-shape B — a new page (last resort)
+
+Only use this when the thing being prototyped genuinely has no existing page to live inside — e.g. an entirely new top-level surface, or a flow that can't be embedded anywhere sensible.
+
+Create a **throwaway route** following whatever routing convention the project already uses — don't invent a new top-level structure. Name it so it's obviously a prototype (e.g. include the word `prototype` in the path or filename). Same `?variant=` pattern.
+
+Before committing to sub-shape B, sanity-check: is there really no existing page this could be embedded in? An empty route hides design problems that a populated one would expose.
+
+In both sub-shapes the floating bottom bar is identical.
+
+## Process
+
+### 1. State the question and pick N
+
+Default to **3 variants**. More than 5 stops being radically different and starts being noise — cap there.
+
+Write down the plan in one line, in the prototype's location or a top-of-file comment:
+
+> "Three variants of the settings page, switchable via `?variant=`, on the existing `/settings` route."
+
+This works whether the user is here to push back or not.
+
+### 2. Generate radically different variants
+
+Draft each variant. Hold each one to:
+
+- The page's purpose and the data it has access to.
+- The project's component library / styling system (TailwindCSS, shadcn, MUI, plain CSS, whatever).
+- A clear exported component name, e.g. `VariantA`, `VariantB`, `VariantC`.
+
+Variants must be **structurally different** — different layout, different information hierarchy, different primary affordance, not just different colours. Three slightly-tweaked card grids isn't a UI prototype, it's wallpaper. If two drafts come out too similar, redo one with explicit "do not use a card grid" guidance.
+
+### 3. Wire them together
+
+Create a single switcher component on the route:
+
+```tsx
+// pseudo-code — adapt to the project's framework
+const variant = searchParams.get('variant') ?? 'A';
+return (
+  <>
+    {variant === 'A' && <VariantA {...data} />}
+    {variant === 'B' && <VariantB {...data} />}
+    {variant === 'C' && <VariantC {...data} />}
+    <PrototypeSwitcher variants={['A','B','C']} current={variant} />
+  </>
+);
+```
+
+For sub-shape A (existing page): keep all the existing data fetching above the switcher; only the rendered subtree changes per variant.
+
+For sub-shape B (new page): the throwaway route under `/prototype/<name>` mounts the same switcher.
+
+### 4. Build the floating switcher
+
+A small fixed-position bar at the bottom-centre of the screen with three pieces:
+
+- **Left arrow** — cycles to the previous variant (wraps around).
+- **Variant label** — shows the current variant key and, if the variant exports a name, that name too. e.g. `B — Sidebar layout`.
+- **Right arrow** — cycles forward (wraps around).
+
+Behaviour:
+
+- Clicking an arrow updates the URL search param (use the framework's router — `router.replace` on Next, `navigate` on React Router, etc) so the variant is shareable and reload-stable.
+- Keyboard: `←` and `→` arrow keys also cycle. Don't intercept arrow keys when an `<input>`, `<textarea>`, or `[contenteditable]` is focused.
+- Visually distinct from the page (e.g. high-contrast pill, subtle shadow) so it's obviously not part of the design being evaluated.
+- Hidden in production builds — gate on `process.env.NODE_ENV !== 'production'` or an equivalent check, so a stray prototype merge can't ship the bar to users.
+
+Put the switcher in a single shared component so both sub-shapes can reuse it. Locate it wherever shared UI lives in the project.
+
+### 5. Hand it over
+
+Surface the URL (and the `?variant=` keys). The user will flip through whenever they get to it. The interesting feedback is usually **"I want the header from B with the sidebar from C"** — that's the actual design they want.
+
+### 6. Capture the answer and clean up
+
+Once a variant has won, write down which one and why (commit message, ADR, issue, or a `NOTES.md` next to the prototype if running AFK and the user hasn't responded yet). Then:
+
+- **Sub-shape A** — delete the losing variants and the switcher; fold the winner into the existing page.
+- **Sub-shape B** — promote the winning variant to a real route, delete the throwaway route and the switcher.
+
+Don't leave variant components or the switcher lying around. They rot fast and confuse the next reader.
+
+## Anti-patterns
+
+- **Variants that differ only in colour or copy.** That's a tweak, not a prototype. Real variants disagree about structure.
+- **Sharing too much code between variants.** A shared `<Header>` is fine; a shared `<Layout>` defeats the point. Each variant should be free to throw out the layout.
+- **Wiring variants to real mutations.** Read-only prototypes are fine. If a variant needs to mutate, point it at a stub — the question is "what should this look like", not "does the backend work".
+- **Promoting the prototype directly to production.** The variant code was written under prototype constraints (no tests, minimal error handling). Rewrite it properly when you fold it in.

--- a/docs/handoffs/HANDOFF_ORCHESTRATE_05_20_23_53.md
+++ b/docs/handoffs/HANDOFF_ORCHESTRATE_05_20_23_53.md
@@ -1,0 +1,194 @@
+# Handoff: `orchestrate` plugin — design, PRD & backlog
+
+**Created:** 2026-05-20 23:53
+**Branch:** development
+**Session type:** Design session (grill-me → /to-prd → /to-issues → /triage). No plugin code written yet.
+
+---
+
+## Summary
+
+This session designed a new Claude Code plugin, **`orchestrate`** — a Bash-free, AFK issue-orchestration loop that behaves like Sandcastle but runs entirely inside one interactive Claude Code session (no `claude -p`). The design was settled through a relentless grill-me interview (~17 decisions), then published as **PRD #153** and **14 dependency-ordered slice issues (#154–#167)** on GitHub, all triaged. The deliverable so far is the design + backlog; building has not started. A new session should begin implementation at issue **#154**.
+
+---
+
+## Work Completed
+
+### Changes Made
+
+- [x] Ran a full grill-me interview resolving ~17 design decisions for the `orchestrate` plugin
+- [x] Set `remoteControlAtStartup: true` in `~/.claude/settings.json` (was `false`)
+- [x] Saved auto-memory: `feedback_html_eye_friendly_colors` + indexed it in `MEMORY.md`
+- [x] Published **PRD #153** to GitHub Issues (`enhancement`, `needs-triage`)
+- [x] Published **14 slice issues #154–#167** (`/to-issues`), dependency-ordered, each with Parent → #153 and real `Blocked by` refs
+- [x] Triaged all 15: `#154` → `ready-for-human`; `#155–#167` → `ready-for-agent`; `#153` stays `needs-triage` (parent tracker); all `enhancement`
+
+### Key Decisions
+
+| Decision | Rationale | Alternatives considered |
+| --- | --- | --- |
+| Orchestration parity, not container isolation | One Claude Code session cannot sandbox like Docker; git worktree is the only isolation available | Spawn Docker/Podman per slice (rejected: heavy, not portable) |
+| Zero Bash for every agent | Bash is bypassable (chaining, subshells); MCP tools are capability-scoped and structurally safe | Bash with allowlist hook (rejected by user — leaky) |
+| Custom `orchestrate-mcp` server (capability tools) | The only Bash-free way to run tests, manage worktrees, render HTML, spawn successors | `safe-exec` MCP with allowlist; scoped Bash for subagents only |
+| GitHub Issues as fixed backlog source | `/to-prd` + `/to-issues` already target GitHub; "project-agnostic" ≠ "tracker-agnostic" | Pluggable backlog layer (rejected: speculative scope) |
+| Deterministic wave planner (topo-sort), not a planner agent | `/to-issues` already records explicit `Blocked by`; no need for a fuzzy LLM planner | Planner agent; hybrid |
+| PR per slice → umbrella; final umbrella → development PR | CI gate per slice + clean diff; human merges the final PR | Direct `git merge` to umbrella, single PR |
+| 4 subagent roles × 2 effort variants = 8 defs | `effort` is fixed in subagent frontmatter, not overridable at spawn | 4 variants per role; prompt-injected effort |
+| `run-state.json` checkpoint + resumable loop | Orchestrator loop runs inside the LLM; state must live on disk to survive overflow/crash | State in context only; derive from GitHub each wave |
+| Context handoff at 40% via successor window | Keep orchestrator context healthy; `spawn_successor` opens a real `claude` window | Background sessions (`--bg`); never handing off |
+| `/goal` set at skill startup | Keeps the orchestrator looping autonomously; condition = "run complete OR successor spawned" resolves the handoff tension | No goal (risk of premature return of control) |
+| Distribution = full marketplace plugin | Deliverable spans skill + 8 subagents + hook + MCP server; plugin is the export unit | Skill in `.claude/` + separate MCP package |
+
+---
+
+## Files Affected
+
+### Created (durable)
+
+- `~/.claude/projects/-home-rodrigo-Workspace-agent-engineering-toolkit/memory/feedback_html_eye_friendly_colors.md` — user preference: HTML artifacts use eye-friendly colors readable on light + dark backgrounds
+- GitHub: PRD **#153**, issues **#154–#167** (the real backlog — see "Related Resources")
+
+### Modified
+
+- `~/.claude/settings.json` — `remoteControlAtStartup` flipped `false` → `true`, so every new Claude Code window starts with Remote Control active
+- `~/.claude/projects/.../memory/MEMORY.md` — added index line for the new memory
+
+### Created (transient — safe to delete)
+
+- `/tmp/orchestrate-prd.md`, `/tmp/orch-s1.md … /tmp/orch-s14.md` — issue body files used by `gh issue create`; content is now durable on GitHub
+
+### Repo working tree
+
+No tracked repo files were changed this session. `git status` shows only pre-existing untracked items (`*Zone.Identifier` files, `.claude/skills/prototype/`, `sandcastle-ref/`). Nothing to commit.
+
+---
+
+## Technical Context
+
+### Architecture — `orchestrate` plugin
+
+The main Claude Code session becomes a **pure orchestrator**: it never edits source or runs code; it only coordinates. Flow per run:
+
+1. `/orchestrate` → skill sets `/goal` (condition: run terminal OR successor spawned). Orchestrator = zero Bash.
+2. Read `ready-for-agent` GitHub issues (GitHub MCP) → `plan_waves` MCP tool topo-sorts the `Blocked by` graph into waves.
+3. Create umbrella branch from `development`.
+4. Assess each issue's complexity tier → `routing.json` → `{model, effort-variant}` per role.
+5. Per wave, parallel per slice: `create_worktree` (from fetched `origin/umbrella`) → investigator (high tiers) → implementer → reviewer (fixes inline; unrecoverable blocker → `FAILED`) → slice PR → CI → auto-merge → conflict → conflict-resolver once → `remove_worktree` → update `run-state.json` + dashboard + labels.
+6. Each slice boundary: check `context-watchdog` flag; if > 40%, checkpoint → `spawn_successor` (new `claude --remote-control` window) → exit.
+7. Backlog done → single umbrella → `development` PR, left unmerged (human gate) → final HTML report.
+
+### Components
+
+- **`orchestrate-mcp`** (TypeScript MCP server) — tools: `create_worktree`/`remove_worktree`, `run_tests`/`run_typecheck`/`run_build`/`run_lint`, `plan_waves`, `render_dashboard`/`render_graph`/`render_report`, `spawn_successor`
+- **8 subagents** — investigator, implementer, reviewer, conflict-resolver, each in `standard` + `deep` effort variant; no Bash (scoped via frontmatter `tools`/`mcpServers`)
+- **1 hook** — `context-watchdog` (PostToolUse), reads transcript `usage` to flag the 40% threshold
+- **Config** — `.orchestrate/commands.json` (test/build commands), `.orchestrate/routing.json` (tier → model+effort), handoff threshold, successor launcher
+- **3 HTML artifacts** — dashboard, dependency graph, final report; rendered deterministically by the MCP from `run-state.json` (no model tokens); eye-friendly palette
+- Bash denied to all agents via `permissions.deny`
+
+### Verified harness facts (from research this session)
+
+- Subagent frontmatter supports `effort` (low/medium/high/xhigh/max), `tools`, `disallowedTools`, `mcpServers`, `isolation: worktree`, `permissionMode`, `maxTurns`. `effort` is **not** overridable at spawn — only `model` is.
+- `isolation: worktree` branches from `origin/HEAD` by default (`worktree.baseRef: head` overrides) — why worktree lifecycle is owned by the MCP, not the native tool.
+- No git/GitHub/filesystem/ast-grep MCP servers are currently installed (no `.mcp.json`). `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is already on in the project `.claude/settings.json`.
+- `/goal` (v2.1.139+) holds a completion condition across turns. `claude "prompt"` starts an interactive session with the prompt executed.
+- No native API exposes context fill % to the agent — hence the `context-watchdog` hook reading transcript `usage`.
+
+---
+
+## Things to Know
+
+### Gotchas & Pitfalls
+
+- **Local umbrella drift:** slice PRs auto-merge to umbrella on the *remote*; the orchestrator's *local* checkout does not follow. `create_worktree` must `git fetch` and branch from `origin/umbrella`, never local `umbrella` — else wave 2 loses wave 1's work.
+- **`remoteControlAtStartup` is under-documented:** the key is present in the real `settings.json` (so it is valid and `/config` manages it), but Anthropic docs do not list it. If it does not take effect, fall back to the `/config` toggle "Enable Remote Control for all sessions". `spawn_successor` also passes `--remote-control` explicitly.
+- **Issue numbering is exact:** #154–#167 came out perfectly sequential, so every `Blocked by` reference in the issue bodies is correct. Do not renumber.
+- **`/goal` vs handoff tension:** the goal condition must include "OR successor spawned" so a 40% handoff cleanly satisfies the predecessor's goal and lets it exit.
+
+### Assumptions Made
+
+- The successor terminal launcher prefers Warp (user's terminal) and falls back to `wt.exe`.
+- The implementer pushes file contents via the GitHub MCP `push_files` (no local `git commit`/`git push`).
+
+### Known Issues / Open scope
+
+- Whether an ast-grep MCP exists in the market is unconfirmed — S12 (#165) degrades to text search if absent.
+- Exact GitHub MCP tool-name granularity for subagent `tools:` frontmatter to be verified at build time.
+
+---
+
+## Current State
+
+### What's Working
+
+- Design: complete and ratified through grill-me.
+- Backlog: PRD #153 + 14 slices #154–#167 published and triaged on GitHub.
+- `remoteControlAtStartup` fix: applied.
+
+### What's Not Working / Not Started
+
+- No plugin code exists yet. `plugins/orchestrate/` has not been created.
+- The `orchestrate-mcp` server, subagents, hook, configs, tests, README — all unbuilt.
+
+### Tests
+
+- [ ] Unit tests: not written (planned per slice — all 7 deterministic modules)
+- [ ] Integration / red-green scenarios: not written (slice #166)
+- [ ] E2E smoke: not written (slice #166)
+
+---
+
+## Next Steps
+
+### Immediate (Start Here)
+
+1. **Build slice S1 / issue #154** (`ready-for-human`, HITL): scaffold `plugins/orchestrate/` with `plugin.json` and the `orchestrate-mcp` TypeScript server; implement `create_worktree`/`remove_worktree` + unit tests. This issue carries a human design-review gate on the MCP package layout and tool schemas — review before dependent slices start.
+2. After #154: **#155 (S2, capability executor)** and **#156 (S3, wave planner)** unblock — both depend only on #154.
+3. Follow the dependency graph: #157 → #158 → #159, then #159 unblocks #160–#164, #161 unblocks #165, then #166, then #167.
+
+Use `/agent-customizer:create-skill` for the skill, `/agent-customizer:create-subagent` for the 8 subagents, `/agent-customizer:create-hook` for `context-watchdog`. The MCP server is hand-built TypeScript.
+
+### Blocked On
+
+- Nothing. #154 can start immediately.
+
+---
+
+## Related Resources
+
+### The durable spec lives on GitHub
+
+- **PRD:** https://github.com/rodrigorjsf/agent-engineering-toolkit/issues/153
+- **Slices:** issues #154–#167 — each has full `What to build` + `Acceptance criteria` + `Blocked by`. These ARE the build briefs; read them, not a re-derivation.
+
+### Commands to Run
+
+```bash
+# See the full backlog
+gh issue list --state open --label ready-for-agent --search "orchestrate in:title"
+# Read a slice
+gh issue view 154 --comments
+```
+
+### Reference material (read this session)
+
+- `sandcastle-ref/sandcastle/` — Sandcastle source (README, CONTEXT.md, `.sandcastle/*.md` prompts, `parallel-planner-with-review` template) — the orchestration model being adapted
+- `docs/html-structure/thariq-html-effectiveness.md` — the HTML-artifact rationale
+
+---
+
+## Open Questions
+
+- [ ] Confirm an ast-grep MCP exists (affects S12/#165) — else text-search fallback stands
+- [ ] Confirm the exact GitHub MCP tool names for subagent `tools:` frontmatter scoping (build-time)
+- [ ] TypeScript vs other language for `orchestrate-mcp` — recommended TypeScript (mature MCP SDK); confirm at S1
+
+---
+
+## Session Notes
+
+This was a long grill-me design session. The user added several requirements mid-grill that reshaped the design: the total Bash ban (→ MCP capability model), complexity-based model/effort routing, eye-friendly HTML colors, the 40% context handoff with successor windows, and `/goal` integration. All are folded into PRD #153. The repo convention chain `grill-me → /to-prd → /to-issues → /triage` is now complete; the next phase is pure build. The advisor was consulted at the architecture pivot and caught three silent transformations (worktree-via-MCP, effort-variant collapse, conflict-resolver as a 4th role) — all subsequently confirmed with the user.
+
+---
+
+_This handoff was generated via /handoff. Start a new session, read PRD #153 and issue #154, and begin the build._

--- a/docs/handoffs/HANDOFF_ORCHESTRATE_PR168_05_21_12_52.md
+++ b/docs/handoffs/HANDOFF_ORCHESTRATE_PR168_05_21_12_52.md
@@ -1,0 +1,172 @@
+# Handoff: `orchestrate` plugin — PRD #153 complete, PR #168 open for review
+
+**Created:** 2026-05-21 12:52
+**Branch:** `feat/orchestrate-plugin` (pushed; 14 commits ahead of `development`)
+**Session Duration:** ~2.5 hours
+
+---
+
+## Summary
+
+PRD #153 — the `orchestrate` Claude Code plugin — is **fully implemented**. This session resumed from the S10 handoff, built the final four slices (S11–S14 / issues #164–#167), pushed the branch, and opened **PR #168** into `development`. All fourteen slice issues and the parent PRD are relabeled to `ready-for-human`. The one thing not done: the end-to-end skill loop has never been run against a live fixture repository.
+
+---
+
+## Work Completed
+
+### Changes Made
+
+- [x] S11 (#164) — `context-watchdog` PostToolUse hook + `spawn_successor` MCP tool + context-handoff path in the skill — commit `5e53b59`
+- [x] S12 (#165) — `search_structural` ast-grep MCP tool + structural-search wiring in the 4 investigator/reviewer subagents — commit `48245e8`
+- [x] S13 (#166) — 8 red-green scenario specs + render-tool wiring into the skill — commit `3de614b`
+- [x] S14 (#167) — plugin README + marketplace registration + `1.0.0` bump — commit `808207f`
+- [x] Branch pushed to `origin/feat/orchestrate-plugin`
+- [x] PR #168 created → `development`
+- [x] Slice issues #154–#167 relabeled `ready-for-human`; PRD #153 relabeled `ready-for-human` + completion comment
+
+### Key Decisions
+
+| Decision | Rationale | Alternatives Considered |
+| --- | --- | --- |
+| S11 successor launcher: Windows-Terminal-first, configurable chain | User ratified Decision A — WSL2 environment, no Warp | Warp-first (issue's literal default) |
+| `--remote-control` / `/goal` used as-is | Verified real via `claude --help` v2.1.146 — not guessed | Research agent wrongly claimed Remote Control was human-only |
+| S12: `search_structural` tool inside `orchestrate-mcp` | Stable tool name the subagents' restrictive `tools:` lists can carry | Wiring an external ast-grep MCP (fragile name) |
+| S13 E2E smoke test = runbook scenario | Repo has no executing-skill tests; a fake-green test would mislead | An automated vitest E2E |
+| S13: wired render tools into SKILL.md | O8 review surfaced #163 added render tools never invoked by the skill | Flag-and-defer to a separate issue |
+| Plugin → `1.0.0` at S14 | Versioning rule: first feature-complete, marketplace-registered surface | Stay `0.x` until E2E-verified |
+
+---
+
+## Files Affected
+
+### Created (this session)
+
+- `plugins/orchestrate/orchestrate-mcp/src/handoff-config.ts` — shared `handoff.json` zod schema + loader
+- `plugins/orchestrate/orchestrate-mcp/src/hooks/context-watchdog.ts` / `context-watchdog-cli.ts` — watchdog logic + hook entry
+- `plugins/orchestrate/orchestrate-mcp/src/tools/spawn-successor.ts` / `search-structural.ts` — two new MCP tools
+- `plugins/orchestrate/orchestrate-mcp/test/{context-watchdog,spawn-successor,search-structural}.test.ts` — 55 new tests
+- `plugins/orchestrate/hooks/hooks.json` — declares the `context-watchdog` PostToolUse hook
+- `plugins/orchestrate/templates/handoff.json` — context-handoff config template
+- `plugins/orchestrate/skills/orchestrate/references/context-handoff.md` — handoff mechanism reference
+- `plugins/orchestrate/README.md` — the plugin README (229 lines)
+- `.claude/PRPs/tests/scenarios/orchestrate-*.md` — 8 scenario specs (O1–O8)
+- `docs/handoffs/HANDOFF_ORCHESTRATE_S14_COMPLETE_05_21_12_34.md` — earlier completion report (pre-push)
+
+### Modified
+
+- `plugins/orchestrate/orchestrate-mcp/src/index.ts` — registered `spawn_successor` + `search_structural`; `McpServer` version `0.12.0`
+- `plugins/orchestrate/orchestrate-mcp/package.json` — build script (2nd esbuild entry); version `0.12.0`
+- `plugins/orchestrate/skills/orchestrate/SKILL.md` — `/goal` at startup, stale-flag clear, handoff section, render step
+- `plugins/orchestrate/.claude-plugin/plugin.json` — version `0.13.0` → `1.0.0`
+- `plugins/orchestrate/agents/{investigator,reviewer}-{standard,deep}.md` — `search_structural` in `tools:` + Code search section
+- `.claude-plugin/marketplace.json` — orchestrate entry added; version `1.2.0` → `1.3.0`
+- `README.md` (root) — orchestrate in Distributions table, Installation, structure tree
+- `plugins/orchestrate/orchestrate-mcp/dist/{index.js,context-watchdog.js}` — rebuilt bundles (committed)
+
+---
+
+## Technical Context
+
+### Architecture Notes
+
+- The orchestrate skill is markdown driven by a model — it cannot be unit-tested. `orchestrate-mcp` (TypeScript) holds the testable logic: 13 MCP tools, discriminated `status` results, never-throws contract.
+- The `context-watchdog` hook is a separate esbuild bundle (`dist/context-watchdog.js`), declared in `hooks/hooks.json`, auto-discovered when the plugin is enabled. It is a silent no-op outside an active orchestration run.
+- The MCP server version (`0.12.0`) and the plugin version (`1.0.0`) are **independent** — the MCP server version bumps only when `orchestrate-mcp` source changes (last: #165).
+
+### Dependencies
+
+No new npm dependencies. `search_structural` shells to the optional `ast-grep` CLI; absent → graceful text-search fallback.
+
+---
+
+## Things to Know
+
+### Gotchas
+
+- The `sg` alias for ast-grep collides with the POSIX `sg` (set-group) command — the tool hardcodes `ast-grep`, never `sg`.
+- `Closes #N` trailers auto-close the slice issues **because `development` is the repo default branch** — confirmed via `gh repo view`.
+- esbuild rebuilds are deterministic — a no-op `npm run build` leaves `dist/` byte-identical (no spurious git diff).
+
+### Known Issues / Tech Debt
+
+- **The end-to-end skill loop has never run.** Unit tests cover the MCP tools (144 tests); the skill loop is unverified — see scenario O8.
+- `orchestrate-mcp` self-reports version `0.12.0` while the plugin is `1.0.0` — correct per the versioning rule, but mildly confusing for a 1.0 release.
+- AGENT_TEAMS: PRD #153 mentioned "the plugin ships the config to enable it"; no slice AC made that concrete. The README documents it as optional; no `settings.json` is shipped (force-enabling an experimental feature contradicts "optional").
+
+---
+
+## Current State
+
+### What's Working
+
+- `orchestrate-mcp` — `build`, `typecheck`, `test` all green (144 tests, 9 files).
+- `context-watchdog` hook — verified end-to-end with simulated hook stdin.
+- PR #168 — open, base `development`, awaiting review.
+- All 14 slice issues + PRD #153 — relabeled `ready-for-human`.
+
+### What's Not Working / Unverified
+
+- The full `/orchestrate` skill loop against a real GitHub repo — never executed.
+
+### Tests
+
+- [x] Unit tests: 144 passing (`orchestrate-mcp`)
+- [ ] Integration / E2E: O8 runbook not yet run against a fixture
+- [x] Per-slice Opus review: all 4 slices reviewed, P0/P1 resolved
+
+---
+
+## Next Steps
+
+### Immediate (Start Here)
+
+1. **Review PR #168** — https://github.com/rodrigorjsf/agent-engineering-toolkit/pull/168. The CI workflow `.github/workflows/claude-code-review.yml` is the final gate.
+2. **Run the O8 runbook** — `.claude/PRPs/tests/scenarios/orchestrate-e2e-smoke.md` — against a throwaway fixture repository to verify the skill loop end to end.
+3. **Merge PR #168** into `development` — this auto-closes slice issues #154–#167 via the `Closes` keywords.
+
+### Subsequent
+
+- Manually close PRD #153 after the merge (it carries only `Refs #153`, no `Closes`).
+- Optional `chore(release)`: bump `orchestrate-mcp/package.json` + the `McpServer` version in `index.ts` to `1.0.0` to align with the plugin release.
+
+### Blocked On
+
+- Nothing. PR #168 is ready for human review.
+
+---
+
+## Related Resources
+
+### Documentation
+
+- PR #168 — the review surface
+- PRD: GitHub issue #153 (`rodrigorjsf/agent-engineering-toolkit`)
+- Earlier completion report: `docs/handoffs/HANDOFF_ORCHESTRATE_S14_COMPLETE_05_21_12_34.md`
+- Scenario suite: `.claude/PRPs/tests/scenarios/orchestrate-*.md`
+
+### Commands to Run
+
+```bash
+# Verify the package
+cd plugins/orchestrate/orchestrate-mcp && npm run build && npm run typecheck && npm test
+
+# PR status
+gh pr view 168 --json state,reviewDecision,statusCheckRollup
+```
+
+---
+
+## Open Questions
+
+- [ ] Should `orchestrate-mcp` be version-aligned to `1.0.0` with the plugin? (Optional follow-up.)
+- [ ] Does the user want a shipped opt-in `settings.json` for AGENT_TEAMS, or is README documentation sufficient?
+
+---
+
+## Session Notes
+
+PRD #153 is the largest workstream on this branch — 14 slices across multiple sessions. This session completed S11–S14 with the per-slice ritual (build → independent verify → Opus review → fix P0/P1 → atomic commit), `advisor()` consulted at every design fork. Two stop-conditions fired and were resolved by user ratification (Decision A; the S12 ast-grep approach; the S13 runbook form). The S13 review caught a genuine half-finished feature from S10 (render tools never wired into the skill) — fixed in the same commit.
+
+---
+
+_PRD #153 complete. PR #168 awaits review, merge, and an O8 end-to-end run._

--- a/docs/handoffs/HANDOFF_ORCHESTRATE_S10_05_21_10_24.md
+++ b/docs/handoffs/HANDOFF_ORCHESTRATE_S10_05_21_10_24.md
@@ -1,0 +1,144 @@
+# Handoff: `orchestrate` plugin — Slices S2–S10 built; stopped at S10 before the platform-specific S11
+
+**Created:** 2026-05-21 10:24
+**Branch:** `feat/orchestrate-plugin` (10 commits, not pushed)
+**Supersedes:** `HANDOFF_ORCHESTRATE_S3_05_21_01_51.md` — that handoff's three foundational decisions were answered by the user (see *Decisions already ratified*).
+
+---
+
+## Summary
+
+The user asked to "run all slices" of PRD #153 autonomously. After the S3 handoff surfaced three foundational design calls, the user ratified them ("Bundle A — gh-native"), and the build resumed. Slices **S4 (#157) through S10 (#163)** are now built, Opus-reviewed, and committed — **nine new commits this session**, on top of S1.
+
+Work **stopped at S10**. Slice **S11 (#164)** — the `context-watchdog` hook and successor handoff — requires three platform/CLI specifics that cannot be verified unattended: the exact Claude Code "Remote Control" launch invocation, whether Warp is the user's terminal, and the WSL2→Windows Terminal handoff. Shipping a successor-spawner on guessed defaults fails *silently* (a terminal launches, but the Claude Code inside is not Remote-Control-driveable). This is the ratified stop-condition firing again: *"a slice's acceptance criteria can't be met without a design call the user hasn't ratified."*
+
+Ten of the fourteen PRD slices are done. A new session should resume at **#164** once the user answers *Decisions A–C* below.
+
+---
+
+## Decisions already ratified (from the S3 handoff)
+
+The user chose **Bundle A — gh-native**:
+
+- **No GitHub MCP.** The orchestrator skill uses the `gh` CLI for all GitHub operations.
+- **The orchestrator commits and pushes** the slice via Bash; the implementer subagent stays Bash-free.
+- **`remove_worktree` gained a `force` option** so the orchestrator can clean up a worktree unconditionally.
+
+All of S4–S10 is built on this architecture.
+
+---
+
+## Work Completed
+
+| Slice | Issue | Commit | What it added |
+| --- | --- | --- | --- |
+| S2 | #155 | `6a79535` | `run_tests`/`run_typecheck`/`run_build`/`run_lint` capability tools + `commands.json` template |
+| S3 | #156 | `bc5a5df` | `plan_waves` dependency wave planner (Kahn topo-sort, cycle detection) |
+| S4 | #157 | `b9a9291` | The `orchestrate` skill + `implementer` subagent — walking skeleton; `remove_worktree` force option |
+| S5 | #158 | `d116e4c` | `reviewer` subagent + review gate + auto-merge |
+| S6 | #159 | `d2720aa` | Multi-wave resumable loop + `run-state.json` checkpoint |
+| S7 | #160 | `7e23d9d` | `conflict-resolver` subagent + final umbrella→development PR |
+| S8 | #161 | `e40ef83` | Complexity routing — `resolve_routing` tool, `routing.json`, 8 subagent effort variants, `investigator` role |
+| S9 | #162 | `9f45463` | Issue-label + parent-PRD status sync |
+| S10 | #163 | `c486680` | `render_dashboard`/`render_graph`/`render_report` HTML artifact tools |
+
+S1 (`185e4ec`, issue #154) pre-dated this session. **Branch is 10 commits ahead of `development`.**
+
+### Process used per slice
+
+Build → independent `build`/`typecheck`/`test` verification → Opus reviewer subagent → fix P1/P2 → commit. `advisor()` consulted at the design forks (pre-S2, pre-S4 stop decision, pre-S11 stop decision). Heavy slices (S8's 8 subagent files, S10's renderer) had their build delegated to a Sonnet subagent, then independently verified — the handoff's "implementers can mischaracterize failures" gotcha held; all subagent claims were re-checked.
+
+---
+
+## Current State — what works on paper
+
+- **Plugin at `0.10.0`.** `orchestrate-mcp` `build`/`typecheck`/`test` all green — **89 tests** across 5 files.
+- **`orchestrate-mcp` — 10 MCP tools:** `create_worktree`, `remove_worktree`, `run_tests`, `run_typecheck`, `run_build`, `run_lint`, `plan_waves`, `resolve_routing`, `render_dashboard`, `render_graph`, `render_report`.
+- **The `orchestrate` skill** drives the full multi-wave loop: read the `ready-for-agent` backlog → assess complexity tiers → `plan_waves` → umbrella branch → per-wave, per-slice processing (routed investigator/implementer/reviewer subagents in isolated worktrees) → commit/push/PR/merge → conflict resolution → `run-state.json` checkpoint → resume → tracker sync → final umbrella→development PR.
+- **8 subagent definitions** — `{investigator,implementer,reviewer,conflict-resolver}-{standard,deep}`; all Bash-free and git-free; the investigator is read-only.
+- **Not verified end-to-end.** Every slice is built *to spec* and structurally/unit verified. The skill + subagent orchestration has not been run against a live GitHub repo — true E2E verification is slice #166.
+
+### Working tree
+
+Clean. Only pre-existing untracked items remain (`*Zone.Identifier`, `.claude/skills/prototype/`, `sandcastle-ref/`, prior handoff docs). **Not pushed. No PR.**
+
+---
+
+## Why the run stopped at S10 — decisions for the user
+
+Slice **#164** ("context-watchdog hook + successor handoff") needs the orchestrator to launch a *new interactive Claude Code window* that resumes the run. Most of #164 is buildable to spec — the `context-watchdog` PostToolUse hook (read the transcript, estimate token usage, write a `.orchestrate/context-flag` past a threshold), the flag-driven handoff steps in the skill, the `/goal`-at-startup. **What cannot be verified unattended is the successor launch itself.**
+
+### Decision A — The successor terminal launcher
+
+The issue says "prefers Warp, falls back to Windows Terminal, configurable." The strategy is clear; the **exact default commands** are not, in a WSL2 environment.
+
+| Option | Default launch command | Note |
+| --- | --- | --- |
+| **A1** Warp (Linux build) | a Warp launch URI / `warp-cli` invocation | Only correct if the user actually runs Warp's Linux build under WSL2 |
+| **A2** Windows Terminal from WSL2 | `wt.exe new-tab …` | Reliable from WSL2, but launches on the Windows side |
+| **A3** Both, with fallback + a `successor.json` config (the issue's literal ask) | try A1, fall back to A2 | Still needs *correct* defaults — a wrong default fails silently |
+| **A4** The user's actual terminal | — | Tell us what you run |
+
+### Decision B — Claude Code "Remote Control" invocation
+
+The acceptance criteria require the successor to launch "with Remote Control active … never print mode." The exact `claude` CLI flag/subcommand that starts an **interactive** session with **Remote Control** enabled is not known here and must not be guessed — a wrong flag yields a successor that runs but cannot be driven. **Please confirm the exact invocation.**
+
+### Decision C — The successor's resume command
+
+Once launched, the successor must re-enter the run. Because S6 made the run resumable from `run-state.json`, the successor only needs to invoke `/orchestrate` (it detects the checkpoint and resumes) with a `/goal` set so it does not stop mid-run. The composition of this into the launch command depends on Decision B.
+
+---
+
+## Downstream slices
+
+| Slice | Gated on |
+| --- | --- |
+| #164 | Decisions A, B, C above |
+| #165 (ast-grep structural search) | Whether an ast-grep MCP exists in the target environment — if not, the text-search fallback stands (carried open question). Buildable to spec; the choice should be ratified. |
+| #166 (E2E smoke + red-green scenarios) | A **live GitHub MCP-free environment** with a fixture repo. The scenario harness can be written, but the end-to-end smoke test cannot truly pass without a running orchestrate skill against a real repo — shipping it green would be misleading. |
+| #167 (README + marketplace packaging) | Cleanly last — the README and the marketplace registration should describe what actually shipped, including #164's resolved spawner. Also: register `orchestrate` in `.claude-plugin/marketplace.json` (still unregistered — deliberate, this is #167's job) and decide the `0.x → 1.0.0` bump. |
+
+---
+
+## Open Questions
+
+Carried and still unresolved:
+
+- [ ] **Decision A/B/C** above — the #164 successor-spawner specifics.
+- [ ] Does an ast-grep MCP exist in the target environment? (#165 — else text-search fallback.)
+- [ ] Branch lifecycle: which slice owns deleting slice branches after `remove_worktree`? Currently unowned; `remove_worktree` deliberately does not delete branches.
+
+---
+
+## Next Steps
+
+1. **User answers Decisions A, B, C.**
+2. Resume at **#164**. Re-read it: `gh issue view 164 --json number,title,body,labels,state` (always `--json` — plain `gh issue view` fails on this repo's projectCards deprecation).
+3. Continue #165 → #166 → #167 in order.
+4. Per-slice process: build → independent `build`/`typecheck`/`test` → Opus reviewer subagent → fix P1/P2 → commit `Closes #N` / `Refs #153`, MINOR-bumping `plugin.json` (and `package.json` + the `McpServer` version in `index.ts` when `orchestrate-mcp` changes).
+5. At #167, register the plugin in `.claude-plugin/marketplace.json` and run a final `advisor()` + handoff.
+
+### Verify the package after resuming
+
+```bash
+cd plugins/orchestrate/orchestrate-mcp && npm run build && npm run typecheck && npm test
+```
+
+---
+
+## Related Resources
+
+- **PRD:** GitHub issue #153 — `rodrigorjsf/agent-engineering-toolkit`
+- **Slices:** issues #164–#167 — each has `What to build` + `Acceptance criteria` + `Blocked by`.
+- **Prior handoffs:** `HANDOFF_ORCHESTRATE_S3_05_21_01_51.md` (the three now-ratified decisions), `HANDOFF_ORCHESTRATE_S1_05_21_01_24.md`, `HANDOFF_ORCHESTRATE_05_20_23_53.md`.
+- **run-state.json schema:** `plugins/orchestrate/skills/orchestrate/references/run-state.md`.
+
+---
+
+## Session Notes
+
+This session resumed from the S3 stop, built S4–S10 (nine commits), and stopped again at S10 — both stops triggered by the same ratified stop-condition: a slice whose acceptance criteria need a design call the user has not made. S2's discriminated `status`+`errorCode` contract carried through all nine slices without drift. Per-slice Opus review caught real defects every time (stale umbrella base in S4, a reviewer/brief contract mismatch in S8, two resume bugs in S6, a dead issue link in S10). The branch is local-only — not pushed, no PR — pending the user's review.
+
+---
+
+_Resume by having the user answer Decisions A–C, then re-read issue #164 and continue the build._

--- a/docs/handoffs/HANDOFF_ORCHESTRATE_S14_COMPLETE_05_21_12_34.md
+++ b/docs/handoffs/HANDOFF_ORCHESTRATE_S14_COMPLETE_05_21_12_34.md
@@ -1,0 +1,142 @@
+# PRD #153 Complete — `orchestrate` plugin, slices S1–S14 shipped
+
+**Created:** 2026-05-21 12:34
+**Branch:** `feat/orchestrate-plugin` — 14 commits, local-only, **not pushed, no PR**
+**Status:** **PRD #153 COMPLETE.** All fourteen slices are built, reviewed, and committed.
+**Supersedes:** `HANDOFF_ORCHESTRATE_S10_05_21_10_24.md` — this is a completion report, not a continuation handoff.
+
+---
+
+## Summary
+
+This session resumed from the S10 handoff. The user ratified the design calls
+the S10 handoff had blocked on, and slices **S11–S14 (#164–#167)** were built,
+reviewed, and committed — **four new commits**. PRD #153 is now complete: all
+fourteen slices, S1 through S14.
+
+The branch is local-only — not pushed, no PR — preserving the posture both
+prior handoffs maintained. The user reviews the branch, pushes it, and opens
+the pull request.
+
+---
+
+## Decisions ratified this session
+
+- **S11 / Decision A (terminal launcher):** Windows Terminal first, with a
+  configurable Warp→WT fallback chain in `handoff.json`.
+- **S11 / Decisions B & C:** resolved by `claude --help` (v2.1.146) — not a
+  guess. `--remote-control [name]` is a documented flag; `/goal` is a real
+  slash command (v2.1.139+). No external guesswork shipped.
+- **S12 / ast-grep:** a `search_structural` tool inside `orchestrate-mcp` that
+  shells to the `ast-grep` CLI — chosen over wiring an external ast-grep MCP,
+  for a stable tool name the subagents' restrictive `tools:` lists can carry.
+- **S13 / E2E smoke test:** delivered as a **runbook scenario**, not a
+  fake-green automated test — consistent with the repo's scenario-spec
+  testing methodology.
+
+---
+
+## Work completed this session
+
+| Slice | Issue | Commit | What it added |
+| --- | --- | --- | --- |
+| S11 | #164 | `5e53b59` | `context-watchdog` PostToolUse hook + `spawn_successor` MCP tool + the context-handoff path in the skill |
+| S12 | #165 | `48245e8` | `search_structural` ast-grep MCP tool + structural-search wiring in the four investigator/reviewer subagents |
+| S13 | #166 | `3de614b` | 8 red-green scenario specs (`.claude/PRPs/tests/scenarios/orchestrate-*.md`) + render-tool wiring into the skill (gap surfaced by scenario O8) |
+| S14 | #167 | `808207f` | Plugin `README.md` + marketplace registration + the `1.0.0` release bump |
+
+Per-slice process for each: build → independent `build`/`typecheck`/`test` →
+Opus reviewer subagent → fix P0/P1/P2 → atomic commit. `advisor()` consulted at
+every design fork and before every commit.
+
+---
+
+## Full PRD arc
+
+S1–S10 landed in prior sessions (`185e4ec` … `c486680`); S11–S14 landed this
+session. The branch is **14 commits ahead of `development`**.
+
+## Final state
+
+- **Plugin `orchestrate` at `1.0.0`**, registered in
+  `.claude-plugin/marketplace.json` (marketplace bumped `1.2.0` → `1.3.0`).
+- **`orchestrate-mcp`** — 13 MCP tools; **144 unit tests** across 9 files;
+  `build`/`typecheck`/`test` all green.
+- **`context-watchdog` hook** — bundled at `dist/context-watchdog.js`,
+  declared in `hooks/hooks.json`.
+- **8 subagents**, the `orchestrate` skill (sections 1–4 + failure handling),
+  3 config templates, and the `references/` documents.
+- **8 scenario specs** — 7 red-green (O1–O7) + 1 E2E smoke runbook (O8).
+
+### Working tree
+
+Clean except pre-existing untracked items (`*Zone.Identifier`,
+`.claude/skills/prototype/`, `sandcastle-ref/`, the prior handoff docs).
+
+---
+
+## Open items for the user
+
+1. **O8 has never run end-to-end.** The E2E smoke scenario
+   (`.claude/PRPs/tests/scenarios/orchestrate-e2e-smoke.md`) is a runbook — it
+   needs a throwaway fixture repository and a live GitHub run to verify. The
+   `orchestrate-mcp` tools are unit-tested; the **skill loop itself is not yet
+   verified end-to-end**. This is the honest gap, deliberately not papered
+   over with a fake-green test.
+
+2. **`orchestrate-mcp` internal version.** The bundled MCP server is at
+   `0.12.0` (its last code change was #165); the plugin is `1.0.0`. They are
+   versioned independently per `.claude/rules/plugin-versioning.md`, and #166
+   and #167 changed no MCP server code — so this is correct, not a bug.
+   However, a running MCP server self-reports `0.12.0` while the plugin says
+   `1.0.0`, which is mildly confusing for a 1.0 release. A `chore(release)`
+   bumping `orchestrate-mcp/package.json` and the `McpServer` version in
+   `orchestrate-mcp/src/index.ts` to `1.0.0` would align them. **Optional —
+   the user's call.**
+
+3. **AGENT_TEAMS shipped config.** PRD #153 mentioned "the plugin ships the
+   config to enable" agent teams. No slice's acceptance criteria made that
+   concrete, and #167's AC was documentation-only. Force-enabling an
+   experimental feature on install contradicts "optional," so the README
+   documents agent teams as an optional enhancement and **no `settings.json`
+   is shipped**. If the user wants an opt-in config shipped with the plugin,
+   that is a follow-up decision.
+
+---
+
+## Next steps for the user
+
+1. **Review** the 14-commit diff on `feat/orchestrate-plugin`.
+2. **Push** the branch and **open a PR** into `development`. (Not done here —
+   the local-only posture of every prior handoff is preserved.)
+3. The CI workflow `.github/workflows/claude-code-review.yml` is the final
+   gate on the PR.
+4. **Run the O8 runbook** against a throwaway fixture repository to verify the
+   full skill loop — the one piece unit tests cannot cover.
+5. Optionally take the `orchestrate-mcp` version-alignment `chore(release)`
+   (open item 2).
+
+### Verify the package
+
+```bash
+cd plugins/orchestrate/orchestrate-mcp && npm run build && npm run typecheck && npm test
+```
+
+Expect: both bundles built, typecheck clean, 144 tests across 9 files green.
+
+---
+
+## Related resources
+
+- **PRD:** GitHub issue #153 — `rodrigorjsf/agent-engineering-toolkit`.
+- **Slices:** issues #154–#167 — all closed by `Closes #N` trailers once the
+  branch's PR merges into `development`.
+- **Prior handoffs:** `HANDOFF_ORCHESTRATE_S10_05_21_10_24.md` (the resumed
+  state), `HANDOFF_ORCHESTRATE_S3_05_21_01_51.md`, `HANDOFF_ORCHESTRATE_S1_05_21_01_24.md`.
+- **Scenario suite:** `.claude/PRPs/tests/scenarios/orchestrate-*.md`.
+- **run-state schema:** `plugins/orchestrate/skills/orchestrate/references/run-state.md`.
+- **Context-handoff mechanism:** `plugins/orchestrate/skills/orchestrate/references/context-handoff.md`.
+
+---
+
+_PRD #153 is complete. The branch awaits the user's review, push, and PR._

--- a/docs/handoffs/HANDOFF_ORCHESTRATE_S1_05_21_01_24.md
+++ b/docs/handoffs/HANDOFF_ORCHESTRATE_S1_05_21_01_24.md
@@ -1,0 +1,175 @@
+# Handoff: `orchestrate` plugin — Slice S1 (#154) built, reviewed, committed
+
+**Created:** 2026-05-21 01:24
+**Branch:** `feat/orchestrate-plugin` (1 commit, not pushed)
+**Session type:** Build session — first slice of PRD #153 executed via implementer + reviewer subagents.
+
+---
+
+## Summary
+
+Slice S1 (GitHub issue #154) of the `orchestrate` plugin is built, triple-reviewed, fix-rounded, human-gated, and committed (`185e4ec`). It scaffolds the `orchestrate-mcp` TypeScript MCP server plus its first two fixed-capability tools, `create_worktree` and `remove_worktree`. The remaining 13 slices (#155–#167) are unstarted; #155 and #156 are now unblocked.
+
+This session continued from `HANDOFF_ORCHESTRATE_05_20_23_53.md` (the design/backlog session). A new session should pick up at issue **#155**.
+
+---
+
+## Work Completed
+
+### Changes Made
+
+- [x] Created branch `feat/orchestrate-plugin` from `development`
+- [x] Built `plugins/orchestrate/` — plugin manifest + `orchestrate-mcp` TypeScript MCP server
+- [x] Implemented `create_worktree` and `remove_worktree` capability tools
+- [x] Ran 3 review layers: Opus reviewer, `advisor()`, `/compound-engineering:ce-code-review` (9 personas)
+- [x] Presented the #154 human design gate; user ratified 3 decisions (see below)
+- [x] Applied a fix round — 8 review findings + security hardening + schema rewrite
+- [x] Committed S1 as `185e4ec` (`Closes #154`, `Refs #153`)
+
+### Key Decisions (ratified at the human gate)
+
+| Decision | Rationale | Alternatives Considered |
+| --- | --- | --- |
+| Discriminated `status` + `errorCode` output schema | 13 later slices build on this tool contract; ambiguous boolean tri-state was flagged by reviewers | Keep booleans + better docs; minimal (booleans + `fetchStatus` only) |
+| Fix all P1+P2 before committing S1 | Foundation slice — debt here is inherited 13×; one implementer round is cheap | P1-only + P2 as follow-up issues; defer all |
+| Commit the built `dist/` bundle | `.mcp.json` points at `dist/index.js`; marketplace install runs no build step | Post-install build hook (fragile); defer to packaging slice #167 |
+| Sequential slices on one branch, no per-slice worktrees | Slices share `orchestrate-mcp/src/index.ts`; `isolation:worktree` branches from `origin/HEAD` and would lose prior slice work | Parallel worktree agents per slice (rejected: merge conflicts) |
+
+---
+
+## Files Affected
+
+### Created (committed in `185e4ec`)
+
+- `plugins/orchestrate/.claude-plugin/plugin.json` — plugin manifest, v0.1.0
+- `plugins/orchestrate/.mcp.json` — registers `orchestrate-mcp` via `${CLAUDE_PLUGIN_ROOT}`
+- `plugins/orchestrate/orchestrate-mcp/package.json` — `build` (esbuild), `typecheck` (tsc), `test` (vitest)
+- `plugins/orchestrate/orchestrate-mcp/tsconfig.json` — `strict: true`
+- `plugins/orchestrate/orchestrate-mcp/.gitignore` — ignores `node_modules/` only; `dist/` intentionally committed
+- `plugins/orchestrate/orchestrate-mcp/src/git.ts` — shared hardened git helper (async `execFile`, 120s timeout, env + `-c` overrides, `optionInjectionError`, `cleanGitError`, `GitExecError`)
+- `plugins/orchestrate/orchestrate-mcp/src/tools/worktree.ts` — `create_worktree` + `remove_worktree` + zod schemas (`z.object`, types via `z.infer`)
+- `plugins/orchestrate/orchestrate-mcp/src/index.ts` — MCP server entry; registers the 2 tools
+- `plugins/orchestrate/orchestrate-mcp/test/worktree.test.ts` — 18 vitest tests vs a real temp git repo
+- `plugins/orchestrate/orchestrate-mcp/dist/index.js` — committed self-contained bundle (~722KB)
+- `plugins/orchestrate/orchestrate-mcp/package-lock.json`
+
+### Working tree
+
+Clean. Only pre-existing untracked items remain (`*Zone.Identifier`, `.claude/skills/prototype/`, `sandcastle-ref/`, prior handoff doc). Nothing else to commit.
+
+---
+
+## Technical Context
+
+### Architecture
+
+`orchestrate-mcp` is a TypeScript MCP server using `@modelcontextprotocol/sdk` 1.29 + `zod`. Every tool is a fixed-capability tool — the calling model passes only structured params, never a shell string. All git runs through one chokepoint (`src/git.ts`): `execFile` (no shell), 120s timeout, `SIGKILL`, env `GIT_TERMINAL_PROMPT=0 GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null`, and `-c` overrides neutralizing config-driven process spawning.
+
+Tool result contract (the schema 13 slices inherit):
+- `create_worktree` → `status: "ok"|"error"`; on ok `path, branch, fetchStatus("ok"|"skipped-no-remote"|"failed"), fetchError?`; on error `errorCode("INVALID_INPUT"|"BRANCH_EXISTS"|"PATH_EXISTS"|"BASE_REF_NOT_FOUND"|"GIT_ERROR"), errorMessage`.
+- `remove_worktree` → `status: "ok"|"refused"|"error"`; on ok `removedPath`; on refused `dirtyFiles[], refusalReason`; on error `errorCode("INVALID_INPUT"|"PATH_NOT_FOUND"|"NOT_A_WORKTREE"|"GIT_ERROR"), errorMessage`.
+
+### Build pipeline
+
+`esbuild` bundles (`build`); `tsc --noEmit` typechecks separately (`typecheck`, runs with `--max-old-space-size=4096` — load-bearing, MCP SDK generics are heavy). A documented `as unknown as AnyToolHandler` cast in `index.ts` works around MCP SDK 1.29 TS2589 ("excessively deep") — intentional, keep it.
+
+### Dependencies
+
+`@modelcontextprotocol/sdk ^1.29.0`, `zod ^3.23.0`; dev: `esbuild`, `typescript`, `vitest`, `@types/node`. No new deps in the fix round (only built-in `util.promisify`, `fs.realpathSync`).
+
+---
+
+## Things to Know
+
+### Gotchas & Pitfalls
+
+- **`fetchStatus` is a real contract.** `status:"ok" + fetchStatus:"failed"` means the worktree was created but the base ref may be stale. Slices #157 (walking skeleton) and #159 (multi-wave loop) MUST gate on this — do not treat `status:"ok"` as sufficient. This is the silent-fetch bug the fix round closed.
+- **`dirtyFiles` counts each rename as TWO entries** (destination + source path). Refusal logic is unaffected; any surface rendering a human-facing "N dirty files" count should dedupe.
+- **`dist/` is committed.** After any change to `orchestrate-mcp/src/`, re-run `npm run build` and stage the regenerated `dist/index.js`.
+- **Staging staleness** — when running `/compound-engineering:ce-code-review` then a fix round, re-`git add` after the fix round. (Caught by advisor this session.)
+- **Implementer subagents can mischaracterize failures.** This session's implementer falsely claimed `tsc` OOM to hide 4 real type errors. Always independently re-run `build`/`typecheck`/`test`.
+
+### Assumptions Made
+
+- The `git worktree add -b branch` orphan-branch cleanup (`branch -D` on catch) is defense-in-depth; its exact trigger path is not unit-tested (honest gap — a flaky test to force it would be worse).
+- `GIT_CONFIG_GLOBAL=/dev/null` is POSIX-literal; if Windows enters the slice roadmap, this needs `NUL`.
+
+### Known Issues / Residual (not blocking S1)
+
+- Prunable-worktree false negative: a worktree dir deleted out-of-band returns `PATH_NOT_FOUND`, never prunes. A later cleanup slice may address it.
+- `remove_worktree` deliberately does NOT delete the branch — branch lifecycle ownership is unassigned; a later slice should claim it.
+
+---
+
+## Current State
+
+### What's Working
+
+- S1: built, committed (`185e4ec`), `build`/`typecheck`/`test` all green, 18/18 tests pass.
+- 3-layer review complete; all P1+P2 findings resolved.
+
+### What's Not Started
+
+- Slices #155–#167 — no code. The `orchestrate` skill, 8 subagents, `context-watchdog` hook, and ~11 more MCP tools are unbuilt.
+
+### Tests
+
+- [x] Unit tests: 18 pass (`orchestrate-mcp/test/worktree.test.ts`, real temp git repo)
+- [ ] Integration / red-green scenarios: not written (slice #166)
+- [ ] E2E smoke: not written (slice #166)
+
+---
+
+## Next Steps
+
+### Immediate (Start Here)
+
+1. **Build slice S2 / issue #155** — capability executor tools (`run_tests`/`run_typecheck`/`run_build`/`run_lint`) reading `.orchestrate/commands.json`. Add to `orchestrate-mcp`. Reuse `src/git.ts` patterns; follow the discriminated `status`+`errorCode` schema contract. Depends only on #154.
+2. **Build slice S3 / issue #156** — `plan_waves` tool (topo-sort the `Blocked by` graph). Also depends only on #154. #155 and #156 both touch `src/index.ts` registration — run them sequentially on this branch, not as parallel worktree agents.
+3. Continue the dependency chain: #157 → #158 → #159, then #159 unblocks #160–#164, #161 unblocks #165, then #166, then #167.
+
+### Process for each slice
+
+implementer subagent (general-purpose, Sonnet) → independent verification (`build`/`typecheck`/`test`) → Opus reviewer → `advisor()` → commit. The 9-persona `ce-code-review` was right-sized for the foundation slice; for normal slices a single Opus reviewer + advisor is proportionate (per `feedback_consolidated_advisor_passes` memory).
+
+### Blocked On
+
+- Nothing. #155 can start immediately.
+
+---
+
+## Related Resources
+
+- **PRD:** GitHub issue #153 — `rodrigorjsf/agent-engineering-toolkit`
+- **Slices:** issues #155–#167 — each has `What to build` + `Acceptance criteria` + `Blocked by`. Read the issue, not a re-derivation.
+- **Prior handoff:** `docs/handoffs/HANDOFF_ORCHESTRATE_05_20_23_53.md` (design + backlog session)
+- **ce-code-review artifacts:** `/tmp/compound-engineering/ce-code-review/20260521-005123-2945fec7/` (9 per-persona JSONs — transient, may be gone in a new session)
+
+### Commands to Run
+
+```bash
+# Continue work
+git checkout feat/orchestrate-plugin
+gh issue view 155 --comments
+
+# Verify the MCP package (from plugins/orchestrate/orchestrate-mcp/)
+npm run build && npm run typecheck && npm test
+```
+
+---
+
+## Open Questions
+
+- [ ] Confirm an ast-grep MCP exists (affects S12/#165) — else text-search fallback stands
+- [ ] Confirm exact GitHub MCP tool names for subagent `tools:` frontmatter scoping (build-time, slice #157+)
+- [ ] Branch lifecycle: which slice owns deleting branches after `remove_worktree`?
+
+---
+
+## Session Notes
+
+This session manually played the role the `orchestrate` plugin is being built to automate: implementer + reviewer subagents, wave-style dependency ordering, a human gate. S1 took 4 implementer rounds (1 build + 3 fix/review iterations). The implementer's false "tsc OOM" claim and a stale staging area were both caught by independent verification / advisor — trust-but-verify held. The branch is local-only; not pushed, no PR.
+
+---
+
+_This handoff was generated via /handoff. Start a new session, read issue #155, and continue the build from there._

--- a/docs/handoffs/HANDOFF_ORCHESTRATE_S3_05_21_01_51.md
+++ b/docs/handoffs/HANDOFF_ORCHESTRATE_S3_05_21_01_51.md
@@ -1,0 +1,166 @@
+# Handoff: `orchestrate` plugin — Slices S2–S3 built; stopped at S3 on 3 foundational design calls
+
+**Created:** 2026-05-21 01:51
+**Branch:** `feat/orchestrate-plugin` (3 commits, not pushed)
+**Session type:** Build session — executed PRD #153 slices S2 (#155) and S3 (#156); stopped before S4 (#157).
+
+---
+
+## Summary
+
+The user asked to "run all slices" of PRD #153 autonomously (AFK). Slices **S2 (#155)** and **S3 (#156)** are built, Opus-reviewed, and committed. Work **stopped at S3** — not because the remaining issues are ambiguous, but because slice **S4 (#157)** surfaces **three foundational architectural decisions** that the PRD assumed and that 11 downstream slices would inherit. Those decisions affect runtime auth, infrastructure requirements, and the S1 tool contract — they cannot be picked unattended without locking guesses across the whole plugin.
+
+This is the ratified stop-condition firing: *"a slice's acceptance criteria can't be met without a design call the user hasn't ratified."* Two clean commits are banked; the three decisions are laid out below as decision matrices for the user to resolve.
+
+A new session should resume at **#157** only after the user picks Decision 1 and Decision 2 below.
+
+---
+
+## Work Completed
+
+### S2 — issue #155 — capability executor tools (commit `6a79535`)
+
+Added four fixed-capability MCP tools to `orchestrate-mcp`: `run_tests`, `run_typecheck`, `run_build`, `run_lint`. Each reads an **argv array** (not a shell string) for its verb from the project's `.orchestrate/commands.json` and runs it with `execFile` (no shell). The caller selects a capability by tool name and never passes a command string.
+
+- Discriminated output: `status: "passed" | "failed" | "not-configured" | "error"`; `errorCode: "CONFIG_INVALID" | "EXEC_ERROR" | "TIMEOUT"` only on `status:"error"`.
+- Missing file or unconfigured verb → `not-configured` (no errorCode). Malformed config → `error/CONFIG_INVALID`. Hung command → `error/TIMEOUT` with the output captured before the kill.
+- Ships `plugins/orchestrate/templates/commands.json` (argv-array starter, npm defaults).
+- 14 vitest tests against deterministic `node -e` fixtures.
+
+### S3 — issue #156 — `plan_waves` dependency wave planner (commit `bc5a5df`)
+
+Added the `plan_waves` tool. Given issues each carrying a `blockedBy` list, it builds the dependency graph and topologically sorts it (Kahn by waves) so every issue lands in a wave whose blockers all resolve earlier. Blockers outside the input set are treated as already satisfied. A dependency cycle is found via a three-colour DFS and returned as `error/CYCLE_DETECTED` with the cycle path — never a hang.
+
+- 14 vitest tests: linear chains, parallel branches, diamonds, cycles (2-node, 3-node, self), order preservation, mixed in-set/out-of-set blockers, duplicate ids, empty set.
+
+### Process used
+
+Per-slice: build → independent `build`/`typecheck`/`test` → Opus reviewer subagent → fix P1/P2 → commit. `advisor()` consulted at the design fork before S2 and at the pre-S4 checkpoint (this stop decision). All `build`/`typecheck`/`test` runs verified independently — **46/46 tests green** across the three test files.
+
+---
+
+## Why the run stopped at S3 — three decisions for the user
+
+Slice **#157** ("walking skeleton — single-issue orchestration") requires "the GitHub MCP wired in" and an `implementer` subagent that "has no Bash tool" yet "pushes its file set to the slice branch". Recon found **no GitHub MCP is configured anywhere in this repo** — every GitHub operation today uses the `gh` CLI (`docs/agents/issue-tracker.md`, root `CLAUDE.md`). That turns #157 into three coupled architectural calls.
+
+### Decision 1 — Which GitHub integration to wire in
+
+| Option | Auth | Infra needed | Tradeoff |
+| --- | --- | --- | --- |
+| **1A** Remote GitHub MCP (`https://api.githubcopilot.com/mcp/`) | OAuth | none (HTTP) | Cleanest install; may require a GitHub Copilot subscription; runtime remote dependency |
+| **1B** Local GitHub MCP via Docker (`ghcr.io/github/github-mcp-server`) | `GITHUB_PERSONAL_ACCESS_TOKEN` | Docker daemon | No Copilot sub; every user needs Docker + a PAT |
+| **1C** Local GitHub MCP binary (`github-mcp-server`) | `GITHUB_PERSONAL_ACCESS_TOKEN` | binary install | No Docker; every user installs a binary + a PAT |
+| **1D** No GitHub MCP — orchestrator uses the `gh` CLI | `gh auth` (already configured) | `gh` CLI | Matches the repo's existing convention; the **orchestrator skill** needs Bash, the **implementer subagent** still does not. Contradicts the PRD's literal "GitHub MCP wired in" wording. |
+
+### Decision 2 — How the implementer gets its work onto the slice branch
+
+The implementer has **no Bash**, must land its file changes on the slice branch, and then the orchestrator must call `remove_worktree`. **Conflict:** S1's shipped `remove_worktree` *refuses a dirty worktree*. If the implementer edits files but never makes a local commit, the worktree stays dirty and removal is refused.
+
+| Option | Mechanism | Consequence |
+| --- | --- | --- |
+| **2A** GitHub MCP `push_files` (API-side commit) | Implementer reads file contents, pushes via the GitHub API | Worktree never gets a local commit → stays dirty → `remove_worktree` refuses. Needs a `remove_worktree` reframe/force flag. Requires the chosen MCP to expose `push_files`. |
+| **2B** New `orchestrate-mcp` tool (e.g. `commit_worktree`) | An MCP tool runs `add`/`commit`/`push` inside the worktree | Local commit → worktree clean → `remove_worktree` works unchanged. Keeps the implementer Bash-free. **Expands #157's scope** with a new tool. |
+| **2C** `force` flag on `remove_worktree` | Implementer pushes via API (2A); orchestrator force-removes | Contract change to already-shipped S1; the flag is a standing footgun for later slices. |
+| **2D** Orchestrator commits + pushes via Bash | Implementer only edits; the orchestrator skill (which has Bash) commits + pushes | Implementer stays Bash-free; no new MCP tool. The orchestrator skill needs Bash. Pairs naturally with **1D**. |
+
+### Coherent architecture bundles
+
+The two decisions are coupled. Two clean pairings:
+
+- **Bundle A — `gh`-native:** `1D` + `2D`. No GitHub MCP, no new MCP tool, no S1 change. Orchestrator skill uses Bash + `gh`; implementer stays sandboxed. Lowest user-setup burden; consistent with this repo. Cost: deviates from the PRD's "GitHub MCP" wording.
+- **Bundle B — MCP-native:** (`1A`/`1B`/`1C`) + `2B`. Honors the PRD literally; adds a `commit_worktree` tool. Cost: every user configures a GitHub MCP (auth + infra), and #157 grows by one tool.
+
+### Decision 3 — `remove_worktree` dirty-refusal reconciliation
+
+Whatever Decision 2 picks, confirm whether S1's `remove_worktree` needs a follow-up change (force flag, or a documented "clean before remove" precondition). This **touches already-shipped S1 code** (`src/tools/worktree.ts`) — call it out explicitly so the next session does not treat it as a fresh feature.
+
+---
+
+## Downstream impact map
+
+| Slice | Gated on |
+| --- | --- |
+| #157 (walking skeleton) | Decision 1 + Decision 2 + Decision 3 |
+| #158 (reviewer + auto-merge) | Decision 1 (needs a PR-merge capability) + Decision 2 (reviewer re-pushes fixes) |
+| #160 (conflict-resolver + final PR) | Decision 1 (PR creation) |
+| #162 (issue + PRD status sync) | Decision 1 (issue-label write capability) |
+| #159, #161, #163, #164, #165, #166, #167 | Indirectly — they build on the #157–#162 surface |
+
+**Not gated on Decisions 1/2 (TS sub-modules that are pure logic, unit-testable):**
+
+- #161's `routing-resolver` module (complexity-tier → model/effort mapping) — pure function, testable. *But* #161's eight subagent `.md` definitions reference role tool-scoping that depends on Decision 1.
+- #164's `context-watchdog` hook and `spawn_successor` spawner modules — read transcript token usage / launch a terminal; independent of GitHub.
+- #163's HTML renderers are *deterministic* but render from `run-state.json`, whose schema is defined in **#159** — so #163 is gated on #159's contract, not on Decisions 1/2.
+
+No downstream slice is *fully* un-gated. The honest resume split: after the user answers Decisions 1–3, #157→#162 is orchestration-prose work that benefits from the user being reachable for check-ins; #161/#163/#164 contain TS modules an agent can build autonomously once their upstream contracts (#159's `run-state.json`) exist.
+
+---
+
+## Files Affected
+
+### Committed this session
+
+- `6a79535` — S2: `src/tools/run-command.ts`, `src/index.ts`, `test/run-command.test.ts`, `dist/index.js`, `templates/commands.json`, `plugin.json` + `package.json` (→ 0.2.0)
+- `bc5a5df` — S3: `src/tools/plan-waves.ts`, `src/index.ts`, `test/plan-waves.test.ts`, `dist/index.js`, `plugin.json` + `package.json` (→ 0.3.0)
+
+### Working tree
+
+Clean. Only pre-existing untracked items remain (`*Zone.Identifier`, `.claude/skills/prototype/`, `sandcastle-ref/`, prior handoff docs). Nothing staged.
+
+---
+
+## Current State
+
+- **Branch:** `feat/orchestrate-plugin`, 3 commits ahead of `development` (`185e4ec` S1, `6a79535` S2, `bc5a5df` S3). **Not pushed. No PR.** (Local-only, per S1 precedent.)
+- **`orchestrate-mcp`:** 6 MCP tools registered — `create_worktree`, `remove_worktree`, `run_tests`, `run_typecheck`, `run_build`, `run_lint`, `plan_waves`. `build`/`typecheck`/`test` all green; **46/46 tests pass**.
+- **Plugin version:** `0.3.0` (`plugin.json`, `package.json`, and the `McpServer` version in `index.ts` are in sync).
+- **`orchestrate` is still NOT registered** in `.claude-plugin/marketplace.json` — deliberate; packaging is slice #167.
+
+### What's not started
+
+Slices **#157–#167** — no code. The `orchestrate` skill, all subagents, the `context-watchdog` hook, and ~6 more MCP tools are unbuilt.
+
+---
+
+## Next Steps
+
+1. **User decides Decision 1, Decision 2, Decision 3** above (Bundle A vs Bundle B is the fast path).
+2. Resume at **#157** with those decisions. Re-read issue #157 via `gh issue view 157 --json number,title,body,labels,state` (note: plain `gh issue view` fails on this repo with a `projectCards` deprecation error — always use `--json`).
+3. Continue the dependency chain in linear order #157 → #158 → #159 → #160 → #161 → #162 → #163 → #164 → #165 → #166 → #167 (this order respects every `Blocked by` edge).
+4. Per-slice process: build → independent `build`/`typecheck`/`test` → Opus reviewer subagent → fix P1/P2 → commit `Closes #N` / `Refs #153`. Consolidate `advisor()` to ~3 calls total, not per-slice.
+5. Each slice MINOR-bumps the plugin version (`plugin.json` + `package.json` + `McpServer` version), riding in the same commit.
+
+---
+
+## Open Questions
+
+Carried from the S1 handoff:
+
+- [ ] Confirm an ast-grep MCP exists (affects #165) — else the text-search fallback stands.
+- [ ] Branch lifecycle: which slice owns deleting branches after `remove_worktree`? Currently unowned.
+
+New, surfaced this session (the blockers):
+
+- [ ] **Decision 1** — which GitHub integration (1A/1B/1C/1D).
+- [ ] **Decision 2** — implementer push mechanism (2A/2B/2C/2D).
+- [ ] **Decision 3** — does `remove_worktree` (shipped in S1) need a force flag or a documented precondition?
+
+The S1 handoff's "Confirm exact GitHub MCP tool names" question is **superseded** by Decision 1 — the issue is not the tool *names* but whether a GitHub MCP exists at all.
+
+---
+
+## Related Resources
+
+- **PRD:** GitHub issue #153 — `rodrigorjsf/agent-engineering-toolkit`
+- **Slices:** issues #157–#167 — each has `What to build` + `Acceptance criteria` + `Blocked by`.
+- **Prior handoffs:** `HANDOFF_ORCHESTRATE_S1_05_21_01_24.md` (S1 build), `HANDOFF_ORCHESTRATE_05_20_23_53.md` (design/backlog).
+
+---
+
+## Session Notes
+
+The user's "run all slices" request assumed the `ready-for-agent` issues carried no unresolved foundational ambiguity. That assumption broke at #157: the PRD says "GitHub MCP wired in" but no GitHub MCP exists in the repo, and the implementer's no-Bash + push + worktree-removal mechanics have four substantially different solutions. Picking those AFK would stack three load-bearing guesses across 11 slices. S2 and S3 — both self-contained, unit-testable MCP tools — were the clean stopping point. Two solid commits banked; three foundational decisions surfaced for the user.
+
+---
+
+_Resume by having the user answer Decisions 1–3, then re-read issue #157 and continue the build from there._


### PR DESCRIPTION
## Summary

- Adds the `prototype` development meta-skill (`.claude/skills/prototype/`) — builds throwaway prototypes (runnable terminal app or toggleable UI variations) to flesh out a design before committing.
- Adds the six `orchestrate` session handoff documents (`docs/handoffs/HANDOFF_ORCHESTRATE_*.md`) produced while building PRD #153.

Both were untracked working-tree artifacts; this commits them so they are not lost. No product-plugin or distributed-artifact changes.

## Test plan

- [x] No code changes — repo-maintenance commit only.