### PR TITLE
Standalone parity (create-skill + improve-skill, no subagent)

### DIFF
--- a/.claude/rules/standalone-skills.md
+++ b/.claude/rules/standalone-skills.md
@@ -24,3 +24,49 @@ paths:
 - SKILL.md `name` field: ≤64 chars, lowercase letters/numbers/hyphens only, no XML tags
 - SKILL.md `description` field: non-empty, ≤1024 chars, third person, no XML tags
 - SKILL.md body: under 500 lines
+
+## Canonical Tag Vocabulary (skills/**/SKILL.md)
+
+Every `SKILL.md` body (post-frontmatter) under `skills/**` MUST wrap its logical blocks in the canonical semantic-tag vocabulary:
+
+**Mandatory tags** — hard-fail if any are missing:
+- `<TRIGGER when="...">` or `<TRIGGER when="..." />` — plain-language activation cue; required for skills
+- `<BEHAVIOUR avoid="..." always="...">` — behavioural guidelines, mindset, posture
+- `<HARD_RULES priority="hard">` — inviolable constraints (NEVER / EVERY / ALWAYS); legacy `<RULES>` is an accepted alias (no migration required until next touch)
+- `<PROCESS>` containing at least one `<PHASE id="N" name="X">` — ordered execution phases; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** — absence is never a finding:
+`<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Non-canonical attribute names produce a *warn* finding (typo guard); they do not hard-fail.
+
+**Validation strictness tiers** (deterministic — apply verbatim):
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| Hard-fail | Any mandatory tag missing | Fix before proceeding |
+| Hard-fail | Unbalanced tags (open without close, or close without open) | Fix before proceeding |
+| Hard-fail | Malformed attribute syntax (missing quotes, stray `=`, unterminated quote) | Fix before proceeding |
+| Warn | Non-canonical attribute name outside the closed set | Surface warning; do not block |
+| Silent | Absence of any optional tag | No finding |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing `id=` is a hard-fail.
+
+## Artifact Format Routing (skills/**/SKILL.md)
+
+When a standalone skill generates an output artifact, the default format is:
+
+- **HTML** for human-rich agent-executable artifacts: plans, PRDs, design specs, reports, prototypes, code-review writeups, custom editors
+- **Markdown** (mandatory) for: `SKILL.md`, `AGENTS.md`, `README.md`, `CONTEXT.md`, ADR files, commit messages, PR bodies, GitHub issues, code comments
+
+Explicit user override (`generate as markdown`) always wins over the default.
+
+Standalone skills that generate HTML artifacts MUST ship a baseline HTML skeleton under `assets/templates/` and carry the canonical semantic-tag scaffold (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`) inside the HTML `<body>`.
+
+## Validation Strictness
+
+Meta-skill self-validation loops MUST:
+1. Check all mandatory canonical tags are present and balanced
+2. Hard-fail on missing mandatory tags, unbalanced tags, or malformed attribute syntax
+3. Warn (do not block) on non-canonical attribute names
+4. Run at most 3 iterations before surfacing remaining failures to the user

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -7,81 +7,116 @@ description: "Creates new SKILL.md files with references, templates, and frontma
 
 Generates a new SKILL.md file with supporting references and templates, grounded in the docs corpus and project conventions.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new skill from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
-- **NEVER** create skills that explain what Claude already knows (language syntax, obvious conventions)
+<HARD_RULES priority="hard">
+- **NEVER** create skills that explain what the agent already knows (language syntax, obvious conventions)
 - **NEVER** inline reference content in SKILL.md body — use the `references/` subdirectory
 - **NEVER** exceed 500 lines in the SKILL.md body
 - **EVERY** reference file must be ≤ 200 lines with source attribution
 - **EVERY** skill must use relative `references/` paths for all bundled file references (not hardcoded absolute paths)
 - **EVERY** skill description must be third-person and include a "Use when..." trigger phrase
 - **EVERY** generated skill must preserve the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** generated SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** new skill whose output is a human-rich agent-executable artifact (plan, PRD, spec, report, prototype, code-review writeup, custom editor) MUST default to an HTML output template — unless the user explicitly says "generate as markdown" (or equivalent), in which case that override always wins
+- **NEVER** default to HTML for agent-loaded or tooling-locked artifacts (`SKILL.md`, `AGENTS.md`, `README.md`, `CONTEXT.md`, ADR files, commit messages, PR bodies, GitHub issues, code comments) — these are Markdown-mandatory regardless of user request phrasing
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="name-collision-check">
+  Check if a skill with the same name already exists at:
 
-Check if a skill with the same name already exists at:
+  - `skills/{requested-name}/SKILL.md`
 
-- `.claude/skills/{requested-name}/SKILL.md`
-- `plugins/*/skills/{requested-name}/SKILL.md`
+  **If a skill already exists:**
 
-**If a skill already exists at either location:**
+  1. Inform the user: "A skill named `{requested-name}` already exists."
+  2. Suggest using `improve-skill` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
 
-1. Inform the user: "A skill named `{requested-name}` already exists."
-2. Suggest using the `improve-skill` skill to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
+  **If no skill exists with that name:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no skill exists with that name:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Read `references/artifact-analyzer.md` and follow its analysis instructions to analyze the project at the current working directory.
 
-### Phase 1: Codebase Analysis
+  Focus on: existing skill directory structure, naming patterns, and any skill that is similar to `{requested-name}` in purpose. Also identify the project layout: whether this is a monorepo with multiple service packages or a single-package project, and report any service directory paths for use in scope resolution.
+  </PHASE>
 
-Read `references/artifact-analyzer.md` and follow its analysis instructions to analyze the project at the current working directory.
+  <PHASE id="2" name="generate-skill">
+  **Load context.** Read these references:
 
-Focus on: existing skill directory structure, naming patterns, and any skill that is similar to `{requested-name}` in purpose.
+  - `references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
+  - `references/skill-format-reference.md` — frontmatter fields, name validation, string substitution variables
 
-### Phase 2: Generate Skill
+  Decide skill structure: phases, reference file names, and whether `assets/templates/` is needed.
 
-Before generating, read these reference documents:
+  **Classify output artifact format.** Read `references/artifact-format-routing.md` and apply its routing table to the new skill being generated:
 
-- `references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
-- `references/skill-format-reference.md` — frontmatter fields, name validation, string substitution variables
-- `references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
-- `references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
+  1. Identify what kind of artifact the new skill will produce (plan/PRD/spec/report/prototype vs. SKILL.md/AGENTS.md/README/etc.).
+  2. Apply the routing table: human-rich agent-executable artifacts default to **HTML**; agent-loaded and tooling-locked artifacts are **Markdown-mandatory**.
+  3. Check for explicit override: if the user said "generate as markdown" (or equivalent), that override wins regardless of artifact type.
+  4. If the verdict is **HTML**: copy `assets/templates/html-artifact-skeleton.html` into the new skill's `assets/templates/` directory (rename to match the artifact type). The new skill must instruct its generation phase to populate the canonical semantic tags inside the HTML `<body>`.
+  5. If the verdict is **Markdown**: use `assets/templates/skill-md.md` or a Markdown template appropriate to the artifact type.
 
-Read `assets/templates/skill-md.md` and fill its placeholders using:
+  **Apply patterns.** Read these references:
 
-- User requirements for the new skill
-- Phase 1 analysis output (naming conventions, existing patterns)
-- Evidence from the reference files above
+  - `references/behavioral-guidelines.md` — behavior and safe persuasion patterns for skills
+  - `references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
 
-Generate the complete skill directory structure:
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-format-reference.md
+  - artifact-format-routing.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-1. `SKILL.md` — primary skill file with frontmatter and phase definitions
-2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
-3. `assets/templates/` — create stub template files if the skill generates output files
+  Read the chosen output template (HTML skeleton or `skill-md.md`) and fill its placeholders using:
 
-### Phase 3: Self-Validation
+  - User requirements for the new skill
+  - Phase 1 analysis output (naming conventions, existing patterns)
+  - Evidence from the reference files above
 
-Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
+  If Phase 1 detects a monorepo or multi-service layout, make the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope.
 
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  Generate the complete skill directory structure:
 
-### Phase 4: Present and Write
+  1. `SKILL.md` — primary skill file with frontmatter and a body carrying the canonical semantic-tag vocabulary
+  2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
+  3. `assets/templates/` — create the appropriate output template (HTML or Markdown per the routing verdict); for validator-type skills that only report findings, `assets/templates/` may be omitted
+  </PHASE>
 
-1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates)
-2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
-3. Ask for confirmation before writing any files
-4. On approval, write all files to the target location
+  <PHASE id="3" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
+
+  If Phase 1 detected a monorepo or multi-service layout, add one extra validation pass: confirm the generated phases name the target service, package, or workspace explicitly.
+
+  The loop evaluates all hard limits, quality checks, and canonical semantic-tag strictness tiers — fixes any failures, and re-evaluates: maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
+
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates)
+  2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
+  3. Ask for confirmation before writing any files
+  4. On approval, write all files to the target location
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md` and loop the generated skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/skills/create-skill/assets/fixtures/MANIFEST.md
+++ b/skills/create-skill/assets/fixtures/MANIFEST.md
@@ -1,0 +1,27 @@
+# Fixture Corpus — Skill Body Convention
+
+Regression corpus for the canonical semantic-tag strictness tiers defined in
+`references/skill-validation-criteria.md` ("Canonical Semantic-Tag Convention"
+section). Each fixture is a minimal SKILL.md body that exercises exactly one
+validation outcome.
+
+To use: run the validation loop from `references/skill-validation-criteria.md` against each
+fixture file and confirm the produced verdict matches the **Expected verdict**
+column below. Any mismatch means the strictness-tier text is ambiguous and must
+be tightened — the corpus is the regression test for that clarity.
+
+These fixtures are test data, not real skills. They are not loaded by the
+`create-skill` skill at runtime.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes only | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** — missing mandatory tag |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** — missing mandatory tag |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** — missing mandatory tag |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** — missing mandatory tag |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** — missing mandatory tag |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** — unbalanced tags |
+| `malformed-attribute.md` | `<PHASE>` `name` value missing its quotes | **hard-fail** — malformed attribute syntax |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a non-canonical `mood=` attribute | **warn** — non-canonical attribute name; passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** — alias satisfies the `<HARD_RULES>` check |

--- a/skills/create-skill/assets/fixtures/compliant-baseline.md
+++ b/skills/create-skill/assets/fixtures/compliant-baseline.md
@@ -1,0 +1,39 @@
+---
+name: fixture-compliant-baseline
+description: "Fixture skill exercising the compliant baseline. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. All mandatory tags present, balanced, canonical attributes only. -->
+
+# Fixture Compliant Baseline
+
+One-sentence purpose statement for the baseline fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION>
+Read the validation criteria and loop until all checks pass.
+</VALIDATION>

--- a/skills/create-skill/assets/fixtures/malformed-attribute.md
+++ b/skills/create-skill/assets/fixtures/malformed-attribute.md
@@ -1,0 +1,35 @@
+---
+name: fixture-malformed-attribute
+description: "Fixture skill with a malformed PHASE attribute. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The <PHASE> name attribute value is missing its quotes. -->
+
+# Fixture Malformed Attribute
+
+One-sentence purpose statement for the malformed-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name=analysis>
+  DEFECT: the name attribute value above is unquoted — malformed attribute syntax.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/missing-behaviour.md
+++ b/skills/create-skill/assets/fixtures/missing-behaviour.md
@@ -1,0 +1,28 @@
+---
+name: fixture-missing-behaviour
+description: "Fixture skill with the mandatory BEHAVIOUR tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <BEHAVIOUR> tag is absent. -->
+
+# Fixture Missing Behaviour
+
+One-sentence purpose statement for the missing-behaviour fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/missing-hard-rules.md
+++ b/skills/create-skill/assets/fixtures/missing-hard-rules.md
@@ -1,0 +1,30 @@
+---
+name: fixture-missing-hard-rules
+description: "Fixture skill with the mandatory HARD_RULES tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. Both <HARD_RULES> and its <RULES> alias are absent. -->
+
+# Fixture Missing Hard Rules
+
+One-sentence purpose statement for the missing-hard-rules fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/missing-phase.md
+++ b/skills/create-skill/assets/fixtures/missing-phase.md
@@ -1,0 +1,27 @@
+---
+name: fixture-missing-phase
+description: "Fixture skill whose PROCESS contains zero PHASE elements. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is present but contains zero <PHASE> elements. -->
+
+# Fixture Missing Phase
+
+One-sentence purpose statement for the missing-phase fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+The process container holds no phases — this is the defect under test.
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/missing-process.md
+++ b/skills/create-skill/assets/fixtures/missing-process.md
@@ -1,0 +1,23 @@
+---
+name: fixture-missing-process
+description: "Fixture skill with the mandatory PROCESS tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <PROCESS> tag is absent. -->
+
+# Fixture Missing Process
+
+One-sentence purpose statement for the missing-process fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>

--- a/skills/create-skill/assets/fixtures/missing-trigger.md
+++ b/skills/create-skill/assets/fixtures/missing-trigger.md
@@ -1,0 +1,33 @@
+---
+name: fixture-missing-trigger
+description: "Fixture skill with the mandatory TRIGGER tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <TRIGGER> tag is absent. -->
+
+# Fixture Missing Trigger
+
+One-sentence purpose statement for the missing-trigger fixture.
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/non-canonical-attribute.md
+++ b/skills/create-skill/assets/fixtures/non-canonical-attribute.md
@@ -1,0 +1,36 @@
+---
+name: fixture-non-canonical-attribute
+description: "Fixture skill with a non-canonical attribute name. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: warn. <BEHAVIOUR> carries a non-canonical `mood=` attribute; all mandatory tags are present and balanced, so it passes otherwise. -->
+
+# Fixture Non-Canonical Attribute
+
+One-sentence purpose statement for the non-canonical-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical"
+  mood="optimistic">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/rules-alias.md
+++ b/skills/create-skill/assets/fixtures/rules-alias.md
@@ -1,0 +1,35 @@
+---
+name: fixture-rules-alias
+description: "Fixture skill using the legacy RULES alias instead of HARD_RULES. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. Uses the legacy <RULES> tag, which is an accepted alias of <HARD_RULES>; all else compliant. -->
+
+# Fixture Rules Alias
+
+One-sentence purpose statement for the rules-alias fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<RULES>
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/unbalanced-tag.md
+++ b/skills/create-skill/assets/fixtures/unbalanced-tag.md
@@ -1,0 +1,35 @@
+---
+name: fixture-unbalanced-tag
+description: "Fixture skill with an unbalanced PROCESS tag. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is opened but never closed. -->
+
+# Fixture Unbalanced Tag
+
+One-sentence purpose statement for the unbalanced-tag fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+<!-- DEFECT: the <PROCESS> opening tag above has no matching </PROCESS> closing tag. -->

--- a/skills/create-skill/assets/templates/html-artifact-skeleton.html
+++ b/skills/create-skill/assets/templates/html-artifact-skeleton.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{artifact-title}}</title>
+  <style>
+    :root {
+      --color-text:          #1f2937;
+      --color-text-muted:    #4b5563;
+      --color-text-strong:   #111827;
+      --color-bg:            #ffffff;
+      --color-border:        #e5e7eb;
+      --color-code-bg:       #f3f4f6;
+
+      --color-trigger-text:  #374151;
+
+      --color-behaviour-bg:  #f0f4ff;
+      --color-behaviour-bar: #2563eb;
+
+      --color-hardrules-bg:  #fef2f2;
+      --color-hardrules-bar: #dc2626;
+
+      --color-phase-bg:      #fafafa;
+      --color-phase-label:   #111827;
+
+      --color-antipattern-bg:  #fffbeb;
+      --color-antipattern-bar: #d97706;
+
+      --color-output-bg:  #f0fdf4;
+      --color-output-bar: #16a34a;
+
+      --color-validation-bg:  #f5f3ff;
+      --color-validation-bar: #7c3aed;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --color-text:          #e5e7eb;
+        --color-text-muted:    #9ca3af;
+        --color-text-strong:   #f9fafb;
+        --color-bg:            #111827;
+        --color-border:        #374151;
+        --color-code-bg:       #1f2937;
+
+        --color-trigger-text:  #d1d5db;
+
+        --color-behaviour-bg:  #1e2a4a;
+        --color-behaviour-bar: #3b82f6;
+
+        --color-hardrules-bg:  #2d1515;
+        --color-hardrules-bar: #ef4444;
+
+        --color-phase-bg:      #1f2937;
+        --color-phase-label:   #f9fafb;
+
+        --color-antipattern-bg:  #2d2209;
+        --color-antipattern-bar: #f59e0b;
+
+        --color-output-bg:  #052e16;
+        --color-output-bar: #22c55e;
+
+        --color-validation-bg:  #1e1533;
+        --color-validation-bar: #a78bfa;
+      }
+    }
+
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 900px;
+      margin: 2rem auto;
+      padding: 1rem;
+      line-height: 1.6;
+      color: var(--color-text);
+      background: var(--color-bg);
+    }
+
+    BEHAVIOUR, HARD_RULES, PROCESS, PHASE, PREFLIGHT, REFERENCES,
+    EXAMPLE, ANTI_PATTERN, OUTPUT, VALIDATION, TRIGGER {
+      display: block;
+      margin: 1rem 0;
+    }
+
+    TRIGGER {
+      font-style: italic;
+      color: var(--color-trigger-text);
+    }
+
+    BEHAVIOUR {
+      background: var(--color-behaviour-bg);
+      border-left: 4px solid var(--color-behaviour-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    HARD_RULES[priority="hard"] {
+      background: var(--color-hardrules-bg);
+      border-left: 4px solid var(--color-hardrules-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    PROCESS {
+      border-top: 1px solid var(--color-border);
+      padding-top: 1rem;
+    }
+
+    PHASE {
+      background: var(--color-phase-bg);
+      border: 1px solid var(--color-border);
+      padding: 1rem;
+      margin: 0.5rem 0;
+      border-radius: 4px;
+    }
+
+    PHASE::before {
+      content: "Phase " attr(id) " — " attr(name);
+      display: block;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: var(--color-phase-label);
+    }
+
+    ANTI_PATTERN {
+      background: var(--color-antipattern-bg);
+      border-left: 4px solid var(--color-antipattern-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    OUTPUT {
+      background: var(--color-output-bg);
+      border-left: 4px solid var(--color-output-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    VALIDATION {
+      background: var(--color-validation-bg);
+      border-left: 4px solid var(--color-validation-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    code, pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      background: var(--color-code-bg);
+      padding: 0.125rem 0.25rem;
+      border-radius: 3px;
+    }
+
+    pre {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>{{artifact-title}}</h1>
+    <TRIGGER when="...">...</TRIGGER>
+    <BEHAVIOUR avoid="..." always="...">...</BEHAVIOUR>
+    <HARD_RULES priority="hard">...</HARD_RULES>
+    <PROCESS>
+      <PHASE id="1" name="...">...</PHASE>
+    </PROCESS>
+    <OUTPUT format="...">...</OUTPUT>
+    <VALIDATION>...</VALIDATION>
+  </main>
+</body>
+</html>

--- a/skills/create-skill/assets/templates/skill-md.md
+++ b/skills/create-skill/assets/templates/skill-md.md
@@ -3,49 +3,70 @@ name: [skill-name-kebab-case]
 description: "[What this skill does and when to use it. Third person.]"
 ---
 <!-- TEMPLATE: SKILL.md Entry Point
-     Placement: .claude/skills/[skill-name]/SKILL.md or plugins/[plugin]/skills/[skill-name]/SKILL.md
+     Placement: skills/[skill-name]/SKILL.md
      Rule: name ≤ 64 chars, lowercase letters/numbers/hyphens only
      Rule: description ≤ 1024 chars, third person, no XML tags
      Rule: Body under 500 lines
-     Rule: Use references/ for evidence-based guidance
-     Rule: Use assets/templates/ for output templates
+     Rule: Use relative references/ paths for evidence-based guidance
+     Rule: Use relative assets/templates/ paths for output templates
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name the target service/workspace explicitly
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory: <TRIGGER>, <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
+           Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
+           Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: YAML frontmatter is untouched — do NOT duplicate the <TRIGGER> cue into description
+     Rule: Standalone skills MUST NOT author hooks, subagents, path-scoped rules, or CLAUDE.md hierarchy
 -->
 
 # [Skill Title]
 
 [One-sentence purpose statement]
 
-## Behavioral Guidelines
+<TRIGGER when="[plain-language activation cue — mirror the 'Use when ...' phrase from the description]" />
 
+<BEHAVIOUR
+  avoid="make decisions without surfacing assumptions; add speculative scope"
+  always="surface assumptions first; keep changes surgical">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - [Critical constraint 1]
 - [Critical constraint 2]
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
-<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  <PREFLIGHT name="artifact-collision-check">
+  <!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  </PREFLIGHT>
 
-### Phase 1: [Analysis Phase Name]
-<!-- Inline analysis steps go here -->
+  <PHASE id="1" name="[analysis-phase-name]">
+  Read `references/artifact-analyzer.md` and follow its analysis instructions.
+  <!-- If monorepo, record the target service/workspace for use in subsequent phases -->
+  </PHASE>
 
-### Phase 2: [Generation Phase Name]
-<!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  <PHASE id="2" name="[generation-phase-name]">
+  <!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  </PHASE>
 
-### Phase 3: Self-Validation
-<!-- Read references/[type]-validation-criteria.md -->
+  <PHASE id="3" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
+  Maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-### Phase 4: Present and Write
-<!-- Show artifact with evidence citations, write on approval -->
+  <PHASE id="4" name="present-and-write">
+  Show artifact with evidence citations. Ask for confirmation. Write on approval.
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md`, loop until all hard limits, quality checks, and canonical semantic-tag strictness tiers pass.
+</VALIDATION>

--- a/skills/create-skill/references/artifact-format-routing.md
+++ b/skills/create-skill/references/artifact-format-routing.md
@@ -1,0 +1,110 @@
+# Artifact Format Routing
+
+Evidence-based routing rule for deciding whether a skill's generated output artifact
+should default to HTML or Markdown.
+Source: Skill body convention (canonical tag vocabulary), HTML artifact effectiveness research
+
+---
+
+## Routing Table
+
+When `create-skill` generates a new skill, the new skill's output format is
+determined by the artifact kind that new skill produces:
+
+| Artifact kind                                  | Default format | Reason                                            |
+| ---------------------------------------------- | -------------- | ------------------------------------------------- |
+| Plan, PRD, design spec                         | HTML           | Human-rich + agent-executable                     |
+| Report (weekly status, research, explainer)    | HTML           | Human-rich + agent-executable                     |
+| Prototype, custom editor, code-review writeup  | HTML           | Interactivity benefits from HTML                  |
+| `SKILL.md`                                     | Markdown       | Agent-loaded; spec-mandated                       |
+| `AGENTS.md`                                    | Markdown       | Agent-loaded; spec-mandated                       |
+| `README.md`                                    | Markdown       | Tooling-locked (npm/GitHub renderers)             |
+| `CONTEXT.md`                                   | Markdown       | Tooling-locked (agent context readers)            |
+| ADR files (`*.md` in `docs/adr/`)              | Markdown       | Tooling-locked (ADR convention)                   |
+| Commit message, PR body, GitHub issue          | Markdown       | Tooling-locked (GitHub renderers)                 |
+| Code comments                                  | Markdown-ish   | Tooling-locked (compiler/linter parses)           |
+
+Explicit user override (`generate as markdown`) always wins over the default.
+
+---
+
+## How to classify
+
+During the generation phase, before choosing the output template:
+
+1. **Identify the output artifact kind** — ask: "What does this new skill produce?
+   A plan/PRD/spec/report? Or a platform config file (SKILL.md, README, ADR)?"
+
+2. **Apply the routing table above.** The left column describes the artifact kind;
+   the Default format column gives the verdict.
+
+3. **Check for explicit override.** If the user said "generate as markdown" (or
+   equivalent phrasing like "output markdown", "use .md", "markdown format"), the
+   override wins regardless of the routing table verdict.
+
+4. **Act on the verdict:**
+   - **HTML default** → use `assets/templates/html-artifact-skeleton.html`
+     as the output template for the new skill. Instruct the new skill to carry the
+     canonical semantic tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>`
+     with one or more `<PHASE id name>`, plus relevant optional tags `<OUTPUT>`,
+     `<VALIDATION>`) inside the HTML `<body>`. Copy the skeleton into
+     the new skill's `assets/templates/` directory.
+   - **Markdown default** → use the standard `assets/templates/skill-md.md`
+     template (or a Markdown template appropriate to the artifact type).
+   - **Explicit override** → apply the user's stated format regardless of the table.
+
+---
+
+## HTML skeleton location
+
+The HTML baseline skeleton lives at:
+
+```
+assets/templates/html-artifact-skeleton.html
+```
+
+It is a valid HTML5 document with:
+- `<meta charset>` and `<meta name="viewport">`
+- Scoped CSS targeting each semantic tag (`BEHAVIOUR`, `HARD_RULES`, `PHASE`, `OUTPUT`,
+  `VALIDATION`, `ANTI_PATTERN`, etc.) with adaptive colors (light and dark mode via
+  CSS custom properties and `@media (prefers-color-scheme: dark)`)
+- Placeholder `{{artifact-title}}` in `<title>` and `<h1>`
+- A `<main>` block containing the canonical semantic-tag scaffold
+
+When generating a new HTML-defaulting skill, copy this skeleton into the new skill's
+`assets/templates/` directory (e.g., as `<artifact-type>.html`). Replace
+`{{artifact-title}}` with the artifact name appropriate to the new skill.
+
+---
+
+## Canonical semantic tags in HTML artifacts
+
+Generated HTML artifacts MUST carry the canonical semantic tags inside the HTML body.
+The same vocabulary that governs `SKILL.md` bodies applies:
+
+**Mandatory tags (HTML artifact)**:
+- `<TRIGGER when="...">` — plain-language activation context
+- `<BEHAVIOUR avoid="..." always="...">` — behavioural guidelines
+- `<HARD_RULES priority="hard">` — inviolable constraints
+- `<PROCESS>` containing at least one `<PHASE id="N" name="...">` — ordered execution steps
+
+**Optional tags (HTML artifact)**:
+- `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`.
+
+These tags are valid HTML5 — browsers treat unknown elements as inline by default;
+the CSS in the skeleton promotes each to `display: block` with semantic styling.
+
+---
+
+## Why HTML for human-rich artifacts
+
+HTML artifacts serve two consumers: humans (CSS layout, diagrams, interactive controls)
+and the next agent session (parseable semantic-tag structure). The dual-consumer design
+is why HTML artifacts embed canonical semantic tags — the same parse target serves both.
+
+Markdown past ~100 lines stops being read; rich visualisations get faked with ASCII;
+HTML renders natively in any browser without extra tooling. For agent-loaded and
+tooling-locked files the tradeoffs reverse: spec compliance, diffability, and
+renderer compatibility make Markdown mandatory.

--- a/skills/create-skill/references/skill-validation-criteria.md
+++ b/skills/create-skill/references/skill-validation-criteria.md
@@ -1,7 +1,19 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md,
+karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical tag vocabulary)
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
@@ -12,36 +24,107 @@ Any skill violating these criteria must be fixed before proceeding:
 | Criterion | Threshold | Source |
 |-----------|-----------|--------|
 | SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
+| Reference files | ≤ 200 lines each | Reference files hard limit |
 | Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
 | `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
 | `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Contradictions between phases | 0 | Agent picks arbitrarily when contradictions exist |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
+*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X"); required for skills
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. Report it as a `<HARD_RULES>` alias candidate (informational), not as a violation. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+| **Informational** | Legacy `<RULES>` tag present — alias for `<HARD_RULES>` | Surface as alias candidate; do not fail or warn |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+### Structured violation report format
+
+When evaluating a target skill body, report every finding using this format:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+[HARD-FAIL] Missing mandatory tag: <TRIGGER> — required for skills
+[HARD-FAIL] Unbalanced tag: <PROCESS> opened at line 42, no closing tag found
+[HARD-FAIL] Malformed attribute: <PHASE id=1 name="x"> — attribute value `1` missing quotes
+[WARN]      Non-canonical attribute: <BEHAVIOUR mood="high"> — `mood` is outside the closed set
+[INFO]      Legacy alias: <RULES> at line 20 — satisfies <HARD_RULES> check; candidate for organic retrofit to <HARD_RULES>
+──────────────────────────────────
+Result: HARD-FAIL (3 blocking violations, 1 warning, 1 informational)
+```
+
+A compliant target produces:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+No violations found.
+──────────────────────────────────
+Result: PASS
+```
 
 ---
 
 ## Quality Checks (All must pass)
 
-- [ ] Bundled file references use relative paths within the skill directory (e.g., `references/...` and `assets/templates/...`), not absolute or cross-directory paths
+- [ ] Has a self-validation phase that reads the skill's `references/*validation-criteria.md`
+- [ ] Bundled file references use relative `references/...` and `assets/templates/...` paths — never absolute or cross-directory paths
 - [ ] `description` written in third person ("Processes..." not "I process..." or "You can use...")
 - [ ] `description` includes what the skill does AND when to use it
 - [ ] Progressive disclosure applied: references loaded per phase, not all upfront
 - [ ] No reference content inlined in SKILL.md body (should be in `references/` subdirectory)
 - [ ] Each phase instruction is concise (≤10 lines); depth lives in reference files
-- [ ] Reference files cited explicitly so Claude knows what to load and when
-- [ ] `disable-model-invocation: true` set for side-effect workflows (commit, deploy, send)
+- [ ] Reference files cited explicitly so the agent knows what to load and when
 - [ ] Prompt engineering strategy applied: skill follows relevant strategy from prompt-engineering-strategies.md (role prompting for skills, progressive disclosure for phases)
 - [ ] Behavioral guidelines applied: the skill surfaces assumptions before acting, prefers the simplest adequate path, keeps changes surgical, and defines explicit validation targets
 - [ ] Persuasion cues, if present, stay inside the ethical constraint: they improve compliance with legitimate work only and never weaken safeguards, refusals, or scope boundaries
 - [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
-- [ ] Standalone skill phases include explicit inline bash commands or instructions to read references that contain those commands — no Task-tool delegation.
+- [ ] Standalone skill phases include explicit inline analysis steps or instructions to read references that contain those steps — no subagent delegation
 - [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-best-practices.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
+- [ ] Skill does not author hooks, subagents, path-scoped rules, or CLAUDE.md hierarchy
 
 ---
 
 ## If This Is an IMPROVE Operation — Also Check
+
+**Canonical Tag Vocabulary:**
+
+- [ ] Target skill body uses all mandatory tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with at least one `<PHASE>`)
+- [ ] All tags in target skill body are balanced (no unmatched open/close)
+- [ ] All attribute syntax in target skill body is well-formed (no missing quotes, no stray `=`)
+- [ ] Non-canonical attributes in target skill body surfaced as warnings (not hard-fails)
+- [ ] Legacy `<RULES>` in target skill body reported as informational alias candidate (not a fail)
 
 **Information Preservation:**
 
@@ -60,9 +143,33 @@ Any skill violating these criteria must be fixed before proceeding:
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above
-2. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation
-3. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing skills when ALL criteria pass
+1. Evaluate the skill against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
+2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The fixture corpus at `assets/fixtures/` is the regression test for the strictness tiers.
+Each fixture is annotated in `assets/fixtures/MANIFEST.md` with its expected verdict.
+Running the validation loop against the corpus MUST produce exactly the verdict below —
+any deviation means the strictness-tier text above is ambiguous and must be tightened.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check); surface informational alias candidate |

--- a/skills/improve-skill/SKILL.md
+++ b/skills/improve-skill/SKILL.md
@@ -7,18 +7,20 @@ description: "Evaluates and optimizes existing SKILL.md files against evidence-b
 
 Evaluate an existing SKILL.md file against evidence-based quality criteria and apply improvements to optimize token usage, reduce bloat, and align with proven patterns.
 
-## Behavioral Guidelines
+<TRIGGER when="improving or auditing an existing skill" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **ALWAYS** evaluate before modifying — never change files without analysis
 - **ALWAYS** present changes to the user before applying them
 - **NEVER** remove evidence-grounded references or citations
@@ -26,91 +28,105 @@ Evaluate an existing SKILL.md file against evidence-based quality criteria and a
 - **NEVER** exceed 500 lines in SKILL.md or 200 lines in reference files after improvements
 - **PRESERVE** all genuinely useful skill phases and instructions — only remove waste
 - **PRESERVE** or strengthen the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** improved SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** tag-vocabulary violation found in the target skill must be reported with the specific tag name, line reference, and strictness tier (hard-fail / warn / informational) before proposing a fix
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="skill-exists-check">
+  Check if a skill exists at:
 
-Check if a skill exists at:
+  - The user-provided path
+  - `skills/{name}/SKILL.md`
 
-- The user-provided path
-- `.claude/skills/{name}/SKILL.md`
-- `plugins/*/skills/{name}/SKILL.md`
+  **If no skill found:**
 
-**If no skill found:**
+  1. Inform the user: "No skill found at the specified path."
+  2. Suggest using `create-skill` to create a new one instead.
+  3. **STOP**
 
-1. Inform the user: "No skill found at the specified path."
-2. Suggest using the `create-skill` skill to create a new one instead.
-3. **STOP**
+  **If skill found:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If skill found:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="evaluate">
+  Read `references/skill-evaluator.md` and follow its evaluation instructions to evaluate the skill at `{target-path}`. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter valid), structural quality (progressive disclosure, phase structure, reference loading), and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+  </PHASE>
 
-### Phase 1: Evaluate
+  <PHASE id="2" name="codebase-context">
+  Read `references/artifact-analyzer.md` and follow its analysis instructions.
 
-Read `references/skill-evaluator.md` and follow its evaluation instructions to evaluate the skill at `{target-path}`. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter valid), structural quality (progressive disclosure, phase structure, reference loading), and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+  Focus on: naming conventions for similar skills and any other skills that overlap in purpose.
+  </PHASE>
 
-### Phase 2: Codebase Context
+  <PHASE id="3" name="generate-improvement-plan">
+  Read these reference documents:
 
-Read `references/artifact-analyzer.md` and follow its analysis instructions.
+  - `references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
+  - `references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
+  - `references/behavioral-guidelines.md` — behavior and safe persuasion patterns for skills
+  - `references/prompt-engineering-strategies.md` — skill-specific prompting strategies
 
-Focus on: naming conventions for similar skills and any other skills that overlap in purpose.
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-evaluation-criteria.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-### Phase 3: Generate Improvement Plan
+  Based on both evaluation and analysis results, create improvement plan with categories:
 
-Read these reference documents:
+  1. **Removals** — bloat (inlined content, over-specified instructions), stale (broken refs, removed tools), duplicates
+  2. **Refactoring** — progressive disclosure optimization, phase consolidation, reference path corrections
+  3. **Additions** — missing sections (canonical tags, preflight check, self-validation, output format). Only suggest Hard Rules or Preflight if the skill has user-facing interactions or side effects — do NOT suggest them for informational/analysis-only skills that read and report.
 
-- `references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
-- `references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
-- `references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
-- `references/prompt-engineering-strategies.md` — skill-specific prompting strategies
+  If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
 
-Based on both evaluation and analysis results, create improvement plan with categories:
+  **Standalone constraint**: This is the standalone distribution — suggest only skills as improvement targets. Do not suggest creating hooks, subagents, or path-scoped rules (these require host-application plugin infrastructure or are outside the standalone authoring boundary). When evaluation criteria mention hooks or subagents as improvement mechanisms, substitute with the closest available mechanism (a skill for workflow guidance).
+  </PHASE>
 
-1. **Removals** — bloat (inlined content, over-specified instructions), stale (broken agent refs, removed tools), duplicates
-2. **Refactoring** — progressive disclosure optimization, phase consolidation, reference path corrections
-3. **Additions** — missing sections (Hard Rules, preflight check, self-validation, output format). Only suggest Hard Rules or Preflight if the skill has user-facing interactions or side effects — do NOT suggest them for informational/analysis-only skills that read and report.
+  <PHASE id="4" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
 
-If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+  </PHASE>
 
-**Standalone constraint**: This is the standalone distribution — suggest only skills and path-scoped rules as improvement targets. Do not suggest creating hooks or subagents (these require Claude Code plugin infrastructure). When evaluation criteria mention hooks or subagents as improvement mechanisms, substitute with the closest available mechanism (a rule for path-scoped enforcement, a skill for workflow guidance).
+  <PHASE id="5" name="present-and-apply">
+  1. Show a summary overview of all improvements found, grouped by category:
+     - **Removals**: X items (bloat: X, stale: X, duplicates: X)
+     - **Refactoring**: X items (progressive disclosure: X, phase structure: X, reference paths: X)
+     - **Additions**: X items
 
-### Phase 4: Self-Validation
+  2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
 
-Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
+     **WHAT**: The specific content and its current location (file:lines)
+     **WHY**: Evidence-based justification with source reference
+     **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
+     **OPTIONS**:
+     - **Option A** (recommended): Primary action
+     - **Option B**: Alternative action
+     - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
 
-For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+     Wait for the user to select an option for each suggestion before proceeding to the next.
+     If the user selects "Keep as-is", preserve the content in its exact current location.
 
-### Phase 5: Present and Apply
+  3. After all suggestions are reviewed, show aggregate token impact analysis:
+     - **Total lines**: before → after
+     - **Removed tokens**: total waste eliminated
+     - **Deferred suggestions**: X items kept as-is
 
-1. Show a summary overview of all improvements found, grouped by category:
-   - **Removals**: X items (bloat: X, stale: X, duplicates: X)
-   - **Refactoring**: X items (progressive disclosure: X, phase structure: X, reference paths: X)
-   - **Additions**: X items
+  4. Apply ONLY the approved changes (options A or B selections).
 
-2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+  5. Report final metrics:
+     - Lines before → after
+     - Files affected
+     - Estimated token savings per session
+     - Suggestions applied: X of Y (Z deferred)
+  </PHASE>
 
-   **WHAT**: The specific content and its current location (file:lines)
-   **WHY**: Evidence-based justification with source reference
-   **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
-   **OPTIONS**:
-   - **Option A** (recommended): Primary action
-   - **Option B**: Alternative action
-   - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
+</PROCESS>
 
-   Wait for the user to select an option for each suggestion before proceeding to the next.
-   If the user selects "Keep as-is", preserve the content in its exact current location.
-
-3. After all suggestions are reviewed, show aggregate token impact analysis:
-   - **Total lines**: before → after
-   - **Removed tokens**: total waste eliminated
-   - **Deferred suggestions**: X items kept as-is
-
-4. Apply ONLY the approved changes (options A or B selections).
-
-5. Report final metrics:
-   - Lines before → after
-   - Files affected
-   - Estimated token savings per session
-   - Suggestions applied: X of Y (Z deferred)
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md` and loop the improved skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/skills/improve-skill/assets/templates/skill-md.md
+++ b/skills/improve-skill/assets/templates/skill-md.md
@@ -3,49 +3,70 @@ name: [skill-name-kebab-case]
 description: "[What this skill does and when to use it. Third person.]"
 ---
 <!-- TEMPLATE: SKILL.md Entry Point
-     Placement: .claude/skills/[skill-name]/SKILL.md or plugins/[plugin]/skills/[skill-name]/SKILL.md
+     Placement: skills/[skill-name]/SKILL.md
      Rule: name ≤ 64 chars, lowercase letters/numbers/hyphens only
      Rule: description ≤ 1024 chars, third person, no XML tags
      Rule: Body under 500 lines
-     Rule: Use references/ for evidence-based guidance
-     Rule: Use assets/templates/ for output templates
+     Rule: Use relative references/ paths for evidence-based guidance
+     Rule: Use relative assets/templates/ paths for output templates
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name the target service/workspace explicitly
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory: <TRIGGER>, <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
+           Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
+           Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: YAML frontmatter is untouched — do NOT duplicate the <TRIGGER> cue into description
+     Rule: Standalone skills MUST NOT author hooks, subagents, path-scoped rules, or CLAUDE.md hierarchy
 -->
 
 # [Skill Title]
 
 [One-sentence purpose statement]
 
-## Behavioral Guidelines
+<TRIGGER when="[plain-language activation cue — mirror the 'Use when ...' phrase from the description]" />
 
+<BEHAVIOUR
+  avoid="make decisions without surfacing assumptions; add speculative scope"
+  always="surface assumptions first; keep changes surgical">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - [Critical constraint 1]
 - [Critical constraint 2]
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
-<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  <PREFLIGHT name="artifact-collision-check">
+  <!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  </PREFLIGHT>
 
-### Phase 1: [Analysis Phase Name]
-<!-- Inline analysis steps go here -->
+  <PHASE id="1" name="[analysis-phase-name]">
+  Read `references/artifact-analyzer.md` and follow its analysis instructions.
+  <!-- If monorepo, record the target service/workspace for use in subsequent phases -->
+  </PHASE>
 
-### Phase 2: [Generation Phase Name]
-<!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  <PHASE id="2" name="[generation-phase-name]">
+  <!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  </PHASE>
 
-### Phase 3: Self-Validation
-<!-- Read references/[type]-validation-criteria.md -->
+  <PHASE id="3" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
+  Maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-### Phase 4: Present and Write
-<!-- Show artifact with evidence citations, write on approval -->
+  <PHASE id="4" name="present-and-write">
+  Show artifact with evidence citations. Ask for confirmation. Write on approval.
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md`, loop until all hard limits, quality checks, and canonical semantic-tag strictness tiers pass.
+</VALIDATION>

--- a/skills/improve-skill/references/skill-evaluation-criteria.md
+++ b/skills/improve-skill/references/skill-evaluation-criteria.md
@@ -21,7 +21,7 @@ Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
 | Criterion | Threshold | Source |
 |-----------|-----------|--------|
 | SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
+| Reference files | ≤ 200 lines each | Reference files hard limit |
 | Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
 | `description` field | Present, non-empty, ≤ 1024 chars | Required for skill discovery and Agent Skills spec |
 | `name` field | Present, non-empty, 1-64 chars, kebab-case | Agent Skills specification |
@@ -29,7 +29,7 @@ Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
 
 A skill violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
 
-*Source: skills/skill-authoring-best-practices.md line 259; `.claude/rules/reference-files.md`*
+*Source: skills/skill-authoring-best-practices.md line 259*
 
 ---
 

--- a/skills/improve-skill/references/skill-validation-criteria.md
+++ b/skills/improve-skill/references/skill-validation-criteria.md
@@ -1,7 +1,19 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md,
+karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical tag vocabulary)
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
@@ -12,36 +24,107 @@ Any skill violating these criteria must be fixed before proceeding:
 | Criterion | Threshold | Source |
 |-----------|-----------|--------|
 | SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
+| Reference files | ≤ 200 lines each | Reference files hard limit |
 | Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
 | `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
 | `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Contradictions between phases | 0 | Agent picks arbitrarily when contradictions exist |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
+*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X"); required for skills
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. Report it as a `<HARD_RULES>` alias candidate (informational), not as a violation. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+| **Informational** | Legacy `<RULES>` tag present — alias for `<HARD_RULES>` | Surface as alias candidate; do not fail or warn |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+### Structured violation report format
+
+When evaluating a target skill body, report every finding using this format:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+[HARD-FAIL] Missing mandatory tag: <TRIGGER> — required for skills
+[HARD-FAIL] Unbalanced tag: <PROCESS> opened at line 42, no closing tag found
+[HARD-FAIL] Malformed attribute: <PHASE id=1 name="x"> — attribute value `1` missing quotes
+[WARN]      Non-canonical attribute: <BEHAVIOUR mood="high"> — `mood` is outside the closed set
+[INFO]      Legacy alias: <RULES> at line 20 — satisfies <HARD_RULES> check; candidate for organic retrofit to <HARD_RULES>
+──────────────────────────────────
+Result: HARD-FAIL (3 blocking violations, 1 warning, 1 informational)
+```
+
+A compliant target produces:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+No violations found.
+──────────────────────────────────
+Result: PASS
+```
 
 ---
 
 ## Quality Checks (All must pass)
 
-- [ ] Bundled file references use relative `references/` paths (not hardcoded absolute paths)
+- [ ] Has a self-validation phase that reads the skill's `references/*validation-criteria.md`
+- [ ] Bundled file references use relative `references/...` and `assets/templates/...` paths — never absolute or cross-directory paths
 - [ ] `description` written in third person ("Processes..." not "I process..." or "You can use...")
 - [ ] `description` includes what the skill does AND when to use it
 - [ ] Progressive disclosure applied: references loaded per phase, not all upfront
 - [ ] No reference content inlined in SKILL.md body (should be in `references/` subdirectory)
 - [ ] Each phase instruction is concise (≤10 lines); depth lives in reference files
-- [ ] Reference files cited explicitly so Claude knows what to load and when
-- [ ] `disable-model-invocation: true` set for side-effect workflows (commit, deploy, send)
+- [ ] Reference files cited explicitly so the agent knows what to load and when
 - [ ] Prompt engineering strategy applied: skill follows relevant strategy from prompt-engineering-strategies.md (role prompting for skills, progressive disclosure for phases)
 - [ ] Behavioral guidelines applied: the skill surfaces assumptions before acting, prefers the simplest adequate path, keeps changes surgical, and defines explicit validation targets
 - [ ] Persuasion cues, if present, stay inside the ethical constraint: they improve compliance with legitimate work only and never weaken safeguards, refusals, or scope boundaries
 - [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
-- [ ] Standalone skill phases include explicit inline bash commands or instructions to read references that contain those commands — no Task-tool delegation.
+- [ ] Standalone skill phases include explicit inline analysis steps or instructions to read references that contain those steps — no subagent delegation
 - [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-best-practices.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
+- [ ] Skill does not author hooks, subagents, path-scoped rules, or CLAUDE.md hierarchy
 
 ---
 
 ## If This Is an IMPROVE Operation — Also Check
+
+**Canonical Tag Vocabulary:**
+
+- [ ] Target skill body uses all mandatory tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with at least one `<PHASE>`)
+- [ ] All tags in target skill body are balanced (no unmatched open/close)
+- [ ] All attribute syntax in target skill body is well-formed (no missing quotes, no stray `=`)
+- [ ] Non-canonical attributes in target skill body surfaced as warnings (not hard-fails)
+- [ ] Legacy `<RULES>` in target skill body reported as informational alias candidate (not a fail)
 
 **Information Preservation:**
 
@@ -60,9 +143,36 @@ Any skill violating these criteria must be fixed before proceeding:
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above
-2. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation
-3. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing skills when ALL criteria pass
+1. Evaluate the skill against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
+2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The strictness tiers above are exercised by a regression corpus shipped with the
+sibling `create-skill` skill at `skills/create-skill/assets/fixtures/` (see its
+`MANIFEST.md`). `improve-skill` does not ship its own copy — the strictness-tier
+logic is identical, so the `create-skill` corpus is the single regression test
+for both. The table below documents the expected verdict for each fixture so the
+contract is visible here too; running the validation loop against any body MUST
+produce exactly these verdicts.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check); surface informational alias candidate |


### PR DESCRIPTION
Implements #149. Mirrors the canonical semantic-tag convention onto the standalone distribution: the standalone-skills path-scoped rule, the create-skill and improve-skill SKILL.md bodies, authoring templates and validation criteria, plus the HTML artifact baseline skeleton and a 10-fixture corpus. Bundled artifacts kept fully self-contained and platform-neutral per ADR-0006. No subagent flows. No version bumps (deferred to #152).