### PR TITLE
Skill body convention tracer (Claude Code customizer, create-skill end-to-end)

### DIFF
--- a/.claude/rules/plugin-skills.md
+++ b/.claude/rules/plugin-skills.md
@@ -20,3 +20,8 @@ paths:
 - SKILL.md `name` field: ≤64 chars, lowercase letters/numbers/hyphens only, no XML tags
 - SKILL.md `description` field: non-empty, ≤1024 chars, third person, no XML tags
 - SKILL.md body: under 500 lines
+- SKILL.md body MUST carry the canonical semantic-tag vocabulary: mandatory `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`; optional `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>` (see `wiki/knowledge/skill-body-convention.md`)
+- Semantic tags use the closed attribute set only — `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`; `id=` is mandatory on every `<PHASE>`; non-canonical attribute names are a warn-tier finding, not a hard fail
+- The legacy `<RULES>` tag is an alias of `<HARD_RULES>` — it satisfies the mandatory `<HARD_RULES>` check; migrate each occurrence to `<HARD_RULES>` on next touch, no scheduled mass rename
+- Self-validation loops apply three strictness tiers: hard-fail on a missing mandatory tag, unbalanced open/close tags, or malformed attribute syntax; warn on non-canonical attribute names; stay silent on absent optional tags (see `wiki/knowledge/skill-body-convention.md`)
+- YAML frontmatter stays untouched by the semantic-tag convention — each platform's official spec governs it; the `<TRIGGER>` cue lives in the body, never duplicated into frontmatter

--- a/plugins/agent-customizer/skills/create-skill/SKILL.md
+++ b/plugins/agent-customizer/skills/create-skill/SKILL.md
@@ -7,18 +7,20 @@ description: "Creates new SKILL.md files with references, templates, and frontma
 
 Generates a new SKILL.md file with supporting references and templates, grounded in the docs corpus and project conventions.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new Claude Code skill from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create skills that explain what Claude already knows (language syntax, obvious conventions)
 - **NEVER** inline reference content in SKILL.md body — use the `references/` subdirectory
 - **NEVER** exceed 500 lines in the SKILL.md body
@@ -26,79 +28,89 @@ Generates a new SKILL.md file with supporting references and templates, grounded
 - **EVERY** skill must use `${CLAUDE_SKILL_DIR}` for all bundled file references (not hardcoded paths)
 - **EVERY** skill description must be third-person and include a "Use when..." trigger phrase
 - **EVERY** generated skill must preserve the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** generated SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="name-collision-check">
+  Check if a skill with the same name already exists at:
 
-Check if a skill with the same name already exists at:
+  - `.claude/skills/{requested-name}/SKILL.md`
+  - `plugins/*/skills/{requested-name}/SKILL.md`
 
-- `.claude/skills/{requested-name}/SKILL.md`
-- `plugins/*/skills/{requested-name}/SKILL.md`
+  **If a skill already exists at either location:**
 
-**If a skill already exists at either location:**
+  1. Inform the user: "A skill named `{requested-name}` already exists."
+  2. Suggest using `/agent-customizer:improve-skill` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
 
-1. Inform the user: "A skill named `{requested-name}` already exists."
-2. Suggest using `/agent-customizer:improve-skill` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
+  **If no skill exists with that name:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no skill exists with that name:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Codebase Analysis
+  > Analyze the project to understand existing skills, naming conventions, and integration patterns. Focus on: existing skill directory structure, naming patterns, which skills delegate to agents, plugin conventions in CLAUDE.md files, and any skill that is similar to `{requested-name}` in purpose. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing skills, naming conventions, and integration patterns. Focus on: existing skill directory structure, naming patterns, which skills delegate to agents, plugin conventions in CLAUDE.md files, and any skill that is similar to `{requested-name}` in purpose. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
+  <PHASE id="2" name="generate-skill">
+  **Load context.** Drop any references from Phase 1. Read these references:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  - `${CLAUDE_SKILL_DIR}/references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
+  - `${CLAUDE_SKILL_DIR}/references/skill-format-reference.md` — frontmatter fields, name validation, string substitution variables
 
-### Phase 2: Generate Skill
+  Decide skill structure: phases, reference file names, and whether `assets/templates/` is needed.
 
-#### Phase 2a: Load Context
+  **Apply patterns.** Drop the load-context references above. Read these references:
 
-Drop any references from Phase 1. Read these references:
+  - `${CLAUDE_SKILL_DIR}/references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
 
-- `${CLAUDE_SKILL_DIR}/references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
-- `${CLAUDE_SKILL_DIR}/references/skill-format-reference.md` — frontmatter fields, name validation, string substitution variables
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-format-reference.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-Decide skill structure: phases, reference file names, and whether `assets/templates/` is needed.
+  Read `${CLAUDE_SKILL_DIR}/assets/templates/skill-md.md` and fill its placeholders using:
 
-#### Phase 2b: Apply Patterns
+  - User requirements for the new skill
+  - Phase 1 analysis output (naming conventions, existing patterns, plugin context)
+  - Evidence from the reference files above
 
-Drop Phase 2a references. Read these references:
+  If Phase 1 detects a monorepo or multi-service layout, make the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope. Do not leave multi-service boundaries implicit.
 
-- `${CLAUDE_SKILL_DIR}/references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
+  Generate the complete skill directory structure:
 
-Read `${CLAUDE_SKILL_DIR}/assets/templates/skill-md.md` and fill its placeholders using:
+  1. `SKILL.md` — primary skill file with frontmatter and a body carrying the canonical semantic-tag vocabulary
+  2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
+  3. `assets/templates/` — create stub template files if the skill generates output files
 
-- User requirements for the new skill
-- Phase 1 analysis output (naming conventions, existing patterns, plugin context)
-- Evidence from the reference files above
+     For validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted.
+  </PHASE>
 
-If Phase 1 detects a monorepo or multi-service layout, make the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope. Do not leave multi-service boundaries implicit.
+  <PHASE id="3" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
 
-Generate the complete skill directory structure:
+  If Phase 1 detected a monorepo or multi-service layout, add one extra validation pass: confirm the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope.
 
-1. `SKILL.md` — primary skill file with frontmatter and phase definitions
-2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
-3. `assets/templates/` — create stub template files if the skill generates output files
+  The loop evaluates all hard limits and quality checks — including the canonical semantic-tag strictness tiers — fixes any failures, and re-evaluates: maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-   For validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted.
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates)
+  2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
+  3. Ask for confirmation before writing any files
+  4. On approval, write all files to the target location
+  </PHASE>
 
-### Phase 3: Self-Validation
+</PROCESS>
 
-Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
-
-If Phase 1 detected a monorepo or multi-service layout, add one extra validation pass: confirm the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope.
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates)
-2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
-3. Ask for confirmation before writing any files
-4. On approval, write all files to the target location
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and loop the generated skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/MANIFEST.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/MANIFEST.md
@@ -1,0 +1,27 @@
+# Fixture Corpus — Skill Body Convention
+
+Regression corpus for the canonical semantic-tag strictness tiers defined in
+`references/skill-validation-criteria.md` ("Canonical Semantic-Tag Convention"
+section). Each fixture is a minimal SKILL.md body that exercises exactly one
+validation outcome.
+
+To use: run the validation loop from `skill-validation-criteria.md` against each
+fixture file and confirm the produced verdict matches the **Expected verdict**
+column below. Any mismatch means the strictness-tier text is ambiguous and must
+be tightened — the corpus is the regression test for that clarity.
+
+These fixtures are test data, not real skills. They are not loaded by the
+`create-skill` skill at runtime.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes only | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** — missing mandatory tag |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** — missing mandatory tag |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** — missing mandatory tag |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** — missing mandatory tag |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** — missing mandatory tag |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** — unbalanced tags |
+| `malformed-attribute.md` | `<PHASE>` `name` value missing its quotes | **hard-fail** — malformed attribute syntax |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a non-canonical `mood=` attribute | **warn** — non-canonical attribute name; passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** — alias satisfies the `<HARD_RULES>` check |

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/compliant-baseline.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/compliant-baseline.md
@@ -1,0 +1,39 @@
+---
+name: fixture-compliant-baseline
+description: "Fixture skill exercising the compliant baseline. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. All mandatory tags present, balanced, canonical attributes only. -->
+
+# Fixture Compliant Baseline
+
+One-sentence purpose statement for the baseline fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION>
+Read the validation criteria and loop until all checks pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/malformed-attribute.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/malformed-attribute.md
@@ -1,0 +1,35 @@
+---
+name: fixture-malformed-attribute
+description: "Fixture skill with a malformed PHASE attribute. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The <PHASE> name attribute value is missing its quotes. -->
+
+# Fixture Malformed Attribute
+
+One-sentence purpose statement for the malformed-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name=analysis>
+  DEFECT: the name attribute value above is unquoted — malformed attribute syntax.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-behaviour.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-behaviour.md
@@ -1,0 +1,28 @@
+---
+name: fixture-missing-behaviour
+description: "Fixture skill with the mandatory BEHAVIOUR tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <BEHAVIOUR> tag is absent. -->
+
+# Fixture Missing Behaviour
+
+One-sentence purpose statement for the missing-behaviour fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-hard-rules.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-hard-rules.md
@@ -1,0 +1,30 @@
+---
+name: fixture-missing-hard-rules
+description: "Fixture skill with the mandatory HARD_RULES tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. Both <HARD_RULES> and its <RULES> alias are absent. -->
+
+# Fixture Missing Hard Rules
+
+One-sentence purpose statement for the missing-hard-rules fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-phase.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-phase.md
@@ -1,0 +1,27 @@
+---
+name: fixture-missing-phase
+description: "Fixture skill whose PROCESS contains zero PHASE elements. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is present but contains zero <PHASE> elements. -->
+
+# Fixture Missing Phase
+
+One-sentence purpose statement for the missing-phase fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+The process container holds no phases — this is the defect under test.
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-process.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-process.md
@@ -1,0 +1,23 @@
+---
+name: fixture-missing-process
+description: "Fixture skill with the mandatory PROCESS tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <PROCESS> tag is absent. -->
+
+# Fixture Missing Process
+
+One-sentence purpose statement for the missing-process fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-trigger.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-trigger.md
@@ -1,0 +1,33 @@
+---
+name: fixture-missing-trigger
+description: "Fixture skill with the mandatory TRIGGER tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <TRIGGER> tag is absent. -->
+
+# Fixture Missing Trigger
+
+One-sentence purpose statement for the missing-trigger fixture.
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/non-canonical-attribute.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/non-canonical-attribute.md
@@ -1,0 +1,36 @@
+---
+name: fixture-non-canonical-attribute
+description: "Fixture skill with a non-canonical attribute name. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: warn. <BEHAVIOUR> carries a non-canonical `mood=` attribute; all mandatory tags are present and balanced, so it passes otherwise. -->
+
+# Fixture Non-Canonical Attribute
+
+One-sentence purpose statement for the non-canonical-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical"
+  mood="optimistic">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/rules-alias.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/rules-alias.md
@@ -1,0 +1,35 @@
+---
+name: fixture-rules-alias
+description: "Fixture skill using the legacy RULES alias instead of HARD_RULES. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. Uses the legacy <RULES> tag, which is an accepted alias of <HARD_RULES>; all else compliant. -->
+
+# Fixture Rules Alias
+
+One-sentence purpose statement for the rules-alias fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<RULES>
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/unbalanced-tag.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/unbalanced-tag.md
@@ -1,0 +1,35 @@
+---
+name: fixture-unbalanced-tag
+description: "Fixture skill with an unbalanced PROCESS tag. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is opened but never closed. -->
+
+# Fixture Unbalanced Tag
+
+One-sentence purpose statement for the unbalanced-tag fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+<!-- DEFECT: the <PROCESS> opening tag above has no matching </PROCESS> closing tag. -->

--- a/plugins/agent-customizer/skills/create-skill/assets/templates/skill-md.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/templates/skill-md.md
@@ -11,41 +11,60 @@ description: "[What this skill does and when to use it. Third person.]"
      Rule: Use ${CLAUDE_SKILL_DIR}/assets/templates/ for output templates
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name the target service/workspace explicitly
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
+           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+           <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
+           Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
+           Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: YAML frontmatter is untouched — do NOT duplicate the <TRIGGER> cue into description
 -->
 
 # [Skill Title]
 
 [One-sentence purpose statement]
 
-## Behavioral Guidelines
+<TRIGGER when="[plain-language activation cue — mirror the 'Use when ...' phrase from the description]" />
 
+<BEHAVIOUR
+  avoid="make decisions without surfacing assumptions; add speculative scope"
+  always="surface assumptions first; keep changes surgical">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - [Critical constraint 1]
 - [Critical constraint 2]
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
-<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  <PREFLIGHT name="artifact-collision-check">
+  <!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  </PREFLIGHT>
 
-### Phase 1: [Analysis Phase Name]
-<!-- Delegate to appropriate subagent; if monorepo, record the target service/workspace -->
+  <PHASE id="1" name="[analysis-phase-name]">
+  <!-- Delegate to appropriate subagent; if monorepo, record the target service/workspace -->
+  </PHASE>
 
-### Phase 2: [Generation Phase Name]
-<!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  <PHASE id="2" name="[generation-phase-name]">
+  <!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  </PHASE>
 
-### Phase 3: Self-Validation
-<!-- Read ${CLAUDE_SKILL_DIR}/references/[type]-validation-criteria.md -->
+  <PHASE id="3" name="self-validation">
+  <!-- Read ${CLAUDE_SKILL_DIR}/references/[type]-validation-criteria.md and loop until all checks pass -->
+  </PHASE>
 
-### Phase 4: Present and Write
-<!-- Show artifact with evidence citations, write on approval -->
+  <PHASE id="4" name="present-and-write">
+  <!-- Show artifact with evidence citations, write on approval -->
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+<!-- Read ${CLAUDE_SKILL_DIR}/references/[type]-validation-criteria.md, loop until pass -->
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-skill/references/skill-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-skill/references/skill-validation-criteria.md
@@ -1,7 +1,18 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`, `wiki/knowledge/skill-body-convention.md`
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
@@ -19,6 +30,38 @@ Any skill violating these criteria must be fixed before proceeding:
 | Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
 
 *Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X")
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|-------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
 ---
 
@@ -40,6 +83,9 @@ Any skill violating these criteria must be fixed before proceeding:
 - [ ] Plugin skill body contains no inline bash analysis commands — analysis must be delegated to registered agents (applies to skills in `plugins/*/skills/`)
 - [ ] Standalone skill body includes explicit bash commands for each analysis step (applies to skills in `skills/`)
 - [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-best-practices.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
 
 ---
 
@@ -62,10 +108,30 @@ Any skill violating these criteria must be fixed before proceeding:
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above
+1. Evaluate the skill against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
-3. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing skills when ALL criteria pass
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The fixture corpus at `${CLAUDE_SKILL_DIR}/assets/fixtures/` is the regression test for the strictness tiers. Each fixture is annotated in `assets/fixtures/MANIFEST.md` with its expected verdict. Running the validation loop against the corpus MUST produce exactly the verdict below for each fixture — any deviation means the strictness-tier text above is ambiguous and must be tightened.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check) |


### PR DESCRIPTION
Implements #144. Tracer-bullet slice of PRD #143: applies the canonical semantic-tag convention end-to-end across one distribution / one artifact type / one meta-skill (agent-customizer create-skill). Touches the path-scoped rule, the authoring template, the validation-criteria reference, the create-skill SKILL.md body itself, and adds a 10-fixture validation corpus. No version bumps (deferred to #152).