### PR TITLE
Quality-gate content updates (4 skills, body unchanged)

### DIFF
--- a/.claude/skills/agent-customizer-quality-gate/SKILL.md
+++ b/.claude/skills/agent-customizer-quality-gate/SKILL.md
@@ -85,15 +85,60 @@ combine the evaluator instructions with this appended instruction:
 
 ---
 
-## Phase 5: Findings Synthesis
+## Phase 5: Canonical Semantic-Tag Convention Checks
 
-Aggregate all outputs from Phases 1–4.
+Read `.claude/skills/agent-customizer-quality-gate/references/quality-gate-criteria.md`
+Section `## Canonical Semantic-Tag Convention Checks`.
+
+**Skill targets** — for each file matching `plugins/agent-customizer/skills/**/SKILL.md`:
+
+1. Parse the body (everything after the closing `---` of the YAML frontmatter).
+2. Apply checks V1–V9 from the criteria reference using the strictness tiers below.
+3. For any `<RULES>` occurrence, record it as an **informational alias candidate** (not a fail,
+   not a warn — surface it in the summary as: "File X uses `<RULES>`; consider renaming to
+   `<HARD_RULES>` on next touch (legacy alias — satisfies the V3 check)").
+
+**Subagent targets** — for each file matching `plugins/agent-customizer/agents/**/*.md`:
+
+1. Parse the body after the YAML frontmatter.
+2. Apply checks VA1–VA8. `<TRIGGER>` absence is **silent** — do not record it as a finding.
+3. For any `<RULES>` occurrence, record as informational (same rule as above).
+
+**Strictness tiers (apply verbatim):**
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| Hard-fail | Any mandatory tag missing; unbalanced open/close tag; malformed attribute syntax (`id=` absent on `<PHASE>`, unquoted attribute value, stray `=`, unterminated quote) | Record as CRITICAL finding; counts toward FAIL |
+| Warn | Non-canonical attribute name (outside `avoid`, `always`, `when`, `name`, `id`, `priority`) | Record as MAJOR warning; does not block PASS |
+| Silent | Absence of optional tag; `<TRIGGER>` absent in subagent body | No finding |
+| Informational | `<RULES>` present (legacy alias) | Surface as alias candidate note; no verdict impact |
+
+**Fixture corpus validation** — after checking the live plugin files, validate the gate's own
+fixture corpus at `.claude/skills/agent-customizer-quality-gate/assets/fixtures/`:
+
+- Run each `skill/*.md` fixture through V1–V9 checks and confirm the verdict matches
+  `skill/MANIFEST.md`.
+- Run each `subagent/*.md` fixture through VA1–VA8 checks and confirm the verdict matches
+  `subagent/MANIFEST.md`.
+- Any mismatch between observed verdict and MANIFEST verdict is itself a CRITICAL finding
+  (the strictness-tier text is ambiguous).
+
+Collect structured output as `tag_convention_report`, which contains:
+- Per-file check results for each skill and subagent body
+- Informational `<RULES>` alias candidate list
+- Fixture corpus validation results (pass/mismatch per fixture)
+
+---
+
+## Phase 6: Findings Synthesis
+
+Aggregate all outputs from Phases 1–5.
 
 Read `.claude/skills/agent-customizer-quality-gate/references/quality-gate-criteria.md`
 Sections `## Plugin SKILL.md Checks`, `## Agent File Checks`, `## Reference File Checks`,
-`## Shared-Copy Parity Checks`, `## Docs Drift Checks`, `## Scenario Checks`, and
-`## Plugin Manifest Checks`. Cross-reference those category headings against Phase 1–4
-results to confirm full coverage.
+`## Shared-Copy Parity Checks`, `## Docs Drift Checks`, `## Scenario Checks`,
+`## Plugin Manifest Checks`, and `## Canonical Semantic-Tag Convention Checks`.
+Cross-reference those category headings against Phase 1–5 results to confirm full coverage.
 
 Compute and display the **Quality Gate Dashboard**:
 
@@ -107,6 +152,7 @@ Intra-Plugin Parity                  14    [N]     [N]   [PASS/FAIL]
 Docs Drift                          [N]    [N]     [N]   [PASS/FAIL]
 Red-Green Scenario Coverage          16    [N]     [N]   [PASS/FAIL]
 Plugin Manifest                       3    [N]     [N]   [PASS/FAIL]
+Canonical Semantic-Tag Convention   [N]    [N]     [N]   [PASS/FAIL]
 ─────────────────────────────────────────────────────────────
 OVERALL                             [N]    [N]     [N]   [PASS/FAIL]
 ═══════════════════════════════════════════════════════════

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/MANIFEST.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/MANIFEST.md
@@ -1,0 +1,27 @@
+# Fixture Corpus — Skill Body Convention (Skill Variant)
+
+Regression corpus for the canonical semantic-tag strictness tiers defined in
+`wiki/knowledge/skill-body-convention.md`. Each fixture is a minimal SKILL.md
+body that exercises exactly one validation outcome for **skill** targets.
+
+This corpus covers `plugins/agent-customizer/skills/**/SKILL.md` bodies.
+
+To use: run the Canonical Semantic-Tag Convention check against each fixture
+file and confirm the produced verdict matches the **Expected verdict** column
+below. Any mismatch means the strictness-tier text is ambiguous and must be
+tightened — the corpus is the regression test for that clarity.
+
+These fixtures are test data only. They are not loaded by any gate at runtime.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes only | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** — missing mandatory tag |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** — missing mandatory tag |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** — missing mandatory tag |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** — missing mandatory tag |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** — missing mandatory tag |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** — unbalanced tags |
+| `malformed-attribute.md` | `<PHASE>` `name` value missing its quotes | **hard-fail** — malformed attribute syntax |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a non-canonical `mood=` attribute | **warn** — non-canonical attribute name; passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** — alias satisfies the `<HARD_RULES>` check; additionally reported as an informational `<HARD_RULES>` alias candidate (not a violation) |

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/compliant-baseline.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/compliant-baseline.md
@@ -1,0 +1,39 @@
+---
+name: fixture-compliant-baseline
+description: "Fixture skill exercising the compliant baseline. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. All mandatory tags present, balanced, canonical attributes only. -->
+
+# Fixture Compliant Baseline
+
+One-sentence purpose statement for the baseline fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION>
+Read the validation criteria and loop until all checks pass.
+</VALIDATION>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/malformed-attribute.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/malformed-attribute.md
@@ -1,0 +1,35 @@
+---
+name: fixture-malformed-attribute
+description: "Fixture skill with a malformed PHASE attribute. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The <PHASE> name attribute value is missing its quotes. -->
+
+# Fixture Malformed Attribute
+
+One-sentence purpose statement for the malformed-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name=analysis>
+  DEFECT: the name attribute value above is unquoted — malformed attribute syntax.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-behaviour.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-behaviour.md
@@ -1,0 +1,28 @@
+---
+name: fixture-missing-behaviour
+description: "Fixture skill with the mandatory BEHAVIOUR tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <BEHAVIOUR> tag is absent. -->
+
+# Fixture Missing Behaviour
+
+One-sentence purpose statement for the missing-behaviour fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-hard-rules.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-hard-rules.md
@@ -1,0 +1,30 @@
+---
+name: fixture-missing-hard-rules
+description: "Fixture skill with the mandatory HARD_RULES tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. Both <HARD_RULES> and its <RULES> alias are absent. -->
+
+# Fixture Missing Hard Rules
+
+One-sentence purpose statement for the missing-hard-rules fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-phase.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-phase.md
@@ -1,0 +1,27 @@
+---
+name: fixture-missing-phase
+description: "Fixture skill whose PROCESS contains zero PHASE elements. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is present but contains zero <PHASE> elements. -->
+
+# Fixture Missing Phase
+
+One-sentence purpose statement for the missing-phase fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+The process container holds no phases — this is the defect under test.
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-process.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-process.md
@@ -1,0 +1,23 @@
+---
+name: fixture-missing-process
+description: "Fixture skill with the mandatory PROCESS tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <PROCESS> tag is absent. -->
+
+# Fixture Missing Process
+
+One-sentence purpose statement for the missing-process fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-trigger.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-trigger.md
@@ -1,0 +1,33 @@
+---
+name: fixture-missing-trigger
+description: "Fixture skill with the mandatory TRIGGER tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <TRIGGER> tag is absent. -->
+
+# Fixture Missing Trigger
+
+One-sentence purpose statement for the missing-trigger fixture.
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/non-canonical-attribute.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/non-canonical-attribute.md
@@ -1,0 +1,36 @@
+---
+name: fixture-non-canonical-attribute
+description: "Fixture skill with a non-canonical attribute name. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: warn. <BEHAVIOUR> carries a non-canonical `mood=` attribute; all mandatory tags are present and balanced, so it passes otherwise. -->
+
+# Fixture Non-Canonical Attribute
+
+One-sentence purpose statement for the non-canonical-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical"
+  mood="optimistic">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/rules-alias.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/rules-alias.md
@@ -1,0 +1,35 @@
+---
+name: fixture-rules-alias
+description: "Fixture skill using the legacy RULES alias instead of HARD_RULES. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. Uses the legacy <RULES> tag, which is an accepted alias of <HARD_RULES>; all else compliant. The gate additionally reports this as an informational <HARD_RULES> alias candidate — not a violation. -->
+
+# Fixture Rules Alias
+
+One-sentence purpose statement for the rules-alias fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<RULES>
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/unbalanced-tag.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/unbalanced-tag.md
@@ -1,0 +1,35 @@
+---
+name: fixture-unbalanced-tag
+description: "Fixture skill with an unbalanced PROCESS tag. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is opened but never closed. -->
+
+# Fixture Unbalanced Tag
+
+One-sentence purpose statement for the unbalanced-tag fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+<!-- DEFECT: the <PROCESS> opening tag above has no matching </PROCESS> closing tag. -->

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/MANIFEST.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/MANIFEST.md
@@ -1,0 +1,34 @@
+# Fixture Corpus — Skill Body Convention (Subagent Variant)
+
+Regression corpus for the canonical semantic-tag strictness tiers defined in
+`wiki/knowledge/skill-body-convention.md`. Each fixture is a minimal subagent
+definition body that exercises exactly one validation outcome for **subagent**
+targets.
+
+This corpus covers `plugins/agent-customizer/agents/**/*.md` bodies.
+
+The subagent variant differs from the skill variant in one critical respect:
+`<TRIGGER>` is **optional** for subagents (they are spawned by skills, not
+user-invoked). Its absence is silent — never a finding. All other mandatory
+tags (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`) are hard-fail
+when absent, same as for skills.
+
+To use: run the Canonical Semantic-Tag Convention check against each fixture
+file and confirm the produced verdict matches the **Expected verdict** column
+below. Any mismatch means the strictness-tier text is ambiguous and must be
+tightened — the corpus is the regression test for that clarity.
+
+These fixtures are test data only. They are not loaded by any gate at runtime.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-with-trigger.md` | None — all mandatory tags present, `<TRIGGER>` also present, balanced, canonical attributes only | **pass** |
+| `compliant-without-trigger.md` | `<TRIGGER>` absent (subagent variant — optional) | **pass** — `<TRIGGER>` absence is silent for subagents |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** — missing mandatory tag |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** — missing mandatory tag |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** — missing mandatory tag |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** — missing mandatory tag |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** — unbalanced tags |
+| `malformed-attribute.md` | `<PHASE>` `name` value missing its quotes | **hard-fail** — malformed attribute syntax |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a non-canonical `mood=` attribute | **warn** — non-canonical attribute name; passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** — alias satisfies the `<HARD_RULES>` check; additionally reported as an informational `<HARD_RULES>` alias candidate (not a violation) |

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/compliant-with-trigger.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/compliant-with-trigger.md
@@ -1,0 +1,42 @@
+---
+name: fixture-compliant-with-trigger
+description: "Fixture subagent exercising the compliant baseline with TRIGGER present. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. All mandatory tags present, <TRIGGER> also present, balanced, canonical attributes only. -->
+
+# Fixture Compliant With Trigger
+
+One-sentence identity statement for the compliant-with-trigger fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>
+
+<OUTPUT>
+Return findings as a structured list with file paths and descriptions.
+</OUTPUT>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/compliant-without-trigger.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/compliant-without-trigger.md
@@ -1,0 +1,40 @@
+---
+name: fixture-compliant-without-trigger
+description: "Fixture subagent exercising the compliant baseline with TRIGGER absent. Use when validating the subagent-specific TRIGGER-optional variant."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. <TRIGGER> is absent — for subagents this is SILENT (not a hard-fail). All other mandatory tags are present, balanced, and use canonical attributes only. -->
+
+# Fixture Compliant Without Trigger
+
+One-sentence identity statement for the compliant-without-trigger fixture.
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>
+
+<OUTPUT>
+Return findings as a structured list with file paths and descriptions.
+</OUTPUT>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/malformed-attribute.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/malformed-attribute.md
@@ -1,0 +1,38 @@
+---
+name: fixture-malformed-attribute
+description: "Fixture subagent with a malformed PHASE attribute. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The <PHASE> name attribute value is missing its quotes. -->
+
+# Fixture Malformed Attribute
+
+One-sentence identity statement for the malformed-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name=analysis>
+  DEFECT: the name attribute value above is unquoted — malformed attribute syntax.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-behaviour.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-behaviour.md
@@ -1,0 +1,31 @@
+---
+name: fixture-missing-behaviour
+description: "Fixture subagent with the mandatory BEHAVIOUR tag absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <BEHAVIOUR> tag is absent. -->
+
+# Fixture Missing Behaviour
+
+One-sentence identity statement for the missing-behaviour fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-hard-rules.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-hard-rules.md
@@ -1,0 +1,33 @@
+---
+name: fixture-missing-hard-rules
+description: "Fixture subagent with the mandatory HARD_RULES tag absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. Both <HARD_RULES> and its <RULES> alias are absent. -->
+
+# Fixture Missing Hard Rules
+
+One-sentence identity statement for the missing-hard-rules fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-phase.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-phase.md
@@ -1,0 +1,30 @@
+---
+name: fixture-missing-phase
+description: "Fixture subagent whose PROCESS contains zero PHASE elements. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is present but contains zero <PHASE> elements. -->
+
+# Fixture Missing Phase
+
+One-sentence identity statement for the missing-phase fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+The process container holds no phases — this is the defect under test.
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-process.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-process.md
@@ -1,0 +1,26 @@
+---
+name: fixture-missing-process
+description: "Fixture subagent with the mandatory PROCESS tag absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <PROCESS> tag is absent. -->
+
+# Fixture Missing Process
+
+One-sentence identity statement for the missing-process fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/non-canonical-attribute.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/non-canonical-attribute.md
@@ -1,0 +1,39 @@
+---
+name: fixture-non-canonical-attribute
+description: "Fixture subagent with a non-canonical attribute name. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: warn. <BEHAVIOUR> carries a non-canonical `mood=` attribute; all mandatory tags are present and balanced, so it passes otherwise. -->
+
+# Fixture Non-Canonical Attribute
+
+One-sentence identity statement for the non-canonical-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format"
+  mood="optimistic">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/rules-alias.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/rules-alias.md
@@ -1,0 +1,38 @@
+---
+name: fixture-rules-alias
+description: "Fixture subagent using the legacy RULES alias instead of HARD_RULES. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. Uses the legacy <RULES> tag, which is an accepted alias of <HARD_RULES>; all else compliant. The gate additionally reports this as an informational <HARD_RULES> alias candidate — not a violation. -->
+
+# Fixture Rules Alias
+
+One-sentence identity statement for the rules-alias fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<RULES>
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/unbalanced-tag.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/unbalanced-tag.md
@@ -1,0 +1,38 @@
+---
+name: fixture-unbalanced-tag
+description: "Fixture subagent with an unbalanced PROCESS tag. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is opened but never closed. -->
+
+# Fixture Unbalanced Tag
+
+One-sentence identity statement for the unbalanced-tag fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+<!-- DEFECT: the <PROCESS> opening tag above has no matching </PROCESS> closing tag. -->

--- a/.claude/skills/agent-customizer-quality-gate/references/quality-gate-criteria.md
+++ b/.claude/skills/agent-customizer-quality-gate/references/quality-gate-criteria.md
@@ -15,8 +15,9 @@ Source: `.claude/rules/plugin-skills.md`, `.claude/rules/reference-files.md`,
 6. [Docs Drift Checks](#docs-drift-checks)
 7. [Red-Green Scenario Checks](#red-green-scenario-checks)
 8. [Plugin Manifest Checks](#plugin-manifest-checks)
-9. [Severity Classification](#severity-classification)
-10. [Report Template](#report-template)
+9. [Canonical Semantic-Tag Convention Checks](#canonical-semantic-tag-convention-checks)
+10. [Severity Classification](#severity-classification)
+11. [Report Template](#report-template)
 
 ---
 
@@ -145,6 +146,62 @@ Applies to `plugins/agent-customizer/.claude-plugin/plugin.json`
 
 ---
 
+## Canonical Semantic-Tag Convention Checks
+
+Applies to all SKILL.md bodies under `plugins/agent-customizer/skills/**/SKILL.md` and all
+subagent bodies under `plugins/agent-customizer/agents/**/*.md`.
+Source: `wiki/knowledge/skill-body-convention.md`, `docs/adr/0007-skill-body-semantic-tag-convention.md`
+
+### Skill targets (`plugins/agent-customizer/skills/**/SKILL.md`)
+
+Mandatory tags: `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` (or legacy `<RULES>` alias), `<PROCESS>`
+containing at least one `<PHASE id="N" name="X">`.
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| V1 | `<TRIGGER>` present in body | Hard-fail if absent | CRITICAL |
+| V2 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| V3 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| V4 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| V5 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| V6 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| V7 | All opened tags have a matching closing tag (no unbalanced open/close) | Hard-fail if unbalanced | CRITICAL |
+| V8 | All attribute values are properly quoted (no bare `=`, no unterminated quotes) | Hard-fail if malformed | CRITICAL |
+| V9 | All attribute names belong to the closed set: `avoid`, `always`, `when`, `name`, `id`, `priority` | Warn if non-canonical | MAJOR |
+| V10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+### Subagent targets (`plugins/agent-customizer/agents/**/*.md`)
+
+Mandatory tags: `<BEHAVIOUR>`, `<HARD_RULES>` (or `<RULES>` alias), `<PROCESS>` with at least one
+`<PHASE id="N" name="X">`. `<TRIGGER>` is OPTIONAL for subagents — its absence is SILENT (never a
+finding).
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| VA1 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| VA2 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| VA3 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| VA4 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| VA5 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| VA6 | All opened tags have a matching closing tag | Hard-fail if unbalanced | CRITICAL |
+| VA7 | All attribute values properly quoted | Hard-fail if malformed | CRITICAL |
+| VA8 | All attribute names in closed set | Warn if non-canonical | MAJOR |
+| VA9 | `<TRIGGER>` absence | Silent — no finding | — |
+| VA10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+### Fixture corpus
+
+The golden fixture corpus for these checks lives under
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/`.
+
+- `skill/` — 10 fixtures for skill-body validation (see `skill/MANIFEST.md`)
+- `subagent/` — 10 fixtures for subagent-body validation (see `subagent/MANIFEST.md`)
+
+Running the checks above against the corpus MUST produce the verdict documented in each MANIFEST.
+Any mismatch means the strictness-tier text above is ambiguous and must be tightened.
+
+---
+
 ## Severity Classification
 
 | Severity | Meaning | Must Fix Before Release? |
@@ -173,6 +230,7 @@ Use this structure for `.specs/reports/agent-customizer-quality-gate-[YYYY-MM-DD
 | Docs Drift | [N] | [N] | [N] | PASS/FAIL |
 | Red-Green Scenario Coverage | 16 | [N] | [N] | PASS/FAIL |
 | Plugin Manifest | 3 | [N] | [N] | PASS/FAIL |
+| Canonical Semantic-Tag Convention | [N] | [N] | [N] | PASS/FAIL |
 | **OVERALL** | [N] | [N] | [N] | **FAIL** |
 
 ## Findings

--- a/.claude/skills/cursor-customizer-quality-gate/SKILL.md
+++ b/.claude/skills/cursor-customizer-quality-gate/SKILL.md
@@ -98,15 +98,63 @@ appended instruction:
 
 ---
 
-## Phase 5: Findings Synthesis
+## Phase 5: Canonical Semantic-Tag Convention Checks
 
-Aggregate all outputs from Phases 1–4.
+Read `.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md`
+Section `## Canonical Semantic-Tag Convention Checks`.
+
+**Skill targets** — for each file matching `plugins/cursor-customizer/skills/**/SKILL.md`:
+
+1. Parse the body (everything after the closing `---` of the YAML frontmatter).
+2. Apply checks V1–V9 from the criteria reference using the strictness tiers below.
+3. For any `<RULES>` occurrence, record it as an **informational alias candidate** (not a fail,
+   not a warn — surface it as: "File X uses `<RULES>`; consider renaming to `<HARD_RULES>` on
+   next touch (legacy alias — satisfies the V3 check)").
+
+**Subagent targets** — for each file matching `plugins/cursor-customizer/agents/**/*.md`:
+
+1. Parse the body after the YAML frontmatter.
+2. Apply checks VA1–VA8. `<TRIGGER>` absence is **silent** — do not record it as a finding.
+3. For any `<RULES>` occurrence, record as informational (same rule as above).
+
+Note: Cursor subagents use `model: inherit` and `readonly: true` frontmatter. The body convention
+(semantic tags) is platform-agnostic — the same strictness tiers apply regardless of frontmatter.
+
+**Strictness tiers (apply verbatim):**
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| Hard-fail | Any mandatory tag missing; unbalanced open/close tag; malformed attribute syntax (`id=` absent on `<PHASE>`, unquoted attribute value, stray `=`, unterminated quote) | Record as CRITICAL finding; counts toward FAIL |
+| Warn | Non-canonical attribute name (outside `avoid`, `always`, `when`, `name`, `id`, `priority`) | Record as MAJOR warning; does not block PASS |
+| Silent | Absence of optional tag; `<TRIGGER>` absent in subagent body | No finding |
+| Informational | `<RULES>` present (legacy alias) | Surface as alias candidate note; no verdict impact |
+
+**Fixture corpus validation** — after checking the live plugin files, validate the golden corpus at
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/`:
+
+- Run each `skill/*.md` fixture through V1–V9 checks and confirm the verdict matches
+  `skill/MANIFEST.md`.
+- Run each `subagent/*.md` fixture through VA1–VA8 checks and confirm the verdict matches
+  `subagent/MANIFEST.md`.
+- Any mismatch between observed verdict and MANIFEST verdict is itself a CRITICAL finding.
+
+Collect structured output as `tag_convention_report`, which contains:
+- Per-file check results for each skill and subagent body
+- Informational `<RULES>` alias candidate list
+- Fixture corpus validation results (pass/mismatch per fixture)
+
+---
+
+## Phase 6: Findings Synthesis
+
+Aggregate all outputs from Phases 1–5.
 
 Read `.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md` Sections
 `## Plugin SKILL.md Checks`, `## Cursor Subagent Checks`, `## Reference File Checks`,
 `## Template File Checks`, `## Intra-Plugin Parity Checks`, `## Docs Drift Checks`,
-`## Red-Green Scenario Checks`, `## Plugin Manifest Checks`, and
-`## Known-Accepted Exceptions`. Cross-reference those category headings against Phase 1–4 results
+`## Red-Green Scenario Checks`, `## Plugin Manifest Checks`,
+`## Canonical Semantic-Tag Convention Checks`, and
+`## Known-Accepted Exceptions`. Cross-reference those category headings against Phase 1–5 results
 to confirm full coverage. Apply the documented known-accepted exceptions before classifying
 findings — those exceptions must NOT appear as violations in the final report.
 
@@ -122,6 +170,7 @@ Intra-Plugin Parity                  19    [N]     [N]   [PASS/FAIL]
 Docs Drift                          [N]    [N]     [N]   [PASS/FAIL]
 Red-Green Scenario Coverage          16    [N]     [N]   [PASS/FAIL]
 Plugin Manifest                       3    [N]     [N]   [PASS/FAIL]
+Canonical Semantic-Tag Convention   [N]    [N]     [N]   [PASS/FAIL]
 ─────────────────────────────────────────────────────────────
 OVERALL                             [N]    [N]     [N]   [PASS/FAIL]
 ═══════════════════════════════════════════════════════════

--- a/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/MANIFEST.md
+++ b/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/MANIFEST.md
@@ -1,0 +1,17 @@
+# Fixture Corpus — Skill Body Convention (Skill Variant, Shared)
+
+> **Shared corpus redirect** — the canonical golden fixture files live at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+>
+> The semantic-tag convention body rules are platform-agnostic (per ADR-0007 and
+> `wiki/knowledge/skill-body-convention.md`). Tag vocabulary and strictness tiers
+> are identical for Claude Code skills, Cursor skills, and standalone skills.
+> One corpus serves all gates; duplicating it would add maintenance overhead
+> without adding coverage.
+>
+> **To run the Canonical Semantic-Tag Convention skill-body check for this gate:**
+> read fixtures from `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+> and use the MANIFEST.md there for the expected verdicts.
+
+This covers `plugins/cursor-customizer/skills/**/SKILL.md` bodies.
+The expected verdict table is in the shared MANIFEST at the path above.

--- a/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/compliant-baseline.md
+++ b/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/compliant-baseline.md
@@ -1,0 +1,3 @@
+> **Shared corpus stub** — use the canonical file at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/compliant-baseline.md`
+> The semantic-tag body convention is platform-agnostic; fixtures are not duplicated per gate.

--- a/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/missing-behaviour.md
+++ b/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/missing-behaviour.md
@@ -1,0 +1,3 @@
+> **Shared corpus stub** — use the canonical file at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-behaviour.md`
+> The semantic-tag body convention is platform-agnostic; fixtures are not duplicated per gate.

--- a/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/missing-trigger.md
+++ b/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/missing-trigger.md
@@ -1,0 +1,3 @@
+> **Shared corpus stub** — use the canonical file at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-trigger.md`
+> The semantic-tag body convention is platform-agnostic; fixtures are not duplicated per gate.

--- a/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/subagent/MANIFEST.md
+++ b/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/subagent/MANIFEST.md
@@ -1,0 +1,21 @@
+# Fixture Corpus — Skill Body Convention (Subagent Variant, Shared)
+
+> **Shared corpus redirect** — the canonical golden fixture files live at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/`
+>
+> The semantic-tag convention body rules are platform-agnostic (per ADR-0007 and
+> `wiki/knowledge/skill-body-convention.md`). Tag vocabulary and strictness tiers
+> are identical for Claude Code subagents and Cursor subagents — only the YAML
+> frontmatter differs by platform. Since the check targets only the body (post-
+> frontmatter content), the same fixtures serve both platforms.
+>
+> **To run the Canonical Semantic-Tag Convention subagent-body check for this gate:**
+> read fixtures from `.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/`
+> and use the MANIFEST.md there for the expected verdicts.
+
+This covers `plugins/cursor-customizer/agents/**/*.md` bodies.
+The expected verdict table is in the shared MANIFEST at the path above.
+
+Note: Cursor subagents use `model: inherit` and `readonly: true` frontmatter (no `tools:`
+or `maxTurns:`). The fixture frontmatter in the shared corpus uses Claude Code conventions,
+but the body validation (which is what these checks test) is identical across platforms.

--- a/.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md
+++ b/.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md
@@ -21,9 +21,10 @@ Source: `.claude/rules/cursor-plugin-skills.md`, `.claude/rules/reference-files.
 9. [Drift Manifest Completeness Checks](#drift-manifest-completeness-checks)
 10. [Product-Strict Textual Compliance](#product-strict-textual-compliance)
 11. [Known-Accepted Exceptions](#known-accepted-exceptions)
-12. [Severity Classification](#severity-classification)
-13. [Expected Results Checklist](#expected-results-checklist)
-14. [Report Template](#report-template)
+12. [Canonical Semantic-Tag Convention Checks](#canonical-semantic-tag-convention-checks)
+13. [Severity Classification](#severity-classification)
+14. [Expected Results Checklist](#expected-results-checklist)
+15. [Report Template](#report-template)
 
 ---
 
@@ -225,6 +226,72 @@ in sync.
 
 ---
 
+## Canonical Semantic-Tag Convention Checks
+
+Applies to all SKILL.md bodies under `plugins/cursor-customizer/skills/**/SKILL.md` and all
+subagent bodies under `plugins/cursor-customizer/agents/**/*.md`.
+Source: `wiki/knowledge/skill-body-convention.md`, `docs/adr/0007-skill-body-semantic-tag-convention.md`
+
+The tag vocabulary and strictness tiers are platform-agnostic. Cursor subagents differ from
+Claude Code subagents only in YAML frontmatter (`model: inherit`, `readonly: true`, no `tools:`
+or `maxTurns:` fields) — the body convention is identical.
+
+### Skill targets (`plugins/cursor-customizer/skills/**/SKILL.md`)
+
+Mandatory tags: `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` (or legacy `<RULES>` alias), `<PROCESS>`
+containing at least one `<PHASE id="N" name="X">`.
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| V1 | `<TRIGGER>` present in body | Hard-fail if absent | CRITICAL |
+| V2 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| V3 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| V4 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| V5 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| V6 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| V7 | All opened tags have a matching closing tag (no unbalanced open/close) | Hard-fail if unbalanced | CRITICAL |
+| V8 | All attribute values are properly quoted (no bare `=`, no unterminated quotes) | Hard-fail if malformed | CRITICAL |
+| V9 | All attribute names belong to the closed set: `avoid`, `always`, `when`, `name`, `id`, `priority` | Warn if non-canonical | MAJOR |
+| V10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+### Subagent targets (`plugins/cursor-customizer/agents/**/*.md`)
+
+Mandatory tags: `<BEHAVIOUR>`, `<HARD_RULES>` (or `<RULES>` alias), `<PROCESS>` with at least one
+`<PHASE id="N" name="X">`. `<TRIGGER>` is OPTIONAL for subagents — its absence is SILENT (never a
+finding).
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| VA1 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| VA2 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| VA3 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| VA4 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| VA5 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| VA6 | All opened tags have a matching closing tag | Hard-fail if unbalanced | CRITICAL |
+| VA7 | All attribute values properly quoted | Hard-fail if malformed | CRITICAL |
+| VA8 | All attribute names in closed set | Warn if non-canonical | MAJOR |
+| VA9 | `<TRIGGER>` absence | Silent — no finding | — |
+| VA10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+### Fixture corpus
+
+The golden fixture corpus for these checks is the shared corpus at:
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/`
+
+- `skill/` — 10 fixtures for skill-body validation (see `skill/MANIFEST.md`)
+- `subagent/` — 10 fixtures for subagent-body validation (see `subagent/MANIFEST.md`)
+
+Note on subagent fixtures: fixture frontmatter uses Claude Code conventions; the body convention
+being validated is platform-agnostic, so the same fixtures apply.
+
+Running the checks above against the corpus MUST produce the verdict documented in each MANIFEST.
+Any mismatch means the strictness-tier text above is ambiguous and must be tightened.
+
+This gate also maintains redirect stubs at:
+`.claude/skills/cursor-customizer-quality-gate/assets/fixtures/`
+
+---
+
 ## Severity Classification
 
 | Severity | Meaning | Must Fix Before Release? |
@@ -250,6 +317,7 @@ outputs to confirm full coverage. Every category heading below MUST appear in th
 - Plugin Manifest
 - Drift Manifest Completeness
 - Product-Strict Textual Compliance
+- Canonical Semantic-Tag Convention
 
 ---
 
@@ -273,6 +341,7 @@ Use this structure for `.specs/reports/cursor-customizer-quality-gate-[YYYY-MM-D
 | Plugin Manifest | 3 | [N] | [N] | PASS/FAIL |
 | Drift Manifest Completeness | 3 | [N] | [N] | PASS/FAIL |
 | Product-Strict Textual Compliance | 1 | [N] | [N] | PASS/FAIL |
+| Canonical Semantic-Tag Convention | [N] | [N] | [N] | PASS/FAIL |
 | **OVERALL** | [N] | [N] | [N] | **FAIL** |
 
 ## Findings

--- a/.claude/skills/cursor-initializer-quality-gate/SKILL.md
+++ b/.claude/skills/cursor-initializer-quality-gate/SKILL.md
@@ -62,25 +62,63 @@ Read `.claude/skills/cursor-initializer-quality-gate/agents/scenario-evaluator.m
 
 ---
 
-## Phase 4: Findings Synthesis
+## Phase 4: Canonical Semantic-Tag Convention Checks
 
-Aggregate all outputs from Phases 1, 2, and 3.
+Read `.claude/skills/cursor-initializer-quality-gate/references/quality-gate-criteria.md`
+Section `## Canonical Semantic-Tag Convention Checks`.
 
-Read `.claude/skills/cursor-initializer-quality-gate/references/quality-gate-criteria.md` Section `## Expected Results Checklist`. Cross-reference the category headings in the checklist against the Phase 1–3 results to confirm every category was covered.
+**Skill targets** — for each file matching `plugins/cursor-initializer/skills/**/SKILL.md`:
+
+1. Parse the body (everything after the closing `---` of the YAML frontmatter).
+2. Apply checks V1–V9 from the criteria reference using the strictness tiers below.
+3. For any `<RULES>` occurrence, record it as an **informational alias candidate** (not a fail,
+   not a warn — surface it as: "File X uses `<RULES>`; consider renaming to `<HARD_RULES>` on
+   next touch (legacy alias — satisfies the V3 check)").
+
+Note: `cursor-initializer` has no subagent flows; skip the subagent-body checks.
+
+**Strictness tiers (apply verbatim):**
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| Hard-fail | Any mandatory tag missing; unbalanced open/close tag; malformed attribute syntax (`id=` absent on `<PHASE>`, unquoted attribute value, stray `=`, unterminated quote) | Record as CRITICAL finding; counts toward FAIL |
+| Warn | Non-canonical attribute name (outside `avoid`, `always`, `when`, `name`, `id`, `priority`) | Record as MAJOR warning; does not block PASS |
+| Silent | Absence of optional tag | No finding |
+| Informational | `<RULES>` present (legacy alias) | Surface as alias candidate note; no verdict impact |
+
+**Fixture corpus validation** — after checking the live plugin files, validate the golden corpus at
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`:
+
+- Run each fixture through V1–V9 checks and confirm the verdict matches `MANIFEST.md` there.
+- Any mismatch between observed verdict and MANIFEST verdict is itself a CRITICAL finding.
+
+Collect structured output as `tag_convention_report`, which contains:
+- Per-file check results for each skill body
+- Informational `<RULES>` alias candidate list
+- Fixture corpus validation results (pass/mismatch per fixture)
+
+---
+
+## Phase 5: Findings Synthesis
+
+Aggregate all outputs from Phases 1, 2, 3, and 4.
+
+Read `.claude/skills/cursor-initializer-quality-gate/references/quality-gate-criteria.md` Section `## Expected Results Checklist`. Cross-reference the category headings in the checklist against the Phase 1–4 results to confirm every category was covered.
 
 Compute and display the **Quality Gate Dashboard**:
 
 ```
 Quality Gate Dashboard — cursor-initializer [DATE]
-═══════════════════════════════════════════════════
-Category                    Checks  Passed  Failed  Status
-─────────────────────────────────────────────────────────
-Static Artifact Compliance    [N]     [N]     [N]   [PASS/FAIL]
-Cross-Copy Parity             [N]     [N]     [N]   [PASS/FAIL]
-Red-Green Test Coverage         4     [N]     [N]   [PASS/FAIL]
-─────────────────────────────────────────────────────────
-OVERALL                       [N]     [N]     [N]   [PASS/FAIL]
-═══════════════════════════════════════════════════
+═══════════════════════════════════════════════════════════
+Category                        Checks  Passed  Failed  Status
+──────────────────────────────────────────────────────────
+Static Artifact Compliance        [N]     [N]     [N]   [PASS/FAIL]
+Cross-Copy Parity                 [N]     [N]     [N]   [PASS/FAIL]
+Red-Green Test Coverage             4     [N]     [N]   [PASS/FAIL]
+Canonical Semantic-Tag Convention [N]     [N]     [N]   [PASS/FAIL]
+──────────────────────────────────────────────────────────
+OVERALL                           [N]     [N]     [N]   [PASS/FAIL]
+═══════════════════════════════════════════════════════════
 ```
 
 **If all checks pass:**
@@ -88,11 +126,11 @@ OVERALL                       [N]     [N]     [N]   [PASS/FAIL]
 
 **Stop here. Do NOT write any report file to `.specs/reports/`.**
 
-**If any checks fail:** Proceed to Phase 5.
+**If any checks fail:** Proceed to Phase 6.
 
 ---
 
-## Phase 5: Findings Report
+## Phase 6: Findings Report
 
 Generate `.specs/reports/cursor-quality-gate-[YYYY-MM-DD]-findings.md`.
 

--- a/.claude/skills/cursor-initializer-quality-gate/assets/fixtures/MANIFEST.md
+++ b/.claude/skills/cursor-initializer-quality-gate/assets/fixtures/MANIFEST.md
@@ -1,0 +1,20 @@
+# Fixture Corpus — Skill Body Convention (Skill Variant, Shared)
+
+> **Shared corpus redirect** — the canonical golden fixture files live at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+>
+> The semantic-tag convention body rules are platform-agnostic (per ADR-0007 and
+> `wiki/knowledge/skill-body-convention.md`). Tag vocabulary and strictness tiers
+> are identical for Claude Code skills, Cursor skills, and standalone skills.
+> One corpus serves all gates; duplicating it would add maintenance overhead
+> without adding coverage.
+>
+> **To run the Canonical Semantic-Tag Convention skill-body check for this gate:**
+> read fixtures from `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+> and use the MANIFEST.md there for the expected verdicts.
+
+This covers `plugins/cursor-initializer/skills/**/SKILL.md` bodies.
+The expected verdict table is in the shared MANIFEST at the path above.
+
+Note: `cursor-initializer` has no subagent flows — only skill bodies need to be checked
+for this gate (per Convention scope v1 and the issue AC for cursor-initializer-quality-gate).

--- a/.claude/skills/cursor-initializer-quality-gate/references/quality-gate-criteria.md
+++ b/.claude/skills/cursor-initializer-quality-gate/references/quality-gate-criteria.md
@@ -10,8 +10,9 @@ Source: `.claude/rules/cursor-plugin-skills.md`, `.claude/rules/reference-files.
 ## Contents
 
 1. [Expected Results Checklist](#expected-results-checklist)
-2. [Severity Classification](#severity-classification)
-3. [Report Template](#report-template)
+2. [Canonical Semantic-Tag Convention Checks](#canonical-semantic-tag-convention-checks)
+3. [Severity Classification](#severity-classification)
+4. [Report Template](#report-template)
 
 ---
 
@@ -82,6 +83,39 @@ Source: `.claude/rules/cursor-plugin-skills.md`, `.claude/rules/reference-files.
 
 ---
 
+## Canonical Semantic-Tag Convention Checks
+
+Applies to all SKILL.md bodies under `plugins/cursor-initializer/skills/**/SKILL.md`.
+There are no subagent flows in cursor-initializer; subagent body checks are out of scope
+for this gate.
+Source: `wiki/knowledge/skill-body-convention.md`, `docs/adr/0007-skill-body-semantic-tag-convention.md`
+
+Mandatory tags for skills: `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` (or legacy `<RULES>` alias),
+`<PROCESS>` containing at least one `<PHASE id="N" name="X">`.
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| V1 | `<TRIGGER>` present in body | Hard-fail if absent | CRITICAL |
+| V2 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| V3 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| V4 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| V5 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| V6 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| V7 | All opened tags have a matching closing tag (no unbalanced open/close) | Hard-fail if unbalanced | CRITICAL |
+| V8 | All attribute values are properly quoted (no bare `=`, no unterminated quotes) | Hard-fail if malformed | CRITICAL |
+| V9 | All attribute names belong to the closed set: `avoid`, `always`, `when`, `name`, `id`, `priority` | Warn if non-canonical | MAJOR |
+| V10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+### Fixture corpus
+
+The golden fixture corpus for skill-body checks is the shared corpus at:
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+
+See the MANIFEST.md at that path for the 10 fixtures and their expected verdicts.
+A redirect stub lives at `.claude/skills/cursor-initializer-quality-gate/assets/fixtures/MANIFEST.md`.
+
+---
+
 ## Severity Classification
 
 | Severity | Meaning | Must Fix Before Release? |
@@ -108,6 +142,7 @@ Use this structure for `.specs/reports/cursor-quality-gate-[YYYY-MM-DD]-findings
 | Static Artifact Compliance | [N] | [N] | [N] | FAIL |
 | Cross-Copy Parity | [N] | [N] | [N] | PASS/FAIL |
 | Red-Green Test Coverage | 4 | [N] | [N] | PASS/FAIL |
+| Canonical Semantic-Tag Convention | [N] | [N] | [N] | PASS/FAIL |
 | **OVERALL** | [N] | [N] | [N] | **FAIL** |
 
 ---

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -83,26 +83,66 @@ Read `.claude/skills/quality-gate/agents/scenario-evaluator.md`. Skip the YAML f
 
 ---
 
-## Phase 5: Findings Synthesis
+## Phase 5: Canonical Semantic-Tag Convention Checks
 
-Aggregate all outputs from Phases 1, 2, 3, and 4.
+Read `.claude/skills/quality-gate/references/quality-gate-criteria.md`
+Section `## Canonical Semantic-Tag Convention Checks`.
 
-Read `.claude/skills/quality-gate/references/quality-gate-criteria.md` Section `## Expected Results Checklist`. Cross-reference the category headings in the checklist against the Phase 1–4 results to confirm every category was covered. Note any categories with no corresponding results.
+**Skill targets** — apply to both distributions:
+- Plugin: each file matching `plugins/agents-initializer/skills/**/SKILL.md`
+- Standalone: each file matching `skills/**/SKILL.md`
+
+For each file:
+
+1. Parse the body (everything after the closing `---` of the YAML frontmatter).
+2. Apply checks V1–V9 from the criteria reference using the strictness tiers below.
+3. For any `<RULES>` occurrence, record it as an **informational alias candidate** (not a fail,
+   not a warn — surface it as: "File X uses `<RULES>`; consider renaming to `<HARD_RULES>` on
+   next touch (legacy alias — satisfies the V3 check)").
+
+**Strictness tiers (apply verbatim):**
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| Hard-fail | Any mandatory tag missing; unbalanced open/close tag; malformed attribute syntax (`id=` absent on `<PHASE>`, unquoted attribute value, stray `=`, unterminated quote) | Record as CRITICAL finding; counts toward FAIL |
+| Warn | Non-canonical attribute name (outside `avoid`, `always`, `when`, `name`, `id`, `priority`) | Record as MAJOR warning; does not block PASS |
+| Silent | Absence of optional tag | No finding |
+| Informational | `<RULES>` present (legacy alias) | Surface as alias candidate note; no verdict impact |
+
+**Fixture corpus validation** — after checking the live plugin and standalone files, validate the
+golden corpus at `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`:
+
+- Run each fixture through V1–V9 checks and confirm the verdict matches `MANIFEST.md` there.
+- Any mismatch between observed verdict and MANIFEST verdict is itself a CRITICAL finding.
+
+Collect structured output as `tag_convention_report`, which contains:
+- Per-file check results for each plugin skill body and each standalone skill body
+- Informational `<RULES>` alias candidate list
+- Fixture corpus validation results (pass/mismatch per fixture)
+
+---
+
+## Phase 6: Findings Synthesis
+
+Aggregate all outputs from Phases 1, 2, 3, 4, and 5.
+
+Read `.claude/skills/quality-gate/references/quality-gate-criteria.md` Section `## Expected Results Checklist`. Cross-reference the category headings in the checklist against the Phase 1–5 results to confirm every category was covered. Note any categories with no corresponding results.
 
 Compute and display the **Quality Gate Dashboard**:
 
 ```
 Quality Gate Dashboard — agents-initializer [DATE]
-═══════════════════════════════════════════════════
-Category                    Checks  Passed  Failed  Status
-─────────────────────────────────────────────────────────
-Static Artifact Compliance    [N]     [N]     [N]   [PASS/FAIL]
-Cross-Distribution Parity     [N]     [N]     [N]   [PASS/FAIL]
-Docs Drift                    [N]     [N]     [N]   [PASS/FAIL]
-Red-Green Test Coverage         4     [N]     [N]   [PASS/FAIL]
-─────────────────────────────────────────────────────────
-OVERALL                       [N]     [N]     [N]   [PASS/FAIL]
-═══════════════════════════════════════════════════
+═══════════════════════════════════════════════════════════
+Category                        Checks  Passed  Failed  Status
+──────────────────────────────────────────────────────────
+Static Artifact Compliance        [N]     [N]     [N]   [PASS/FAIL]
+Cross-Distribution Parity         [N]     [N]     [N]   [PASS/FAIL]
+Docs Drift                        [N]     [N]     [N]   [PASS/FAIL]
+Red-Green Test Coverage             4     [N]     [N]   [PASS/FAIL]
+Canonical Semantic-Tag Convention [N]     [N]     [N]   [PASS/FAIL]
+──────────────────────────────────────────────────────────
+OVERALL                           [N]     [N]     [N]   [PASS/FAIL]
+═══════════════════════════════════════════════════════════
 ```
 
 **If all checks pass:**
@@ -110,11 +150,11 @@ OVERALL                       [N]     [N]     [N]   [PASS/FAIL]
 
 **Stop here. Do NOT write any report file to `.specs/reports/`.**
 
-**If any checks fail:** Proceed to Phase 6.
+**If any checks fail:** Proceed to Phase 7.
 
 ---
 
-## Phase 6: Findings Report
+## Phase 7: Findings Report
 
 Generate `.specs/reports/quality-gate-[YYYY-MM-DD]-findings.md`.
 

--- a/.claude/skills/quality-gate/assets/fixtures/MANIFEST.md
+++ b/.claude/skills/quality-gate/assets/fixtures/MANIFEST.md
@@ -1,0 +1,21 @@
+# Fixture Corpus — Skill Body Convention (Skill Variant, Shared)
+
+> **Shared corpus redirect** — the canonical golden fixture files live at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+>
+> The semantic-tag convention body rules are platform-agnostic (per ADR-0007 and
+> `wiki/knowledge/skill-body-convention.md`). Tag vocabulary and strictness tiers
+> are identical for plugin skills (agents-initializer) and standalone skills.
+> One corpus serves all gates; duplicating it would add maintenance overhead
+> without adding coverage.
+>
+> **To run the Canonical Semantic-Tag Convention skill-body check for this gate:**
+> read fixtures from `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+> and use the MANIFEST.md there for the expected verdicts.
+
+This covers `plugins/agents-initializer/skills/**/SKILL.md` and `skills/**/SKILL.md` bodies.
+The expected verdict table is in the shared MANIFEST at the path above.
+
+Note: `quality-gate` checks both the agents-initializer plugin skills and the standalone
+skills distribution. Both use the same mandatory tag vocabulary — `<TRIGGER>`, `<BEHAVIOUR>`,
+`<HARD_RULES>`, `<PROCESS>` with `<PHASE>`. The same fixture corpus exercises both.

--- a/.claude/skills/quality-gate/references/quality-gate-criteria.md
+++ b/.claude/skills/quality-gate/references/quality-gate-criteria.md
@@ -6,8 +6,9 @@ Source: `.claude/rules/plugin-skills.md`, `.claude/rules/standalone-skills.md`, 
 ## Contents
 
 1. [Expected Results Checklist](#expected-results-checklist)
-2. [Severity Classification](#severity-classification)
-3. [Report Template](#report-template)
+2. [Canonical Semantic-Tag Convention Checks](#canonical-semantic-tag-convention-checks)
+3. [Severity Classification](#severity-classification)
+4. [Report Template](#report-template)
 
 ---
 
@@ -92,6 +93,43 @@ Source: `.claude/rules/plugin-skills.md`, `.claude/rules/standalone-skills.md`, 
 
 ---
 
+## Canonical Semantic-Tag Convention Checks
+
+Applies to all SKILL.md bodies under `plugins/agents-initializer/skills/**/SKILL.md` and
+`skills/**/SKILL.md` (standalone distribution).
+Source: `wiki/knowledge/skill-body-convention.md`, `docs/adr/0007-skill-body-semantic-tag-convention.md`
+
+Both plugin skills (agents-initializer) and standalone skills use the same mandatory tag
+vocabulary. There are no subagent flows checked by this gate.
+
+Mandatory tags for skills: `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` (or legacy `<RULES>` alias),
+`<PROCESS>` containing at least one `<PHASE id="N" name="X">`.
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| V1 | `<TRIGGER>` present in body | Hard-fail if absent | CRITICAL |
+| V2 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| V3 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| V4 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| V5 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| V6 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| V7 | All opened tags have a matching closing tag (no unbalanced open/close) | Hard-fail if unbalanced | CRITICAL |
+| V8 | All attribute values are properly quoted (no bare `=`, no unterminated quotes) | Hard-fail if malformed | CRITICAL |
+| V9 | All attribute names belong to the closed set: `avoid`, `always`, `when`, `name`, `id`, `priority` | Warn if non-canonical | MAJOR |
+| V10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+Apply checks V1–V10 to both plugin skill bodies and standalone skill bodies.
+
+### Fixture corpus
+
+The golden fixture corpus for skill-body checks is the shared corpus at:
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+
+See the MANIFEST.md at that path for the 10 fixtures and their expected verdicts.
+A redirect stub lives at `.claude/skills/quality-gate/assets/fixtures/MANIFEST.md`.
+
+---
+
 ## Severity Classification
 
 | Severity | Meaning | Must Fix Before Release? |
@@ -118,6 +156,7 @@ Use this structure for `.specs/reports/quality-gate-[YYYY-MM-DD]-findings.md`:
 | Static Artifact Compliance | [N] | [N] | [N] | FAIL |
 | Cross-Distribution Parity | [N] | [N] | [N] | PASS/FAIL |
 | Red-Green Test Coverage | 4 | [N] | [N] | PASS/FAIL |
+| Canonical Semantic-Tag Convention | [N] | [N] | [N] | PASS/FAIL |
 | **OVERALL** | [N] | [N] | [N] | **FAIL** |
 
 ---


### PR DESCRIPTION
Implements #151. Teaches the four quality-gate skills under .claude/skills/ to assert the canonical semantic-tag convention against plugin and standalone targets — content-only updates, gate bodies stay plain markdown per Convention scope v1. Ships one shared golden fixture corpus (skill + subagent variants) hosted by agent-customizer-quality-gate, with redirect references from the other three gates. No version bumps (deferred to #152).