### PR TITLE
Improve verbs retrofit (Claude Code customizer, improve-skill + improve-subagent)

### DIFF
--- a/plugins/agent-customizer/skills/improve-skill/SKILL.md
+++ b/plugins/agent-customizer/skills/improve-skill/SKILL.md
@@ -7,18 +7,20 @@ description: "Evaluates and optimizes existing SKILL.md files against evidence-b
 
 Evaluate an existing SKILL.md file against evidence-based quality criteria and apply improvements to optimize token usage, reduce bloat, and align with proven patterns.
 
-## Behavioral Guidelines
+<TRIGGER when="improving or auditing an existing Claude Code skill" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **ALWAYS** evaluate before modifying — never change files without analysis
 - **ALWAYS** present changes to the user before applying them
 - **NEVER** remove evidence-grounded references or citations
@@ -26,98 +28,113 @@ Evaluate an existing SKILL.md file against evidence-based quality criteria and a
 - **NEVER** exceed 500 lines in SKILL.md or 200 lines in reference files after improvements
 - **PRESERVE** all genuinely useful skill phases and instructions — only remove waste
 - **PRESERVE** or strengthen the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** improved SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** tag-vocabulary violation found in the target skill must be reported with the specific tag name, line reference, and strictness tier (hard-fail / warn / informational) before proposing a fix
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="skill-exists-check">
+  Check if a skill exists at:
 
-Check if a skill exists at:
+  - The user-provided path
+  - `.claude/skills/{name}/SKILL.md`
+  - `plugins/*/skills/{name}/SKILL.md`
 
-- The user-provided path
-- `.claude/skills/{name}/SKILL.md`
-- `plugins/*/skills/{name}/SKILL.md`
+  **If no skill found:**
 
-**If no skill found:**
+  1. Inform the user: "No skill found at the specified path."
+  2. Suggest using `/agent-customizer:create-skill` to create a new one instead.
+  3. **STOP**
 
-1. Inform the user: "No skill found at the specified path."
-2. Suggest using `/agent-customizer:create-skill` to create a new one instead.
-3. **STOP**
+  **If skill found:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If skill found:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="evaluate">
+  Delegate to the `skill-evaluator` agent with this task:
 
-### Phase 1: Evaluate
+  > Evaluate the skill at `{target-path}`. Read the SKILL.md and all files in the skill directory. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter valid), structural quality (progressive disclosure, phase structure, reference loading), and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW) and quality scores per dimension.
 
-Delegate to the `skill-evaluator` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Evaluate the skill at `{target-path}`. Read the SKILL.md and all files in the skill directory. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter valid), structural quality (progressive disclosure, phase structure, reference loading), and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW) and quality scores per dimension.
+  <PHASE id="2" name="codebase-context">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  > Analyze the project to understand the context around the skill being improved. Focus on: which agents the skill delegates to and whether those agents still exist, naming conventions for similar skills, any other skills that overlap in purpose, and the plugin structure.
 
-### Phase 2: Codebase Context
+  Wait for it to complete and parse its structured output.
+  </PHASE>
 
-Delegate to the `artifact-analyzer` agent with this task:
+  <PHASE id="3" name="generate-improvement-plan">
+  #### Phase 3a: Diagnose
 
-> Analyze the project to understand the context around the skill being improved. Focus on: which agents the skill delegates to and whether those agents still exist, naming conventions for similar skills, any other skills that overlap in purpose, and the plugin structure.
+  Drop Phases 1–2 references. Read:
 
-Wait for it to complete and parse its structured output.
+  - `${CLAUDE_SKILL_DIR}/references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
+  - `${CLAUDE_SKILL_DIR}/references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
 
-### Phase 3: Generate Improvement Plan
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-evaluation-criteria.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-#### Phase 3a: Diagnose
+  Identify issues from both agent reports. Do not write the plan yet.
 
-Drop Phases 1–2 references. Read:
+  #### Phase 3b: Plan
 
-- `${CLAUDE_SKILL_DIR}/references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
-- `${CLAUDE_SKILL_DIR}/references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
+  Drop Phase 3a references. Read:
 
-Identify issues from both agent reports. Do not write the plan yet.
+  - `${CLAUDE_SKILL_DIR}/references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — skill-specific prompting strategies
 
-#### Phase 3b: Plan
+  Create improvement plan: **Removals** (bloat: inlined content, over-specified instructions; stale: broken agent refs, removed tools; duplicates); **Refactoring** (progressive disclosure, phase consolidation, reference paths); **Additions** (missing sections — suggest Hard Rules/Preflight only for user-facing skills, not analysis-only). If all categories yield zero items, conclude "No improvements needed" and proceed to Phase 5.
+  </PHASE>
 
-Drop Phase 3a references. Read:
+  <PHASE id="4" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
 
-- `${CLAUDE_SKILL_DIR}/references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — skill-specific prompting strategies
+  For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+  </PHASE>
 
-Create improvement plan: **Removals** (bloat: inlined content, over-specified instructions; stale: broken agent refs, removed tools; duplicates); **Refactoring** (progressive disclosure, phase consolidation, reference paths); **Additions** (missing sections — suggest Hard Rules/Preflight only for user-facing skills, not analysis-only). If all categories yield zero items, conclude "No improvements needed" and proceed to Phase 5.
+  <PHASE id="5" name="present-and-apply">
+  1. Show a summary overview of all improvements found, grouped by category:
+     - **Removals**: X items (bloat: X, stale: X, duplicates: X)
+     - **Refactoring**: X items (progressive disclosure: X, phase structure: X, reference paths: X)
+     - **Additions**: X items
 
-### Phase 4: Self-Validation
+  2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
 
-Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
+     **WHAT**: The specific content and its current location (file:lines)
+     **WHY**: Evidence-based justification with source reference
+     **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
+     **OPTIONS**:
+     - **Option A** (recommended): Primary action
+     - **Option B**: Alternative action
+     - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
 
-For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+     Wait for the user to select an option for each suggestion before proceeding to the next.
+     If the user selects "Keep as-is", preserve the content in its exact current location.
 
-### Phase 5: Present and Apply
+  3. After all suggestions are reviewed, show aggregate token impact analysis:
+     - **Total lines**: before → after
+     - **Removed tokens**: total waste eliminated
+     - **Deferred suggestions**: X items kept as-is
 
-1. Show a summary overview of all improvements found, grouped by category:
-   - **Removals**: X items (bloat: X, stale: X, duplicates: X)
-   - **Refactoring**: X items (progressive disclosure: X, phase structure: X, reference paths: X)
-   - **Additions**: X items
+  4. Apply ONLY the approved changes (options A or B selections).
 
-2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+  5. Report final metrics:
+     - Lines before → after
+     - Files affected
+     - Estimated token savings per session
+     - Suggestions applied: X of Y (Z deferred)
+  </PHASE>
 
-   **WHAT**: The specific content and its current location (file:lines)
-   **WHY**: Evidence-based justification with source reference
-   **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
-   **OPTIONS**:
-   - **Option A** (recommended): Primary action
-   - **Option B**: Alternative action
-   - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
+</PROCESS>
 
-   Wait for the user to select an option for each suggestion before proceeding to the next.
-   If the user selects "Keep as-is", preserve the content in its exact current location.
-
-3. After all suggestions are reviewed, show aggregate token impact analysis:
-   - **Total lines**: before → after
-   - **Removed tokens**: total waste eliminated
-   - **Deferred suggestions**: X items kept as-is
-
-4. Apply ONLY the approved changes (options A or B selections).
-
-5. Report final metrics:
-   - Lines before → after
-   - Files affected
-   - Estimated token savings per session
-   - Suggestions applied: X of Y (Z deferred)
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and loop the improved skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/improve-skill/references/skill-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/skill-validation-criteria.md
@@ -1,35 +1,130 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`, `wiki/knowledge/skill-body-convention.md`
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
 ## Hard Limits (Auto-fail if violated)
 
-Apply the canonical Hard Limits Table from `skill-evaluation-criteria.md` (body length, reference length, TOC requirement, frontmatter `description`/`name`, phase-structure thresholds), plus this validation-only addition:
+Any skill violating these criteria must be fixed before proceeding:
 
 | Criterion | Threshold | Source |
 |-----------|-----------|--------|
+| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
+| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
+| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
+| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
+| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
 | Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+
+*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X")
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. Report it as a `<HARD_RULES>` alias candidate (informational), not as a violation. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+| **Informational** | Legacy `<RULES>` tag present — alias for `<HARD_RULES>` | Surface as alias candidate; do not fail or warn |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+### Structured violation report format
+
+When evaluating a target skill body, report every finding using this format:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+[HARD-FAIL] Missing mandatory tag: <TRIGGER> — required for skills
+[HARD-FAIL] Unbalanced tag: <PROCESS> opened at line 42, no closing tag found
+[HARD-FAIL] Malformed attribute: <PHASE id=1 name="x"> — attribute value `1` missing quotes
+[WARN]      Non-canonical attribute: <BEHAVIOUR mood="high"> — `mood` is outside the closed set
+[INFO]      Legacy alias: <RULES> at line 20 — satisfies <HARD_RULES> check; candidate for organic retrofit to <HARD_RULES>
+──────────────────────────────────
+Result: HARD-FAIL (3 blocking violations, 1 warning, 1 informational)
+```
+
+A compliant target produces:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+No violations found.
+──────────────────────────────────
+Result: PASS
+```
 
 ---
 
 ## Quality Checks (All must pass)
 
-**Structure**: self-validation phase reads `references/*validation-criteria.md`; `${CLAUDE_SKILL_DIR}` used for all bundled refs (no hardcoded paths); progressive disclosure applied (references loaded per phase, not upfront); no reference content inlined in SKILL.md body; each phase ≤10 lines with depth in references; reference files cited explicitly.
-
-**Frontmatter**: `description` in third person, includes both what + when to use; `disable-model-invocation: true` set for side-effect workflows (commit, deploy, send).
-
-**Discipline**: behavioral guidelines applied (surface assumptions, simplest path, surgical, validation targets); persuasion cues stay inside the ethical constraint; phase instructions specific and actionable (no "ensure quality").
-
-**Distribution-specific**: plugin skills (`plugins/*/skills/`) delegate analysis to registered agents — no inline bash; standalone skills (`skills/`) include explicit bash commands per analysis step.
-
-**Prompting**: relevant strategy from `prompt-engineering-strategies.md` applied (role prompting for skills, progressive disclosure for phases); evidence citations present for key decisions.
+- [ ] Has a self-validation phase that reads the skill's `references/*validation-criteria.md`
+- [ ] `${CLAUDE_SKILL_DIR}` used for all bundled file references (not hardcoded paths)
+- [ ] `description` written in third person ("Processes..." not "I process..." or "You can use...")
+- [ ] `description` includes what the skill does AND when to use it
+- [ ] Progressive disclosure applied: references loaded per phase, not all upfront
+- [ ] No reference content inlined in SKILL.md body (should be in `references/` subdirectory)
+- [ ] Each phase instruction is concise (≤10 lines); depth lives in reference files
+- [ ] Reference files cited explicitly so Claude knows what to load and when
+- [ ] `disable-model-invocation: true` set for side-effect workflows (commit, deploy, send)
+- [ ] Prompt engineering strategy applied: skill follows relevant strategy from prompt-engineering-strategies.md (role prompting for skills, progressive disclosure for phases)
+- [ ] Behavioral guidelines applied: the skill surfaces assumptions before acting, prefers the simplest adequate path, keeps changes surgical, and defines explicit validation targets
+- [ ] Persuasion cues, if present, stay inside the ethical constraint: they improve compliance with legitimate work only and never weaken safeguards, refusals, or scope boundaries
+- [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
+- [ ] Plugin skill body contains no inline bash analysis commands — analysis must be delegated to registered agents (applies to skills in `plugins/*/skills/`)
+- [ ] Standalone skill body includes explicit bash commands for each analysis step (applies to skills in `skills/`)
+- [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-best-practices.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
 
 ---
 
 ## If This Is an IMPROVE Operation — Also Check
+
+**Canonical Tag Vocabulary:**
+
+- [ ] Target skill body uses all mandatory tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with at least one `<PHASE>`)
+- [ ] All tags in target skill body are balanced (no unmatched open/close)
+- [ ] All attribute syntax in target skill body is well-formed (no missing quotes, no stray `=`)
+- [ ] Non-canonical attributes in target skill body surfaced as warnings (not hard-fails)
+- [ ] Legacy `<RULES>` in target skill body reported as informational alias candidate (not a fail)
 
 **Information Preservation:**
 
@@ -48,10 +143,37 @@ Apply the canonical Hard Limits Table from `skill-evaluation-criteria.md` (body 
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above
+1. Evaluate the skill against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
-3. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing skills when ALL criteria pass
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The strictness tiers above are exercised by a regression corpus shipped with the
+sibling `create-skill` skill at
+`plugins/agent-customizer/skills/create-skill/assets/fixtures/` (see its
+`MANIFEST.md`). `improve-skill` does not ship its own copy — the strictness-tier
+logic is identical, so the `create-skill` corpus is the single regression test
+for both. The table below documents the expected verdict for each fixture so the
+contract is visible here too; running the validation loop against any body MUST
+produce exactly these verdicts.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check); surface informational alias candidate |

--- a/plugins/agent-customizer/skills/improve-subagent/SKILL.md
+++ b/plugins/agent-customizer/skills/improve-subagent/SKILL.md
@@ -7,129 +7,146 @@ description: "Evaluates and optimizes existing subagent definitions against evid
 
 Evaluate an existing subagent definition against evidence-based quality criteria and apply improvements to tighten tool restrictions, fix model selection, and strengthen system prompts.
 
-## Behavioral Guidelines
+<TRIGGER when="improving or auditing an existing Claude Code subagent definition" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **ALWAYS** evaluate before modifying — never change subagents without analysis
 - **ALWAYS** present changes to the user before applying them
 - **NEVER** loosen tool restrictions without explicit rationale
 - **NEVER** downgrade model without confirming the task doesn't require current model capabilities
 - **NEVER** increase maxTurns beyond 20 without justification; never exceed 30 under any circumstances
 - **PRESERVE** specialized domain knowledge in system prompts — only remove generic waste
-</RULES>
+- **EVERY** improved subagent body must carry the canonical semantic-tag vocabulary (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`); `<TRIGGER>` is optional for subagents
+- **EVERY** tag-vocabulary violation found in the target subagent must be reported with the specific tag name, line reference, and strictness tier (hard-fail / warn / informational) before proposing a fix
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="subagent-exists-check">
+  Check if a subagent exists at:
 
-Check if a subagent exists at:
+  - The user-provided path
+  - `.claude/agents/{name}.md`
+  - `plugins/*/agents/{name}.md`
 
-- The user-provided path
-- `.claude/agents/{name}.md`
-- `plugins/*/agents/{name}.md`
+  **If no subagent found:**
 
-**If no subagent found:**
+  1. Inform the user: "No subagent found at the specified path."
+  2. Suggest using `/agent-customizer:create-subagent` to create a new one instead.
+  3. **STOP**
 
-1. Inform the user: "No subagent found at the specified path."
-2. Suggest using `/agent-customizer:create-subagent` to create a new one instead.
-3. **STOP**
+  **If subagent found:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If subagent found:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="evaluate">
+  Delegate to the `subagent-evaluator` agent with this task:
 
-### Phase 1: Evaluate
+  > Evaluate the subagent definition at `{target-path}`. Check YAML frontmatter validity, required fields (name, description, model, maxTurns), name format (lowercase+hyphens), model appropriateness for task, tool restriction (minimum-necessary principle), system prompt structure (role, process, output format, self-verification), and description specificity for routing. Return structured results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
 
-Delegate to the `subagent-evaluator` agent with this task:
+  - If the user provides a specific agent file → scope to that file.
+  - If no specific file → evaluate ALL agents in `.claude/agents/` and `plugins/*/agents/`.
 
-> Evaluate the subagent definition at `{target-path}`. Check YAML frontmatter validity, required fields (name, description, model, maxTurns), name format (lowercase+hyphens), model appropriateness for task, tool restriction (minimum-necessary principle), system prompt structure (role, process, output format, self-verification), and description specificity for routing. Return structured results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-- If the user provides a specific agent file → scope to that file.
-- If no specific file → evaluate ALL agents in `.claude/agents/` and `plugins/*/agents/`.
+  <PHASE id="2" name="codebase-context">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  > Analyze the project to understand the context around subagent definitions. Focus on: all agents and their roles, which skills delegate to which agents, tool restrictions in use, model choices across agents, any agents with similar purposes (potential consolidation), and naming conventions.
 
-### Phase 2: Codebase Context
+  Wait for it to complete and parse its structured output.
+  </PHASE>
 
-Delegate to the `artifact-analyzer` agent with this task:
+  <PHASE id="3" name="generate-improvement-plan">
+  #### Phase 3a: Diagnose
 
-> Analyze the project to understand the context around subagent definitions. Focus on: all agents and their roles, which skills delegate to which agents, tool restrictions in use, model choices across agents, any agents with similar purposes (potential consolidation), and naming conventions.
+  Drop any references from Phases 1–2. Read these references:
 
-Wait for it to complete and parse its structured output.
+  - `${CLAUDE_SKILL_DIR}/references/subagent-authoring-guide.md` — when to use subagents, system prompt structure, model selection, tool restriction, anti-patterns
+  - `${CLAUDE_SKILL_DIR}/references/subagent-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
 
-### Phase 3: Generate Improvement Plan
+  <REFERENCES load="on-demand">
+  - subagent-authoring-guide.md
+  - subagent-evaluation-criteria.md
+  - subagent-config-reference.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-#### Phase 3a: Diagnose
+  Identify all issues from both agent reports: generic boilerplate, model mismatches, overtriggering, missing output format. Do not yet write the full improvement plan.
 
-Drop any references from Phases 1–2. Read these references:
+  #### Phase 3b: Plan
 
-- `${CLAUDE_SKILL_DIR}/references/subagent-authoring-guide.md` — when to use subagents, system prompt structure, model selection, tool restriction, anti-patterns
-- `${CLAUDE_SKILL_DIR}/references/subagent-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
+  Drop Phase 3a references. Read these references:
 
-Identify all issues from both agent reports: generic boilerplate, model mismatches, overtriggering, missing output format. Do not yet write the full improvement plan.
+  - `${CLAUDE_SKILL_DIR}/references/subagent-config-reference.md` — YAML frontmatter fields, model IDs, orchestration patterns, plugin restrictions
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — subagent-specific prompting
 
-#### Phase 3b: Plan
+  Based on Phase 3a findings, create improvement plan with categories:
 
-Drop Phase 3a references. Read these references:
+  1. **Removals** — generic system prompt boilerplate, overtriggering language, redundant instructions
+  2. **Refactoring** — tighten tool list to minimum-necessary, fix model selection, add structured output format, improve description for routing specificity
+  3. **Additions** — missing self-verification section, missing explicit output format, missing constraints block
 
-- `${CLAUDE_SKILL_DIR}/references/subagent-config-reference.md` — YAML frontmatter fields, model IDs, orchestration patterns, plugin restrictions
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — subagent-specific prompting
+  If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  </PHASE>
 
-Based on Phase 3a findings, create improvement plan with categories:
+  <PHASE id="4" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved subagent definition.
 
-1. **Removals** — generic system prompt boilerplate, overtriggering language, redundant instructions
-2. **Refactoring** — tighten tool list to minimum-necessary, fix model selection, add structured output format, improve description for routing specificity
-3. **Additions** — missing self-verification section, missing explicit output format, missing constraints block
+  For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+  </PHASE>
 
-If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  <PHASE id="5" name="present-and-apply">
+  1. Show a summary overview of all improvements found, grouped by category:
+     - **Removals**: X items (generic boilerplate: X, overtriggering: X)
+     - **Refactoring**: X items (tool restrictions: X, model: X, description: X, output format: X)
+     - **Additions**: X items (self-verification: X, output format: X)
 
-### Phase 4: Self-Validation
+  2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
 
-Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved subagent definition.
+     **WHAT**: The specific content and its current location (file:lines)
+     **WHY**: Evidence-based justification with source reference
+     **TOKEN IMPACT**: Estimated tokens saved per invocation
+     **OPTIONS**:
+     - **Option A** (recommended): Primary action
+     - **Option B**: Alternative action
+     - **Option C**: Keep as-is
 
-For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+     Wait for the user to select an option for each suggestion before proceeding to the next.
 
-### Phase 5: Present and Apply
+     For tool restriction changes, show before/after tool lists.
+     For model changes, cite the selection heuristic (haiku for exploration, sonnet for analysis, opus for complex reasoning).
+     For system prompt rewrites, show diff of the prompt sections.
+     Warn if the agent is referenced by skills — list which skills delegate to it.
 
-1. Show a summary overview of all improvements found, grouped by category:
-   - **Removals**: X items (generic boilerplate: X, overtriggering: X)
-   - **Refactoring**: X items (tool restrictions: X, model: X, description: X, output format: X)
-   - **Additions**: X items (self-verification: X, output format: X)
+  3. After all suggestions are reviewed, show aggregate impact:
+     - **System prompt lines**: before → after
+     - **Tool count**: before → after
+     - **Deferred suggestions**: X items kept as-is
 
-2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+  4. Apply ONLY the approved changes.
+     - Warn if plugin restrictions apply (no hooks/mcpServers/permissionMode in plugin agents).
 
-   **WHAT**: The specific content and its current location (file:lines)
-   **WHY**: Evidence-based justification with source reference
-   **TOKEN IMPACT**: Estimated tokens saved per invocation
-   **OPTIONS**:
-   - **Option A** (recommended): Primary action
-   - **Option B**: Alternative action
-   - **Option C**: Keep as-is
+  5. Report final metrics:
+     - Lines before → after
+     - Tools before → after
+     - Suggestions applied: X of Y (Z deferred)
+  </PHASE>
 
-   Wait for the user to select an option for each suggestion before proceeding to the next.
+</PROCESS>
 
-   For tool restriction changes, show before/after tool lists.
-   For model changes, cite the selection heuristic (haiku for exploration, sonnet for analysis, opus for complex reasoning).
-   For system prompt rewrites, show diff of the prompt sections.
-   Warn if the agent is referenced by skills — list which skills delegate to it.
-
-3. After all suggestions are reviewed, show aggregate impact:
-   - **System prompt lines**: before → after
-   - **Tool count**: before → after
-   - **Deferred suggestions**: X items kept as-is
-
-4. Apply ONLY the approved changes.
-   - Warn if plugin restrictions apply (no hooks/mcpServers/permissionMode in plugin agents).
-
-5. Report final metrics:
-   - Lines before → after
-   - Tools before → after
-   - Suggestions applied: X of Y (Z deferred)
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and loop the improved subagent through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
@@ -1,7 +1,18 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Claude Code subagent definitions.
-Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md
+Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md, `wiki/knowledge/skill-body-convention.md`
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
@@ -22,6 +33,70 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 ---
 
+## Canonical Semantic-Tag Convention
+
+The subagent body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the subagent body MUST contain all of these):
+
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Subagent-specific variant**: `<TRIGGER>` is OPTIONAL for subagents (they are spawned by skills, not user-invoked). Its absence is **silent** — never a finding.
+
+**Optional tags** (absence is silent — never a finding): `<TRIGGER>`, `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. Report it as a `<HARD_RULES>` alias candidate (informational), not as a violation. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of `<TRIGGER>` or any other optional tag | No finding; proceed |
+| **Informational** | Legacy `<RULES>` tag present — alias for `<HARD_RULES>` | Surface as alias candidate; do not fail or warn |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
+
+### Structured violation report format
+
+When evaluating a target subagent body, report every finding using this format:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+[HARD-FAIL] Missing mandatory tag: <BEHAVIOUR> — required for subagents
+[HARD-FAIL] Unbalanced tag: <PROCESS> opened at line 35, no closing tag found
+[HARD-FAIL] Malformed attribute: <PHASE id=1 name="x"> — attribute value `1` missing quotes
+[WARN]      Non-canonical attribute: <BEHAVIOUR mood="high"> — `mood` is outside the closed set
+[INFO]      Legacy alias: <RULES> at line 18 — satisfies <HARD_RULES> check; candidate for organic retrofit to <HARD_RULES>
+──────────────────────────────────
+Result: HARD-FAIL (3 blocking violations, 1 warning, 1 informational)
+```
+
+A compliant target produces:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+No violations found.
+──────────────────────────────────
+Result: PASS
+```
+
+Note: `<TRIGGER>` absent in a subagent body is NOT a violation — it produces no report entry.
+
+---
+
 ## Quality Checks (All must pass)
 
 - [ ] `description` specific enough for automatic delegation (includes trigger phrases)
@@ -31,12 +106,23 @@ Any subagent violating these criteria must be fixed before proceeding:
 - [ ] Delegation trigger language is normal ("use when..."), not aggressive ("CRITICAL: MUST always...")
 - [ ] No instructions telling subagent to spawn other subagents (runtime blocks this)
 - [ ] System prompt is task-specific, not generic ("you are a helpful AI")
-- [ ] Evidence citations present: system prompt references source docs for domain-specific constraints (e.g., "per creating-custom-subagents.md")
-- [ ] Prompt engineering strategy applied: system prompt uses role prompting (single-sentence role), structured output format, and confidence filtering per prompt-engineering-strategies.md. **Note:** For evaluation agents that mandate explicit evidence citations per finding (a stricter guarantee), the evidence requirement satisfies the confidence filtering criterion.
+- [ ] Evidence citations present: system prompt references source docs for domain-specific constraints
+- [ ] Prompt engineering strategy applied: system prompt uses role prompting, structured output format, and confidence filtering per prompt-engineering-strategies.md
+- [ ] Canonical semantic tags present: `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched — `name`, `description`, `tools`, `model`, `maxTurns` fields per Anthropic subagent spec
 
 ---
 
 ## If This Is an IMPROVE Operation — Also Check
+
+**Canonical Tag Vocabulary:**
+
+- [ ] Target subagent body uses all mandatory tags (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with at least one `<PHASE>`); `<TRIGGER>` absence is silent — not a finding
+- [ ] All tags in target subagent body are balanced (no unmatched open/close)
+- [ ] All attribute syntax in target subagent body is well-formed (no missing quotes, no stray `=`)
+- [ ] Non-canonical attributes in target subagent body surfaced as warnings (not hard-fails)
+- [ ] Legacy `<RULES>` in target subagent body reported as informational alias candidate (not a fail)
 
 **Information Preservation:**
 
@@ -48,6 +134,7 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 - [ ] `maxTurns` not increased beyond 20 without justification
 - [ ] Scope of subagent not broadened (single-purpose agents are better than general-purpose)
+- [ ] Reference file ≤200 line limit not violated; >100-line files have a `## Contents` TOC
 
 ---
 
@@ -55,10 +142,37 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 Execute this loop for each generated or improved subagent:
 
-1. Evaluate the subagent against ALL criteria above
+1. Evaluate the subagent against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
-3. If ANY criterion fails: identify the specific failure, fix the subagent, restart evaluation
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing subagents when ALL criteria pass
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the subagent, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing subagents when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The strictness tiers above are exercised by a regression corpus shipped with the
+sibling `create-subagent` skill at
+`plugins/agent-customizer/skills/create-subagent/assets/fixtures/` (see its
+`MANIFEST.md`). `improve-subagent` does not ship its own copy — the
+strictness-tier logic is identical, so the `create-subagent` corpus is the single
+regression test for both. The table below documents the expected verdict for each
+fixture so the contract is visible here too; running the validation loop against
+any body MUST produce exactly these verdicts.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-with-trigger.md` | None — all mandatory tags present, `<TRIGGER>` also present, balanced, canonical attributes | **pass** |
+| `compliant-without-trigger.md` | `<TRIGGER>` absent (subagent variant — optional) | **pass** (silence on optional tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check); surface informational alias candidate |


### PR DESCRIPTION
Implements #147. Retrofits improve-skill and improve-subagent to the canonical semantic-tag convention: both SKILL.md bodies adopt the vocabulary, and their validation criteria now check that evaluated TARGET skills/subagents conform — structured violation reports on non-compliant targets, clean pass on compliant ones, legacy `<RULES>` surfaced as an informational alias candidate. No version bumps (deferred to #152).