### PR TITLE
Cursor customizer parity (create+improve x skill+subagent, 4 meta-skills)

### DIFF
--- a/.claude/rules/cursor-plugin-skills.md
+++ b/.claude/rules/cursor-plugin-skills.md
@@ -22,6 +22,12 @@ paths:
 - SKILL.md `name` field: ≤64 chars, lowercase letters/numbers/hyphens only, no XML tags
 - SKILL.md `description` field: non-empty, ≤1024 chars, third person, no XML tags
 - SKILL.md body: under 500 lines
+- SKILL.md body MUST carry the canonical semantic-tag vocabulary: mandatory `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`; optional `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>` (see `wiki/knowledge/skill-body-convention.md`)
+- Semantic tags use the closed attribute set only — `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`; `id=` is mandatory on every `<PHASE>`; non-canonical attribute names are a warn-tier finding, not a hard fail
+- The legacy `<RULES>` tag is an alias of `<HARD_RULES>` — it satisfies the mandatory `<HARD_RULES>` check; migrate each occurrence to `<HARD_RULES>` on next touch, no scheduled mass rename
+- Meta-skills that generate human-rich AND agent-executable artifacts (plans, PRDs, design specs, reports, prototypes) default to HTML output carrying the same canonical tags; Markdown stays mandatory for agent-loaded and tooling-locked files (`SKILL.md`, subagent `.md`, `AGENTS.md`, rules files, `README.md`, commit/PR/issue bodies); explicit user override always wins (see `wiki/knowledge/skill-body-convention.md`)
+- Self-validation loops apply three strictness tiers: hard-fail on a missing mandatory tag, unbalanced open/close tags, or malformed attribute syntax; warn on non-canonical attribute names; stay silent on absent optional tags (see `wiki/knowledge/skill-body-convention.md`)
+- YAML frontmatter stays untouched by the semantic-tag convention — Cursor's official spec governs it; the `<TRIGGER>` cue lives in the body, never duplicated into frontmatter
 - In `cursor-initializer`: `rule-domain-detector` agent walks a four-tier heuristic (tooling-non-obvious → file-pattern → monorepo-scope → on-demand cross-cutting / domain); empty list is the canonical passing output for trivial single-package projects
 - In `cursor-initializer`: `file-evaluator` agent has dual responsibility — per-rule `.mdc` quality assessment, and (when AGENTS.md is present) block-by-block classification of AGENTS.md content by destination activation mode
 - `validation-criteria.md` intentionally diverges between `init-cursor` and `improve-cursor` — `improve-cursor` adds preservation, calibration, and migration-sub-flow-schema rules; these files are NOT a parity family

--- a/plugins/cursor-customizer/skills/create-skill/SKILL.md
+++ b/plugins/cursor-customizer/skills/create-skill/SKILL.md
@@ -7,18 +7,20 @@ description: "Creates new Cursor SKILL.md packages with references, templates, a
 
 Generates a new Cursor SKILL.md package with supporting references and templates, grounded in the Agent Skills open standard and project conventions.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new Cursor skill from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create skills that explain what the agent already knows (language syntax, obvious conventions)
 - **NEVER** inline reference content in SKILL.md body — use the `references/` subdirectory
 - **NEVER** exceed 500 lines in the SKILL.md body
@@ -26,84 +28,108 @@ Generates a new Cursor SKILL.md package with supporting references and templates
 - **EVERY** bundled-path reference inside SKILL.md must use a relative path from the skill root (e.g., `references/foo.md`, `scripts/deploy.sh`)
 - **EVERY** skill description must be third-person, ≤ 1024 chars, and include a "Use when..." trigger phrase
 - **EVERY** generated skill must preserve the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** generated SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** new skill whose output is a human-rich agent-executable artifact (plan, PRD, spec, report, prototype, code-review writeup, custom editor) MUST default to an HTML output template — unless the user explicitly says "generate as markdown" (or equivalent), in which case that override always wins
+- **NEVER** default to HTML for agent-loaded or tooling-locked artifacts (`SKILL.md`, subagent `.md`, `AGENTS.md`, rules files, `README.md`, commit messages, PR bodies, issue bodies, code comments) — these are Markdown-mandatory regardless of user request phrasing
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="name-collision-check">
+  **Default output path.** Per the Cursor distribution default, new skills are written to `.cursor/skills/<name>/SKILL.md`. The Agent Skills standard also recognises `.agents/skills/<name>/SKILL.md` for cross-tool portability across Agent Skills implementations.
 
-#### Default output path
+  Before proceeding, state both options to the user:
 
-Per the Cursor distribution default, new skills are written to `.cursor/skills/<name>/SKILL.md`. The Agent Skills standard also recognises `.agents/skills/<name>/SKILL.md` for cross-tool portability across Agent Skills implementations.
+  - **Default:** `.cursor/skills/<name>/SKILL.md` — Cursor-namespaced; recommended when the skill is Cursor-specific.
+  - **Portable alternative:** `.agents/skills/<name>/SKILL.md` — open-standard; choose when the skill should also be discovered by other Agent Skills implementations.
 
-Before proceeding, state both options to the user:
+  Proceed with the default path unless the user explicitly requests the portable alternative. Do not silently switch paths.
 
-- **Default:** `.cursor/skills/<name>/SKILL.md` — Cursor-namespaced; recommended when the skill is Cursor-specific.
-- **Portable alternative:** `.agents/skills/<name>/SKILL.md` — open-standard; choose when the skill should also be discovered by other Agent Skills implementations.
+  **Name collision check.** Check if a skill with the same name already exists at any of:
 
-Proceed with the default path unless the user explicitly requests the portable alternative. Do not silently switch paths.
+  - `.cursor/skills/{requested-name}/SKILL.md`
+  - `.agents/skills/{requested-name}/SKILL.md`
+  - `~/.cursor/skills/{requested-name}/SKILL.md`
 
-#### Name collision check
+  **If a skill already exists at any of those locations:**
 
-Check if a skill with the same name already exists at any of:
+  1. Inform the user: "A skill named `{requested-name}` already exists."
+  2. Suggest using `/cursor-customizer:improve-skill` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
 
-- `.cursor/skills/{requested-name}/SKILL.md`
-- `.agents/skills/{requested-name}/SKILL.md`
-- `~/.cursor/skills/{requested-name}/SKILL.md`
+  **If no skill exists with that name:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If a skill already exists at any of those locations:**
+  <PHASE id="1" name="project-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-1. Inform the user: "A skill named `{requested-name}` already exists."
-2. Suggest using `/cursor-customizer:improve-skill` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
+  > Analyze the project to understand existing skills, naming conventions, and integration patterns. Focus on: existing skill directory structure under `.cursor/skills/` and `.agents/skills/`, naming patterns, which skills delegate to subagents, project conventions, and any skill that is similar to `{requested-name}` in purpose. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
 
-**If no skill exists with that name:**
-Proceed to Phase 1 below.
+  The agent runs read-only with Cursor-native frontmatter (`model: inherit`, `readonly: true`) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-### Phase 1: Project Analysis
+  <PHASE id="2" name="generate-skill">
+  Before generating, read these reference documents:
 
-Delegate to the `artifact-analyzer` agent with this task:
+  - `references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
+  - `references/skill-format-reference.md` — frontmatter fields, name validation, bundled-path conventions
 
-> Analyze the project to understand existing skills, naming conventions, and integration patterns. Focus on: existing skill directory structure under `.cursor/skills/` and `.agents/skills/`, naming patterns, which skills delegate to subagents, project conventions, and any skill that is similar to `{requested-name}` in purpose. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
+  Decide skill structure: phases, reference file names, and whether `assets/templates/` is needed.
 
-The agent runs read-only with Cursor-native frontmatter (`model: inherit`, `readonly: true`) in an isolated context. Wait for it to complete and parse its structured output.
+  **Classify output artifact format.** Read `references/artifact-format-routing.md` and apply its routing table to the new skill being generated:
 
-### Phase 2: Generate Skill
+  1. Identify what kind of artifact the new skill will produce (plan/PRD/spec/report/prototype vs. SKILL.md/rule/etc.).
+  2. Apply the routing table: human-rich agent-executable artifacts default to **HTML**; agent-loaded and tooling-locked artifacts are **Markdown-mandatory**.
+  3. Check for explicit override: if the user said "generate as markdown" (or equivalent), that override wins regardless of artifact type.
+  4. If the verdict is **HTML**: copy `assets/templates/html-artifact-skeleton.html` into the new skill's `assets/templates/` directory (rename to match the artifact type, e.g., `plan.html`). The new skill must instruct its own generation phase to populate the canonical semantic tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`, plus relevant optional tags) inside the HTML `<body>`.
+  5. If the verdict is **Markdown**: use `assets/templates/skill-md.md` or a Markdown template appropriate to the artifact type.
 
-Before generating, read these reference documents:
+  Then read these reference documents:
 
-- `references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
-- `references/skill-format-reference.md` — frontmatter fields, name validation, bundled-path conventions
-- `references/behavioral-guidelines.md` — discipline cues and safe persuasion patterns for skills
-- `references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
+  - `references/behavioral-guidelines.md` — discipline cues and safe persuasion patterns for skills
+  - `references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
 
-Read `assets/templates/skill-md.md` and fill its placeholders using:
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-format-reference.md
+  - artifact-format-routing.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-- User requirements for the new skill
-- Phase 1 analysis output (naming conventions, existing patterns, project context)
-- Evidence from the reference files above
+  Read the chosen output template (HTML skeleton or `skill-md.md`) and fill its placeholders using:
 
-If Phase 1 detects a monorepo or multi-service layout, make the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope. Do not leave multi-service boundaries implicit.
+  - User requirements for the new skill
+  - Phase 1 analysis output (naming conventions, existing patterns, project context)
+  - Evidence from the reference files above
 
-Generate the complete skill directory structure:
+  If Phase 1 detects a monorepo or multi-service layout, make the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope. Do not leave multi-service boundaries implicit.
 
-1. `SKILL.md` — primary skill file with Cursor-shaped frontmatter and phase definitions
-2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
-3. `assets/templates/` — create stub template files if the skill generates output files
+  Generate the complete skill directory structure:
 
-   For validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted.
+  1. `SKILL.md` — primary skill file with Cursor-shaped frontmatter and a body carrying the canonical semantic-tag vocabulary
+  2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
+  3. `assets/templates/` — create the appropriate output template (HTML or Markdown per the routing verdict above); for validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted
+  </PHASE>
 
-### Phase 3: Self-Validation
+  <PHASE id="3" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
 
-Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
+  If Phase 1 detected a monorepo or multi-service layout, add one extra validation pass: confirm the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope.
 
-If Phase 1 detected a monorepo or multi-service layout, add one extra validation pass: confirm the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope.
+  The loop evaluates all hard limits and quality checks — including the canonical semantic-tag strictness tiers — fixes any failures, and re-evaluates: maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates), including the resolved output path from the preflight choice
+  2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
+  3. Ask for confirmation before writing any files
+  4. On approval, write all files to the target location
+  </PHASE>
 
-### Phase 4: Present and Write
+</PROCESS>
 
-1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates), including the resolved output path from the preflight choice
-2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
-3. Ask for confirmation before writing any files
-4. On approval, write all files to the target location
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md` and loop the generated skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/create-skill/assets/templates/html-artifact-skeleton.html
+++ b/plugins/cursor-customizer/skills/create-skill/assets/templates/html-artifact-skeleton.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{artifact-title}}</title>
+  <style>
+    :root {
+      --color-text:          #1f2937;
+      --color-text-muted:    #4b5563;
+      --color-text-strong:   #111827;
+      --color-bg:            #ffffff;
+      --color-border:        #e5e7eb;
+      --color-code-bg:       #f3f4f6;
+
+      --color-trigger-text:  #374151;
+
+      --color-behaviour-bg:  #f0f4ff;
+      --color-behaviour-bar: #2563eb;
+
+      --color-hardrules-bg:  #fef2f2;
+      --color-hardrules-bar: #dc2626;
+
+      --color-phase-bg:      #fafafa;
+      --color-phase-label:   #111827;
+
+      --color-antipattern-bg:  #fffbeb;
+      --color-antipattern-bar: #d97706;
+
+      --color-output-bg:  #f0fdf4;
+      --color-output-bar: #16a34a;
+
+      --color-validation-bg:  #f5f3ff;
+      --color-validation-bar: #7c3aed;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --color-text:          #e5e7eb;
+        --color-text-muted:    #9ca3af;
+        --color-text-strong:   #f9fafb;
+        --color-bg:            #111827;
+        --color-border:        #374151;
+        --color-code-bg:       #1f2937;
+
+        --color-trigger-text:  #d1d5db;
+
+        --color-behaviour-bg:  #1e2a4a;
+        --color-behaviour-bar: #3b82f6;
+
+        --color-hardrules-bg:  #2d1515;
+        --color-hardrules-bar: #ef4444;
+
+        --color-phase-bg:      #1f2937;
+        --color-phase-label:   #f9fafb;
+
+        --color-antipattern-bg:  #2d2209;
+        --color-antipattern-bar: #f59e0b;
+
+        --color-output-bg:  #052e16;
+        --color-output-bar: #22c55e;
+
+        --color-validation-bg:  #1e1533;
+        --color-validation-bar: #a78bfa;
+      }
+    }
+
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 900px;
+      margin: 2rem auto;
+      padding: 1rem;
+      line-height: 1.6;
+      color: var(--color-text);
+      background: var(--color-bg);
+    }
+
+    BEHAVIOUR, HARD_RULES, PROCESS, PHASE, PREFLIGHT, REFERENCES,
+    EXAMPLE, ANTI_PATTERN, OUTPUT, VALIDATION, TRIGGER {
+      display: block;
+      margin: 1rem 0;
+    }
+
+    TRIGGER {
+      font-style: italic;
+      color: var(--color-trigger-text);
+    }
+
+    BEHAVIOUR {
+      background: var(--color-behaviour-bg);
+      border-left: 4px solid var(--color-behaviour-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    HARD_RULES[priority="hard"] {
+      background: var(--color-hardrules-bg);
+      border-left: 4px solid var(--color-hardrules-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    PROCESS {
+      border-top: 1px solid var(--color-border);
+      padding-top: 1rem;
+    }
+
+    PHASE {
+      background: var(--color-phase-bg);
+      border: 1px solid var(--color-border);
+      padding: 1rem;
+      margin: 0.5rem 0;
+      border-radius: 4px;
+    }
+
+    PHASE::before {
+      content: "Phase " attr(id) " — " attr(name);
+      display: block;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: var(--color-phase-label);
+    }
+
+    ANTI_PATTERN {
+      background: var(--color-antipattern-bg);
+      border-left: 4px solid var(--color-antipattern-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    OUTPUT {
+      background: var(--color-output-bg);
+      border-left: 4px solid var(--color-output-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    VALIDATION {
+      background: var(--color-validation-bg);
+      border-left: 4px solid var(--color-validation-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    code, pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      background: var(--color-code-bg);
+      padding: 0.125rem 0.25rem;
+      border-radius: 3px;
+    }
+
+    pre {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>{{artifact-title}}</h1>
+    <TRIGGER when="...">...</TRIGGER>
+    <BEHAVIOUR avoid="..." always="...">...</BEHAVIOUR>
+    <HARD_RULES priority="hard">...</HARD_RULES>
+    <PROCESS>
+      <PHASE id="1" name="...">...</PHASE>
+    </PROCESS>
+    <OUTPUT format="...">...</OUTPUT>
+    <VALIDATION>...</VALIDATION>
+  </main>
+</body>
+</html>

--- a/plugins/cursor-customizer/skills/create-skill/assets/templates/skill-md.md
+++ b/plugins/cursor-customizer/skills/create-skill/assets/templates/skill-md.md
@@ -15,43 +15,62 @@ description: "[What this skill does and when to use it. Third person. Include tr
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name
            the target service/workspace explicitly
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
+           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+           <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
+           Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
+           Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: YAML frontmatter is untouched — do NOT duplicate the <TRIGGER> cue into description
 -->
 
 # [Skill Title]
 
 [One-sentence purpose statement.]
 
-## Behavioral Guidelines
+<TRIGGER when="[plain-language activation cue — mirror the 'Use when ...' phrase from the description]" />
 
+<BEHAVIOUR
+  avoid="make decisions without surfacing assumptions; add speculative scope"
+  always="surface assumptions first; keep changes surgical">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - [Critical constraint 1]
 - [Critical constraint 2]
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
-<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  <PREFLIGHT name="artifact-collision-check">
+  <!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  </PREFLIGHT>
 
-### Phase 1: [Analysis Phase Name]
-<!-- Delegate to the appropriate Cursor subagent (model: inherit, readonly: true);
-     if monorepo, record the target service/workspace -->
+  <PHASE id="1" name="[analysis-phase-name]">
+  <!-- Delegate to the appropriate Cursor subagent (model: inherit, readonly: true);
+       if monorepo, record the target service/workspace -->
+  </PHASE>
 
-### Phase 2: [Generation Phase Name]
-<!-- Read references via relative paths (references/[file].md), apply templates,
-     and use project-relative paths/globs for the detected service/workspace -->
+  <PHASE id="2" name="[generation-phase-name]">
+  <!-- Read references via relative paths (references/[file].md), apply templates,
+       and use project-relative paths/globs for the detected service/workspace -->
+  </PHASE>
 
-### Phase 3: Self-Validation
-<!-- Read references/[type]-validation-criteria.md and execute its validation loop -->
+  <PHASE id="3" name="self-validation">
+  <!-- Read references/[type]-validation-criteria.md and loop until all checks pass -->
+  </PHASE>
 
-### Phase 4: Present and Write
-<!-- Show artifact with evidence citations, write on user approval -->
+  <PHASE id="4" name="present-and-write">
+  <!-- Show artifact with evidence citations, write on user approval -->
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+<!-- Read references/[type]-validation-criteria.md, loop until pass -->
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/create-skill/references/artifact-format-routing.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/artifact-format-routing.md
@@ -1,0 +1,110 @@
+# Artifact Format Routing
+
+Evidence-based routing rule for deciding whether a skill's generated output artifact
+should default to HTML or Markdown.
+Source: Agent Skills open standard; project convention on HTML artifacts
+(human-rich + agent-executable dual-consumer design).
+
+---
+
+## Routing Table
+
+When `create-skill` generates a new skill, the new skill's output format is
+determined by the artifact kind that new skill produces:
+
+| Artifact kind                                  | Default format | Reason                                            |
+| ---------------------------------------------- | -------------- | ------------------------------------------------- |
+| Plan, PRD, design spec                         | HTML           | Human-rich + agent-executable                     |
+| Report (weekly status, research, explainer)    | HTML           | Human-rich + agent-executable                     |
+| Prototype, custom editor, code-review writeup  | HTML           | Interactivity benefits from HTML                  |
+| `SKILL.md`, subagent `.md`                     | Markdown       | Agent-loaded; spec-mandated                       |
+| `AGENTS.md`                                    | Markdown       | Agent-loaded; spec-mandated                       |
+| `.cursor/rules/*.mdc`                          | Markdown       | Agent-loaded; spec-mandated                       |
+| `README.md`                                    | Markdown       | Tooling-locked (npm/repository renderers)         |
+| Commit message, PR body, issue body            | Markdown       | Tooling-locked (repository renderers)             |
+| Code comments                                  | Markdown-ish   | Tooling-locked (compiler/linter parses)           |
+
+Explicit user override (`generate as markdown`) always wins over the default.
+
+---
+
+## How to classify
+
+During Phase 2 (generate-skill), before choosing the output template:
+
+1. **Identify the output artifact kind** — ask: "What does this new skill produce?
+   A plan/PRD/spec/report? Or a platform config file (SKILL.md, rule)?"
+
+2. **Apply the routing table above.** The left column describes the artifact kind;
+   the Default format column gives the verdict.
+
+3. **Check for explicit override.** If the user said "generate as markdown" (or
+   equivalent phrasing like "output markdown", "use .md", "markdown format"), the
+   override wins regardless of the routing table verdict.
+
+4. **Act on the verdict:**
+   - **HTML default** → use `assets/templates/html-artifact-skeleton.html`
+     as the output template for the new skill. Instruct the new skill to carry the
+     canonical semantic tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>`
+     with one or more `<PHASE id name>`, plus relevant optional tags `<OUTPUT>`,
+     `<VALIDATION>`) inside the HTML `<body>`. Copy the skeleton into the new
+     skill's `assets/templates/` directory.
+   - **Markdown default** → use the standard `assets/templates/skill-md.md`
+     template (or a Markdown template appropriate to the artifact type).
+   - **Explicit override** → apply the user's stated format regardless of the table.
+
+---
+
+## HTML skeleton location
+
+The HTML baseline skeleton lives at:
+
+```
+assets/templates/html-artifact-skeleton.html
+```
+
+It is a valid HTML5 document with:
+- `<meta charset>` and `<meta name="viewport">`
+- Scoped CSS targeting each semantic tag (`BEHAVIOUR`, `HARD_RULES`, `PHASE`, `OUTPUT`,
+  `VALIDATION`, `ANTI_PATTERN`, etc.) with adaptive colors (light and dark mode via
+  CSS custom properties and `@media (prefers-color-scheme: dark)`)
+- Placeholder `{{artifact-title}}` in `<title>` and `<h1>`
+- A `<main>` block containing the canonical semantic-tag scaffold
+
+When generating a new HTML-defaulting skill, copy this skeleton into the new skill's
+`assets/templates/` directory (e.g., as `<artifact-type>.html`). Replace
+`{{artifact-title}}` with the artifact name appropriate to the new skill.
+
+---
+
+## Canonical semantic tags in HTML artifacts
+
+Generated HTML artifacts MUST carry the canonical semantic tags inside the HTML body.
+The same vocabulary that governs `SKILL.md` bodies applies:
+
+**Mandatory tags (HTML artifact)**:
+- `<TRIGGER when="...">` — plain-language activation context
+- `<BEHAVIOUR avoid="..." always="...">` — behavioural guidelines
+- `<HARD_RULES priority="hard">` — inviolable constraints
+- `<PROCESS>` containing at least one `<PHASE id="N" name="...">` — ordered execution steps
+
+**Optional tags (HTML artifact)**:
+- `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`.
+
+These tags are valid HTML5 — browsers treat unknown elements as inline by default;
+the CSS in the skeleton promotes each to `display: block` with semantic styling.
+
+---
+
+## Why HTML for human-rich artifacts
+
+HTML artifacts serve two consumers: humans (CSS layout, diagrams, interactive controls)
+and the next agent session (parseable semantic-tag structure). The dual-consumer design
+is why HTML artifacts embed canonical semantic tags — the same parse target serves both.
+
+Markdown past ~100 lines stops being read; rich visualisations get faked with ASCII;
+HTML renders natively in any browser without extra tooling. For agent-loaded and
+tooling-locked files the tradeoffs reverse: spec compliance, diffability, and
+renderer compatibility make Markdown mandatory.

--- a/plugins/cursor-customizer/skills/create-skill/references/skill-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/skill-validation-criteria.md
@@ -8,6 +8,7 @@ Source: docs/cursor/skills/agent-skills-guide.md
 ## Contents
 
 - Hard limits (auto-fail if violated)
+- Canonical Semantic-Tag Convention
 - Foreign-platform dialect ban (auto-fail if violated)
 - Quality checks (all must pass)
 - Improve-only checks (information preservation, structural)
@@ -30,6 +31,40 @@ Any skill violating these criteria must be fixed before proceeding:
 | Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
 
 *Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X")
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|-------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 
@@ -63,6 +98,9 @@ The Cursor distribution is product-strict. The skill tree (SKILL.md, references,
 - [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
 - [ ] Plugin skill bodies delegate analysis to registered subagents; no inline bash analysis commands
 - [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-guide.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
 
 ---
 
@@ -85,10 +123,11 @@ The Cursor distribution is product-strict. The skill tree (SKILL.md, references,
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above (hard limits, foreign-dialect ban, quality checks, and IMPROVE-only checks if applicable).
+1. Evaluate the skill against ALL criteria above (hard limits, the **Canonical Semantic-Tag Convention** strictness tiers, foreign-dialect ban, quality checks, and IMPROVE-only checks if applicable).
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference.
-3. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation.
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
-5. Only proceed to writing skills when ALL criteria pass.
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation.
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix.
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass.
 
 **Do not skip criteria for "minor" violations.** Hard limits and the foreign-dialect ban are absolute.

--- a/plugins/cursor-customizer/skills/create-subagent/SKILL.md
+++ b/plugins/cursor-customizer/skills/create-subagent/SKILL.md
@@ -7,18 +7,20 @@ description: "Creates new Cursor subagent definitions with the four-key Cursor-n
 
 Generates a new Cursor subagent definition with the four-key Cursor-native frontmatter, a focused system prompt, and an explicit output format. Output is grounded in the Cursor subagents documentation and ADR-0002 product-strict guarantees.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new Cursor subagent from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create subagents with generic system prompts ("you are a helpful AI assistant").
 - **NEVER** emit any frontmatter key outside the four allowed: `name`, `description`, `model`, `readonly`.
 - **NEVER** emit a `model` value other than `inherit`.
@@ -27,78 +29,90 @@ Generates a new Cursor subagent definition with the four-key Cursor-native front
 - **EVERY** description must include a specific "Use when..." trigger phrase so Cursor's agent can route correctly.
 - **DESCRIPTION** must be ≤1024 characters; **NAME** must be kebab-case and distinct from every existing project subagent.
 - **PROJECT SUBAGENTS** MUST NOT instruct the subagent to spawn other subagents — return findings to the parent agent only.
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="name-collision-check">
+  Check whether a subagent with the requested name already exists at:
 
-Check whether a subagent with the requested name already exists at:
+  - `.cursor/agents/{requested-name}.md`
+  - `plugins/*/agents/{requested-name}.md`
 
-- `.cursor/agents/{requested-name}.md`
-- `plugins/*/agents/{requested-name}.md`
+  **If a subagent already exists with that name:**
 
-**If a subagent already exists with that name:**
+  1. Inform the user: "A subagent named `{requested-name}` already exists."
+  2. Suggest using `/cursor-customizer:improve-subagent` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
 
-1. Inform the user: "A subagent named `{requested-name}` already exists."
-2. Suggest using `/cursor-customizer:improve-subagent` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
+  **If no subagent exists with that name:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no subagent exists with that name:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="project-context-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Project Context Analysis
+  > Analyze the project to understand existing Cursor subagents. Focus on: subagent names and roles in `.cursor/agents/` and `plugins/*/agents/`, the description and `readonly` posture of each, which skills delegate to which subagents, and naming conventions. Flag any subagents similar in purpose to `{requested-name}`. Also identify the project layout: whether this is a monorepo with multiple service packages or a single-package project, and report any service directory paths for use in scope resolution.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The `artifact-analyzer` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing Cursor subagents. Focus on: subagent names and roles in `.cursor/agents/` and `plugins/*/agents/`, the description and `readonly` posture of each, which skills delegate to which subagents, and naming conventions. Flag any subagents similar in purpose to `{requested-name}`. Also identify the project layout: whether this is a monorepo with multiple service packages or a single-package project, and report any service directory paths for use in scope resolution.
+  <PHASE id="2" name="generate-subagent">
+  Before generating, read these reference documents:
 
-The `artifact-analyzer` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  - `references/subagent-authoring-guide.md` — when to use a subagent, system prompt structure, the four-key frontmatter contract, description-as-routing-signal, anti-patterns, verification-agent pattern.
+  - `references/subagent-config-reference.md` — full Cursor-native frontmatter specification, model field handling, readonly field handling, file locations, orchestration patterns.
+  - `references/prompt-engineering-strategies.md` — subagent-specific prompting (role prompting, structured output, confidence filtering).
 
-### Phase 2: Generate Subagent
+  <REFERENCES load="on-demand">
+  - subagent-authoring-guide.md
+  - subagent-config-reference.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-Before generating, read these reference documents:
+  Read `assets/templates/subagent-definition.md` and fill its placeholders using:
 
-- `references/subagent-authoring-guide.md` — when to use a subagent, system prompt structure, the four-key frontmatter contract, description-as-routing-signal, anti-patterns, verification-agent pattern.
-- `references/subagent-config-reference.md` — full Cursor-native frontmatter specification, model field handling, readonly field handling, file locations, orchestration patterns.
-- `references/prompt-engineering-strategies.md` — subagent-specific prompting (role prompting, structured output, confidence filtering).
+  - User requirements for the new subagent (role, purpose, scope).
+  - Phase 1 analysis output (existing subagents, naming conventions, delegation patterns).
+  - Evidence from the reference files above.
 
-Read `assets/templates/subagent-definition.md` and fill its placeholders using:
+  Frontmatter posture (non-negotiable):
 
-- User requirements for the new subagent (role, purpose, scope).
-- Phase 1 analysis output (existing subagents, naming conventions, delegation patterns).
-- Evidence from the reference files above.
+  - `model: inherit` — the customizer never embeds a literal model alias or specific model ID.
+  - `readonly: true` — generated subagents are analysis and evaluator roles by default; they report findings to the parent agent.
 
-Frontmatter posture (non-negotiable):
+  If Phase 1 detects a monorepo or multi-service layout, make the generated system prompt name the relevant services, workspaces, and scope boundaries the subagent should inspect. Do not leave multi-service targets implicit.
 
-- `model: inherit` — the customizer never embeds a literal model alias or specific model ID.
-- `readonly: true` — generated subagents are analysis and evaluator roles by default; they report findings to the parent agent.
+  Determine target location:
 
-If Phase 1 detects a monorepo or multi-service layout, make the generated system prompt name the relevant services, workspaces, and scope boundaries the subagent should inspect. Do not leave multi-service targets implicit.
+  - `.cursor/agents/{name}.md` — project-level subagent (project scope).
+  - `plugins/{plugin}/agents/{name}.md` — plugin-scoped subagent (restricted to plugin context).
+  </PHASE>
 
-Determine target location:
+  <PHASE id="3" name="self-validation">
+  Read `references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated subagent definition.
 
-- `.cursor/agents/{name}.md` — project-level subagent (project scope).
-- `plugins/{plugin}/agents/{name}.md` — plugin-scoped subagent (restricted to plugin context).
+  In addition to the shared criteria, enforce two scenario-sensitive checks before proceeding:
 
-### Phase 3: Self-Validation
+  - The frontmatter contains exactly the four allowed keys with the required values (`model: inherit`, `readonly: true`). No other key, no other model value, no other readonly value.
+  - If Phase 1 detected a monorepo or multi-service layout, confirm the generated prompt names the relevant services, workspaces, or scope boundaries explicitly.
 
-Read `references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated subagent definition.
+  The loop evaluates all hard limits and quality checks — including the canonical semantic-tag strictness tiers — fixes any failures, and re-evaluates: maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-In addition to the shared criteria, enforce two scenario-sensitive checks before proceeding:
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated subagent definition.
+  2. Cite the evidence from reference files that informed key decisions:
+     - Why this scope and role (heuristic from `subagent-authoring-guide.md`).
+     - Why the description has these triggers (routing signal from the authoring guide).
+     - Why the system prompt has these sections (structure from prompt-engineering strategies).
+  3. If the user requested any frontmatter key outside the allowed four (or any model value other than `inherit`), refuse and cite `subagent-validation-criteria.md`. Offer to translate the request into a Cursor-native form.
+  4. Ask for confirmation before writing any files.
+  5. On approval, write the subagent definition to the target location.
+  </PHASE>
 
-- The frontmatter contains exactly the four allowed keys with the required values (`model: inherit`, `readonly: true`). No other key, no other model value, no other readonly value.
-- If Phase 1 detected a monorepo or multi-service layout, confirm the generated prompt names the relevant services, workspaces, or scope boundaries explicitly.
+</PROCESS>
 
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete generated subagent definition.
-2. Cite the evidence from reference files that informed key decisions:
-   - Why this scope and role (heuristic from `subagent-authoring-guide.md`).
-   - Why the description has these triggers (routing signal from the authoring guide).
-   - Why the system prompt has these sections (structure from prompt-engineering strategies).
-3. If the user requested any frontmatter key outside the allowed four (or any model value other than `inherit`), refuse and cite `subagent-validation-criteria.md`. Offer to translate the request into a Cursor-native form.
-4. Ask for confirmation before writing any files.
-5. On approval, write the subagent definition to the target location.
+<VALIDATION loop="max-iterations:3">
+Read `references/subagent-validation-criteria.md` and loop the generated subagent through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/create-subagent/assets/templates/subagent-definition.md
+++ b/plugins/cursor-customizer/skills/create-subagent/assets/templates/subagent-definition.md
@@ -11,41 +11,64 @@ readonly: true
      Forbidden: any other frontmatter key; any other model value.
      Rule: Project subagents must not spawn other subagents.
      Rule: name must be kebab-case and distinct from every other subagent name in the project.
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
+           (see wiki/knowledge/skill-body-convention.md). Mandatory for subagents:
+           <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id="N" name="X">.
+           Optional: <TRIGGER>, <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>,
+           <OUTPUT>, <VALIDATION>. Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: <TRIGGER> is optional — omit if the subagent is always spawned by skills, not user-invoked.
 -->
 
 # [Agent Name]
 
 You are a [specific role] specializing in [domain]. [One-sentence identity statement; name target services or scope when relevant.]
 
-## Constraints
+<!-- Optional: include <TRIGGER> if this subagent can also be user-invoked -->
+<!-- <TRIGGER when="[activation condition]" /> -->
 
+<BEHAVIOUR
+  avoid="[what to avoid — e.g., modifying files; surfacing low-confidence findings]"
+  always="[what to always do — e.g., cite evidence; report in structured format]">
+- [Behavioural guideline 1]
+- [Behavioural guideline 2]
 - Do not modify any files — only analyze and report.
-- Do not suggest improvements — describe what exists or what fails.
-- Do not spawn other subagents — return findings to the parent agent.
-- Do not [additional constraint specific to this role].
+</BEHAVIOUR>
 
-## Process
+<HARD_RULES priority="hard">
+- **NEVER** modify any files — describe what exists or what fails, do not change it.
+- **NEVER** suggest improvements — report findings only.
+- **NEVER** spawn other subagents — return findings to the parent agent.
+- **EVERY** finding must cite a specific path or line.
+- **EVERY** output must match the Output Format below exactly.
+</HARD_RULES>
 
-### 1. [First Step]
+<PROCESS>
 
-[What to read, detect, or evaluate.]
+  <PHASE id="1" name="[first-step]">
+  [What to read, detect, or evaluate.]
+  </PHASE>
 
-### 2. [Second Step]
+  <PHASE id="2" name="[second-step]">
+  [How to process findings — filtering, categorizing, structuring.]
+  </PHASE>
 
-[How to process findings.]
+  <PHASE id="3" name="[compile-output]">
+  [How to compile and format the final structured output.]
+  </PHASE>
 
-### 3. [Third Step]
+</PROCESS>
 
-[How to compile output.]
-
-## Output Format
+<OUTPUT>
 
 ```
 [Exact structure the agent must return — headers, tables, sections, with concrete labels.]
 ```
 
-## Self-Verification
+</OUTPUT>
 
+<VALIDATION>
+Before returning output, verify:
 1. [Check 1 — every reported finding cites a specific path or line.]
 2. [Check 2 — output matches the format above.]
 3. [Check 3 — no improvement suggestions included; only findings.]
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/create-subagent/references/subagent-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-subagent/references/subagent-validation-criteria.md
@@ -9,6 +9,7 @@ Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-r
 
 - Hard limits (auto-fail)
 - Allowed frontmatter contract (rejection rules with examples)
+- Canonical Semantic-Tag Convention
 - Quality checks
 - If this is an IMPROVE operation
 - Validation loop instructions
@@ -79,31 +80,13 @@ Required fix: remove the turn-cap key entirely.
 
 A subagent whose `model` value is a literal model name or ID is REJECTED. The `model` value MUST be `inherit`.
 
-Example REJECTED frontmatter (literal alias):
+Example REJECTED `model` values — every one of these is rejected; only `inherit` passes:
 
 ```yaml
----
-name: example-evaluator
-description: "Evaluates things. Use when reviewing artifacts."
-model: sonnet
-readonly: true
----
-```
-
-Example REJECTED frontmatter (other literal aliases):
-
-```yaml
-model: opus
-```
-
-```yaml
-model: haiku
-```
-
-Example REJECTED frontmatter (full model ID prefix):
-
-```yaml
-model: claude-opus-4-6
+model: sonnet          # literal alias
+model: opus            # literal alias
+model: haiku           # literal alias
+model: claude-opus-4-6 # full model ID prefix
 ```
 
 Required fix: set the model value to `inherit`.
@@ -135,6 +118,32 @@ Required fix: remove the extra key.
 
 ---
 
+## Canonical Semantic-Tag Convention
+
+The subagent body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — deterministically.
+
+**Mandatory tags** (the subagent body MUST contain all of these): `<BEHAVIOUR>` (guidelines, posture), `<HARD_RULES>` (inviolable constraints), `<PROCESS>` (container for the ordered phases; MUST contain at least one `<PHASE>`), and `<PHASE id="N" name="X">` (one execution step inside `<PROCESS>`; `id=` mandatory on every `<PHASE>`).
+
+**Optional tags** (absence is silent — never a finding): `<TRIGGER>`, `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`. `<TRIGGER>` is OPTIONAL for subagents because they are spawned by skills, not user-invoked.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | A mandatory tag missing (`<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`); unbalanced tags; malformed attribute syntax (value missing quotes, stray `=`, unterminated quote) | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of `<TRIGGER>` or any other optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
+
+---
+
 ## Quality Checks (All must pass)
 
 - [ ] `description` is action-oriented and includes a specific "Use when..." trigger phrase for delegation routing.
@@ -148,6 +157,9 @@ Required fix: remove the extra key.
 - [ ] No instructions tell the subagent to spawn other subagents (project convention restricts nested launches).
 - [ ] System prompt is task-specific, not generic ("you are a helpful AI").
 - [ ] Prompt engineering strategy applied: role prompting, structured output, and confidence filtering per `prompt-engineering-strategies.md`. For evaluator-type subagents that mandate explicit evidence per finding, the evidence requirement satisfies the confidence-filtering criterion.
+- [ ] Canonical semantic tags present: `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`.
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`.
+- [ ] YAML frontmatter untouched by the convention — the four-key contract (`name`, `description`, `model`, `readonly`) is unchanged.
 
 ---
 
@@ -170,10 +182,11 @@ Required fix: remove the extra key.
 
 Execute this loop for each generated or improved subagent:
 
-1. Evaluate the subagent against ALL criteria above.
+1. Evaluate the subagent against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers.
 2. For improve operations, verify each suggestion in the improvement plan has a WHY field citing a source document — no suggestion may lack a source reference.
-3. If ANY criterion fails: identify the specific failure, fix the subagent, restart evaluation.
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
-5. Only proceed to writing the subagent when ALL criteria pass.
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the subagent, restart evaluation.
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix.
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
+6. Only proceed to writing the subagent when ALL hard-fail and quality criteria pass.
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits. The frontmatter contract is non-negotiable.

--- a/plugins/cursor-customizer/skills/improve-skill/SKILL.md
+++ b/plugins/cursor-customizer/skills/improve-skill/SKILL.md
@@ -7,18 +7,20 @@ description: "Evaluates and optimizes existing Cursor SKILL.md packages against 
 
 Evaluate an existing Cursor SKILL.md package against evidence-based quality criteria and apply improvements to reduce bloat, eliminate foreign-platform dialect, and align with the Agent Skills standard.
 
-## Behavioral Guidelines
+<TRIGGER when="improving or auditing an existing Cursor skill" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **ALWAYS** evaluate before modifying — never change files without analysis
 - **ALWAYS** present changes to the user before applying them
 - **NEVER** remove evidence-grounded references or citations
@@ -26,96 +28,111 @@ Evaluate an existing Cursor SKILL.md package against evidence-based quality crit
 - **NEVER** exceed 500 lines in SKILL.md or 200 lines in reference files after improvements
 - **PRESERVE** all genuinely useful skill phases and instructions — only remove waste
 - **PRESERVE** or strengthen the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** improved SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** tag-vocabulary violation found in the target skill must be reported with the specific tag name, line reference, and strictness tier (hard-fail / warn / informational) before proposing a fix
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="skill-exists-check">
+  Check if a skill exists at:
 
-Check if a skill exists at:
+  - The user-provided path
+  - `.cursor/skills/{name}/SKILL.md`
+  - `.agents/skills/{name}/SKILL.md`
+  - `~/.cursor/skills/{name}/SKILL.md`
 
-- The user-provided path
-- `.cursor/skills/{name}/SKILL.md`
-- `.agents/skills/{name}/SKILL.md`
-- `~/.cursor/skills/{name}/SKILL.md`
+  **If no skill found:**
 
-**If no skill found:**
+  1. Inform the user: "No skill found at the specified path."
+  2. Suggest using `/cursor-customizer:create-skill` to create a new one instead.
+  3. **STOP**
 
-1. Inform the user: "No skill found at the specified path."
-2. Suggest using `/cursor-customizer:create-skill` to create a new one instead.
-3. **STOP**
+  **If skill found:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If skill found:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="evaluate">
+  Delegate to the `skill-evaluator` agent with this task:
 
-### Phase 1: Evaluate
+  > Evaluate the skill at `{target-path}`. Read the SKILL.md and all files in the skill directory. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter shape valid against the Agent Skills standard), structural quality (progressive disclosure, phase structure, reference loading), canonical semantic-tag convention, foreign-platform dialect, and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
 
-Delegate to the `skill-evaluator` agent with this task:
+  The agent runs read-only with Cursor-native frontmatter (`model: inherit`, `readonly: true`) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Evaluate the skill at `{target-path}`. Read the SKILL.md and all files in the skill directory. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter shape valid against the Agent Skills standard), structural quality (progressive disclosure, phase structure, reference loading), foreign-platform dialect, and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+  <PHASE id="2" name="project-context">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-The agent runs read-only with Cursor-native frontmatter (`model: inherit`, `readonly: true`) in an isolated context. Wait for it to complete and parse its structured output.
+  > Analyze the project to understand the context around the skill being improved. Focus on: which subagents the skill delegates to and whether those subagents still exist, naming conventions for similar skills, any other skills that overlap in purpose, and the project structure under `.cursor/` and `.agents/`.
 
-### Phase 2: Project Context
+  Wait for it to complete and parse its structured output.
+  </PHASE>
 
-Delegate to the `artifact-analyzer` agent with this task:
+  <PHASE id="3" name="generate-improvement-plan">
+  Read these reference documents:
 
-> Analyze the project to understand the context around the skill being improved. Focus on: which subagents the skill delegates to and whether those subagents still exist, naming conventions for similar skills, any other skills that overlap in purpose, and the project structure under `.cursor/` and `.agents/`.
+  - `references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
+  - `references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
+  - `references/behavioral-guidelines.md` — discipline cues and safe persuasion patterns for skills
+  - `references/prompt-engineering-strategies.md` — skill-specific prompting strategies
 
-Wait for it to complete and parse its structured output.
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-evaluation-criteria.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-### Phase 3: Generate Improvement Plan
+  Based on both subagent reports, create an improvement plan with categories:
 
-Read these reference documents:
+  1. **Removals** — bloat (inlined content, over-specified instructions), stale (broken subagent refs, removed tools), duplicates, foreign-platform dialect
+  2. **Refactoring** — progressive disclosure optimization, phase consolidation, bundled-path corrections to relative-from-skill-root form, canonical semantic-tag migration (including `<RULES>` → `<HARD_RULES>`)
+  3. **Additions** — missing sections (self-validation, output format). Only suggest Hard Rules or Preflight if the skill has user-facing interactions or side effects — do NOT suggest them for informational/analysis-only skills that read and report.
 
-- `references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
-- `references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
-- `references/behavioral-guidelines.md` — discipline cues and safe persuasion patterns for skills
-- `references/prompt-engineering-strategies.md` — skill-specific prompting strategies
+  If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  </PHASE>
 
-Based on both subagent reports, create an improvement plan with categories:
+  <PHASE id="4" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
 
-1. **Removals** — bloat (inlined content, over-specified instructions), stale (broken subagent refs, removed tools), duplicates, foreign-platform dialect
-2. **Refactoring** — progressive disclosure optimization, phase consolidation, bundled-path corrections to relative-from-skill-root form
-3. **Additions** — missing sections (self-validation, output format). Only suggest Hard Rules or Preflight if the skill has user-facing interactions or side effects — do NOT suggest them for informational/analysis-only skills that read and report.
+  For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. The loop covers all hard limits, quality checks, and the canonical semantic-tag strictness tiers. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+  </PHASE>
 
-If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  <PHASE id="5" name="present-and-apply">
+  1. Show a summary overview of all improvements found, grouped by category:
+     - **Removals**: X items (bloat: X, stale: X, duplicates: X, foreign dialect: X)
+     - **Refactoring**: X items (progressive disclosure: X, phase structure: X, bundled-path corrections: X)
+     - **Additions**: X items
 
-### Phase 4: Self-Validation
+  2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
 
-Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
+     **WHAT**: The specific content and its current location (file:lines)
+     **WHY**: Evidence-based justification with source reference
+     **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
+     **OPTIONS**:
+     - **Option A** (recommended): Primary action
+     - **Option B**: Alternative action
+     - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
 
-For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+     Wait for the user to select an option for each suggestion before proceeding to the next.
+     If the user selects "Keep as-is", preserve the content in its exact current location.
 
-### Phase 5: Present and Apply
+  3. After all suggestions are reviewed, show aggregate token impact analysis:
+     - **Total lines**: before → after
+     - **Removed tokens**: total waste eliminated
+     - **Deferred suggestions**: X items kept as-is
 
-1. Show a summary overview of all improvements found, grouped by category:
-   - **Removals**: X items (bloat: X, stale: X, duplicates: X, foreign dialect: X)
-   - **Refactoring**: X items (progressive disclosure: X, phase structure: X, bundled-path corrections: X)
-   - **Additions**: X items
+  4. Apply ONLY the approved changes (options A or B selections).
 
-2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+  5. Report final metrics:
+     - Lines before → after
+     - Files affected
+     - Estimated token savings per session
+     - Suggestions applied: X of Y (Z deferred)
+  </PHASE>
 
-   **WHAT**: The specific content and its current location (file:lines)
-   **WHY**: Evidence-based justification with source reference
-   **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
-   **OPTIONS**:
-   - **Option A** (recommended): Primary action
-   - **Option B**: Alternative action
-   - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
+</PROCESS>
 
-   Wait for the user to select an option for each suggestion before proceeding to the next.
-   If the user selects "Keep as-is", preserve the content in its exact current location.
-
-3. After all suggestions are reviewed, show aggregate token impact analysis:
-   - **Total lines**: before → after
-   - **Removed tokens**: total waste eliminated
-   - **Deferred suggestions**: X items kept as-is
-
-4. Apply ONLY the approved changes (options A or B selections).
-
-5. Report final metrics:
-   - Lines before → after
-   - Files affected
-   - Estimated token savings per session
-   - Suggestions applied: X of Y (Z deferred)
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md` and loop the improved skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/improve-skill/assets/templates/skill-md.md
+++ b/plugins/cursor-customizer/skills/improve-skill/assets/templates/skill-md.md
@@ -15,43 +15,62 @@ description: "[What this skill does and when to use it. Third person. Include tr
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name
            the target service/workspace explicitly
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
+           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+           <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
+           Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
+           Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: YAML frontmatter is untouched — do NOT duplicate the <TRIGGER> cue into description
 -->
 
 # [Skill Title]
 
 [One-sentence purpose statement.]
 
-## Behavioral Guidelines
+<TRIGGER when="[plain-language activation cue — mirror the 'Use when ...' phrase from the description]" />
 
+<BEHAVIOUR
+  avoid="make decisions without surfacing assumptions; add speculative scope"
+  always="surface assumptions first; keep changes surgical">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - [Critical constraint 1]
 - [Critical constraint 2]
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
-<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  <PREFLIGHT name="artifact-collision-check">
+  <!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  </PREFLIGHT>
 
-### Phase 1: [Analysis Phase Name]
-<!-- Delegate to the appropriate Cursor subagent (model: inherit, readonly: true);
-     if monorepo, record the target service/workspace -->
+  <PHASE id="1" name="[analysis-phase-name]">
+  <!-- Delegate to the appropriate Cursor subagent (model: inherit, readonly: true);
+       if monorepo, record the target service/workspace -->
+  </PHASE>
 
-### Phase 2: [Generation Phase Name]
-<!-- Read references via relative paths (references/[file].md), apply templates,
-     and use project-relative paths/globs for the detected service/workspace -->
+  <PHASE id="2" name="[generation-phase-name]">
+  <!-- Read references via relative paths (references/[file].md), apply templates,
+       and use project-relative paths/globs for the detected service/workspace -->
+  </PHASE>
 
-### Phase 3: Self-Validation
-<!-- Read references/[type]-validation-criteria.md and execute its validation loop -->
+  <PHASE id="3" name="self-validation">
+  <!-- Read references/[type]-validation-criteria.md and loop until all checks pass -->
+  </PHASE>
 
-### Phase 4: Present and Write
-<!-- Show artifact with evidence citations, write on user approval -->
+  <PHASE id="4" name="present-and-write">
+  <!-- Show artifact with evidence citations, write on user approval -->
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+<!-- Read references/[type]-validation-criteria.md, loop until pass -->
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-validation-criteria.md
@@ -8,6 +8,7 @@ Source: docs/cursor/skills/agent-skills-guide.md
 ## Contents
 
 - Hard limits (auto-fail if violated)
+- Canonical Semantic-Tag Convention
 - Foreign-platform dialect ban (auto-fail if violated)
 - Quality checks (all must pass)
 - Improve-only checks (information preservation, structural)
@@ -30,6 +31,40 @@ Any skill violating these criteria must be fixed before proceeding:
 | Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
 
 *Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X")
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|-------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 
@@ -63,6 +98,9 @@ The Cursor distribution is product-strict. The skill tree (SKILL.md, references,
 - [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
 - [ ] Plugin skill bodies delegate analysis to registered subagents; no inline bash analysis commands
 - [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-guide.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
 
 ---
 
@@ -85,10 +123,11 @@ The Cursor distribution is product-strict. The skill tree (SKILL.md, references,
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above (hard limits, foreign-dialect ban, quality checks, and IMPROVE-only checks if applicable).
+1. Evaluate the skill against ALL criteria above (hard limits, the **Canonical Semantic-Tag Convention** strictness tiers, foreign-dialect ban, quality checks, and IMPROVE-only checks if applicable).
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference.
-3. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation.
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
-5. Only proceed to writing skills when ALL criteria pass.
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation.
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix.
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass.
 
 **Do not skip criteria for "minor" violations.** Hard limits and the foreign-dialect ban are absolute.

--- a/plugins/cursor-customizer/skills/improve-subagent/SKILL.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/SKILL.md
@@ -7,18 +7,20 @@ description: "Evaluates and optimizes existing Cursor subagent definitions again
 
 Evaluate an existing Cursor subagent definition against evidence-based quality criteria and apply improvements to fix frontmatter, sharpen the routing description, and strengthen the system prompt.
 
-## Behavioral Guidelines
+<TRIGGER when="improving or auditing an existing Cursor subagent definition" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **ALWAYS** evaluate before modifying — never change subagents without analysis.
 - **ALWAYS** present changes to the user before applying them.
 - **NEVER** loosen the `readonly` posture (true → false) without explicit user rationale.
@@ -26,102 +28,117 @@ Evaluate an existing Cursor subagent definition against evidence-based quality c
 - **NEVER** change the `model` value to anything other than `inherit`.
 - **NEVER** broaden subagent scope (single-purpose subagents are better than general-purpose).
 - **PRESERVE** specialized domain knowledge in system prompts — only remove generic boilerplate.
-</RULES>
+- **EVERY** improved subagent body must carry the canonical semantic-tag vocabulary (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`); `<TRIGGER>` is optional for subagents.
+- **EVERY** tag-vocabulary violation found in the target subagent must be reported with the specific tag name, line reference, and strictness tier (hard-fail / warn / informational) before proposing a fix.
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="subagent-exists-check">
+  Check if a subagent exists at:
 
-Check if a subagent exists at:
+  - The user-provided path
+  - `.cursor/agents/{name}.md`
+  - `plugins/*/agents/{name}.md`
 
-- The user-provided path
-- `.cursor/agents/{name}.md`
-- `plugins/*/agents/{name}.md`
+  **If no subagent found:**
 
-**If no subagent found:**
+  1. Inform the user: "No subagent found at the specified path."
+  2. Suggest using `/cursor-customizer:create-subagent` to create a new one instead.
+  3. **STOP**
 
-1. Inform the user: "No subagent found at the specified path."
-2. Suggest using `/cursor-customizer:create-subagent` to create a new one instead.
-3. **STOP**
+  **If subagent found:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If subagent found:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="evaluate">
+  Delegate to the `subagent-evaluator` agent with this task:
 
-### Phase 1: Evaluate
+  > Evaluate the subagent definition at `{target-path}`. Check YAML frontmatter validity, the four-key contract (only `name`, `description`, `model`, `readonly` allowed; `model` must be `inherit`; `readonly` must be `true`), name format (kebab-case, ≤64 characters, distinct from every other project subagent), description specificity for routing (action-oriented, ≤1024 characters, includes a "Use when..." trigger), system prompt structure (role, constraints, process, output format, self-verification), and any instructions that tell the subagent to spawn other subagents (forbidden by project convention). Return structured results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
 
-Delegate to the `subagent-evaluator` agent with this task:
+  - If the user provides a specific subagent file → scope to that file.
+  - If no specific file → evaluate ALL subagents in `.cursor/agents/` and `plugins/*/agents/`.
 
-> Evaluate the subagent definition at `{target-path}`. Check YAML frontmatter validity, the four-key contract (only `name`, `description`, `model`, `readonly` allowed; `model` must be `inherit`; `readonly` must be `true`), name format (kebab-case, ≤64 characters, distinct from every other project subagent), description specificity for routing (action-oriented, ≤1024 characters, includes a "Use when..." trigger), system prompt structure (role, constraints, process, output format, self-verification), and any instructions that tell the subagent to spawn other subagents (forbidden by project convention). Return structured results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+  The `subagent-evaluator` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-- If the user provides a specific subagent file → scope to that file.
-- If no specific file → evaluate ALL subagents in `.cursor/agents/` and `plugins/*/agents/`.
+  <PHASE id="2" name="project-context">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-The `subagent-evaluator` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  > Analyze the project to understand the context around Cursor subagent definitions. Focus on: all subagents in `.cursor/agents/` and `plugins/*/agents/` (name, description, `model`, `readonly`), which skills delegate to which subagents, any subagents with similar purposes (potential consolidation), and naming conventions. Return the structured artifact-inventory output.
 
-### Phase 2: Project Context
+  The `artifact-analyzer` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-Delegate to the `artifact-analyzer` agent with this task:
+  <PHASE id="3" name="generate-improvement-plan">
+  Read these reference documents:
 
-> Analyze the project to understand the context around Cursor subagent definitions. Focus on: all subagents in `.cursor/agents/` and `plugins/*/agents/` (name, description, `model`, `readonly`), which skills delegate to which subagents, any subagents with similar purposes (potential consolidation), and naming conventions. Return the structured artifact-inventory output.
+  - `references/subagent-authoring-guide.md` — when to use a subagent, system prompt structure, the four-key frontmatter contract, description-as-routing-signal, anti-patterns.
+  - `references/subagent-evaluation-criteria.md` — bloat / staleness indicators, quality rubric.
+  - `references/subagent-config-reference.md` — full Cursor-native frontmatter specification, model and readonly handling, orchestration patterns.
+  - `references/prompt-engineering-strategies.md` — subagent-specific prompting.
 
-The `artifact-analyzer` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  <REFERENCES load="on-demand">
+  - subagent-authoring-guide.md
+  - subagent-evaluation-criteria.md
+  - subagent-config-reference.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-### Phase 3: Generate Improvement Plan
+  Based on the evaluator output and the reference documents, create an improvement plan with categories:
 
-Read these reference documents:
+  1. **Removals** — generic system prompt boilerplate, overtriggering language, redundant instructions, foreign-platform frontmatter keys.
+  2. **Refactoring** — fix `model` to `inherit`, fix `readonly` to `true`, sharpen description for routing specificity, restructure system prompt sections, tighten name to kebab-case, canonical semantic-tag migration (including `<RULES>` → `<HARD_RULES>`).
+  3. **Additions** — missing self-verification section, missing explicit output format, missing constraints block.
 
-- `references/subagent-authoring-guide.md` — when to use a subagent, system prompt structure, the four-key frontmatter contract, description-as-routing-signal, anti-patterns.
-- `references/subagent-evaluation-criteria.md` — bloat / staleness indicators, quality rubric.
-- `references/subagent-config-reference.md` — full Cursor-native frontmatter specification, model and readonly handling, orchestration patterns.
-- `references/prompt-engineering-strategies.md` — subagent-specific prompting.
+  If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  </PHASE>
 
-Based on the evaluator output and the reference documents, create an improvement plan with categories:
+  <PHASE id="4" name="self-validation">
+  Read `references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved subagent definition.
 
-1. **Removals** — generic system prompt boilerplate, overtriggering language, redundant instructions, foreign-platform frontmatter keys.
-2. **Refactoring** — fix `model` to `inherit`, fix `readonly` to `true`, sharpen description for routing specificity, restructure system prompt sections, tighten name to kebab-case.
-3. **Additions** — missing self-verification section, missing explicit output format, missing constraints block.
+  For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. The loop covers all hard limits, quality checks, and the canonical semantic-tag strictness tiers. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+  </PHASE>
 
-If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  <PHASE id="5" name="present-and-apply">
+  1. Show a summary overview of all improvements found, grouped by category:
+     - **Removals**: X items (foreign frontmatter keys: X, generic boilerplate: X, overtriggering: X)
+     - **Refactoring**: X items (model fix: X, readonly fix: X, description: X, prompt structure: X)
+     - **Additions**: X items (self-verification: X, output format: X, constraints block: X)
 
-### Phase 4: Self-Validation
+  2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
 
-Read `references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved subagent definition.
+     **WHAT**: The specific content and its current location (file:lines).
+     **WHY**: Evidence-based justification with source reference.
+     **TOKEN IMPACT**: Estimated tokens saved per invocation.
+     **OPTIONS**:
+     - **Option A** (recommended): Primary action.
+     - **Option B**: Alternative action.
+     - **Option C**: Keep as-is.
 
-For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+     Wait for the user to select an option for each suggestion before proceeding to the next.
 
-### Phase 5: Present and Apply
+     For frontmatter changes, show before/after frontmatter blocks.
+     For description rewrites, show before/after with the routing signal highlighted.
+     For system prompt rewrites, show diff of the prompt sections.
+     Warn if the subagent is referenced by skills — list which skills delegate to it.
 
-1. Show a summary overview of all improvements found, grouped by category:
-   - **Removals**: X items (foreign frontmatter keys: X, generic boilerplate: X, overtriggering: X)
-   - **Refactoring**: X items (model fix: X, readonly fix: X, description: X, prompt structure: X)
-   - **Additions**: X items (self-verification: X, output format: X, constraints block: X)
+  3. After all suggestions are reviewed, show aggregate impact:
+     - **System prompt lines**: before → after.
+     - **Frontmatter keys**: before → after (must converge to the four allowed keys).
+     - **Deferred suggestions**: X items kept as-is.
 
-2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+  4. Apply ONLY the approved changes.
+     - Refuse any approval that would introduce a frontmatter key outside the allowed four, or change `model` away from `inherit`. Surface the conflict to the user and offer to translate into a Cursor-native form.
 
-   **WHAT**: The specific content and its current location (file:lines).
-   **WHY**: Evidence-based justification with source reference.
-   **TOKEN IMPACT**: Estimated tokens saved per invocation.
-   **OPTIONS**:
-   - **Option A** (recommended): Primary action.
-   - **Option B**: Alternative action.
-   - **Option C**: Keep as-is.
+  5. Report final metrics:
+     - Lines before → after.
+     - Frontmatter keys before → after.
+     - Suggestions applied: X of Y (Z deferred).
+  </PHASE>
 
-   Wait for the user to select an option for each suggestion before proceeding to the next.
+</PROCESS>
 
-   For frontmatter changes, show before/after frontmatter blocks.
-   For description rewrites, show before/after with the routing signal highlighted.
-   For system prompt rewrites, show diff of the prompt sections.
-   Warn if the subagent is referenced by skills — list which skills delegate to it.
-
-3. After all suggestions are reviewed, show aggregate impact:
-   - **System prompt lines**: before → after.
-   - **Frontmatter keys**: before → after (must converge to the four allowed keys).
-   - **Deferred suggestions**: X items kept as-is.
-
-4. Apply ONLY the approved changes.
-   - Refuse any approval that would introduce a frontmatter key outside the allowed four, or change `model` away from `inherit`. Surface the conflict to the user and offer to translate into a Cursor-native form.
-
-5. Report final metrics:
-   - Lines before → after.
-   - Frontmatter keys before → after.
-   - Suggestions applied: X of Y (Z deferred).
+<VALIDATION loop="max-iterations:3">
+Read `references/subagent-validation-criteria.md` and loop the improved subagent through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/improve-subagent/assets/templates/subagent-definition.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/assets/templates/subagent-definition.md
@@ -11,41 +11,64 @@ readonly: true
      Forbidden: any other frontmatter key; any other model value.
      Rule: Project subagents must not spawn other subagents.
      Rule: name must be kebab-case and distinct from every other subagent name in the project.
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
+           (see wiki/knowledge/skill-body-convention.md). Mandatory for subagents:
+           <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id="N" name="X">.
+           Optional: <TRIGGER>, <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>,
+           <OUTPUT>, <VALIDATION>. Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: <TRIGGER> is optional — omit if the subagent is always spawned by skills, not user-invoked.
 -->
 
 # [Agent Name]
 
 You are a [specific role] specializing in [domain]. [One-sentence identity statement; name target services or scope when relevant.]
 
-## Constraints
+<!-- Optional: include <TRIGGER> if this subagent can also be user-invoked -->
+<!-- <TRIGGER when="[activation condition]" /> -->
 
+<BEHAVIOUR
+  avoid="[what to avoid — e.g., modifying files; surfacing low-confidence findings]"
+  always="[what to always do — e.g., cite evidence; report in structured format]">
+- [Behavioural guideline 1]
+- [Behavioural guideline 2]
 - Do not modify any files — only analyze and report.
-- Do not suggest improvements — describe what exists or what fails.
-- Do not spawn other subagents — return findings to the parent agent.
-- Do not [additional constraint specific to this role].
+</BEHAVIOUR>
 
-## Process
+<HARD_RULES priority="hard">
+- **NEVER** modify any files — describe what exists or what fails, do not change it.
+- **NEVER** suggest improvements — report findings only.
+- **NEVER** spawn other subagents — return findings to the parent agent.
+- **EVERY** finding must cite a specific path or line.
+- **EVERY** output must match the Output Format below exactly.
+</HARD_RULES>
 
-### 1. [First Step]
+<PROCESS>
 
-[What to read, detect, or evaluate.]
+  <PHASE id="1" name="[first-step]">
+  [What to read, detect, or evaluate.]
+  </PHASE>
 
-### 2. [Second Step]
+  <PHASE id="2" name="[second-step]">
+  [How to process findings — filtering, categorizing, structuring.]
+  </PHASE>
 
-[How to process findings.]
+  <PHASE id="3" name="[compile-output]">
+  [How to compile and format the final structured output.]
+  </PHASE>
 
-### 3. [Third Step]
+</PROCESS>
 
-[How to compile output.]
-
-## Output Format
+<OUTPUT>
 
 ```
 [Exact structure the agent must return — headers, tables, sections, with concrete labels.]
 ```
 
-## Self-Verification
+</OUTPUT>
 
+<VALIDATION>
+Before returning output, verify:
 1. [Check 1 — every reported finding cites a specific path or line.]
 2. [Check 2 — output matches the format above.]
 3. [Check 3 — no improvement suggestions included; only findings.]
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
@@ -9,6 +9,7 @@ Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-r
 
 - Hard limits (auto-fail)
 - Allowed frontmatter contract (rejection rules with examples)
+- Canonical Semantic-Tag Convention
 - Quality checks
 - If this is an IMPROVE operation
 - Validation loop instructions
@@ -79,31 +80,13 @@ Required fix: remove the turn-cap key entirely.
 
 A subagent whose `model` value is a literal model name or ID is REJECTED. The `model` value MUST be `inherit`.
 
-Example REJECTED frontmatter (literal alias):
+Example REJECTED `model` values — every one of these is rejected; only `inherit` passes:
 
 ```yaml
----
-name: example-evaluator
-description: "Evaluates things. Use when reviewing artifacts."
-model: sonnet
-readonly: true
----
-```
-
-Example REJECTED frontmatter (other literal aliases):
-
-```yaml
-model: opus
-```
-
-```yaml
-model: haiku
-```
-
-Example REJECTED frontmatter (full model ID prefix):
-
-```yaml
-model: claude-opus-4-6
+model: sonnet          # literal alias
+model: opus            # literal alias
+model: haiku           # literal alias
+model: claude-opus-4-6 # full model ID prefix
 ```
 
 Required fix: set the model value to `inherit`.
@@ -135,6 +118,32 @@ Required fix: remove the extra key.
 
 ---
 
+## Canonical Semantic-Tag Convention
+
+The subagent body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — deterministically.
+
+**Mandatory tags** (the subagent body MUST contain all of these): `<BEHAVIOUR>` (guidelines, posture), `<HARD_RULES>` (inviolable constraints), `<PROCESS>` (container for the ordered phases; MUST contain at least one `<PHASE>`), and `<PHASE id="N" name="X">` (one execution step inside `<PROCESS>`; `id=` mandatory on every `<PHASE>`).
+
+**Optional tags** (absence is silent — never a finding): `<TRIGGER>`, `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`. `<TRIGGER>` is OPTIONAL for subagents because they are spawned by skills, not user-invoked.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | A mandatory tag missing (`<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`); unbalanced tags; malformed attribute syntax (value missing quotes, stray `=`, unterminated quote) | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of `<TRIGGER>` or any other optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
+
+---
+
 ## Quality Checks (All must pass)
 
 - [ ] `description` is action-oriented and includes a specific "Use when..." trigger phrase for delegation routing.
@@ -148,6 +157,9 @@ Required fix: remove the extra key.
 - [ ] No instructions tell the subagent to spawn other subagents (project convention restricts nested launches).
 - [ ] System prompt is task-specific, not generic ("you are a helpful AI").
 - [ ] Prompt engineering strategy applied: role prompting, structured output, and confidence filtering per `prompt-engineering-strategies.md`. For evaluator-type subagents that mandate explicit evidence per finding, the evidence requirement satisfies the confidence-filtering criterion.
+- [ ] Canonical semantic tags present: `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`.
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`.
+- [ ] YAML frontmatter untouched by the convention — the four-key contract (`name`, `description`, `model`, `readonly`) is unchanged.
 
 ---
 
@@ -170,10 +182,11 @@ Required fix: remove the extra key.
 
 Execute this loop for each generated or improved subagent:
 
-1. Evaluate the subagent against ALL criteria above.
+1. Evaluate the subagent against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers.
 2. For improve operations, verify each suggestion in the improvement plan has a WHY field citing a source document — no suggestion may lack a source reference.
-3. If ANY criterion fails: identify the specific failure, fix the subagent, restart evaluation.
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
-5. Only proceed to writing the subagent when ALL criteria pass.
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the subagent, restart evaluation.
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix.
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
+6. Only proceed to writing the subagent when ALL hard-fail and quality criteria pass.
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits. The frontmatter contract is non-negotiable.


### PR DESCRIPTION
Implements #148. Mirrors the canonical semantic-tag convention onto the cursor-customizer plugin: the cursor-plugin-skills path-scoped rule, all four meta-skill SKILL.md bodies, their authoring templates and validation criteria, plus the HTML artifact baseline skeleton and routing for cursor-customizer create-skill. Product-strict preserved (zero Claude Code references). No version bumps (deferred to #152).