### PR TITLE
Marketplace version cascade (final atomic commit)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-engineering-toolkit",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Multi-plugin marketplace for evidence-based Claude Code artifact engineering. Provides plugins for configuration initialization (AGENTS.md, CLAUDE.md), artifact creation/optimization (skills, hooks, rules, subagents), and autonomous backlog orchestration.",
   "owner": {
     "name": "rodrigorjsf",
@@ -11,7 +11,7 @@
     {
       "name": "agents-initializer",
       "description": "Generate and optimize minimal, scoped AGENTS.md and CLAUDE.md configuration files based on academic research and Anthropic best practices. Uses subagent-driven analysis for context-efficient file generation.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"
@@ -22,7 +22,7 @@
     {
       "name": "agent-customizer",
       "description": "Create and improve Claude Code artifacts (skills, hooks, rules, subagents) with documentation-grounded guidance and evidence traceability.",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"

--- a/plugins/agent-customizer/.claude-plugin/plugin.json
+++ b/plugins/agent-customizer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-customizer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Create and improve Claude Code artifacts (skills, hooks, rules, subagents) with documentation-grounded guidance and evidence traceability.",
   "author": {
     "name": "rodrigorjsf"

--- a/plugins/agents-initializer/.claude-plugin/plugin.json
+++ b/plugins/agents-initializer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-initializer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Evidence-based AGENTS.md and CLAUDE.md initializer and optimizer. Generates minimal, scoped configuration files following progressive disclosure principles — based on the ETH Zurich 'Evaluating AGENTS.md' study and Anthropic's context engineering best practices.",
   "author": {
     "name": "rodrigorjsf"


### PR DESCRIPTION
Implements #152. Final slice of PRD #143: semver-minor version cascade across the manifests touched by the convention rollout — agent-customizer 0.2.0 to 0.3.0, agents-initializer 1.0.1 to 1.1.0, root Claude marketplace 1.3.1 to 1.4.0 (with matching plugin-entry bumps). Cursor marketplace unchanged (no entry-shape change); standalone has no package.json to bump.