### PR TITLE
Subagent body convention (Claude Code customizer, create-subagent)

### DIFF
--- a/plugins/agent-customizer/skills/create-subagent/SKILL.md
+++ b/plugins/agent-customizer/skills/create-subagent/SKILL.md
@@ -5,111 +5,122 @@ description: "Creates new subagent definitions with YAML frontmatter grounded in
 
 # Create Subagent
 
-Generates a new subagent definition with correct YAML frontmatter, minimal tool restrictions, and a structured system prompt grounded in the docs corpus.
+Generates a new subagent definition with correct YAML frontmatter, minimal tool restrictions, and a structured body grounded in the docs corpus.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new Claude Code subagent from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create subagents with generic system prompts ("you are a helpful AI assistant")
 - **NEVER** grant write tools (`Edit`, `Write`) to read-only analysis or review agents; allow `Bash` only for explicitly read-only commands when needed
 - **NEVER** set `maxTurns` > 30 without explicit justification in the system prompt
 - **EVERY** subagent must include: role definition, process steps, output format, and self-verification instructions
 - **EVERY** `description` must include specific "Use when..." trigger phrases so Claude routes correctly
+- **EVERY** generated subagent body must carry the canonical semantic-tag vocabulary (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`); `<TRIGGER>` is optional for subagents
 - **Agents CANNOT spawn other agents** — the Task tool is unavailable at runtime; warn if user requests this
 - Plugin context: `hooks`, `mcpServers`, and `permissionMode` fields are ignored for plugin agents
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="name-collision-check">
+  Check if a subagent with the same name already exists at:
 
-Check if a subagent with the same name already exists at:
+  - `.claude/agents/{requested-name}.md`
+  - `plugins/*/agents/{requested-name}.md`
 
-- `.claude/agents/{requested-name}.md`
-- `plugins/*/agents/{requested-name}.md`
+  **If a subagent already exists with that name:**
 
-**If a subagent already exists with that name:**
+  1. Inform the user: "A subagent named `{requested-name}` already exists."
+  2. Suggest using `/agent-customizer:improve-subagent` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
 
-1. Inform the user: "A subagent named `{requested-name}` already exists."
-2. Suggest using `/agent-customizer:improve-subagent` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
+  **If no subagent exists with that name:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no subagent exists with that name:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Codebase Analysis
+  > Analyze the project to understand existing subagents. Focus on: agent names and roles in `.claude/agents/` and `plugins/*/agents/`, tool restrictions in use, model choices, `maxTurns` values, which skills delegate to which agents, and naming conventions. Flag any agents similar in purpose to `{requested-name}`. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing subagents. Focus on: agent names and roles in `.claude/agents/` and `plugins/*/agents/`, tool restrictions in use, model choices, `maxTurns` values, which skills delegate to which agents, and naming conventions. Flag any agents similar in purpose to `{requested-name}`. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
+  <PHASE id="2" name="generate-subagent">
+  **Load context.** Drop any references from Phase 1. Read these references:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  - `${CLAUDE_SKILL_DIR}/references/subagent-authoring-guide.md` — when to use subagents, system prompt structure, model selection heuristics, tool restriction patterns, anti-patterns
+  - `${CLAUDE_SKILL_DIR}/references/subagent-config-reference.md` — YAML frontmatter fields, valid model IDs, tool allowlist/denylist, orchestration patterns, plugin restrictions
 
-### Phase 2: Generate Subagent
+  Decide model selection, tool restrictions, and target location.
 
-#### Phase 2a: Load Context
+  **Apply patterns.** Drop the load-context references above. Read this reference:
 
-Drop any references from Phase 1. Read these references:
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — subagent-specific prompting (role prompting, structured output, confidence filtering)
 
-- `${CLAUDE_SKILL_DIR}/references/subagent-authoring-guide.md` — when to use subagents, system prompt structure, model selection heuristics, tool restriction patterns, anti-patterns
-- `${CLAUDE_SKILL_DIR}/references/subagent-config-reference.md` — YAML frontmatter fields, valid model IDs, tool allowlist/denylist, orchestration patterns, plugin restrictions
+  <REFERENCES load="on-demand">
+  - subagent-authoring-guide.md
+  - subagent-config-reference.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-Decide model selection, tool restrictions, and target location.
+  Read `${CLAUDE_SKILL_DIR}/assets/templates/subagent-definition.md` and fill its placeholders using:
 
-#### Phase 2b: Apply Patterns
+  - User requirements for the new subagent (role, purpose, tools needed)
+  - Phase 1 analysis output (existing agents, naming conventions, delegation patterns)
+  - Decisions from Phase 2a (model, tools, target location)
 
-Drop Phase 2a references. Read this reference:
+  Apply model selection heuristic:
 
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — subagent-specific prompting (role prompting, structured output, confidence filtering)
+  - `haiku` — narrow read-only lookup agents with no structured judgment, policy evaluation, or config review
+  - `sonnet` — standard analysis, review, and configuration-inspection agents (default for most subagents)
+  - `opus` — complex multi-step reasoning only (requires explicit justification)
 
-Read `${CLAUDE_SKILL_DIR}/assets/templates/subagent-definition.md` and fill its placeholders using:
+  Unless the user explicitly asks for a cheaper exploration agent, choose `sonnet` for any agent that inspects configuration, evaluates compliance, or produces structured findings.
 
-- User requirements for the new subagent (role, purpose, tools needed)
-- Phase 1 analysis output (existing agents, naming conventions, delegation patterns)
-- Decisions from Phase 2a (model, tools, target location)
+  If Phase 1 detects a monorepo or multi-service layout, make the generated system prompt name the relevant services, workspaces, and scope boundaries the agent should inspect. Do not leave multi-service targets implicit.
 
-Apply model selection heuristic:
+  Determine target location:
 
-- `haiku` — narrow read-only lookup agents with no structured judgment, policy evaluation, or config review
-- `sonnet` — standard analysis, review, and configuration-inspection agents (default for most subagents)
-- `opus` — complex multi-step reasoning only (requires explicit justification)
+  - `.claude/agents/{name}.md` — project-level agent (accessible everywhere)
+  - `plugins/{plugin}/agents/{name}.md` — plugin-scoped agent (restricted to plugin context)
+  </PHASE>
 
-Unless the user explicitly asks for a cheaper exploration agent, choose `sonnet` for any agent that inspects configuration, evaluates compliance, or produces structured findings.
+  <PHASE id="3" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated subagent definition.
 
-If Phase 1 detects a monorepo or multi-service layout, make the generated system prompt name the relevant services, workspaces, and scope boundaries the agent should inspect. Do not leave multi-service targets implicit.
+  In addition to the shared criteria, enforce two scenario-sensitive checks before proceeding:
 
-Determine target location:
+  - Treat `sonnet` as the default for configuration inspection, compliance review, and other structured analysis agents unless the user explicitly asks for a cheaper exploration agent
+  - If Phase 1 detected a monorepo or multi-service layout, confirm the generated prompt names the relevant services, workspaces, or scope boundaries explicitly
 
-- `.claude/agents/{name}.md` — project-level agent (accessible everywhere)
-- `plugins/{plugin}/agents/{name}.md` — plugin-scoped agent (restricted to plugin context)
+  The loop evaluates all hard limits, quality checks, and canonical semantic-tag strictness tiers — fixing any failures and re-evaluating — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-### Phase 3: Self-Validation
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated subagent definition
+  2. Cite the evidence from reference files that informed key decisions:
+     - Why this model was chosen (heuristic applied)
+     - Why these tools are included/excluded (principle of least privilege)
+     - What the output format enforces and why
+  3. If the user requested plugin-restricted fields (`hooks`, `mcpServers`, `permissionMode`), warn that these fields are ignored in plugin context
+  4. Ask for confirmation before writing any files
+  5. On approval, write the subagent definition to the target location
+  </PHASE>
 
-Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated subagent definition.
+</PROCESS>
 
-In addition to the shared criteria, enforce two scenario-sensitive checks before proceeding:
-
-- Treat `sonnet` as the default for configuration inspection, compliance review, and other structured analysis agents unless the user explicitly asks for a cheaper exploration agent
-- If Phase 1 detected a monorepo or multi-service layout, confirm the generated prompt names the relevant services, workspaces, or scope boundaries explicitly
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete generated subagent definition
-2. Cite the evidence from reference files that informed key decisions:
-   - Why this model was chosen (heuristic applied)
-   - Why these tools are included/excluded (principle of least privilege)
-   - What the output format enforces and why
-3. If the user requested plugin-restricted fields (`hooks`, `mcpServers`, `permissionMode`), warn that these fields are ignored in plugin context
-4. Ask for confirmation before writing any files
-5. On approval, write the subagent definition to the target location
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and loop the generated subagent through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/MANIFEST.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/MANIFEST.md
@@ -1,0 +1,33 @@
+# Fixture Corpus — Subagent Body Convention
+
+Regression corpus for the canonical semantic-tag strictness tiers defined in
+`references/subagent-validation-criteria.md` ("Canonical Semantic-Tag Convention"
+section). Each fixture is a minimal subagent definition body that exercises exactly
+one validation outcome.
+
+The subagent variant of the convention differs from the skill variant in one
+critical respect: `<TRIGGER>` is **optional** for subagents (they are spawned by
+skills, not user-invoked). Its absence is silent — never a finding. All other
+mandatory tags (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`) are
+hard-fail when absent, same as for skills.
+
+To use: run the validation loop from `subagent-validation-criteria.md` against
+each fixture file and confirm the produced verdict matches the **Expected verdict**
+column below. Any mismatch means the strictness-tier text is ambiguous and must
+be tightened — the corpus is the regression test for that clarity.
+
+These fixtures are test data, not real subagents. They are not loaded by the
+`create-subagent` skill at runtime.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-with-trigger.md` | None — all mandatory tags present, `<TRIGGER>` also present, balanced, canonical attributes only | **pass** |
+| `compliant-without-trigger.md` | `<TRIGGER>` absent (subagent variant — optional) | **pass** — `<TRIGGER>` absence is silent for subagents |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** — missing mandatory tag |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** — missing mandatory tag |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** — missing mandatory tag |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** — missing mandatory tag |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** — unbalanced tags |
+| `malformed-attribute.md` | `<PHASE>` `name` value missing its quotes | **hard-fail** — malformed attribute syntax |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a non-canonical `mood=` attribute | **warn** — non-canonical attribute name; passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** — alias satisfies the `<HARD_RULES>` check |

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/compliant-with-trigger.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/compliant-with-trigger.md
@@ -1,0 +1,42 @@
+---
+name: fixture-compliant-with-trigger
+description: "Fixture subagent exercising the compliant baseline with TRIGGER present. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. All mandatory tags present, <TRIGGER> also present, balanced, canonical attributes only. -->
+
+# Fixture Compliant With Trigger
+
+One-sentence identity statement for the compliant-with-trigger fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>
+
+<OUTPUT>
+Return findings as a structured list with file paths and descriptions.
+</OUTPUT>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/compliant-without-trigger.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/compliant-without-trigger.md
@@ -1,0 +1,40 @@
+---
+name: fixture-compliant-without-trigger
+description: "Fixture subagent exercising the compliant baseline with TRIGGER absent. Use when validating the subagent-specific TRIGGER-optional variant."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. <TRIGGER> is absent — for subagents this is SILENT (not a hard-fail). All other mandatory tags are present, balanced, and use canonical attributes only. -->
+
+# Fixture Compliant Without Trigger
+
+One-sentence identity statement for the compliant-without-trigger fixture.
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>
+
+<OUTPUT>
+Return findings as a structured list with file paths and descriptions.
+</OUTPUT>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/malformed-attribute.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/malformed-attribute.md
@@ -1,0 +1,36 @@
+---
+name: fixture-malformed-attribute
+description: "Fixture subagent with a malformed PHASE attribute. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The <PHASE> name attribute value is missing its quotes. -->
+
+# Fixture Malformed Attribute
+
+One-sentence identity statement for the malformed-attribute fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name=analysis>
+  DEFECT: the name attribute value above is unquoted — malformed attribute syntax.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-behaviour.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-behaviour.md
@@ -1,0 +1,29 @@
+---
+name: fixture-missing-behaviour
+description: "Fixture subagent with the mandatory BEHAVIOUR tag absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <BEHAVIOUR> tag is absent. -->
+
+# Fixture Missing Behaviour
+
+One-sentence identity statement for the missing-behaviour fixture.
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-hard-rules.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-hard-rules.md
@@ -1,0 +1,31 @@
+---
+name: fixture-missing-hard-rules
+description: "Fixture subagent with both HARD_RULES and RULES absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. Both <HARD_RULES> and the <RULES> alias are absent. -->
+
+# Fixture Missing Hard Rules
+
+One-sentence identity statement for the missing-hard-rules fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-phase.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-phase.md
@@ -1,0 +1,28 @@
+---
+name: fixture-missing-phase
+description: "Fixture subagent with PROCESS present but containing zero PHASE elements. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is present but contains zero <PHASE> elements. -->
+
+# Fixture Missing Phase
+
+One-sentence identity statement for the missing-phase fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+<!-- DEFECT: <PROCESS> is present but contains no <PHASE> elements. -->
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-process.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-process.md
@@ -1,0 +1,24 @@
+---
+name: fixture-missing-process
+description: "Fixture subagent with the mandatory PROCESS tag absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <PROCESS> tag is absent. -->
+
+# Fixture Missing Process
+
+One-sentence identity statement for the missing-process fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/non-canonical-attribute.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/non-canonical-attribute.md
@@ -1,0 +1,37 @@
+---
+name: fixture-non-canonical-attribute
+description: "Fixture subagent with a non-canonical attribute name. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: warn. <BEHAVIOUR> carries a non-canonical `mood=` attribute; all mandatory tags are present and balanced, so it passes otherwise. -->
+
+# Fixture Non-Canonical Attribute
+
+One-sentence identity statement for the non-canonical-attribute fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence"
+  mood="optimistic">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/rules-alias.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/rules-alias.md
@@ -1,0 +1,36 @@
+---
+name: fixture-rules-alias
+description: "Fixture subagent using the legacy RULES alias instead of HARD_RULES. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. Uses the legacy <RULES> tag, which is an accepted alias of <HARD_RULES>; all else compliant. -->
+
+# Fixture Rules Alias
+
+One-sentence identity statement for the rules-alias fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<RULES>
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/unbalanced-tag.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/unbalanced-tag.md
@@ -1,0 +1,36 @@
+---
+name: fixture-unbalanced-tag
+description: "Fixture subagent with an unbalanced PROCESS tag. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is opened but never closed. -->
+
+# Fixture Unbalanced Tag
+
+One-sentence identity statement for the unbalanced-tag fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+<!-- DEFECT: the <PROCESS> opening tag above has no matching </PROCESS> closing tag. -->

--- a/plugins/agent-customizer/skills/create-subagent/assets/templates/subagent-definition.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/templates/subagent-definition.md
@@ -13,41 +13,59 @@ maxTurns: [15 for analysis agents, 20 for evaluator agents]
      Rule: Plugin agents CANNOT use hooks, mcpServers, or permissionMode
      Rule: Agents cannot spawn other agents
      Rule: If scope spans multiple services or workspaces, name them explicitly in the prompt
+     Rule: <TRIGGER> is optional — omit if the subagent is always spawned by skills, not user-invoked
+     Rule: Mandatory body tags: <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with at least one <PHASE id="N" name="X">
 -->
 
 # [Agent Name]
 
 [One-sentence identity statement; name target services/workspaces when scope is multi-service]
 
-## Constraints
+<!-- Optional: include <TRIGGER> if this subagent can also be user-invoked -->
+<!-- <TRIGGER when="[activation condition]" /> -->
 
-- Do not [constraint 1 — typically "modify any files"]
-- Do not [constraint 2 — typically "suggest improvements, only report"]
-- Do not [constraint 3]
-- Do not [constraint 4]
+<BEHAVIOUR
+  avoid="[what to avoid — e.g., modifying files; surfacing low-confidence findings]"
+  always="[what to always do — e.g., cite evidence; report in structured format]">
+- [Behavioural guideline 1]
+- [Behavioural guideline 2]
+- Do not modify any files — report only.
+</BEHAVIOUR>
 
-## Process
+<HARD_RULES priority="hard">
+- **NEVER** [inviolable constraint 1 — e.g., "modify files"]
+- **NEVER** [inviolable constraint 2 — e.g., "spawn other subagents"]
+- **EVERY** finding must cite a specific source or file location
+- **EVERY** output must match the Output Format below exactly
+</HARD_RULES>
 
-### 1. [First Step]
+<PROCESS>
 
-[What to analyze/detect/evaluate]
+  <PHASE id="1" name="[first-step]">
+  [What to analyze/detect/evaluate in this step]
+  </PHASE>
 
-### 2. [Second Step]
+  <PHASE id="2" name="[second-step]">
+  [How to process findings — filtering, categorizing, structuring]
+  </PHASE>
 
-[How to process findings]
+  <PHASE id="3" name="[compile-output]">
+  [How to compile and format the final structured output]
+  </PHASE>
 
-### 3. [Third Step]
+</PROCESS>
 
-[How to compile output]
-
-## Output Format
+<OUTPUT>
 
 ```
 [Exact structure the agent must return — headers, tables, sections]
 ```
 
-## Self-Verification
+</OUTPUT>
 
-1. [Check 1]
-2. [Check 2]
-3. [Check 3]
+<VALIDATION>
+Before returning output, verify:
+1. [Self-check 1 — e.g., "All findings cite a file path or source doc"]
+2. [Self-check 2 — e.g., "No files were modified"]
+3. [Self-check 3 — e.g., "Output matches the required format exactly"]
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-subagent/references/subagent-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-subagent/references/subagent-validation-criteria.md
@@ -1,7 +1,18 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Claude Code subagent definitions.
-Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md
+Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md, `wiki/knowledge/skill-body-convention.md`
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
@@ -22,6 +33,41 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 ---
 
+## Canonical Semantic-Tag Convention
+
+The subagent body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the subagent body MUST contain all of these):
+
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Subagent-specific variant**: `<TRIGGER>` is OPTIONAL for subagents (they are spawned by skills, not user-invoked). Its absence is **silent** — never a finding.
+
+**Optional tags** (absence is silent — never a finding): `<TRIGGER>`, `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of `<TRIGGER>` or any other optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
+
+---
+
 ## Quality Checks (All must pass)
 
 - [ ] `description` specific enough for automatic delegation (includes trigger phrases)
@@ -31,8 +77,11 @@ Any subagent violating these criteria must be fixed before proceeding:
 - [ ] Delegation trigger language is normal ("use when..."), not aggressive ("CRITICAL: MUST always...")
 - [ ] No instructions telling subagent to spawn other subagents (runtime blocks this)
 - [ ] System prompt is task-specific, not generic ("you are a helpful AI")
-- [ ] Evidence citations present: system prompt references source docs for domain-specific constraints (e.g., "per creating-custom-subagents.md")
-- [ ] Prompt engineering strategy applied: system prompt uses role prompting (single-sentence role), structured output format, and confidence filtering per prompt-engineering-strategies.md. **Note:** For evaluation agents that mandate explicit evidence citations per finding (a stricter guarantee), the evidence requirement satisfies the confidence filtering criterion.
+- [ ] Evidence citations present: system prompt references source docs for domain-specific constraints
+- [ ] Prompt engineering strategy applied: system prompt uses role prompting, structured output format, and confidence filtering per prompt-engineering-strategies.md
+- [ ] Canonical semantic tags present: `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched — `name`, `description`, `tools`, `model`, `maxTurns` fields per Anthropic subagent spec
 
 ---
 
@@ -48,6 +97,7 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 - [ ] `maxTurns` not increased beyond 20 without justification
 - [ ] Scope of subagent not broadened (single-purpose agents are better than general-purpose)
+- [ ] Reference file ≤200 line limit not violated; >100-line files have a `## Contents` TOC
 
 ---
 
@@ -55,10 +105,30 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 Execute this loop for each generated or improved subagent:
 
-1. Evaluate the subagent against ALL criteria above
+1. Evaluate the subagent against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
-3. If ANY criterion fails: identify the specific failure, fix the subagent, restart evaluation
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing subagents when ALL criteria pass
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the subagent, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing subagents when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The fixture corpus at `${CLAUDE_SKILL_DIR}/assets/fixtures/` is the regression test for the strictness tiers. Each fixture is annotated in `assets/fixtures/MANIFEST.md` with its expected verdict. Running the validation loop against the corpus MUST produce exactly the verdict below for each fixture — any deviation means the strictness-tier text above is ambiguous and must be tightened.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-with-trigger.md` | None — all mandatory tags present, `<TRIGGER>` also present, balanced, canonical attributes | **pass** |
+| `compliant-without-trigger.md` | `<TRIGGER>` absent (subagent variant — optional) | **pass** (silence on optional tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check) |


### PR DESCRIPTION
Implements #146. Mirrors the canonical semantic-tag convention onto subagent definitions via agent-customizer create-subagent: the authoring template, validation criteria, and create-subagent's own SKILL.md body adopt the vocabulary, with `<TRIGGER>` optional for generated subagents. Adds a 10-fixture corpus. Existing files under agents/ untouched (Tier-3). No version bumps (deferred to #152).