### PR TITLE
HTML artifact routing in create-skill (Claude Code customizer)

### DIFF
--- a/plugins/agent-customizer/skills/create-skill/SKILL.md
+++ b/plugins/agent-customizer/skills/create-skill/SKILL.md
@@ -29,6 +29,8 @@ Generates a new SKILL.md file with supporting references and templates, grounded
 - **EVERY** skill description must be third-person and include a "Use when..." trigger phrase
 - **EVERY** generated skill must preserve the ethical constraint: persuasion cues support legitimate work only, never safety bypass
 - **EVERY** generated SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** new skill whose output is a human-rich agent-executable artifact (plan, PRD, spec, report, prototype, code-review writeup, custom editor) MUST default to an HTML output template — unless the user explicitly says "generate as markdown" (or equivalent), in which case that override always wins
+- **NEVER** default to HTML for agent-loaded or tooling-locked artifacts (`SKILL.md`, `AGENTS.md`, `CLAUDE.md`, rules files, wiki pages, ADRs, `CONTEXT.md`, `README.md`, commit messages, PR bodies, GitHub issues, code comments) — these are Markdown-mandatory regardless of user request phrasing
 </HARD_RULES>
 
 <PROCESS>
@@ -65,6 +67,14 @@ Generates a new SKILL.md file with supporting references and templates, grounded
 
   Decide skill structure: phases, reference file names, and whether `assets/templates/` is needed.
 
+  **Classify output artifact format.** Read `${CLAUDE_SKILL_DIR}/references/artifact-format-routing.md` and apply its routing table to the new skill being generated:
+
+  1. Identify what kind of artifact the new skill will produce (plan/PRD/spec/report/prototype vs. SKILL.md/rule/ADR/README/etc.).
+  2. Apply the routing table: human-rich agent-executable artifacts default to **HTML**; agent-loaded and tooling-locked artifacts are **Markdown-mandatory**.
+  3. Check for explicit override: if the user said "generate as markdown" (or equivalent), that override wins regardless of artifact type.
+  4. If the verdict is **HTML**: copy `${CLAUDE_SKILL_DIR}/assets/templates/html-artifact-skeleton.html` into the new skill's `assets/templates/` directory (rename to match the artifact type, e.g., `plan.html`). The new skill must instruct its own generation phase to populate the canonical semantic tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`, plus relevant optional tags) inside the HTML `<body>`.
+  5. If the verdict is **Markdown**: use `${CLAUDE_SKILL_DIR}/assets/templates/skill-md.md` or a Markdown template appropriate to the artifact type.
+
   **Apply patterns.** Drop the load-context references above. Read these references:
 
   - `${CLAUDE_SKILL_DIR}/references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
@@ -73,11 +83,12 @@ Generates a new SKILL.md file with supporting references and templates, grounded
   <REFERENCES load="on-demand">
   - skill-authoring-guide.md
   - skill-format-reference.md
+  - artifact-format-routing.md
   - behavioral-guidelines.md
   - prompt-engineering-strategies.md
   </REFERENCES>
 
-  Read `${CLAUDE_SKILL_DIR}/assets/templates/skill-md.md` and fill its placeholders using:
+  Read the chosen output template (HTML skeleton or `skill-md.md`) and fill its placeholders using:
 
   - User requirements for the new skill
   - Phase 1 analysis output (naming conventions, existing patterns, plugin context)
@@ -89,9 +100,7 @@ Generates a new SKILL.md file with supporting references and templates, grounded
 
   1. `SKILL.md` — primary skill file with frontmatter and a body carrying the canonical semantic-tag vocabulary
   2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
-  3. `assets/templates/` — create stub template files if the skill generates output files
-
-     For validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted.
+  3. `assets/templates/` — create the appropriate output template (HTML or Markdown per the routing verdict above); for validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted
   </PHASE>
 
   <PHASE id="3" name="self-validation">

--- a/plugins/agent-customizer/skills/create-skill/assets/templates/html-artifact-skeleton.html
+++ b/plugins/agent-customizer/skills/create-skill/assets/templates/html-artifact-skeleton.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{artifact-title}}</title>
+  <style>
+    :root {
+      --color-text:          #1f2937;
+      --color-text-muted:    #4b5563;
+      --color-text-strong:   #111827;
+      --color-bg:            #ffffff;
+      --color-border:        #e5e7eb;
+      --color-code-bg:       #f3f4f6;
+
+      --color-trigger-text:  #374151;
+
+      --color-behaviour-bg:  #f0f4ff;
+      --color-behaviour-bar: #2563eb;
+
+      --color-hardrules-bg:  #fef2f2;
+      --color-hardrules-bar: #dc2626;
+
+      --color-phase-bg:      #fafafa;
+      --color-phase-label:   #111827;
+
+      --color-antipattern-bg:  #fffbeb;
+      --color-antipattern-bar: #d97706;
+
+      --color-output-bg:  #f0fdf4;
+      --color-output-bar: #16a34a;
+
+      --color-validation-bg:  #f5f3ff;
+      --color-validation-bar: #7c3aed;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --color-text:          #e5e7eb;
+        --color-text-muted:    #9ca3af;
+        --color-text-strong:   #f9fafb;
+        --color-bg:            #111827;
+        --color-border:        #374151;
+        --color-code-bg:       #1f2937;
+
+        --color-trigger-text:  #d1d5db;
+
+        --color-behaviour-bg:  #1e2a4a;
+        --color-behaviour-bar: #3b82f6;
+
+        --color-hardrules-bg:  #2d1515;
+        --color-hardrules-bar: #ef4444;
+
+        --color-phase-bg:      #1f2937;
+        --color-phase-label:   #f9fafb;
+
+        --color-antipattern-bg:  #2d2209;
+        --color-antipattern-bar: #f59e0b;
+
+        --color-output-bg:  #052e16;
+        --color-output-bar: #22c55e;
+
+        --color-validation-bg:  #1e1533;
+        --color-validation-bar: #a78bfa;
+      }
+    }
+
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 900px;
+      margin: 2rem auto;
+      padding: 1rem;
+      line-height: 1.6;
+      color: var(--color-text);
+      background: var(--color-bg);
+    }
+
+    BEHAVIOUR, HARD_RULES, PROCESS, PHASE, PREFLIGHT, REFERENCES,
+    EXAMPLE, ANTI_PATTERN, OUTPUT, VALIDATION, TRIGGER {
+      display: block;
+      margin: 1rem 0;
+    }
+
+    TRIGGER {
+      font-style: italic;
+      color: var(--color-trigger-text);
+    }
+
+    BEHAVIOUR {
+      background: var(--color-behaviour-bg);
+      border-left: 4px solid var(--color-behaviour-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    HARD_RULES[priority="hard"] {
+      background: var(--color-hardrules-bg);
+      border-left: 4px solid var(--color-hardrules-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    PROCESS {
+      border-top: 1px solid var(--color-border);
+      padding-top: 1rem;
+    }
+
+    PHASE {
+      background: var(--color-phase-bg);
+      border: 1px solid var(--color-border);
+      padding: 1rem;
+      margin: 0.5rem 0;
+      border-radius: 4px;
+    }
+
+    PHASE::before {
+      content: "Phase " attr(id) " — " attr(name);
+      display: block;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: var(--color-phase-label);
+    }
+
+    ANTI_PATTERN {
+      background: var(--color-antipattern-bg);
+      border-left: 4px solid var(--color-antipattern-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    OUTPUT {
+      background: var(--color-output-bg);
+      border-left: 4px solid var(--color-output-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    VALIDATION {
+      background: var(--color-validation-bg);
+      border-left: 4px solid var(--color-validation-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    code, pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      background: var(--color-code-bg);
+      padding: 0.125rem 0.25rem;
+      border-radius: 3px;
+    }
+
+    pre {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>{{artifact-title}}</h1>
+    <TRIGGER when="...">...</TRIGGER>
+    <BEHAVIOUR avoid="..." always="...">...</BEHAVIOUR>
+    <HARD_RULES priority="hard">...</HARD_RULES>
+    <PROCESS>
+      <PHASE id="1" name="...">...</PHASE>
+    </PROCESS>
+    <OUTPUT format="...">...</OUTPUT>
+    <VALIDATION>...</VALIDATION>
+  </main>
+</body>
+</html>

--- a/plugins/agent-customizer/skills/create-skill/references/artifact-format-routing.md
+++ b/plugins/agent-customizer/skills/create-skill/references/artifact-format-routing.md
@@ -1,0 +1,117 @@
+# Artifact Format Routing
+
+Evidence-based routing rule for deciding whether a skill's generated output artifact
+should default to HTML or Markdown.
+Source: wiki/knowledge/skill-body-convention.md (Artifact format routing section),
+CONTEXT.md (HTML-structural body convention — "Artifact format routing" entry),
+wiki/knowledge/html-artifact-effectiveness.md
+
+---
+
+## Routing Table
+
+When `create-skill` generates a new skill, the new skill's output format is
+determined by the artifact kind that new skill produces:
+
+| Artifact kind                                  | Default format | Reason                                            |
+| ---------------------------------------------- | -------------- | ------------------------------------------------- |
+| Plan, PRD, design spec                         | HTML           | Human-rich + agent-executable                     |
+| Report (weekly status, research, explainer)    | HTML           | Human-rich + agent-executable                     |
+| Prototype, custom editor, code-review writeup  | HTML           | Interactivity benefits from HTML                  |
+| `SKILL.md`, subagent `.md`                     | Markdown       | Agent-loaded; spec-mandated                       |
+| `AGENTS.md`, `CLAUDE.md`                       | Markdown       | Agent-loaded; spec-mandated                       |
+| `.claude/rules/*.md`, `.cursor/rules/*.mdc`    | Markdown       | Agent-loaded; spec-mandated                       |
+| `wiki/knowledge/*.md`                          | Markdown       | Agent-loaded by wiki-routing rule                 |
+| `docs/adr/*.md`                                | Markdown       | Tooling-locked (ADR convention)                   |
+| `CONTEXT.md`                                   | Markdown       | Tooling-locked (`grill-with-docs` reads it)       |
+| `README.md`                                    | Markdown       | Tooling-locked (npm/GitHub renderers)             |
+| Commit message, PR body, GitHub issue          | Markdown       | Tooling-locked (GitHub renderers)                 |
+| Code comments                                  | Markdown-ish   | Tooling-locked (compiler/linter parses)           |
+
+Explicit user override (`generate as markdown`) always wins over the default.
+
+---
+
+## How to classify
+
+During Phase 2 (generate-skill), before choosing the output template:
+
+1. **Identify the output artifact kind** — ask: "What does this new skill produce?
+   A plan/PRD/spec/report? Or a platform config file (SKILL.md, rule, ADR)?"
+
+2. **Apply the routing table above.** The left column describes the artifact kind;
+   the Default format column gives the verdict.
+
+3. **Check for explicit override.** If the user said "generate as markdown" (or
+   equivalent phrasing like "output markdown", "use .md", "markdown format"), the
+   override wins regardless of the routing table verdict.
+
+4. **Act on the verdict:**
+   - **HTML default** → use `${CLAUDE_SKILL_DIR}/assets/templates/html-artifact-skeleton.html`
+     as the output template for the new skill. Instruct the new skill to carry the
+     canonical semantic tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>`
+     with one or more `<PHASE id name>`, plus relevant optional tags `<OUTPUT>`,
+     `<VALIDATION>`) inside the HTML `<body>`. Copy or reference the skeleton into
+     the new skill's `assets/templates/` directory.
+   - **Markdown default** → use the standard `${CLAUDE_SKILL_DIR}/assets/templates/skill-md.md`
+     template (or a Markdown template appropriate to the artifact type).
+   - **Explicit override** → apply the user's stated format regardless of the table.
+
+---
+
+## HTML skeleton location
+
+The HTML baseline skeleton lives at:
+
+```
+${CLAUDE_SKILL_DIR}/assets/templates/html-artifact-skeleton.html
+```
+
+It is a valid HTML5 document with:
+- `<meta charset>` and `<meta name="viewport">`
+- Scoped CSS targeting each semantic tag (`BEHAVIOUR`, `HARD_RULES`, `PHASE`, `OUTPUT`,
+  `VALIDATION`, `ANTI_PATTERN`, etc.) with adaptive colors (light and dark mode via
+  CSS custom properties and `@media (prefers-color-scheme: dark)`)
+- Placeholder `{{artifact-title}}` in `<title>` and `<h1>`
+- A `<main>` block containing the canonical semantic-tag scaffold
+
+When generating a new HTML-defaulting skill, copy this skeleton into the new skill's
+`assets/templates/` directory (e.g., as `<artifact-type>.html`). Replace
+`{{artifact-title}}` with the artifact name appropriate to the new skill.
+
+---
+
+## Canonical semantic tags in HTML artifacts
+
+Generated HTML artifacts MUST carry the canonical semantic tags inside the HTML body.
+The same vocabulary that governs `SKILL.md` bodies applies:
+
+**Mandatory tags (HTML artifact)**:
+- `<TRIGGER when="...">` — plain-language activation context
+- `<BEHAVIOUR avoid="..." always="...">` — behavioural guidelines
+- `<HARD_RULES priority="hard">` — inviolable constraints
+- `<PROCESS>` containing at least one `<PHASE id="N" name="...">` — ordered execution steps
+
+**Optional tags (HTML artifact)**:
+- `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`.
+
+These tags are valid HTML5 — browsers treat unknown elements as inline by default;
+the CSS in the skeleton promotes each to `display: block` with semantic styling.
+
+---
+
+## Why HTML for human-rich artifacts
+
+HTML artifacts serve two consumers: humans (CSS layout, diagrams, interactive controls)
+and the next LLM session (parseable semantic-tag structure). The dual-consumer design
+is why this project's HTML artifacts embed canonical semantic tags — the same parse
+target serves both.
+
+Markdown past ~100 lines stops being read; rich visualisations get faked with ASCII;
+HTML renders natively in any browser without extra tooling. For agent-loaded and
+tooling-locked files the tradeoffs reverse: spec compliance, diffability, and
+renderer compatibility make Markdown mandatory.
+
+Source: wiki/knowledge/html-artifact-effectiveness.md (Core argument, Where HTML wins)


### PR DESCRIPTION
Implements #145. Extends agent-customizer create-skill with Artifact format routing: human-rich agent-executable artifacts default to an HTML baseline skeleton carrying canonical semantic tags; agent-loaded/tooling-locked artifacts stay Markdown; explicit 'generate as markdown' override wins. Ships the HTML5 skeleton asset with light/dark-adaptive CSS. No version bumps (deferred to #152).