### PR TITLE
Tier-2 exemplar retrofits (5 skills across 3 distributions)

### DIFF
--- a/plugins/agent-customizer/skills/create-hook/SKILL.md
+++ b/plugins/agent-customizer/skills/create-hook/SKILL.md
@@ -7,18 +7,20 @@ description: "Creates new hook configurations for Claude Code lifecycle events, 
 
 Generates a new hook configuration for a Claude Code lifecycle event, with correct JSON schema, handler type, and exit code behavior grounded in the docs corpus.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new Claude Code hook from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create hooks with invalid event names — only events from the 22-event list in hook-events-reference.md are valid
 - **NEVER** use broad matchers (`"*"`) for blocking hooks — overly broad matchers block too many operations
 - **NEVER** hardcode secrets in command strings — use environment variables (e.g., `$MY_SECRET`)
@@ -26,85 +28,91 @@ Generates a new hook configuration for a Claude Code lifecycle event, with corre
 - **EVERY** hook must use a handler type supported by the selected event — verify this against the handler support matrix in `hook-events-reference.md`
 - **EVERY** `command` hook must document the decision path used by the script: exit `2` + stderr for blocking, or exit `0` with JSON decision output when applicable
 - **EVERY** hook configuration must produce valid JSON before writing
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="conflict-check">
+  Check if hooks already exist for the target event in:
 
-Check if hooks already exist for the target event in:
+  - `.claude/settings.json`
+  - `.claude/settings.local.json`
+  - Plugin `hooks/hooks.json`
 
-- `.claude/settings.json`
-- `.claude/settings.local.json`
-- Plugin `hooks/hooks.json`
+  **If the exact same event + matcher combination already exists:**
 
-**If the exact same event + matcher combination already exists:**
+  1. Inform the user: "A hook for `{event}` with this matcher already exists."
+  2. Suggest using `/agent-customizer:improve-hook` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different matcher/event combination or use the improve skill.
 
-1. Inform the user: "A hook for `{event}` with this matcher already exists."
-2. Suggest using `/agent-customizer:improve-hook` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different matcher/event combination or use the improve skill.
+  **If no hook exists for this event+matcher combination:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no hook exists for this event+matcher combination:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Codebase Analysis
+  > Analyze the project to understand existing hook configurations. Focus on: hooks defined in `.claude/settings.json`, `.claude/settings.local.json`, and plugin `hooks/hooks.json`; project hook scripts in `.claude/hooks/`; plugin hook scripts in `scripts/`; event types currently in use; handler types used (command/http/prompt/agent); and any gaps in lifecycle event coverage. Also read root `CLAUDE.md`, `README.md`, and any service-level README files to understand non-standard build commands, tooling, or conventions that hook scripts should use. Also identify project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in hook script path resolution.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing hook configurations. Focus on: hooks defined in `.claude/settings.json`, `.claude/settings.local.json`, and plugin `hooks/hooks.json`; project hook scripts in `.claude/hooks/`; plugin hook scripts in `scripts/`; event types currently in use; handler types used (command/http/prompt/agent); and any gaps in lifecycle event coverage. Also read root `CLAUDE.md`, `README.md`, and any service-level README files to understand non-standard build commands, tooling, or conventions that hook scripts should use. Also identify project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in hook script path resolution.
+  <PHASE id="2" name="generate-hook">
+  #### Phase 2a: Load Context
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  Drop any references from Phase 1. Read these references:
 
-### Phase 2: Generate Hook
+  - `${CLAUDE_SKILL_DIR}/references/hook-authoring-guide.md` — when to use hooks, 4 handler types, exit code semantics, blocking vs non-blocking behavior
+  - `${CLAUDE_SKILL_DIR}/references/hook-events-reference.md` — all 22 valid events, matcher fields per event, full JSON schema
 
-#### Phase 2a: Load Context
+  Verify the selected event supports the requested handler type using the handler support matrix. If unsupported, stop and ask the user to change the event or handler choice. Determine target location (`.claude/settings.json`, `.claude/settings.local.json`, or `hooks/hooks.json`) and hook script paths.
 
-Drop any references from Phase 1. Read these references:
+  #### Phase 2b: Apply Patterns
 
-- `${CLAUDE_SKILL_DIR}/references/hook-authoring-guide.md` — when to use hooks, 4 handler types, exit code semantics, blocking vs non-blocking behavior
-- `${CLAUDE_SKILL_DIR}/references/hook-events-reference.md` — all 22 valid events, matcher fields per event, full JSON schema
+  Drop Phase 2a references. Read this reference:
 
-Verify the selected event supports the requested handler type using the handler support matrix. If unsupported, stop and ask the user to change the event or handler choice. Determine target location (`.claude/settings.json`, `.claude/settings.local.json`, or `hooks/hooks.json`) and hook script paths.
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — hook-specific prompting (zero-shot only for hooks)
 
-#### Phase 2b: Apply Patterns
+  Read `${CLAUDE_SKILL_DIR}/assets/templates/hook-config.md` and fill its placeholders using:
 
-Drop Phase 2a references. Read this reference:
+  - User requirements for the new hook (event, purpose, handler type)
+  - Phase 1 analysis output (existing hooks, coverage gaps)
+  - Decisions from Phase 2a (event validation, target location, handler type)
 
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — hook-specific prompting (zero-shot only for hooks)
+  For blocking pre-write hooks, translate the user intent into an explicit write-tool matcher instead of a wildcard or omitted matcher. Use a concrete matcher pattern for write-capable tools in the target environment (for example `Write|Edit|Create`) and keep it specific to the operations that should block.
 
-Read `${CLAUDE_SKILL_DIR}/assets/templates/hook-config.md` and fill its placeholders using:
+  In a monorepo with multiple service packages, hook script paths must be workspace-relative (e.g., `packages/api/scripts/validate.sh`, not just `scripts/validate.sh`). Confirm the correct path from the Phase 1 analysis before writing.
 
-- User requirements for the new hook (event, purpose, handler type)
-- Phase 1 analysis output (existing hooks, coverage gaps)
-- Decisions from Phase 2a (event validation, target location, handler type)
+  Generate the complete hook configuration:
 
-For blocking pre-write hooks, translate the user intent into an explicit write-tool matcher instead of a wildcard or omitted matcher. Use a concrete matcher pattern for write-capable tools in the target environment (for example `Write|Edit|Create`) and keep it specific to the operations that should block.
+  1. Hook JSON block — to be merged into the `hooks` key of the selected target file
+  2. Shell script (if `command` type):
+     - Project/local hook: write to `.claude/hooks/{name}.sh` with executable permissions
+     - Plugin hook: write to `scripts/{name}.sh` with executable permissions and reference it with `${CLAUDE_PLUGIN_ROOT}/scripts/{name}.sh`
 
-In a monorepo with multiple service packages, hook script paths must be workspace-relative (e.g., `packages/api/scripts/validate.sh`, not just `scripts/validate.sh`). Confirm the correct path from the Phase 1 analysis before writing.
+  **Important**: The hook JSON must be merged into the selected target file, not replace it. Read the current target file first and produce the merged result.
+  </PHASE>
 
-Generate the complete hook configuration:
+  <PHASE id="3" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/hook-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated hook configuration.
 
-1. Hook JSON block — to be merged into the `hooks` key of the selected target file
-2. Shell script (if `command` type):
-   - Project/local hook: write to `.claude/hooks/{name}.sh` with executable permissions
-   - Plugin hook: write to `scripts/{name}.sh` with executable permissions and reference it with `${CLAUDE_PLUGIN_ROOT}/scripts/{name}.sh`
+  The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-**Important**: The hook JSON must be merged into the selected target file, not replace it. Read the current target file first and produce the merged result.
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete hook configuration (JSON + shell script if applicable)
+  2. Cite the evidence from reference files that informed key decisions:
+     - Which event was chosen and why
+     - Why this handler type (command/http/prompt/agent)
+     - What the exit code behavior means for this event
+  3. Ask for confirmation before writing any files
+  4. On approval:
+     - Merge hook JSON into the selected target file
+     - Write shell script to `.claude/hooks/{name}.sh` or `scripts/{name}.sh` and set executable (`chmod +x`)
+  </PHASE>
 
-### Phase 3: Self-Validation
+</PROCESS>
 
-Read `${CLAUDE_SKILL_DIR}/references/hook-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated hook configuration.
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete hook configuration (JSON + shell script if applicable)
-2. Cite the evidence from reference files that informed key decisions:
-   - Which event was chosen and why
-   - Why this handler type (command/http/prompt/agent)
-   - What the exit code behavior means for this event
-3. Ask for confirmation before writing any files
-4. On approval:
-   - Merge hook JSON into the selected target file
-   - Write shell script to `.claude/hooks/{name}.sh` or `scripts/{name}.sh` and set executable (`chmod +x`)
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/hook-validation-criteria.md` and loop the generated hook configuration through every hard limit and quality check until all pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-rule/SKILL.md
+++ b/plugins/agent-customizer/skills/create-rule/SKILL.md
@@ -7,85 +7,93 @@ description: "Creates new path-scoped .claude/rules/ files grounded in the docs 
 
 Generates a new `.claude/rules/` file with correct glob patterns and minimal, specific instructions grounded in the docs corpus.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new path-scoped .claude/rules/ rule from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create path-scoped rules longer than 50 lines
 - **NEVER** create rules for standard conventions Claude already knows (e.g., "write clean code")
 - **NEVER** use overly broad glob patterns (`**/*`) unless truly global scope is required
 - **EVERY** generated rule MUST have `paths:` YAML frontmatter listing the target glob patterns
 - **EVERY** instruction must be specific and verifiable — not vague guidance
 - **ONE** topic per rule file — do not bundle unrelated instructions
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="conflict-check">
+  Check if a rule file already exists in `.claude/rules/` covering the same topic:
 
-Check if a rule file already exists in `.claude/rules/` covering the same topic:
+  - Same filename (e.g., `.claude/rules/{topic}.md` already exists)
+  - Existing rule with overlapping glob patterns that would create contradiction or duplication
 
-- Same filename (e.g., `.claude/rules/{topic}.md` already exists)
-- Existing rule with overlapping glob patterns that would create contradiction or duplication
+  **If a conflicting or duplicate rule already exists:**
 
-**If a conflicting or duplicate rule already exists:**
+  1. Inform the user: "A rule covering `{topic}` or overlapping glob patterns already exists."
+  2. Suggest using `/agent-customizer:improve-rule` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different topic/pattern scope or use the improve skill.
 
-1. Inform the user: "A rule covering `{topic}` or overlapping glob patterns already exists."
-2. Suggest using `/agent-customizer:improve-rule` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different topic/pattern scope or use the improve skill.
+  **If no conflicting rule exists:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no conflicting rule exists:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Codebase Analysis
+  > Analyze the project to understand existing rules in `.claude/rules/`. Focus on: rule filenames and topics, glob patterns in use, any overlaps or contradictions between rules, gaps where path-scoped rules would add value, and the conventions in CLAUDE.md files that could inform rule content. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in glob pattern scoping.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing rules in `.claude/rules/`. Focus on: rule filenames and topics, glob patterns in use, any overlaps or contradictions between rules, gaps where path-scoped rules would add value, and the conventions in CLAUDE.md files that could inform rule content. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in glob pattern scoping.
+  <PHASE id="2" name="generate-rule">
+  Drop any references from Phase 1. Read these reference documents:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  - `${CLAUDE_SKILL_DIR}/references/rule-authoring-guide.md` — when to use rules, path-scoping, glob syntax, and anti-patterns
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — rule-specific prompting (zero-shot, no examples in rules)
 
-### Phase 2: Generate Rule
+  Read `${CLAUDE_SKILL_DIR}/assets/templates/rule-file.md` and fill its placeholders using:
 
-Drop any references from Phase 1. Read these reference documents:
+  - User requirements for the new rule (topic, target paths, instructions)
+  - Phase 1 analysis output (existing rules, gaps, potential contradictions)
+  - Evidence from the reference files above
 
-- `${CLAUDE_SKILL_DIR}/references/rule-authoring-guide.md` — when to use rules, path-scoping, glob syntax, and anti-patterns
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — rule-specific prompting (zero-shot, no examples in rules)
+  Generate a path-scoped rule:
 
-Read `${CLAUDE_SKILL_DIR}/assets/templates/rule-file.md` and fill its placeholders using:
+  - Include `paths:` YAML frontmatter with specific glob patterns (max 50 lines)
 
-- User requirements for the new rule (topic, target paths, instructions)
-- Phase 1 analysis output (existing rules, gaps, potential contradictions)
-- Evidence from the reference files above
+  In a monorepo, scope glob patterns to the relevant service or package subtree (e.g., `services/api/**/*.go` rather than `**/*.go`). Do not use project-wide language globs (`**/*.go`, `**/*.ts`) when the rule is scoped to a specific service — language-only globs match across every package and defeat path-scoping.
 
-Generate a path-scoped rule:
+  Generate: `.claude/rules/{topic-name}.md`
+  </PHASE>
 
-- Include `paths:` YAML frontmatter with specific glob patterns (max 50 lines)
+  <PHASE id="3" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/rule-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated rule.
 
-In a monorepo, scope glob patterns to the relevant service or package subtree (e.g., `services/api/**/*.go` rather than `**/*.go`). Do not use project-wide language globs (`**/*.go`, `**/*.ts`) when the rule is scoped to a specific service — language-only globs match across every package and defeat path-scoping.
+  The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Additionally, cross-check against ALL existing rule files in `.claude/rules/` for contradictions and overlapping glob patterns. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-Generate: `.claude/rules/{topic-name}.md`
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated rule file
+  2. Cite the evidence from reference files that informed key decisions:
+     - Why this glob pattern (what files it targets and why)
+     - Why each instruction is necessary (what mistakes it prevents)
+     - Why this `paths:` scope is correct for the rule
+  3. Ask for confirmation before writing any files
+  4. On approval, write the rule file to `.claude/rules/{topic-name}.md`
+  </PHASE>
 
-### Phase 3: Self-Validation
+</PROCESS>
 
-Read `${CLAUDE_SKILL_DIR}/references/rule-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated rule.
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Additionally, cross-check against ALL existing rule files in `.claude/rules/` for contradictions and overlapping glob patterns. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete generated rule file
-2. Cite the evidence from reference files that informed key decisions:
-   - Why this glob pattern (what files it targets and why)
-   - Why each instruction is necessary (what mistakes it prevents)
-   - Why this `paths:` scope is correct for the rule
-3. Ask for confirmation before writing any files
-4. On approval, write the rule file to `.claude/rules/{topic-name}.md`
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/rule-validation-criteria.md` and loop the generated rule through every hard limit and quality check until all pass.
+</VALIDATION>

--- a/plugins/agents-initializer/skills/init-claude/SKILL.md
+++ b/plugins/agents-initializer/skills/init-claude/SKILL.md
@@ -18,18 +18,20 @@ Claude Code's configuration hierarchy enables powerful progressive disclosure:
 - **`.claude/rules/`** — path-scoped rules triggered only when matching files are read
 - **Domain files** — referenced via progressive disclosure pointers
 
-## Behavioral Guidelines
+<TRIGGER when="initializing CLAUDE.md hierarchy for a project" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** generate a single file with everything — use hierarchical progressive disclosure
 - **NEVER** include directory/file structure listings (research proves these don't help agents navigate)
 - **NEVER** include obvious language conventions the model already knows
@@ -39,79 +41,85 @@ Claude Code's configuration hierarchy enables powerful progressive disclosure:
 - Scope CLAUDE.md target: **10-30 lines**
 - `.claude/rules/` files: **focused, path-scoped, one topic per file**
 - Domain files: only when non-standard patterns are detected
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="existing-file-check">
+  Check if `CLAUDE.md` exists in the current working directory.
 
-Check if `CLAUDE.md` exists in the current working directory.
+  **If it already exists:**
 
-**If it already exists:**
+  1. Inform the user: "CLAUDE.md already exists in this project. Switching to the improve workflow to optimize your existing configuration."
+  2. Invoke the `improve-claude` skill and follow its complete process.
+  3. **STOP** — do not proceed to Phase 1 or any subsequent phase of this init skill.
 
-1. Inform the user: "CLAUDE.md already exists in this project. Switching to the improve workflow to optimize your existing configuration."
-2. Invoke the `improve-claude` skill and follow its complete process.
-3. **STOP** — do not proceed to Phase 1 or any subsequent phase of this init skill.
+  **If it does not exist:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If it does not exist:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Delegate to the `codebase-analyzer` agent with this task:
 
-### Phase 1: Codebase Analysis
+  > Analyze the project at the current working directory. Return ONLY non-standard, non-obvious information that would cause Claude to make mistakes if it didn't know them. Be ruthlessly minimal.
 
-Delegate to the `codebase-analyzer` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  Require the parsed output to surface non-default config overrides, repo-wide critical constraints, and any cross-scope prerequisites needed for the root file.
+  </PHASE>
 
-> Analyze the project at the current working directory. Return ONLY non-standard, non-obvious information that would cause Claude to make mistakes if it didn't know them. Be ruthlessly minimal.
+  <PHASE id="2" name="scope-detection">
+  Delegate to the `scope-detector` agent with this task:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
-Require the parsed output to surface non-default config overrides, repo-wide critical constraints, and any cross-scope prerequisites needed for the root file.
+  > Detect scopes in the project at the current working directory. Only flag scopes with genuinely different tooling or conventions. A simple single-package project should have ZERO additional scopes. Also identify areas that would benefit from path-scoped .claude/rules/ files. Check shared/library packages in monorepos — even utility packages may need their own scope if they have unique constraints (e.g., zero-dependency rules, dual exports, conditional imports).
 
-### Phase 2: Scope Detection
+  Wait for it to complete and parse its structured output.
+  Require the parsed output to state explicitly when a simple single-package project needs zero additional scopes.
+  </PHASE>
 
-Delegate to the `scope-detector` agent with this task:
+  <PHASE id="3" name="generate-files">
+  #### Phase 3a: Hierarchy Decisions
 
-> Detect scopes in the project at the current working directory. Only flag scopes with genuinely different tooling or conventions. A simple single-package project should have ZERO additional scopes. Also identify areas that would benefit from path-scoped .claude/rules/ files. Check shared/library packages in monorepos — even utility packages may need their own scope if they have unique constraints (e.g., zero-dependency rules, dual exports, conditional imports).
+  Drop Phases 1–2 references. Read:
 
-Wait for it to complete and parse its structured output.
-Require the parsed output to state explicitly when a simple single-package project needs zero additional scopes.
+  - `${CLAUDE_SKILL_DIR}/references/progressive-disclosure-guide.md` — hierarchy decisions and loading tiers
+  - `${CLAUDE_SKILL_DIR}/references/what-not-to-include.md` — content exclusion criteria
 
-### Phase 3: Generate Files
+  Decide which file types to generate and what content belongs in each tier.
 
-#### Phase 3a: Hierarchy Decisions
+  #### Phase 3b: Generate Files
 
-Drop Phases 1–2 references. Read:
+  Drop Phase 3a references. Read:
 
-- `${CLAUDE_SKILL_DIR}/references/progressive-disclosure-guide.md` — hierarchy decisions and loading tiers
-- `${CLAUDE_SKILL_DIR}/references/what-not-to-include.md` — content exclusion criteria
+  - `${CLAUDE_SKILL_DIR}/references/context-optimization.md` — token budget guidelines
+  - `${CLAUDE_SKILL_DIR}/references/claude-rules-system.md` — .claude/rules/ conventions and path-scoping
 
-Decide which file types to generate and what content belongs in each tier.
+  Generate the file hierarchy:
 
-#### Phase 3b: Generate Files
+  **Root CLAUDE.md** — Read `${CLAUDE_SKILL_DIR}/assets/templates/root-claude-md.md`. Fill placeholders. Remove empty sections. Target: 15-40 lines.
 
-Drop Phase 3a references. Read:
+  **Subdirectory CLAUDE.md (per detected scope)** — If scopes detected, read `${CLAUDE_SKILL_DIR}/assets/templates/scoped-claude-md.md`. Only scope-specific content differing from root.
 
-- `${CLAUDE_SKILL_DIR}/references/context-optimization.md` — token budget guidelines
-- `${CLAUDE_SKILL_DIR}/references/claude-rules-system.md` — .claude/rules/ conventions and path-scoping
+  **`.claude/rules/` Files (Path-Scoped Rules)** — If file-pattern-specific rules detected, read `${CLAUDE_SKILL_DIR}/assets/templates/claude-rule.md`. Consult `claude-rules-system.md` (already loaded) for when to create rules files vs using CLAUDE.md, path-scoping conventions, and convention vs domain-critical rule categories.
 
-Generate the file hierarchy:
+  **Domain Files** — If non-standard domain patterns detected, read `${CLAUDE_SKILL_DIR}/assets/templates/domain-doc.md`.
+  </PHASE>
 
-**Root CLAUDE.md** — Read `${CLAUDE_SKILL_DIR}/assets/templates/root-claude-md.md`. Fill placeholders. Remove empty sections. Target: 15-40 lines.
+  <PHASE id="4" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/validation-criteria.md` and execute its **Validation Loop Instructions** against every generated file. Check general criteria AND CLAUDE.md-specific structural checks (path-scoping, minimal always-loaded content). For init flows, treat the Hard Rules size targets (root 15-40 lines, scoped 10-30 lines) as required validation gates — if a monorepo root exceeds target, move scope-specific detail into subdirectory CLAUDE.md, rules, or domain files and rerun. Maximum 3 iterations.
+  </PHASE>
 
-**Subdirectory CLAUDE.md (per detected scope)** — If scopes detected, read `${CLAUDE_SKILL_DIR}/assets/templates/scoped-claude-md.md`. Only scope-specific content differing from root.
+  <PHASE id="5" name="present-and-write">
+  1. Show the user ALL generated files with their content before writing
+  2. Explain briefly why each file exists and what evidence supports its content
+  3. Include a concise validation summary: iteration count, final root line count, scoped file count, and any fixes made during self-validation
+  4. Highlight which files are always-loaded (root CLAUDE.md) vs on-demand (subdirectory, rules)
+  5. Ask for confirmation before writing files
+  6. Write all files to the project
+  7. Create `.claude/rules/` directory if generating rules files
+  </PHASE>
 
-**`.claude/rules/` Files (Path-Scoped Rules)** — If file-pattern-specific rules detected, read `${CLAUDE_SKILL_DIR}/assets/templates/claude-rule.md`. Consult `claude-rules-system.md` (already loaded) for when to create rules files vs using CLAUDE.md, path-scoping conventions, and convention vs domain-critical rule categories.
+</PROCESS>
 
-**Domain Files** — If non-standard domain patterns detected, read `${CLAUDE_SKILL_DIR}/assets/templates/domain-doc.md`.
-
-### Phase 4: Self-Validation
-
-Read `${CLAUDE_SKILL_DIR}/references/validation-criteria.md` and execute its **Validation Loop Instructions** against every generated file. Check general criteria AND CLAUDE.md-specific structural checks (path-scoping, minimal always-loaded content). For init flows, treat the Hard Rules size targets (root 15-40 lines, scoped 10-30 lines) as required validation gates — if a monorepo root exceeds target, move scope-specific detail into subdirectory CLAUDE.md, rules, or domain files and rerun. Maximum 3 iterations.
-
-### Phase 5: Present and Write
-
-1. Show the user ALL generated files with their content before writing
-2. Explain briefly why each file exists and what evidence supports its content
-3. Include a concise validation summary: iteration count, final root line count, scoped file count, and any fixes made during self-validation
-4. Highlight which files are always-loaded (root CLAUDE.md) vs on-demand (subdirectory, rules)
-5. Ask for confirmation before writing files
-6. Write all files to the project
-7. Create `.claude/rules/` directory if generating rules files
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/validation-criteria.md` and loop every generated file through all hard limits, quality checks, and CLAUDE.md-specific structural checks until all pass.
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/create-rule/SKILL.md
+++ b/plugins/cursor-customizer/skills/create-rule/SKILL.md
@@ -7,18 +7,20 @@ description: "Creates a new .cursor/rules/*.mdc rule grounded in the docs corpus
 
 Generates a new `.cursor/rules/*.mdc` rule with the correct activation-mode frontmatter and minimal, specific instructions grounded in the Cursor docs corpus.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new .cursor/rules/*.mdc rule from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create rules longer than 200 lines
 - **NEVER** create rules for standard conventions the agent already knows (e.g., "write clean code")
 - **NEVER** use overly broad globs (`**/*`) on auto-attached rules unless truly global scope is required
@@ -27,74 +29,80 @@ Generates a new `.cursor/rules/*.mdc` rule with the correct activation-mode fron
 - **EVERY** generated rule MUST set exactly one well-formed activation mode (always / globs / description)
 - **EVERY** instruction must be specific and verifiable — not vague guidance
 - **ONE** concern per rule file — do not bundle unrelated instructions
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="conflict-check">
+  Confirm the project is already initialized for Cursor (`.cursor/rules/` directory exists or the user is creating the first rule). Then check for conflicts:
 
-Confirm the project is already initialized for Cursor (`.cursor/rules/` directory exists or the user is creating the first rule). Then check for conflicts:
+  - Same filename (e.g., `.cursor/rules/{topic}.mdc` already exists)
+  - Existing rule with overlapping globs that would create contradiction or duplication
+  - Existing rule covering the same topic via `description:`-mode
 
-- Same filename (e.g., `.cursor/rules/{topic}.mdc` already exists)
-- Existing rule with overlapping globs that would create contradiction or duplication
-- Existing rule covering the same topic via `description:`-mode
+  **If a conflicting or duplicate rule already exists:**
 
-**If a conflicting or duplicate rule already exists:**
+  1. Inform the user: "A rule covering `{topic}` or overlapping globs already exists."
+  2. Suggest using `/cursor-customizer:improve-rule` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different topic/scope or use the improve skill.
 
-1. Inform the user: "A rule covering `{topic}` or overlapping globs already exists."
-2. Suggest using `/cursor-customizer:improve-rule` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different topic/scope or use the improve skill.
+  **If no conflicting rule exists:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no conflicting rule exists:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="project-context-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Project Context Analysis
+  > Analyze the project to understand existing rules in `.cursor/rules/`. Focus on: rule filenames and topics, activation modes in use, glob patterns in use, any overlaps or contradictions between rules, gaps where a rule would add value, and the conventions in any present `AGENTS.md` files that could inform rule content. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in glob scoping.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The agent runs in an isolated context with read-only access. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing rules in `.cursor/rules/`. Focus on: rule filenames and topics, activation modes in use, glob patterns in use, any overlaps or contradictions between rules, gaps where a rule would add value, and the conventions in any present `AGENTS.md` files that could inform rule content. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in glob scoping.
+  <PHASE id="2" name="activation-mode-selection-and-generation">
+  Before generating, read these reference documents:
 
-The agent runs in an isolated context with read-only access. Wait for it to complete and parse its structured output.
+  - `references/rule-authoring-guide.md` — when to use rules, frontmatter contract, the four activation modes, glob syntax, and anti-patterns
+  - `references/prompt-engineering-strategies.md` — rule-specific prompting (zero-shot, no examples in rules)
 
-### Phase 2: Activation-Mode Selection and Generation
+  Map the user's intent to one activation mode using the rules-authoring guide:
 
-Before generating, read these reference documents:
+  - **Critical tooling / project-wide constraint** → `alwaysApply: true` → read `assets/templates/cursor-rule-always.mdc`
+  - **Pattern-relative convention** (test files, generated code, monorepo packages, sensitive-handler files) → `globs:` → read `assets/templates/cursor-rule-globs.mdc`
+  - **Cross-cutting / domain topic the agent should pull in by name** (authentication, observability, accessibility, API design) → `description:` → read `assets/templates/cursor-rule-description.mdc`
 
-- `references/rule-authoring-guide.md` — when to use rules, frontmatter contract, the four activation modes, glob syntax, and anti-patterns
-- `references/prompt-engineering-strategies.md` — rule-specific prompting (zero-shot, no examples in rules)
+  Fill the chosen template's placeholders using:
 
-Map the user's intent to one activation mode using the rules-authoring guide:
+  - User requirements for the new rule (topic, target globs or description sentence, instructions)
+  - Phase 1 analysis output (existing rules, gaps, potential contradictions)
+  - Evidence from the reference files above
 
-- **Critical tooling / project-wide constraint** → `alwaysApply: true` → read `assets/templates/cursor-rule-always.mdc`
-- **Pattern-relative convention** (test files, generated code, monorepo packages, sensitive-handler files) → `globs:` → read `assets/templates/cursor-rule-globs.mdc`
-- **Cross-cutting / domain topic the agent should pull in by name** (authentication, observability, accessibility, API design) → `description:` → read `assets/templates/cursor-rule-description.mdc`
+  Generate a single rule:
 
-Fill the chosen template's placeholders using:
+  - Frontmatter contains ONLY the three permitted fields and matches the chosen activation mode
+  - Body ≤ 200 lines (significantly shorter for `alwaysApply: true` — every line loads on every conversation)
+  - In a monorepo with `globs:`-mode, scope the glob to the relevant package subtree (e.g., `services/api/**/*.go`), not a language-only glob (`**/*.go`)
 
-- User requirements for the new rule (topic, target globs or description sentence, instructions)
-- Phase 1 analysis output (existing rules, gaps, potential contradictions)
-- Evidence from the reference files above
+  Write target: `.cursor/rules/{topic-name}.mdc` (kebab-case).
+  </PHASE>
 
-Generate a single rule:
+  <PHASE id="3" name="self-validation">
+  Read `references/rule-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated rule.
 
-- Frontmatter contains ONLY the three permitted fields and matches the chosen activation mode
-- Body ≤ 200 lines (significantly shorter for `alwaysApply: true` — every line loads on every conversation)
-- In a monorepo with `globs:`-mode, scope the glob to the relevant package subtree (e.g., `services/api/**/*.go`), not a language-only glob (`**/*.go`)
+  The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Failed checks re-enter Phase 2's generation step. Additionally, cross-check against ALL existing rule files in `.cursor/rules/` for contradictions and overlapping globs. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-Write target: `.cursor/rules/{topic-name}.mdc` (kebab-case).
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated rule file
+  2. Cite the evidence from reference files that informed key decisions:
+     - Why this activation mode (what content nature drove the choice)
+     - Why this glob pattern or description sentence (what scope it targets and why)
+     - Why each instruction is necessary (what mistake it prevents)
+  3. Ask for confirmation before writing any files
+  4. On approval, write the rule file to `.cursor/rules/{topic-name}.mdc`
+  </PHASE>
 
-### Phase 3: Self-Validation
+</PROCESS>
 
-Read `references/rule-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated rule.
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Failed checks re-enter Phase 2's generation step. Additionally, cross-check against ALL existing rule files in `.cursor/rules/` for contradictions and overlapping globs. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete generated rule file
-2. Cite the evidence from reference files that informed key decisions:
-   - Why this activation mode (what content nature drove the choice)
-   - Why this glob pattern or description sentence (what scope it targets and why)
-   - Why each instruction is necessary (what mistake it prevents)
-3. Ask for confirmation before writing any files
-4. On approval, write the rule file to `.cursor/rules/{topic-name}.mdc`
+<VALIDATION loop="max-iterations:3">
+Read `references/rule-validation-criteria.md` and loop the generated rule through every hard limit and quality check until all pass.
+</VALIDATION>

--- a/skills/init-agents/SKILL.md
+++ b/skills/init-agents/SKILL.md
@@ -11,18 +11,20 @@ Generate an evidence-based AGENTS.md file hierarchy for this project. Instead of
 
 Auto-generated comprehensive AGENTS.md files **reduce** agent task success by ~3% while **increasing cost by 20%+**. Developer-written **minimal** files improve success by ~4%. This skill generates files that mimic what an experienced developer would write: only non-obvious tooling and conventions.
 
-## Behavioral Guidelines
+<TRIGGER when="initializing AGENTS.md hierarchy for a project" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** generate a single file with everything — use hierarchical progressive disclosure
 - **NEVER** include directory/file structure listings (research proves these don't help agents navigate)
 - **NEVER** include obvious language conventions the model already knows
@@ -31,68 +33,74 @@ Auto-generated comprehensive AGENTS.md files **reduce** agent task success by ~3
 - Root file target: **15-40 lines**
 - Scope files target: **10-30 lines**
 - Domain files: only when non-standard patterns are detected
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="existing-file-check">
+  Check if `AGENTS.md` exists in the current working directory.
 
-Check if `AGENTS.md` exists in the current working directory.
+  **If it already exists:**
 
-**If it already exists:**
+  1. Inform the user: "AGENTS.md already exists in this project. Switching to the improve workflow to optimize your existing configuration."
+  2. Invoke the `improve-agents` skill and follow its complete process.
+  3. **STOP** — do not proceed to Phase 1 or any subsequent phase of this init skill.
 
-1. Inform the user: "AGENTS.md already exists in this project. Switching to the improve workflow to optimize your existing configuration."
-2. Invoke the `improve-agents` skill and follow its complete process.
-3. **STOP** — do not proceed to Phase 1 or any subsequent phase of this init skill.
+  **If it does not exist:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If it does not exist:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Read `references/codebase-analyzer.md` and follow its codebase analysis instructions to analyze the project at the current working directory.
 
-### Phase 1: Codebase Analysis
+  Focus: Return ONLY non-standard, non-obvious information that would cause an agent to make mistakes if it didn't know them. Be ruthlessly minimal.
+  </PHASE>
 
-Read `references/codebase-analyzer.md` and follow its codebase analysis instructions to analyze the project at the current working directory.
+  <PHASE id="2" name="scope-detection">
+  Read `references/scope-detector.md` and follow its scope detection instructions for the project at the current working directory.
 
-Focus: Return ONLY non-standard, non-obvious information that would cause an agent to make mistakes if it didn't know them. Be ruthlessly minimal.
+  Focus: Only flag scopes with genuinely different tooling or conventions. A simple single-package project should have ZERO additional scopes. Check shared/library packages for unique constraints even if they are not user-facing, and treat repo-internal tooling directories as root/domain-doc candidates unless they truly need their own config file.
+  </PHASE>
 
-### Phase 2: Scope Detection
+  <PHASE id="3" name="generate-files">
+  Before generating, read these reference documents:
 
-Read `references/scope-detector.md` and follow its scope detection instructions for the project at the current working directory.
+  - `references/progressive-disclosure-guide.md` — file hierarchy decisions
+  - `references/what-not-to-include.md` — content exclusion criteria
+  - `references/context-optimization.md` — token budget guidelines
 
-Focus: Only flag scopes with genuinely different tooling or conventions. A simple single-package project should have ZERO additional scopes. Check shared/library packages for unique constraints even if they are not user-facing, and treat repo-internal tooling directories as root/domain-doc candidates unless they truly need their own config file.
+  Using ONLY the information from Phase 1 and Phase 2, generate the file hierarchy:
 
-### Phase 3: Generate Files
+  #### Root AGENTS.md
 
-Before generating, read these reference documents:
+  Read `assets/templates/root-agents-md.md`. Fill its placeholders using ONLY the analysis output from Phase 1 and Phase 2. Follow the HTML comment instructions in the template to determine which sections to include or remove. Remove any section that would be empty. Target: 15-40 lines.
 
-- `references/progressive-disclosure-guide.md` — file hierarchy decisions
-- `references/what-not-to-include.md` — content exclusion criteria
-- `references/context-optimization.md` — token budget guidelines
+  #### Scope AGENTS.md (per detected scope)
 
-Using ONLY the information from Phase 1 and Phase 2, generate the file hierarchy:
+  If scopes were detected, read `assets/templates/scoped-agents-md.md` for each scope. Only include scope-specific content that differs from root.
 
-#### Root AGENTS.md
+  #### Domain Files (only if non-standard patterns detected)
 
-Read `assets/templates/root-agents-md.md`. Fill its placeholders using ONLY the analysis output from Phase 1 and Phase 2. Follow the HTML comment instructions in the template to determine which sections to include or remove. Remove any section that would be empty. Target: 15-40 lines.
+  If the codebase-analyzer identified non-standard domain patterns, read `assets/templates/domain-doc.md` and generate a file per domain.
+  </PHASE>
 
-#### Scope AGENTS.md (per detected scope)
+  <PHASE id="4" name="self-validation">
+  Read `references/validation-criteria.md` and execute its **Validation Loop Instructions** against every generated file.
 
-If scopes were detected, read `assets/templates/scoped-agents-md.md` for each scope. Only include scope-specific content that differs from root.
+  The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass for ALL files.
+  For init flows, treat output-size targets as required validation gates: the root file MUST finish within 15-40 lines and each scoped file MUST finish within 10-30 lines. If a monorepo root exceeds target, move scope-specific detail down or trim non-essential context and rerun the validation loop.
+  </PHASE>
 
-#### Domain Files (only if non-standard patterns detected)
+  <PHASE id="5" name="present-and-write">
+  1. Show the user ALL generated files with their content before writing
+  2. Explain briefly why each file exists and what evidence supports its content
+  3. Include a concise validation summary: iteration count, final root line count, scoped file count, and any fixes made during self-validation
+  4. Ask for confirmation before writing files
+  5. Write all files to the project
+  </PHASE>
 
-If the codebase-analyzer identified non-standard domain patterns, read `assets/templates/domain-doc.md` and generate a file per domain.
+</PROCESS>
 
-### Phase 4: Self-Validation
-
-Read `references/validation-criteria.md` and execute its **Validation Loop Instructions** against every generated file.
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass for ALL files.
-For init flows, treat output-size targets as required validation gates: the root file MUST finish within 15-40 lines and each scoped file MUST finish within 10-30 lines. If a monorepo root exceeds target, move scope-specific detail down or trim non-essential context and rerun the validation loop.
-
-### Phase 5: Present and Write
-
-1. Show the user ALL generated files with their content before writing
-2. Explain briefly why each file exists and what evidence supports its content
-3. Include a concise validation summary: iteration count, final root line count, scoped file count, and any fixes made during self-validation
-4. Ask for confirmation before writing files
-5. Write all files to the project
+<VALIDATION loop="max-iterations:3">
+Read `references/validation-criteria.md` and loop every generated file through all hard limits and quality checks until all pass.
+</VALIDATION>


### PR DESCRIPTION
Implements #150. Retrofits five Tier-2 exemplar SKILL.md bodies to the canonical semantic-tag convention — create-rule and create-hook (agent-customizer), create-rule (cursor-customizer), init-agents (standalone), init-claude (agents-initializer). Body structure only; domain behavior preserved. Legacy `<RULES>` migrated to `<HARD_RULES>` in all five. Cursor exemplar product-strict, standalone exemplar self-contained. No version bumps (deferred to #152).