### PR TITLE
orchestrate run 20260521-201015 — PRD #143 skill body semantic-tag convention

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-engineering-toolkit",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Multi-plugin marketplace for evidence-based Claude Code artifact engineering. Provides plugins for configuration initialization (AGENTS.md, CLAUDE.md), artifact creation/optimization (skills, hooks, rules, subagents), and autonomous backlog orchestration.",
   "owner": {
     "name": "rodrigorjsf",
@@ -11,7 +11,7 @@
     {
       "name": "agents-initializer",
       "description": "Generate and optimize minimal, scoped AGENTS.md and CLAUDE.md configuration files based on academic research and Anthropic best practices. Uses subagent-driven analysis for context-efficient file generation.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"
@@ -22,7 +22,7 @@
     {
       "name": "agent-customizer",
       "description": "Create and improve Claude Code artifacts (skills, hooks, rules, subagents) with documentation-grounded guidance and evidence traceability.",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"

--- a/.claude/rules/cursor-plugin-skills.md
+++ b/.claude/rules/cursor-plugin-skills.md
@@ -22,6 +22,12 @@ paths:
 - SKILL.md `name` field: ≤64 chars, lowercase letters/numbers/hyphens only, no XML tags
 - SKILL.md `description` field: non-empty, ≤1024 chars, third person, no XML tags
 - SKILL.md body: under 500 lines
+- SKILL.md body MUST carry the canonical semantic-tag vocabulary: mandatory `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`; optional `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>` (see `wiki/knowledge/skill-body-convention.md`)
+- Semantic tags use the closed attribute set only — `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`; `id=` is mandatory on every `<PHASE>`; non-canonical attribute names are a warn-tier finding, not a hard fail
+- The legacy `<RULES>` tag is an alias of `<HARD_RULES>` — it satisfies the mandatory `<HARD_RULES>` check; migrate each occurrence to `<HARD_RULES>` on next touch, no scheduled mass rename
+- Meta-skills that generate human-rich AND agent-executable artifacts (plans, PRDs, design specs, reports, prototypes) default to HTML output carrying the same canonical tags; Markdown stays mandatory for agent-loaded and tooling-locked files (`SKILL.md`, subagent `.md`, `AGENTS.md`, rules files, `README.md`, commit/PR/issue bodies); explicit user override always wins (see `wiki/knowledge/skill-body-convention.md`)
+- Self-validation loops apply three strictness tiers: hard-fail on a missing mandatory tag, unbalanced open/close tags, or malformed attribute syntax; warn on non-canonical attribute names; stay silent on absent optional tags (see `wiki/knowledge/skill-body-convention.md`)
+- YAML frontmatter stays untouched by the semantic-tag convention — Cursor's official spec governs it; the `<TRIGGER>` cue lives in the body, never duplicated into frontmatter
 - In `cursor-initializer`: `rule-domain-detector` agent walks a four-tier heuristic (tooling-non-obvious → file-pattern → monorepo-scope → on-demand cross-cutting / domain); empty list is the canonical passing output for trivial single-package projects
 - In `cursor-initializer`: `file-evaluator` agent has dual responsibility — per-rule `.mdc` quality assessment, and (when AGENTS.md is present) block-by-block classification of AGENTS.md content by destination activation mode
 - `validation-criteria.md` intentionally diverges between `init-cursor` and `improve-cursor` — `improve-cursor` adds preservation, calibration, and migration-sub-flow-schema rules; these files are NOT a parity family

--- a/.claude/rules/plugin-skills.md
+++ b/.claude/rules/plugin-skills.md
@@ -20,3 +20,8 @@ paths:
 - SKILL.md `name` field: ≤64 chars, lowercase letters/numbers/hyphens only, no XML tags
 - SKILL.md `description` field: non-empty, ≤1024 chars, third person, no XML tags
 - SKILL.md body: under 500 lines
+- SKILL.md body MUST carry the canonical semantic-tag vocabulary: mandatory `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`; optional `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>` (see `wiki/knowledge/skill-body-convention.md`)
+- Semantic tags use the closed attribute set only — `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`; `id=` is mandatory on every `<PHASE>`; non-canonical attribute names are a warn-tier finding, not a hard fail
+- The legacy `<RULES>` tag is an alias of `<HARD_RULES>` — it satisfies the mandatory `<HARD_RULES>` check; migrate each occurrence to `<HARD_RULES>` on next touch, no scheduled mass rename
+- Self-validation loops apply three strictness tiers: hard-fail on a missing mandatory tag, unbalanced open/close tags, or malformed attribute syntax; warn on non-canonical attribute names; stay silent on absent optional tags (see `wiki/knowledge/skill-body-convention.md`)
+- YAML frontmatter stays untouched by the semantic-tag convention — each platform's official spec governs it; the `<TRIGGER>` cue lives in the body, never duplicated into frontmatter

--- a/.claude/rules/reference-files.md
+++ b/.claude/rules/reference-files.md
@@ -2,7 +2,9 @@
 paths:
   - "plugins/agents-initializer/skills/*/references/*.md"
   - "plugins/cursor-initializer/skills/*/references/*.md"
+  - "plugins/cursor-customizer/skills/*/references/*.md"
   - "plugins/agent-customizer/skills/*/references/*.md"
+  - "plugins/orchestrate/skills/*/references/*.md"
   - "skills/*/references/*.md"
 ---
 # Reference File Conventions
@@ -10,7 +12,7 @@ paths:
 - Files over 100 lines MUST include a `## Contents` table of contents after the title block
 - Maximum 200 lines per reference file
 - Content must be framed as "read as instructions" — not as executable scripts
-- Each file must have a clear source attribution (e.g., `Source: docs/research-*.md`)
+- Reference files MUST be self-contained — no `Source:` attribution lines, and no inline citations (file paths, line ranges, or external document names) pointing to documents outside the skill's own bundle; a reference file may only mention sibling files inside its own skill directory
 - Identical-content parity applies only to explicitly shared references and same-platform copies
 - Platform-specific references may reuse filenames when their content is intentionally platform-native
 - No nested references — reference files must not import or reference other reference files

--- a/.claude/rules/standalone-skills.md
+++ b/.claude/rules/standalone-skills.md
@@ -24,3 +24,49 @@ paths:
 - SKILL.md `name` field: ≤64 chars, lowercase letters/numbers/hyphens only, no XML tags
 - SKILL.md `description` field: non-empty, ≤1024 chars, third person, no XML tags
 - SKILL.md body: under 500 lines
+
+## Canonical Tag Vocabulary (skills/**/SKILL.md)
+
+Every `SKILL.md` body (post-frontmatter) under `skills/**` MUST wrap its logical blocks in the canonical semantic-tag vocabulary:
+
+**Mandatory tags** — hard-fail if any are missing:
+- `<TRIGGER when="...">` or `<TRIGGER when="..." />` — plain-language activation cue; required for skills
+- `<BEHAVIOUR avoid="..." always="...">` — behavioural guidelines, mindset, posture
+- `<HARD_RULES priority="hard">` — inviolable constraints (NEVER / EVERY / ALWAYS); legacy `<RULES>` is an accepted alias (no migration required until next touch)
+- `<PROCESS>` containing at least one `<PHASE id="N" name="X">` — ordered execution phases; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** — absence is never a finding:
+`<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Non-canonical attribute names produce a *warn* finding (typo guard); they do not hard-fail.
+
+**Validation strictness tiers** (deterministic — apply verbatim):
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| Hard-fail | Any mandatory tag missing | Fix before proceeding |
+| Hard-fail | Unbalanced tags (open without close, or close without open) | Fix before proceeding |
+| Hard-fail | Malformed attribute syntax (missing quotes, stray `=`, unterminated quote) | Fix before proceeding |
+| Warn | Non-canonical attribute name outside the closed set | Surface warning; do not block |
+| Silent | Absence of any optional tag | No finding |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing `id=` is a hard-fail.
+
+## Artifact Format Routing (skills/**/SKILL.md)
+
+When a standalone skill generates an output artifact, the default format is:
+
+- **HTML** for human-rich agent-executable artifacts: plans, PRDs, design specs, reports, prototypes, code-review writeups, custom editors
+- **Markdown** (mandatory) for: `SKILL.md`, `AGENTS.md`, `README.md`, `CONTEXT.md`, ADR files, commit messages, PR bodies, GitHub issues, code comments
+
+Explicit user override (`generate as markdown`) always wins over the default.
+
+Standalone skills that generate HTML artifacts MUST ship a baseline HTML skeleton under `assets/templates/` and carry the canonical semantic-tag scaffold (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`) inside the HTML `<body>`.
+
+## Validation Strictness
+
+Meta-skill self-validation loops MUST:
+1. Check all mandatory canonical tags are present and balanced
+2. Hard-fail on missing mandatory tags, unbalanced tags, or malformed attribute syntax
+3. Warn (do not block) on non-canonical attribute names
+4. Run at most 3 iterations before surfacing remaining failures to the user

--- a/.claude/skills/agent-customizer-quality-gate/SKILL.md
+++ b/.claude/skills/agent-customizer-quality-gate/SKILL.md
@@ -85,15 +85,60 @@ combine the evaluator instructions with this appended instruction:
 
 ---
 
-## Phase 5: Findings Synthesis
+## Phase 5: Canonical Semantic-Tag Convention Checks
 
-Aggregate all outputs from Phases 1–4.
+Read `.claude/skills/agent-customizer-quality-gate/references/quality-gate-criteria.md`
+Section `## Canonical Semantic-Tag Convention Checks`.
+
+**Skill targets** — for each file matching `plugins/agent-customizer/skills/**/SKILL.md`:
+
+1. Parse the body (everything after the closing `---` of the YAML frontmatter).
+2. Apply checks V1–V9 from the criteria reference using the strictness tiers below.
+3. For any `<RULES>` occurrence, record it as an **informational alias candidate** (not a fail,
+   not a warn — surface it in the summary as: "File X uses `<RULES>`; consider renaming to
+   `<HARD_RULES>` on next touch (legacy alias — satisfies the V3 check)").
+
+**Subagent targets** — for each file matching `plugins/agent-customizer/agents/**/*.md`:
+
+1. Parse the body after the YAML frontmatter.
+2. Apply checks VA1–VA8. `<TRIGGER>` absence is **silent** — do not record it as a finding.
+3. For any `<RULES>` occurrence, record as informational (same rule as above).
+
+**Strictness tiers (apply verbatim):**
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| Hard-fail | Any mandatory tag missing; unbalanced open/close tag; malformed attribute syntax (`id=` absent on `<PHASE>`, unquoted attribute value, stray `=`, unterminated quote) | Record as CRITICAL finding; counts toward FAIL |
+| Warn | Non-canonical attribute name (outside `avoid`, `always`, `when`, `name`, `id`, `priority`) | Record as MAJOR warning; does not block PASS |
+| Silent | Absence of optional tag; `<TRIGGER>` absent in subagent body | No finding |
+| Informational | `<RULES>` present (legacy alias) | Surface as alias candidate note; no verdict impact |
+
+**Fixture corpus validation** — after checking the live plugin files, validate the gate's own
+fixture corpus at `.claude/skills/agent-customizer-quality-gate/assets/fixtures/`:
+
+- Run each `skill/*.md` fixture through V1–V9 checks and confirm the verdict matches
+  `skill/MANIFEST.md`.
+- Run each `subagent/*.md` fixture through VA1–VA8 checks and confirm the verdict matches
+  `subagent/MANIFEST.md`.
+- Any mismatch between observed verdict and MANIFEST verdict is itself a CRITICAL finding
+  (the strictness-tier text is ambiguous).
+
+Collect structured output as `tag_convention_report`, which contains:
+- Per-file check results for each skill and subagent body
+- Informational `<RULES>` alias candidate list
+- Fixture corpus validation results (pass/mismatch per fixture)
+
+---
+
+## Phase 6: Findings Synthesis
+
+Aggregate all outputs from Phases 1–5.
 
 Read `.claude/skills/agent-customizer-quality-gate/references/quality-gate-criteria.md`
 Sections `## Plugin SKILL.md Checks`, `## Agent File Checks`, `## Reference File Checks`,
-`## Shared-Copy Parity Checks`, `## Docs Drift Checks`, `## Scenario Checks`, and
-`## Plugin Manifest Checks`. Cross-reference those category headings against Phase 1–4
-results to confirm full coverage.
+`## Shared-Copy Parity Checks`, `## Docs Drift Checks`, `## Scenario Checks`,
+`## Plugin Manifest Checks`, and `## Canonical Semantic-Tag Convention Checks`.
+Cross-reference those category headings against Phase 1–5 results to confirm full coverage.
 
 Compute and display the **Quality Gate Dashboard**:
 
@@ -107,6 +152,7 @@ Intra-Plugin Parity                  14    [N]     [N]   [PASS/FAIL]
 Docs Drift                          [N]    [N]     [N]   [PASS/FAIL]
 Red-Green Scenario Coverage          16    [N]     [N]   [PASS/FAIL]
 Plugin Manifest                       3    [N]     [N]   [PASS/FAIL]
+Canonical Semantic-Tag Convention   [N]    [N]     [N]   [PASS/FAIL]
 ─────────────────────────────────────────────────────────────
 OVERALL                             [N]    [N]     [N]   [PASS/FAIL]
 ═══════════════════════════════════════════════════════════

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/MANIFEST.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/MANIFEST.md
@@ -1,0 +1,27 @@
+# Fixture Corpus — Skill Body Convention (Skill Variant)
+
+Regression corpus for the canonical semantic-tag strictness tiers defined in
+`wiki/knowledge/skill-body-convention.md`. Each fixture is a minimal SKILL.md
+body that exercises exactly one validation outcome for **skill** targets.
+
+This corpus covers `plugins/agent-customizer/skills/**/SKILL.md` bodies.
+
+To use: run the Canonical Semantic-Tag Convention check against each fixture
+file and confirm the produced verdict matches the **Expected verdict** column
+below. Any mismatch means the strictness-tier text is ambiguous and must be
+tightened — the corpus is the regression test for that clarity.
+
+These fixtures are test data only. They are not loaded by any gate at runtime.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes only | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** — missing mandatory tag |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** — missing mandatory tag |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** — missing mandatory tag |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** — missing mandatory tag |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** — missing mandatory tag |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** — unbalanced tags |
+| `malformed-attribute.md` | `<PHASE>` `name` value missing its quotes | **hard-fail** — malformed attribute syntax |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a non-canonical `mood=` attribute | **warn** — non-canonical attribute name; passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** — alias satisfies the `<HARD_RULES>` check; additionally reported as an informational `<HARD_RULES>` alias candidate (not a violation) |

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/compliant-baseline.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/compliant-baseline.md
@@ -1,0 +1,39 @@
+---
+name: fixture-compliant-baseline
+description: "Fixture skill exercising the compliant baseline. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. All mandatory tags present, balanced, canonical attributes only. -->
+
+# Fixture Compliant Baseline
+
+One-sentence purpose statement for the baseline fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION>
+Read the validation criteria and loop until all checks pass.
+</VALIDATION>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/malformed-attribute.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/malformed-attribute.md
@@ -1,0 +1,35 @@
+---
+name: fixture-malformed-attribute
+description: "Fixture skill with a malformed PHASE attribute. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The <PHASE> name attribute value is missing its quotes. -->
+
+# Fixture Malformed Attribute
+
+One-sentence purpose statement for the malformed-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name=analysis>
+  DEFECT: the name attribute value above is unquoted — malformed attribute syntax.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-behaviour.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-behaviour.md
@@ -1,0 +1,28 @@
+---
+name: fixture-missing-behaviour
+description: "Fixture skill with the mandatory BEHAVIOUR tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <BEHAVIOUR> tag is absent. -->
+
+# Fixture Missing Behaviour
+
+One-sentence purpose statement for the missing-behaviour fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-hard-rules.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-hard-rules.md
@@ -1,0 +1,30 @@
+---
+name: fixture-missing-hard-rules
+description: "Fixture skill with the mandatory HARD_RULES tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. Both <HARD_RULES> and its <RULES> alias are absent. -->
+
+# Fixture Missing Hard Rules
+
+One-sentence purpose statement for the missing-hard-rules fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-phase.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-phase.md
@@ -1,0 +1,27 @@
+---
+name: fixture-missing-phase
+description: "Fixture skill whose PROCESS contains zero PHASE elements. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is present but contains zero <PHASE> elements. -->
+
+# Fixture Missing Phase
+
+One-sentence purpose statement for the missing-phase fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+The process container holds no phases — this is the defect under test.
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-process.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-process.md
@@ -1,0 +1,23 @@
+---
+name: fixture-missing-process
+description: "Fixture skill with the mandatory PROCESS tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <PROCESS> tag is absent. -->
+
+# Fixture Missing Process
+
+One-sentence purpose statement for the missing-process fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-trigger.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-trigger.md
@@ -1,0 +1,33 @@
+---
+name: fixture-missing-trigger
+description: "Fixture skill with the mandatory TRIGGER tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <TRIGGER> tag is absent. -->
+
+# Fixture Missing Trigger
+
+One-sentence purpose statement for the missing-trigger fixture.
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/non-canonical-attribute.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/non-canonical-attribute.md
@@ -1,0 +1,36 @@
+---
+name: fixture-non-canonical-attribute
+description: "Fixture skill with a non-canonical attribute name. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: warn. <BEHAVIOUR> carries a non-canonical `mood=` attribute; all mandatory tags are present and balanced, so it passes otherwise. -->
+
+# Fixture Non-Canonical Attribute
+
+One-sentence purpose statement for the non-canonical-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical"
+  mood="optimistic">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/rules-alias.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/rules-alias.md
@@ -1,0 +1,35 @@
+---
+name: fixture-rules-alias
+description: "Fixture skill using the legacy RULES alias instead of HARD_RULES. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. Uses the legacy <RULES> tag, which is an accepted alias of <HARD_RULES>; all else compliant. The gate additionally reports this as an informational <HARD_RULES> alias candidate — not a violation. -->
+
+# Fixture Rules Alias
+
+One-sentence purpose statement for the rules-alias fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<RULES>
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/unbalanced-tag.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/unbalanced-tag.md
@@ -1,0 +1,35 @@
+---
+name: fixture-unbalanced-tag
+description: "Fixture skill with an unbalanced PROCESS tag. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is opened but never closed. -->
+
+# Fixture Unbalanced Tag
+
+One-sentence purpose statement for the unbalanced-tag fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+<!-- DEFECT: the <PROCESS> opening tag above has no matching </PROCESS> closing tag. -->

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/MANIFEST.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/MANIFEST.md
@@ -1,0 +1,34 @@
+# Fixture Corpus — Skill Body Convention (Subagent Variant)
+
+Regression corpus for the canonical semantic-tag strictness tiers defined in
+`wiki/knowledge/skill-body-convention.md`. Each fixture is a minimal subagent
+definition body that exercises exactly one validation outcome for **subagent**
+targets.
+
+This corpus covers `plugins/agent-customizer/agents/**/*.md` bodies.
+
+The subagent variant differs from the skill variant in one critical respect:
+`<TRIGGER>` is **optional** for subagents (they are spawned by skills, not
+user-invoked). Its absence is silent — never a finding. All other mandatory
+tags (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`) are hard-fail
+when absent, same as for skills.
+
+To use: run the Canonical Semantic-Tag Convention check against each fixture
+file and confirm the produced verdict matches the **Expected verdict** column
+below. Any mismatch means the strictness-tier text is ambiguous and must be
+tightened — the corpus is the regression test for that clarity.
+
+These fixtures are test data only. They are not loaded by any gate at runtime.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-with-trigger.md` | None — all mandatory tags present, `<TRIGGER>` also present, balanced, canonical attributes only | **pass** |
+| `compliant-without-trigger.md` | `<TRIGGER>` absent (subagent variant — optional) | **pass** — `<TRIGGER>` absence is silent for subagents |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** — missing mandatory tag |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** — missing mandatory tag |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** — missing mandatory tag |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** — missing mandatory tag |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** — unbalanced tags |
+| `malformed-attribute.md` | `<PHASE>` `name` value missing its quotes | **hard-fail** — malformed attribute syntax |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a non-canonical `mood=` attribute | **warn** — non-canonical attribute name; passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** — alias satisfies the `<HARD_RULES>` check; additionally reported as an informational `<HARD_RULES>` alias candidate (not a violation) |

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/compliant-with-trigger.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/compliant-with-trigger.md
@@ -1,0 +1,42 @@
+---
+name: fixture-compliant-with-trigger
+description: "Fixture subagent exercising the compliant baseline with TRIGGER present. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. All mandatory tags present, <TRIGGER> also present, balanced, canonical attributes only. -->
+
+# Fixture Compliant With Trigger
+
+One-sentence identity statement for the compliant-with-trigger fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>
+
+<OUTPUT>
+Return findings as a structured list with file paths and descriptions.
+</OUTPUT>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/compliant-without-trigger.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/compliant-without-trigger.md
@@ -1,0 +1,40 @@
+---
+name: fixture-compliant-without-trigger
+description: "Fixture subagent exercising the compliant baseline with TRIGGER absent. Use when validating the subagent-specific TRIGGER-optional variant."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. <TRIGGER> is absent — for subagents this is SILENT (not a hard-fail). All other mandatory tags are present, balanced, and use canonical attributes only. -->
+
+# Fixture Compliant Without Trigger
+
+One-sentence identity statement for the compliant-without-trigger fixture.
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>
+
+<OUTPUT>
+Return findings as a structured list with file paths and descriptions.
+</OUTPUT>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/malformed-attribute.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/malformed-attribute.md
@@ -1,0 +1,38 @@
+---
+name: fixture-malformed-attribute
+description: "Fixture subagent with a malformed PHASE attribute. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The <PHASE> name attribute value is missing its quotes. -->
+
+# Fixture Malformed Attribute
+
+One-sentence identity statement for the malformed-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name=analysis>
+  DEFECT: the name attribute value above is unquoted — malformed attribute syntax.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-behaviour.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-behaviour.md
@@ -1,0 +1,31 @@
+---
+name: fixture-missing-behaviour
+description: "Fixture subagent with the mandatory BEHAVIOUR tag absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <BEHAVIOUR> tag is absent. -->
+
+# Fixture Missing Behaviour
+
+One-sentence identity statement for the missing-behaviour fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-hard-rules.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-hard-rules.md
@@ -1,0 +1,33 @@
+---
+name: fixture-missing-hard-rules
+description: "Fixture subagent with the mandatory HARD_RULES tag absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. Both <HARD_RULES> and its <RULES> alias are absent. -->
+
+# Fixture Missing Hard Rules
+
+One-sentence identity statement for the missing-hard-rules fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-phase.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-phase.md
@@ -1,0 +1,30 @@
+---
+name: fixture-missing-phase
+description: "Fixture subagent whose PROCESS contains zero PHASE elements. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is present but contains zero <PHASE> elements. -->
+
+# Fixture Missing Phase
+
+One-sentence identity statement for the missing-phase fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+The process container holds no phases — this is the defect under test.
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-process.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/missing-process.md
@@ -1,0 +1,26 @@
+---
+name: fixture-missing-process
+description: "Fixture subagent with the mandatory PROCESS tag absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <PROCESS> tag is absent. -->
+
+# Fixture Missing Process
+
+One-sentence identity statement for the missing-process fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/non-canonical-attribute.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/non-canonical-attribute.md
@@ -1,0 +1,39 @@
+---
+name: fixture-non-canonical-attribute
+description: "Fixture subagent with a non-canonical attribute name. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: warn. <BEHAVIOUR> carries a non-canonical `mood=` attribute; all mandatory tags are present and balanced, so it passes otherwise. -->
+
+# Fixture Non-Canonical Attribute
+
+One-sentence identity statement for the non-canonical-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format"
+  mood="optimistic">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/rules-alias.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/rules-alias.md
@@ -1,0 +1,38 @@
+---
+name: fixture-rules-alias
+description: "Fixture subagent using the legacy RULES alias instead of HARD_RULES. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. Uses the legacy <RULES> tag, which is an accepted alias of <HARD_RULES>; all else compliant. The gate additionally reports this as an informational <HARD_RULES> alias candidate — not a violation. -->
+
+# Fixture Rules Alias
+
+One-sentence identity statement for the rules-alias fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<RULES>
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/unbalanced-tag.md
+++ b/.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/unbalanced-tag.md
@@ -1,0 +1,38 @@
+---
+name: fixture-unbalanced-tag
+description: "Fixture subagent with an unbalanced PROCESS tag. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is opened but never closed. -->
+
+# Fixture Unbalanced Tag
+
+One-sentence identity statement for the unbalanced-tag fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+<!-- DEFECT: the <PROCESS> opening tag above has no matching </PROCESS> closing tag. -->

--- a/.claude/skills/agent-customizer-quality-gate/references/quality-gate-criteria.md
+++ b/.claude/skills/agent-customizer-quality-gate/references/quality-gate-criteria.md
@@ -15,8 +15,9 @@ Source: `.claude/rules/plugin-skills.md`, `.claude/rules/reference-files.md`,
 6. [Docs Drift Checks](#docs-drift-checks)
 7. [Red-Green Scenario Checks](#red-green-scenario-checks)
 8. [Plugin Manifest Checks](#plugin-manifest-checks)
-9. [Severity Classification](#severity-classification)
-10. [Report Template](#report-template)
+9. [Canonical Semantic-Tag Convention Checks](#canonical-semantic-tag-convention-checks)
+10. [Severity Classification](#severity-classification)
+11. [Report Template](#report-template)
 
 ---
 
@@ -145,6 +146,62 @@ Applies to `plugins/agent-customizer/.claude-plugin/plugin.json`
 
 ---
 
+## Canonical Semantic-Tag Convention Checks
+
+Applies to all SKILL.md bodies under `plugins/agent-customizer/skills/**/SKILL.md` and all
+subagent bodies under `plugins/agent-customizer/agents/**/*.md`.
+Source: `wiki/knowledge/skill-body-convention.md`, `docs/adr/0007-skill-body-semantic-tag-convention.md`
+
+### Skill targets (`plugins/agent-customizer/skills/**/SKILL.md`)
+
+Mandatory tags: `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` (or legacy `<RULES>` alias), `<PROCESS>`
+containing at least one `<PHASE id="N" name="X">`.
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| V1 | `<TRIGGER>` present in body | Hard-fail if absent | CRITICAL |
+| V2 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| V3 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| V4 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| V5 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| V6 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| V7 | All opened tags have a matching closing tag (no unbalanced open/close) | Hard-fail if unbalanced | CRITICAL |
+| V8 | All attribute values are properly quoted (no bare `=`, no unterminated quotes) | Hard-fail if malformed | CRITICAL |
+| V9 | All attribute names belong to the closed set: `avoid`, `always`, `when`, `name`, `id`, `priority` | Warn if non-canonical | MAJOR |
+| V10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+### Subagent targets (`plugins/agent-customizer/agents/**/*.md`)
+
+Mandatory tags: `<BEHAVIOUR>`, `<HARD_RULES>` (or `<RULES>` alias), `<PROCESS>` with at least one
+`<PHASE id="N" name="X">`. `<TRIGGER>` is OPTIONAL for subagents — its absence is SILENT (never a
+finding).
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| VA1 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| VA2 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| VA3 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| VA4 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| VA5 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| VA6 | All opened tags have a matching closing tag | Hard-fail if unbalanced | CRITICAL |
+| VA7 | All attribute values properly quoted | Hard-fail if malformed | CRITICAL |
+| VA8 | All attribute names in closed set | Warn if non-canonical | MAJOR |
+| VA9 | `<TRIGGER>` absence | Silent — no finding | — |
+| VA10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+### Fixture corpus
+
+The golden fixture corpus for these checks lives under
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/`.
+
+- `skill/` — 10 fixtures for skill-body validation (see `skill/MANIFEST.md`)
+- `subagent/` — 10 fixtures for subagent-body validation (see `subagent/MANIFEST.md`)
+
+Running the checks above against the corpus MUST produce the verdict documented in each MANIFEST.
+Any mismatch means the strictness-tier text above is ambiguous and must be tightened.
+
+---
+
 ## Severity Classification
 
 | Severity | Meaning | Must Fix Before Release? |
@@ -173,6 +230,7 @@ Use this structure for `.specs/reports/agent-customizer-quality-gate-[YYYY-MM-DD
 | Docs Drift | [N] | [N] | [N] | PASS/FAIL |
 | Red-Green Scenario Coverage | 16 | [N] | [N] | PASS/FAIL |
 | Plugin Manifest | 3 | [N] | [N] | PASS/FAIL |
+| Canonical Semantic-Tag Convention | [N] | [N] | [N] | PASS/FAIL |
 | **OVERALL** | [N] | [N] | [N] | **FAIL** |
 
 ## Findings

--- a/.claude/skills/cursor-customizer-quality-gate/SKILL.md
+++ b/.claude/skills/cursor-customizer-quality-gate/SKILL.md
@@ -98,15 +98,63 @@ appended instruction:
 
 ---
 
-## Phase 5: Findings Synthesis
+## Phase 5: Canonical Semantic-Tag Convention Checks
 
-Aggregate all outputs from Phases 1–4.
+Read `.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md`
+Section `## Canonical Semantic-Tag Convention Checks`.
+
+**Skill targets** — for each file matching `plugins/cursor-customizer/skills/**/SKILL.md`:
+
+1. Parse the body (everything after the closing `---` of the YAML frontmatter).
+2. Apply checks V1–V9 from the criteria reference using the strictness tiers below.
+3. For any `<RULES>` occurrence, record it as an **informational alias candidate** (not a fail,
+   not a warn — surface it as: "File X uses `<RULES>`; consider renaming to `<HARD_RULES>` on
+   next touch (legacy alias — satisfies the V3 check)").
+
+**Subagent targets** — for each file matching `plugins/cursor-customizer/agents/**/*.md`:
+
+1. Parse the body after the YAML frontmatter.
+2. Apply checks VA1–VA8. `<TRIGGER>` absence is **silent** — do not record it as a finding.
+3. For any `<RULES>` occurrence, record as informational (same rule as above).
+
+Note: Cursor subagents use `model: inherit` and `readonly: true` frontmatter. The body convention
+(semantic tags) is platform-agnostic — the same strictness tiers apply regardless of frontmatter.
+
+**Strictness tiers (apply verbatim):**
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| Hard-fail | Any mandatory tag missing; unbalanced open/close tag; malformed attribute syntax (`id=` absent on `<PHASE>`, unquoted attribute value, stray `=`, unterminated quote) | Record as CRITICAL finding; counts toward FAIL |
+| Warn | Non-canonical attribute name (outside `avoid`, `always`, `when`, `name`, `id`, `priority`) | Record as MAJOR warning; does not block PASS |
+| Silent | Absence of optional tag; `<TRIGGER>` absent in subagent body | No finding |
+| Informational | `<RULES>` present (legacy alias) | Surface as alias candidate note; no verdict impact |
+
+**Fixture corpus validation** — after checking the live plugin files, validate the golden corpus at
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/`:
+
+- Run each `skill/*.md` fixture through V1–V9 checks and confirm the verdict matches
+  `skill/MANIFEST.md`.
+- Run each `subagent/*.md` fixture through VA1–VA8 checks and confirm the verdict matches
+  `subagent/MANIFEST.md`.
+- Any mismatch between observed verdict and MANIFEST verdict is itself a CRITICAL finding.
+
+Collect structured output as `tag_convention_report`, which contains:
+- Per-file check results for each skill and subagent body
+- Informational `<RULES>` alias candidate list
+- Fixture corpus validation results (pass/mismatch per fixture)
+
+---
+
+## Phase 6: Findings Synthesis
+
+Aggregate all outputs from Phases 1–5.
 
 Read `.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md` Sections
 `## Plugin SKILL.md Checks`, `## Cursor Subagent Checks`, `## Reference File Checks`,
 `## Template File Checks`, `## Intra-Plugin Parity Checks`, `## Docs Drift Checks`,
-`## Red-Green Scenario Checks`, `## Plugin Manifest Checks`, and
-`## Known-Accepted Exceptions`. Cross-reference those category headings against Phase 1–4 results
+`## Red-Green Scenario Checks`, `## Plugin Manifest Checks`,
+`## Canonical Semantic-Tag Convention Checks`, and
+`## Known-Accepted Exceptions`. Cross-reference those category headings against Phase 1–5 results
 to confirm full coverage. Apply the documented known-accepted exceptions before classifying
 findings — those exceptions must NOT appear as violations in the final report.
 
@@ -122,6 +170,7 @@ Intra-Plugin Parity                  19    [N]     [N]   [PASS/FAIL]
 Docs Drift                          [N]    [N]     [N]   [PASS/FAIL]
 Red-Green Scenario Coverage          16    [N]     [N]   [PASS/FAIL]
 Plugin Manifest                       3    [N]     [N]   [PASS/FAIL]
+Canonical Semantic-Tag Convention   [N]    [N]     [N]   [PASS/FAIL]
 ─────────────────────────────────────────────────────────────
 OVERALL                             [N]    [N]     [N]   [PASS/FAIL]
 ═══════════════════════════════════════════════════════════

--- a/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/MANIFEST.md
+++ b/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/MANIFEST.md
@@ -1,0 +1,17 @@
+# Fixture Corpus — Skill Body Convention (Skill Variant, Shared)
+
+> **Shared corpus redirect** — the canonical golden fixture files live at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+>
+> The semantic-tag convention body rules are platform-agnostic (per ADR-0007 and
+> `wiki/knowledge/skill-body-convention.md`). Tag vocabulary and strictness tiers
+> are identical for Claude Code skills, Cursor skills, and standalone skills.
+> One corpus serves all gates; duplicating it would add maintenance overhead
+> without adding coverage.
+>
+> **To run the Canonical Semantic-Tag Convention skill-body check for this gate:**
+> read fixtures from `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+> and use the MANIFEST.md there for the expected verdicts.
+
+This covers `plugins/cursor-customizer/skills/**/SKILL.md` bodies.
+The expected verdict table is in the shared MANIFEST at the path above.

--- a/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/compliant-baseline.md
+++ b/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/compliant-baseline.md
@@ -1,0 +1,3 @@
+> **Shared corpus stub** — use the canonical file at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/compliant-baseline.md`
+> The semantic-tag body convention is platform-agnostic; fixtures are not duplicated per gate.

--- a/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/missing-behaviour.md
+++ b/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/missing-behaviour.md
@@ -1,0 +1,3 @@
+> **Shared corpus stub** — use the canonical file at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-behaviour.md`
+> The semantic-tag body convention is platform-agnostic; fixtures are not duplicated per gate.

--- a/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/missing-trigger.md
+++ b/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/skill/missing-trigger.md
@@ -1,0 +1,3 @@
+> **Shared corpus stub** — use the canonical file at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/missing-trigger.md`
+> The semantic-tag body convention is platform-agnostic; fixtures are not duplicated per gate.

--- a/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/subagent/MANIFEST.md
+++ b/.claude/skills/cursor-customizer-quality-gate/assets/fixtures/subagent/MANIFEST.md
@@ -1,0 +1,21 @@
+# Fixture Corpus — Skill Body Convention (Subagent Variant, Shared)
+
+> **Shared corpus redirect** — the canonical golden fixture files live at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/`
+>
+> The semantic-tag convention body rules are platform-agnostic (per ADR-0007 and
+> `wiki/knowledge/skill-body-convention.md`). Tag vocabulary and strictness tiers
+> are identical for Claude Code subagents and Cursor subagents — only the YAML
+> frontmatter differs by platform. Since the check targets only the body (post-
+> frontmatter content), the same fixtures serve both platforms.
+>
+> **To run the Canonical Semantic-Tag Convention subagent-body check for this gate:**
+> read fixtures from `.claude/skills/agent-customizer-quality-gate/assets/fixtures/subagent/`
+> and use the MANIFEST.md there for the expected verdicts.
+
+This covers `plugins/cursor-customizer/agents/**/*.md` bodies.
+The expected verdict table is in the shared MANIFEST at the path above.
+
+Note: Cursor subagents use `model: inherit` and `readonly: true` frontmatter (no `tools:`
+or `maxTurns:`). The fixture frontmatter in the shared corpus uses Claude Code conventions,
+but the body validation (which is what these checks test) is identical across platforms.

--- a/.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md
+++ b/.claude/skills/cursor-customizer-quality-gate/references/quality-gate-criteria.md
@@ -21,9 +21,10 @@ Source: `.claude/rules/cursor-plugin-skills.md`, `.claude/rules/reference-files.
 9. [Drift Manifest Completeness Checks](#drift-manifest-completeness-checks)
 10. [Product-Strict Textual Compliance](#product-strict-textual-compliance)
 11. [Known-Accepted Exceptions](#known-accepted-exceptions)
-12. [Severity Classification](#severity-classification)
-13. [Expected Results Checklist](#expected-results-checklist)
-14. [Report Template](#report-template)
+12. [Canonical Semantic-Tag Convention Checks](#canonical-semantic-tag-convention-checks)
+13. [Severity Classification](#severity-classification)
+14. [Expected Results Checklist](#expected-results-checklist)
+15. [Report Template](#report-template)
 
 ---
 
@@ -225,6 +226,72 @@ in sync.
 
 ---
 
+## Canonical Semantic-Tag Convention Checks
+
+Applies to all SKILL.md bodies under `plugins/cursor-customizer/skills/**/SKILL.md` and all
+subagent bodies under `plugins/cursor-customizer/agents/**/*.md`.
+Source: `wiki/knowledge/skill-body-convention.md`, `docs/adr/0007-skill-body-semantic-tag-convention.md`
+
+The tag vocabulary and strictness tiers are platform-agnostic. Cursor subagents differ from
+Claude Code subagents only in YAML frontmatter (`model: inherit`, `readonly: true`, no `tools:`
+or `maxTurns:` fields) — the body convention is identical.
+
+### Skill targets (`plugins/cursor-customizer/skills/**/SKILL.md`)
+
+Mandatory tags: `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` (or legacy `<RULES>` alias), `<PROCESS>`
+containing at least one `<PHASE id="N" name="X">`.
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| V1 | `<TRIGGER>` present in body | Hard-fail if absent | CRITICAL |
+| V2 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| V3 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| V4 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| V5 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| V6 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| V7 | All opened tags have a matching closing tag (no unbalanced open/close) | Hard-fail if unbalanced | CRITICAL |
+| V8 | All attribute values are properly quoted (no bare `=`, no unterminated quotes) | Hard-fail if malformed | CRITICAL |
+| V9 | All attribute names belong to the closed set: `avoid`, `always`, `when`, `name`, `id`, `priority` | Warn if non-canonical | MAJOR |
+| V10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+### Subagent targets (`plugins/cursor-customizer/agents/**/*.md`)
+
+Mandatory tags: `<BEHAVIOUR>`, `<HARD_RULES>` (or `<RULES>` alias), `<PROCESS>` with at least one
+`<PHASE id="N" name="X">`. `<TRIGGER>` is OPTIONAL for subagents — its absence is SILENT (never a
+finding).
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| VA1 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| VA2 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| VA3 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| VA4 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| VA5 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| VA6 | All opened tags have a matching closing tag | Hard-fail if unbalanced | CRITICAL |
+| VA7 | All attribute values properly quoted | Hard-fail if malformed | CRITICAL |
+| VA8 | All attribute names in closed set | Warn if non-canonical | MAJOR |
+| VA9 | `<TRIGGER>` absence | Silent — no finding | — |
+| VA10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+### Fixture corpus
+
+The golden fixture corpus for these checks is the shared corpus at:
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/`
+
+- `skill/` — 10 fixtures for skill-body validation (see `skill/MANIFEST.md`)
+- `subagent/` — 10 fixtures for subagent-body validation (see `subagent/MANIFEST.md`)
+
+Note on subagent fixtures: fixture frontmatter uses Claude Code conventions; the body convention
+being validated is platform-agnostic, so the same fixtures apply.
+
+Running the checks above against the corpus MUST produce the verdict documented in each MANIFEST.
+Any mismatch means the strictness-tier text above is ambiguous and must be tightened.
+
+This gate also maintains redirect stubs at:
+`.claude/skills/cursor-customizer-quality-gate/assets/fixtures/`
+
+---
+
 ## Severity Classification
 
 | Severity | Meaning | Must Fix Before Release? |
@@ -250,6 +317,7 @@ outputs to confirm full coverage. Every category heading below MUST appear in th
 - Plugin Manifest
 - Drift Manifest Completeness
 - Product-Strict Textual Compliance
+- Canonical Semantic-Tag Convention
 
 ---
 
@@ -273,6 +341,7 @@ Use this structure for `.specs/reports/cursor-customizer-quality-gate-[YYYY-MM-D
 | Plugin Manifest | 3 | [N] | [N] | PASS/FAIL |
 | Drift Manifest Completeness | 3 | [N] | [N] | PASS/FAIL |
 | Product-Strict Textual Compliance | 1 | [N] | [N] | PASS/FAIL |
+| Canonical Semantic-Tag Convention | [N] | [N] | [N] | PASS/FAIL |
 | **OVERALL** | [N] | [N] | [N] | **FAIL** |
 
 ## Findings

--- a/.claude/skills/cursor-initializer-quality-gate/SKILL.md
+++ b/.claude/skills/cursor-initializer-quality-gate/SKILL.md
@@ -62,25 +62,63 @@ Read `.claude/skills/cursor-initializer-quality-gate/agents/scenario-evaluator.m
 
 ---
 
-## Phase 4: Findings Synthesis
+## Phase 4: Canonical Semantic-Tag Convention Checks
 
-Aggregate all outputs from Phases 1, 2, and 3.
+Read `.claude/skills/cursor-initializer-quality-gate/references/quality-gate-criteria.md`
+Section `## Canonical Semantic-Tag Convention Checks`.
 
-Read `.claude/skills/cursor-initializer-quality-gate/references/quality-gate-criteria.md` Section `## Expected Results Checklist`. Cross-reference the category headings in the checklist against the Phase 1–3 results to confirm every category was covered.
+**Skill targets** — for each file matching `plugins/cursor-initializer/skills/**/SKILL.md`:
+
+1. Parse the body (everything after the closing `---` of the YAML frontmatter).
+2. Apply checks V1–V9 from the criteria reference using the strictness tiers below.
+3. For any `<RULES>` occurrence, record it as an **informational alias candidate** (not a fail,
+   not a warn — surface it as: "File X uses `<RULES>`; consider renaming to `<HARD_RULES>` on
+   next touch (legacy alias — satisfies the V3 check)").
+
+Note: `cursor-initializer` has no subagent flows; skip the subagent-body checks.
+
+**Strictness tiers (apply verbatim):**
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| Hard-fail | Any mandatory tag missing; unbalanced open/close tag; malformed attribute syntax (`id=` absent on `<PHASE>`, unquoted attribute value, stray `=`, unterminated quote) | Record as CRITICAL finding; counts toward FAIL |
+| Warn | Non-canonical attribute name (outside `avoid`, `always`, `when`, `name`, `id`, `priority`) | Record as MAJOR warning; does not block PASS |
+| Silent | Absence of optional tag | No finding |
+| Informational | `<RULES>` present (legacy alias) | Surface as alias candidate note; no verdict impact |
+
+**Fixture corpus validation** — after checking the live plugin files, validate the golden corpus at
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`:
+
+- Run each fixture through V1–V9 checks and confirm the verdict matches `MANIFEST.md` there.
+- Any mismatch between observed verdict and MANIFEST verdict is itself a CRITICAL finding.
+
+Collect structured output as `tag_convention_report`, which contains:
+- Per-file check results for each skill body
+- Informational `<RULES>` alias candidate list
+- Fixture corpus validation results (pass/mismatch per fixture)
+
+---
+
+## Phase 5: Findings Synthesis
+
+Aggregate all outputs from Phases 1, 2, 3, and 4.
+
+Read `.claude/skills/cursor-initializer-quality-gate/references/quality-gate-criteria.md` Section `## Expected Results Checklist`. Cross-reference the category headings in the checklist against the Phase 1–4 results to confirm every category was covered.
 
 Compute and display the **Quality Gate Dashboard**:
 
 ```
 Quality Gate Dashboard — cursor-initializer [DATE]
-═══════════════════════════════════════════════════
-Category                    Checks  Passed  Failed  Status
-─────────────────────────────────────────────────────────
-Static Artifact Compliance    [N]     [N]     [N]   [PASS/FAIL]
-Cross-Copy Parity             [N]     [N]     [N]   [PASS/FAIL]
-Red-Green Test Coverage         4     [N]     [N]   [PASS/FAIL]
-─────────────────────────────────────────────────────────
-OVERALL                       [N]     [N]     [N]   [PASS/FAIL]
-═══════════════════════════════════════════════════
+═══════════════════════════════════════════════════════════
+Category                        Checks  Passed  Failed  Status
+──────────────────────────────────────────────────────────
+Static Artifact Compliance        [N]     [N]     [N]   [PASS/FAIL]
+Cross-Copy Parity                 [N]     [N]     [N]   [PASS/FAIL]
+Red-Green Test Coverage             4     [N]     [N]   [PASS/FAIL]
+Canonical Semantic-Tag Convention [N]     [N]     [N]   [PASS/FAIL]
+──────────────────────────────────────────────────────────
+OVERALL                           [N]     [N]     [N]   [PASS/FAIL]
+═══════════════════════════════════════════════════════════
 ```
 
 **If all checks pass:**
@@ -88,11 +126,11 @@ OVERALL                       [N]     [N]     [N]   [PASS/FAIL]
 
 **Stop here. Do NOT write any report file to `.specs/reports/`.**
 
-**If any checks fail:** Proceed to Phase 5.
+**If any checks fail:** Proceed to Phase 6.
 
 ---
 
-## Phase 5: Findings Report
+## Phase 6: Findings Report
 
 Generate `.specs/reports/cursor-quality-gate-[YYYY-MM-DD]-findings.md`.
 

--- a/.claude/skills/cursor-initializer-quality-gate/assets/fixtures/MANIFEST.md
+++ b/.claude/skills/cursor-initializer-quality-gate/assets/fixtures/MANIFEST.md
@@ -1,0 +1,20 @@
+# Fixture Corpus — Skill Body Convention (Skill Variant, Shared)
+
+> **Shared corpus redirect** — the canonical golden fixture files live at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+>
+> The semantic-tag convention body rules are platform-agnostic (per ADR-0007 and
+> `wiki/knowledge/skill-body-convention.md`). Tag vocabulary and strictness tiers
+> are identical for Claude Code skills, Cursor skills, and standalone skills.
+> One corpus serves all gates; duplicating it would add maintenance overhead
+> without adding coverage.
+>
+> **To run the Canonical Semantic-Tag Convention skill-body check for this gate:**
+> read fixtures from `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+> and use the MANIFEST.md there for the expected verdicts.
+
+This covers `plugins/cursor-initializer/skills/**/SKILL.md` bodies.
+The expected verdict table is in the shared MANIFEST at the path above.
+
+Note: `cursor-initializer` has no subagent flows — only skill bodies need to be checked
+for this gate (per Convention scope v1 and the issue AC for cursor-initializer-quality-gate).

--- a/.claude/skills/cursor-initializer-quality-gate/references/quality-gate-criteria.md
+++ b/.claude/skills/cursor-initializer-quality-gate/references/quality-gate-criteria.md
@@ -10,8 +10,9 @@ Source: `.claude/rules/cursor-plugin-skills.md`, `.claude/rules/reference-files.
 ## Contents
 
 1. [Expected Results Checklist](#expected-results-checklist)
-2. [Severity Classification](#severity-classification)
-3. [Report Template](#report-template)
+2. [Canonical Semantic-Tag Convention Checks](#canonical-semantic-tag-convention-checks)
+3. [Severity Classification](#severity-classification)
+4. [Report Template](#report-template)
 
 ---
 
@@ -82,6 +83,39 @@ Source: `.claude/rules/cursor-plugin-skills.md`, `.claude/rules/reference-files.
 
 ---
 
+## Canonical Semantic-Tag Convention Checks
+
+Applies to all SKILL.md bodies under `plugins/cursor-initializer/skills/**/SKILL.md`.
+There are no subagent flows in cursor-initializer; subagent body checks are out of scope
+for this gate.
+Source: `wiki/knowledge/skill-body-convention.md`, `docs/adr/0007-skill-body-semantic-tag-convention.md`
+
+Mandatory tags for skills: `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` (or legacy `<RULES>` alias),
+`<PROCESS>` containing at least one `<PHASE id="N" name="X">`.
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| V1 | `<TRIGGER>` present in body | Hard-fail if absent | CRITICAL |
+| V2 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| V3 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| V4 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| V5 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| V6 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| V7 | All opened tags have a matching closing tag (no unbalanced open/close) | Hard-fail if unbalanced | CRITICAL |
+| V8 | All attribute values are properly quoted (no bare `=`, no unterminated quotes) | Hard-fail if malformed | CRITICAL |
+| V9 | All attribute names belong to the closed set: `avoid`, `always`, `when`, `name`, `id`, `priority` | Warn if non-canonical | MAJOR |
+| V10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+### Fixture corpus
+
+The golden fixture corpus for skill-body checks is the shared corpus at:
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+
+See the MANIFEST.md at that path for the 10 fixtures and their expected verdicts.
+A redirect stub lives at `.claude/skills/cursor-initializer-quality-gate/assets/fixtures/MANIFEST.md`.
+
+---
+
 ## Severity Classification
 
 | Severity | Meaning | Must Fix Before Release? |
@@ -108,6 +142,7 @@ Use this structure for `.specs/reports/cursor-quality-gate-[YYYY-MM-DD]-findings
 | Static Artifact Compliance | [N] | [N] | [N] | FAIL |
 | Cross-Copy Parity | [N] | [N] | [N] | PASS/FAIL |
 | Red-Green Test Coverage | 4 | [N] | [N] | PASS/FAIL |
+| Canonical Semantic-Tag Convention | [N] | [N] | [N] | PASS/FAIL |
 | **OVERALL** | [N] | [N] | [N] | **FAIL** |
 
 ---

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -83,26 +83,66 @@ Read `.claude/skills/quality-gate/agents/scenario-evaluator.md`. Skip the YAML f
 
 ---
 
-## Phase 5: Findings Synthesis
+## Phase 5: Canonical Semantic-Tag Convention Checks
 
-Aggregate all outputs from Phases 1, 2, 3, and 4.
+Read `.claude/skills/quality-gate/references/quality-gate-criteria.md`
+Section `## Canonical Semantic-Tag Convention Checks`.
 
-Read `.claude/skills/quality-gate/references/quality-gate-criteria.md` Section `## Expected Results Checklist`. Cross-reference the category headings in the checklist against the Phase 1–4 results to confirm every category was covered. Note any categories with no corresponding results.
+**Skill targets** — apply to both distributions:
+- Plugin: each file matching `plugins/agents-initializer/skills/**/SKILL.md`
+- Standalone: each file matching `skills/**/SKILL.md`
+
+For each file:
+
+1. Parse the body (everything after the closing `---` of the YAML frontmatter).
+2. Apply checks V1–V9 from the criteria reference using the strictness tiers below.
+3. For any `<RULES>` occurrence, record it as an **informational alias candidate** (not a fail,
+   not a warn — surface it as: "File X uses `<RULES>`; consider renaming to `<HARD_RULES>` on
+   next touch (legacy alias — satisfies the V3 check)").
+
+**Strictness tiers (apply verbatim):**
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| Hard-fail | Any mandatory tag missing; unbalanced open/close tag; malformed attribute syntax (`id=` absent on `<PHASE>`, unquoted attribute value, stray `=`, unterminated quote) | Record as CRITICAL finding; counts toward FAIL |
+| Warn | Non-canonical attribute name (outside `avoid`, `always`, `when`, `name`, `id`, `priority`) | Record as MAJOR warning; does not block PASS |
+| Silent | Absence of optional tag | No finding |
+| Informational | `<RULES>` present (legacy alias) | Surface as alias candidate note; no verdict impact |
+
+**Fixture corpus validation** — after checking the live plugin and standalone files, validate the
+golden corpus at `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`:
+
+- Run each fixture through V1–V9 checks and confirm the verdict matches `MANIFEST.md` there.
+- Any mismatch between observed verdict and MANIFEST verdict is itself a CRITICAL finding.
+
+Collect structured output as `tag_convention_report`, which contains:
+- Per-file check results for each plugin skill body and each standalone skill body
+- Informational `<RULES>` alias candidate list
+- Fixture corpus validation results (pass/mismatch per fixture)
+
+---
+
+## Phase 6: Findings Synthesis
+
+Aggregate all outputs from Phases 1, 2, 3, 4, and 5.
+
+Read `.claude/skills/quality-gate/references/quality-gate-criteria.md` Section `## Expected Results Checklist`. Cross-reference the category headings in the checklist against the Phase 1–5 results to confirm every category was covered. Note any categories with no corresponding results.
 
 Compute and display the **Quality Gate Dashboard**:
 
 ```
 Quality Gate Dashboard — agents-initializer [DATE]
-═══════════════════════════════════════════════════
-Category                    Checks  Passed  Failed  Status
-─────────────────────────────────────────────────────────
-Static Artifact Compliance    [N]     [N]     [N]   [PASS/FAIL]
-Cross-Distribution Parity     [N]     [N]     [N]   [PASS/FAIL]
-Docs Drift                    [N]     [N]     [N]   [PASS/FAIL]
-Red-Green Test Coverage         4     [N]     [N]   [PASS/FAIL]
-─────────────────────────────────────────────────────────
-OVERALL                       [N]     [N]     [N]   [PASS/FAIL]
-═══════════════════════════════════════════════════
+═══════════════════════════════════════════════════════════
+Category                        Checks  Passed  Failed  Status
+──────────────────────────────────────────────────────────
+Static Artifact Compliance        [N]     [N]     [N]   [PASS/FAIL]
+Cross-Distribution Parity         [N]     [N]     [N]   [PASS/FAIL]
+Docs Drift                        [N]     [N]     [N]   [PASS/FAIL]
+Red-Green Test Coverage             4     [N]     [N]   [PASS/FAIL]
+Canonical Semantic-Tag Convention [N]     [N]     [N]   [PASS/FAIL]
+──────────────────────────────────────────────────────────
+OVERALL                           [N]     [N]     [N]   [PASS/FAIL]
+═══════════════════════════════════════════════════════════
 ```
 
 **If all checks pass:**
@@ -110,11 +150,11 @@ OVERALL                       [N]     [N]     [N]   [PASS/FAIL]
 
 **Stop here. Do NOT write any report file to `.specs/reports/`.**
 
-**If any checks fail:** Proceed to Phase 6.
+**If any checks fail:** Proceed to Phase 7.
 
 ---
 
-## Phase 6: Findings Report
+## Phase 7: Findings Report
 
 Generate `.specs/reports/quality-gate-[YYYY-MM-DD]-findings.md`.
 

--- a/.claude/skills/quality-gate/assets/fixtures/MANIFEST.md
+++ b/.claude/skills/quality-gate/assets/fixtures/MANIFEST.md
@@ -1,0 +1,21 @@
+# Fixture Corpus — Skill Body Convention (Skill Variant, Shared)
+
+> **Shared corpus redirect** — the canonical golden fixture files live at:
+> `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+>
+> The semantic-tag convention body rules are platform-agnostic (per ADR-0007 and
+> `wiki/knowledge/skill-body-convention.md`). Tag vocabulary and strictness tiers
+> are identical for plugin skills (agents-initializer) and standalone skills.
+> One corpus serves all gates; duplicating it would add maintenance overhead
+> without adding coverage.
+>
+> **To run the Canonical Semantic-Tag Convention skill-body check for this gate:**
+> read fixtures from `.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+> and use the MANIFEST.md there for the expected verdicts.
+
+This covers `plugins/agents-initializer/skills/**/SKILL.md` and `skills/**/SKILL.md` bodies.
+The expected verdict table is in the shared MANIFEST at the path above.
+
+Note: `quality-gate` checks both the agents-initializer plugin skills and the standalone
+skills distribution. Both use the same mandatory tag vocabulary — `<TRIGGER>`, `<BEHAVIOUR>`,
+`<HARD_RULES>`, `<PROCESS>` with `<PHASE>`. The same fixture corpus exercises both.

--- a/.claude/skills/quality-gate/references/quality-gate-criteria.md
+++ b/.claude/skills/quality-gate/references/quality-gate-criteria.md
@@ -6,8 +6,9 @@ Source: `.claude/rules/plugin-skills.md`, `.claude/rules/standalone-skills.md`, 
 ## Contents
 
 1. [Expected Results Checklist](#expected-results-checklist)
-2. [Severity Classification](#severity-classification)
-3. [Report Template](#report-template)
+2. [Canonical Semantic-Tag Convention Checks](#canonical-semantic-tag-convention-checks)
+3. [Severity Classification](#severity-classification)
+4. [Report Template](#report-template)
 
 ---
 
@@ -92,6 +93,43 @@ Source: `.claude/rules/plugin-skills.md`, `.claude/rules/standalone-skills.md`, 
 
 ---
 
+## Canonical Semantic-Tag Convention Checks
+
+Applies to all SKILL.md bodies under `plugins/agents-initializer/skills/**/SKILL.md` and
+`skills/**/SKILL.md` (standalone distribution).
+Source: `wiki/knowledge/skill-body-convention.md`, `docs/adr/0007-skill-body-semantic-tag-convention.md`
+
+Both plugin skills (agents-initializer) and standalone skills use the same mandatory tag
+vocabulary. There are no subagent flows checked by this gate.
+
+Mandatory tags for skills: `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` (or legacy `<RULES>` alias),
+`<PROCESS>` containing at least one `<PHASE id="N" name="X">`.
+
+| # | Check | Tier | Severity |
+|---|-------|------|----------|
+| V1 | `<TRIGGER>` present in body | Hard-fail if absent | CRITICAL |
+| V2 | `<BEHAVIOUR>` present in body | Hard-fail if absent | CRITICAL |
+| V3 | `<HARD_RULES>` or `<RULES>` alias present in body | Hard-fail if absent | CRITICAL |
+| V4 | `<PROCESS>` present in body | Hard-fail if absent | CRITICAL |
+| V5 | `<PROCESS>` contains at least one `<PHASE>` | Hard-fail if zero `<PHASE>` | CRITICAL |
+| V6 | Every `<PHASE>` carries a mandatory `id=` attribute | Hard-fail if `id=` absent | CRITICAL |
+| V7 | All opened tags have a matching closing tag (no unbalanced open/close) | Hard-fail if unbalanced | CRITICAL |
+| V8 | All attribute values are properly quoted (no bare `=`, no unterminated quotes) | Hard-fail if malformed | CRITICAL |
+| V9 | All attribute names belong to the closed set: `avoid`, `always`, `when`, `name`, `id`, `priority` | Warn if non-canonical | MAJOR |
+| V10 | `<RULES>` occurrences reported as informational `<HARD_RULES>` alias candidates | Informational (not a fail or warn) | — |
+
+Apply checks V1–V10 to both plugin skill bodies and standalone skill bodies.
+
+### Fixture corpus
+
+The golden fixture corpus for skill-body checks is the shared corpus at:
+`.claude/skills/agent-customizer-quality-gate/assets/fixtures/skill/`
+
+See the MANIFEST.md at that path for the 10 fixtures and their expected verdicts.
+A redirect stub lives at `.claude/skills/quality-gate/assets/fixtures/MANIFEST.md`.
+
+---
+
 ## Severity Classification
 
 | Severity | Meaning | Must Fix Before Release? |
@@ -118,6 +156,7 @@ Use this structure for `.specs/reports/quality-gate-[YYYY-MM-DD]-findings.md`:
 | Static Artifact Compliance | [N] | [N] | [N] | FAIL |
 | Cross-Distribution Parity | [N] | [N] | [N] | PASS/FAIL |
 | Red-Green Test Coverage | 4 | [N] | [N] | PASS/FAIL |
+| Canonical Semantic-Tag Convention | [N] | [N] | [N] | PASS/FAIL |
 | **OVERALL** | [N] | [N] | [N] | **FAIL** |
 
 ---

--- a/plugins/agent-customizer/.claude-plugin/plugin.json
+++ b/plugins/agent-customizer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-customizer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Create and improve Claude Code artifacts (skills, hooks, rules, subagents) with documentation-grounded guidance and evidence traceability.",
   "author": {
     "name": "rodrigorjsf"

--- a/plugins/agent-customizer/agents/hook-evaluator.md
+++ b/plugins/agent-customizer/agents/hook-evaluator.md
@@ -22,13 +22,13 @@ You are a hook configuration quality assessment specialist. Analyze the target h
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| JSON structure | Valid JSON; no syntax errors | hooks/claude-hook-reference-doc.md |
-| Event name | From recognized event list | hooks/claude-hook-reference-doc.md lines 22-46 |
-| Handler type | `command`, `http`, `prompt`, or `agent` only | hooks/claude-hook-reference-doc.md lines 249-257 |
-| `command` path | Script file exists and is executable | hooks/automate-workflow-with-hooks.md |
-| Exit code behavior | Exit 2 effect is event-dependent | Blocks: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, SessionStart, SessionEnd, PreCompact, PostCompact, Notification. StopFailure ignores exit code entirely. |
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON structure | Valid JSON; no syntax errors |
+| Event name | From recognized event list |
+| Handler type | `command`, `http`, `prompt`, or `agent` only |
+| `command` path | Script file exists and is executable |
+| Exit code behavior | Exit 2 effect is event-dependent. Blocks: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, SessionStart, SessionEnd, PreCompact, PostCompact, Notification. StopFailure ignores exit code entirely. |
 
 ### Valid Hook Event Types
 

--- a/plugins/agent-customizer/agents/rule-evaluator.md
+++ b/plugins/agent-customizer/agents/rule-evaluator.md
@@ -22,12 +22,12 @@ You are a path-scoped rule quality assessment specialist. Analyze either a speci
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 50 lines | Context budget: loaded when matching files read |
-| YAML frontmatter | Valid YAML if present | memory/how-claude-remembers-a-project.md |
-| `paths:` field | Required; array format; valid glob patterns | memory/how-claude-remembers-a-project.md lines 147-164 |
-| Contradictions with other rules | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 50 lines |
+| YAML frontmatter | Valid YAML if present |
+| `paths:` field | Required; array format; valid glob patterns |
+| Contradictions with other rules | 0 |
 
 ### Quality Checks
 

--- a/plugins/agent-customizer/agents/skill-evaluator.md
+++ b/plugins/agent-customizer/agents/skill-evaluator.md
@@ -22,13 +22,13 @@ You are a skill quality assessment specialist. Analyze the target SKILL.md file 
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | reference-files.md rule constraint |
-| `description` field | Present and non-empty | Required for skill discovery |
-| `name` field format | Lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| `description` field | Present and non-empty |
+| `name` field format | Lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
 ### Structural Checks
 

--- a/plugins/agent-customizer/agents/subagent-evaluator.md
+++ b/plugins/agent-customizer/agents/subagent-evaluator.md
@@ -22,14 +22,14 @@ You are a subagent definition quality assessment specialist. Analyze the target 
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | subagents/creating-custom-subagents.md |
-| `name` field | Lowercase letters and hyphens only | subagents/creating-custom-subagents.md lines 217-220 |
-| `description` field | Present and non-empty | subagents/creating-custom-subagents.md lines 217-220 |
-| `model` field | Recognized alias or full model ID | subagents/creating-custom-subagents.md lines 234-241 |
-| `maxTurns` | ≤ 30 (justify if higher) | subagents/research-subagent-best-practices.md |
-| System prompt | Not empty; task-specific | subagents/creating-custom-subagents.md lines 199-212 |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens only |
+| `description` field | Present and non-empty |
+| `model` field | Recognized alias or full model ID |
+| `maxTurns` | ≤ 30 (justify if higher) |
+| System prompt | Not empty; task-specific |
 
 ### Quality Checks
 

--- a/plugins/agent-customizer/skills/create-hook/SKILL.md
+++ b/plugins/agent-customizer/skills/create-hook/SKILL.md
@@ -7,18 +7,20 @@ description: "Creates new hook configurations for Claude Code lifecycle events, 
 
 Generates a new hook configuration for a Claude Code lifecycle event, with correct JSON schema, handler type, and exit code behavior grounded in the docs corpus.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new Claude Code hook from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create hooks with invalid event names — only events from the 22-event list in hook-events-reference.md are valid
 - **NEVER** use broad matchers (`"*"`) for blocking hooks — overly broad matchers block too many operations
 - **NEVER** hardcode secrets in command strings — use environment variables (e.g., `$MY_SECRET`)
@@ -26,85 +28,91 @@ Generates a new hook configuration for a Claude Code lifecycle event, with corre
 - **EVERY** hook must use a handler type supported by the selected event — verify this against the handler support matrix in `hook-events-reference.md`
 - **EVERY** `command` hook must document the decision path used by the script: exit `2` + stderr for blocking, or exit `0` with JSON decision output when applicable
 - **EVERY** hook configuration must produce valid JSON before writing
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="conflict-check">
+  Check if hooks already exist for the target event in:
 
-Check if hooks already exist for the target event in:
+  - `.claude/settings.json`
+  - `.claude/settings.local.json`
+  - Plugin `hooks/hooks.json`
 
-- `.claude/settings.json`
-- `.claude/settings.local.json`
-- Plugin `hooks/hooks.json`
+  **If the exact same event + matcher combination already exists:**
 
-**If the exact same event + matcher combination already exists:**
+  1. Inform the user: "A hook for `{event}` with this matcher already exists."
+  2. Suggest using `/agent-customizer:improve-hook` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different matcher/event combination or use the improve skill.
 
-1. Inform the user: "A hook for `{event}` with this matcher already exists."
-2. Suggest using `/agent-customizer:improve-hook` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different matcher/event combination or use the improve skill.
+  **If no hook exists for this event+matcher combination:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no hook exists for this event+matcher combination:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Codebase Analysis
+  > Analyze the project to understand existing hook configurations. Focus on: hooks defined in `.claude/settings.json`, `.claude/settings.local.json`, and plugin `hooks/hooks.json`; project hook scripts in `.claude/hooks/`; plugin hook scripts in `scripts/`; event types currently in use; handler types used (command/http/prompt/agent); and any gaps in lifecycle event coverage. Also read root `CLAUDE.md`, `README.md`, and any service-level README files to understand non-standard build commands, tooling, or conventions that hook scripts should use. Also identify project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in hook script path resolution.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing hook configurations. Focus on: hooks defined in `.claude/settings.json`, `.claude/settings.local.json`, and plugin `hooks/hooks.json`; project hook scripts in `.claude/hooks/`; plugin hook scripts in `scripts/`; event types currently in use; handler types used (command/http/prompt/agent); and any gaps in lifecycle event coverage. Also read root `CLAUDE.md`, `README.md`, and any service-level README files to understand non-standard build commands, tooling, or conventions that hook scripts should use. Also identify project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in hook script path resolution.
+  <PHASE id="2" name="generate-hook">
+  #### Phase 2a: Load Context
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  Drop any references from Phase 1. Read these references:
 
-### Phase 2: Generate Hook
+  - `${CLAUDE_SKILL_DIR}/references/hook-authoring-guide.md` — when to use hooks, 4 handler types, exit code semantics, blocking vs non-blocking behavior
+  - `${CLAUDE_SKILL_DIR}/references/hook-events-reference.md` — all 22 valid events, matcher fields per event, full JSON schema
 
-#### Phase 2a: Load Context
+  Verify the selected event supports the requested handler type using the handler support matrix. If unsupported, stop and ask the user to change the event or handler choice. Determine target location (`.claude/settings.json`, `.claude/settings.local.json`, or `hooks/hooks.json`) and hook script paths.
 
-Drop any references from Phase 1. Read these references:
+  #### Phase 2b: Apply Patterns
 
-- `${CLAUDE_SKILL_DIR}/references/hook-authoring-guide.md` — when to use hooks, 4 handler types, exit code semantics, blocking vs non-blocking behavior
-- `${CLAUDE_SKILL_DIR}/references/hook-events-reference.md` — all 22 valid events, matcher fields per event, full JSON schema
+  Drop Phase 2a references. Read this reference:
 
-Verify the selected event supports the requested handler type using the handler support matrix. If unsupported, stop and ask the user to change the event or handler choice. Determine target location (`.claude/settings.json`, `.claude/settings.local.json`, or `hooks/hooks.json`) and hook script paths.
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — hook-specific prompting (zero-shot only for hooks)
 
-#### Phase 2b: Apply Patterns
+  Read `${CLAUDE_SKILL_DIR}/assets/templates/hook-config.md` and fill its placeholders using:
 
-Drop Phase 2a references. Read this reference:
+  - User requirements for the new hook (event, purpose, handler type)
+  - Phase 1 analysis output (existing hooks, coverage gaps)
+  - Decisions from Phase 2a (event validation, target location, handler type)
 
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — hook-specific prompting (zero-shot only for hooks)
+  For blocking pre-write hooks, translate the user intent into an explicit write-tool matcher instead of a wildcard or omitted matcher. Use a concrete matcher pattern for write-capable tools in the target environment (for example `Write|Edit|Create`) and keep it specific to the operations that should block.
 
-Read `${CLAUDE_SKILL_DIR}/assets/templates/hook-config.md` and fill its placeholders using:
+  In a monorepo with multiple service packages, hook script paths must be workspace-relative (e.g., `packages/api/scripts/validate.sh`, not just `scripts/validate.sh`). Confirm the correct path from the Phase 1 analysis before writing.
 
-- User requirements for the new hook (event, purpose, handler type)
-- Phase 1 analysis output (existing hooks, coverage gaps)
-- Decisions from Phase 2a (event validation, target location, handler type)
+  Generate the complete hook configuration:
 
-For blocking pre-write hooks, translate the user intent into an explicit write-tool matcher instead of a wildcard or omitted matcher. Use a concrete matcher pattern for write-capable tools in the target environment (for example `Write|Edit|Create`) and keep it specific to the operations that should block.
+  1. Hook JSON block — to be merged into the `hooks` key of the selected target file
+  2. Shell script (if `command` type):
+     - Project/local hook: write to `.claude/hooks/{name}.sh` with executable permissions
+     - Plugin hook: write to `scripts/{name}.sh` with executable permissions and reference it with `${CLAUDE_PLUGIN_ROOT}/scripts/{name}.sh`
 
-In a monorepo with multiple service packages, hook script paths must be workspace-relative (e.g., `packages/api/scripts/validate.sh`, not just `scripts/validate.sh`). Confirm the correct path from the Phase 1 analysis before writing.
+  **Important**: The hook JSON must be merged into the selected target file, not replace it. Read the current target file first and produce the merged result.
+  </PHASE>
 
-Generate the complete hook configuration:
+  <PHASE id="3" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/hook-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated hook configuration.
 
-1. Hook JSON block — to be merged into the `hooks` key of the selected target file
-2. Shell script (if `command` type):
-   - Project/local hook: write to `.claude/hooks/{name}.sh` with executable permissions
-   - Plugin hook: write to `scripts/{name}.sh` with executable permissions and reference it with `${CLAUDE_PLUGIN_ROOT}/scripts/{name}.sh`
+  The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-**Important**: The hook JSON must be merged into the selected target file, not replace it. Read the current target file first and produce the merged result.
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete hook configuration (JSON + shell script if applicable)
+  2. Cite the evidence from reference files that informed key decisions:
+     - Which event was chosen and why
+     - Why this handler type (command/http/prompt/agent)
+     - What the exit code behavior means for this event
+  3. Ask for confirmation before writing any files
+  4. On approval:
+     - Merge hook JSON into the selected target file
+     - Write shell script to `.claude/hooks/{name}.sh` or `scripts/{name}.sh` and set executable (`chmod +x`)
+  </PHASE>
 
-### Phase 3: Self-Validation
+</PROCESS>
 
-Read `${CLAUDE_SKILL_DIR}/references/hook-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated hook configuration.
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete hook configuration (JSON + shell script if applicable)
-2. Cite the evidence from reference files that informed key decisions:
-   - Which event was chosen and why
-   - Why this handler type (command/http/prompt/agent)
-   - What the exit code behavior means for this event
-3. Ask for confirmation before writing any files
-4. On approval:
-   - Merge hook JSON into the selected target file
-   - Write shell script to `.claude/hooks/{name}.sh` or `scripts/{name}.sh` and set executable (`chmod +x`)
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/hook-validation-criteria.md` and loop the generated hook configuration through every hard limit and quality check until all pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-hook/references/hook-authoring-guide.md
+++ b/plugins/agent-customizer/skills/create-hook/references/hook-authoring-guide.md
@@ -1,7 +1,6 @@
 # Hook Authoring Guide
 
 Evidence-based guidance for creating Claude Code hooks that enforce deterministic behavior.
-Source: hooks/automate-workflow-with-hooks.md, hooks/claude-hook-reference-doc.md
 
 ---
 
@@ -30,7 +29,6 @@ Hooks provide **deterministic control** — they always fire, regardless of LLM 
 
 Examples: auto-formatting after edits, blocking destructive commands, sending notifications, auditing config changes.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 1-13*
 
 ---
 
@@ -62,7 +60,6 @@ Level 3: **Handler** — what to run when matched
 
 Omit `matcher` or use `""` / `"*"` to match all occurrences.
 
-*Source: hooks/claude-hook-reference-doc.md lines 132-141*
 
 ---
 
@@ -83,7 +80,6 @@ Omit `matcher` or use `""` / `"*"` to match all occurrences.
 
 **Use `http`** for centralizing audit trails across projects or sending to external services.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 569-625; hooks/claude-hook-reference-doc.md lines 249-257*
 
 ---
 
@@ -107,7 +103,6 @@ The `matcher` field is a **regex string** filtering on different fields per even
 
 MCP tools follow pattern `mcp__<server>__<tool>` — use `mcp__server__.*` to match all tools from a server.
 
-*Source: hooks/claude-hook-reference-doc.md lines 162-203*
 
 ---
 
@@ -122,7 +117,6 @@ MCP tools follow pattern `mcp__<server>__<tool>` — use `mcp__server__.*` to ma
 | Skill/agent frontmatter | While component active | Yes |
 | Managed policy settings | Organization-wide | Yes, admin-controlled |
 
-*Source: hooks/automate-workflow-with-hooks.md lines 552-565*
 
 ---
 
@@ -142,13 +136,11 @@ For **command** hooks:
 
 For **prompt/agent** hooks — return JSON `{"ok": true/false, "reason": "..."}`. When `ok: false`, Claude receives `reason` as its next instruction.
 
-*Source: hooks/automate-workflow-with-hooks.md lines ~393-420; hooks/claude-hook-reference-doc.md lines 80-88*
 
 ### Hook Output Discipline
 
 **Golden rule of hook output: success silent, failure verbose.** Stdout/stderr from hooks is injected into Claude's context. A passing typecheck or 4,000-line test log on every PostToolUse pushes the smart zone into the dumb zone. Emit nothing on success; emit specific error traces only on failure.
 
-*Source: harness-engineering.md*
 
 ---
 
@@ -162,4 +154,3 @@ For **prompt/agent** hooks — return JSON `{"ok": true/false, "reason": "..."}`
 
 Test with `--debug` to see hook execution details, including which hooks matched, exit codes, and output.
 
-*Source: hooks/claude-hook-reference-doc.md lines 2050-2065*

--- a/plugins/agent-customizer/skills/create-hook/references/hook-events-reference.md
+++ b/plugins/agent-customizer/skills/create-hook/references/hook-events-reference.md
@@ -1,7 +1,6 @@
 # Hook Events Reference
 
 Complete reference for all 22 Claude Code hook events: triggers, matcher fields, and input/output schemas.
-Source: hooks/claude-hook-reference-doc.md
 
 ---
 
@@ -42,7 +41,6 @@ Source: hooks/claude-hook-reference-doc.md
 | `Elicitation` | When MCP server requests input | Yes |
 | `ElicitationResult` | After user responds to MCP elicitation | Yes |
 
-*Source: hooks/claude-hook-reference-doc.md lines 22-46*
 
 ---
 
@@ -62,7 +60,6 @@ Source: hooks/claude-hook-reference-doc.md
 | `Elicitation`, `ElicitationResult` | MCP server name | your configured server names |
 | No matcher | always fires | `UserPromptSubmit`, `Stop`, `TeammateIdle`, `TaskCompleted`, `WorktreeCreate`, `WorktreeRemove` |
 
-*Source: hooks/claude-hook-reference-doc.md lines 162-179*
 
 ---
 
@@ -115,7 +112,6 @@ Source: hooks/claude-hook-reference-doc.md
 
 **Agent-specific fields:** `type`, `prompt` (required), `timeout` (optional, default 60s)
 
-*Source: hooks/claude-hook-reference-doc.md lines 258-310*
 
 ---
 
@@ -131,7 +127,6 @@ Source: hooks/claude-hook-reference-doc.md
 The 8 agentic loop events that support all handler types:
 `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `UserPromptSubmit`, `Stop`, `SubagentStop`, `TaskCompleted`
 
-*Source: hooks/claude-hook-reference-doc.md lines 249-257*
 
 ---
 
@@ -165,4 +160,3 @@ Inject dynamic context at session start:
 
 Stdout from the hook is injected as additional context.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 70-200*

--- a/plugins/agent-customizer/skills/create-hook/references/hook-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-hook/references/hook-validation-criteria.md
@@ -1,7 +1,6 @@
 # Hook Validation Criteria
 
 Quality checklist for generated and improved Claude Code hook configurations.
-Source: hooks/claude-hook-reference-doc.md, hooks/automate-workflow-with-hooks.md
 
 ---
 
@@ -9,15 +8,13 @@ Source: hooks/claude-hook-reference-doc.md, hooks/automate-workflow-with-hooks.m
 
 Any hook violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| JSON structure | Valid JSON; no syntax errors | hooks/claude-hook-reference-doc.md |
-| Event name | From recognized 22-event list | hooks/claude-hook-reference-doc.md lines 22-46 |
-| Handler type | `command`, `http`, `prompt`, or `agent` only | hooks/claude-hook-reference-doc.md lines 249-257 |
-| `command` path | Script file exists and is executable *(validation-phase check; during staleness evaluation, relative paths are treated as plausible — see hook-evaluation-criteria.md)* | hooks/automate-workflow-with-hooks.md |
-| Exit code behavior | Exit 2 effect is event-dependent — see full table in hook reference | Blocks execution on exit 2: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop, TeammateIdle, TaskCompleted, ConfigChange, Elicitation, ElicitationResult. Any non-zero exit code fails creation (not just exit 2): WorktreeCreate. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, Notification, SubagentStart, SessionStart, SessionEnd, PreCompact, PostCompact. Failures logged in debug mode only (not shown to user): WorktreeRemove. Exit code ignored: StopFailure, InstructionsLoaded. |
-
-*Source: hooks/claude-hook-reference-doc.md "Exit code 2 behavior per event" table*
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON structure | Valid JSON; no syntax errors |
+| Event name | From recognized 22-event list |
+| Handler type | `command`, `http`, `prompt`, or `agent` only |
+| `command` path | Script file exists and is executable *(validation-phase check; during staleness evaluation, relative paths are treated as plausible — see hook-evaluation-criteria.md)* |
+| Exit code behavior | Exit 2 effect is event-dependent — see full table in hook reference. Blocks execution on exit 2: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop, TeammateIdle, TaskCompleted, ConfigChange, Elicitation, ElicitationResult. Any non-zero exit code fails creation (not just exit 2): WorktreeCreate. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, Notification, SubagentStart, SessionStart, SessionEnd, PreCompact, PostCompact. Failures logged in debug mode only (not shown to user): WorktreeRemove. Exit code ignored: StopFailure, InstructionsLoaded. |
 
 ---
 

--- a/plugins/agent-customizer/skills/create-hook/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/create-hook/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/create-rule/SKILL.md
+++ b/plugins/agent-customizer/skills/create-rule/SKILL.md
@@ -7,85 +7,93 @@ description: "Creates new path-scoped .claude/rules/ files grounded in the docs 
 
 Generates a new `.claude/rules/` file with correct glob patterns and minimal, specific instructions grounded in the docs corpus.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new path-scoped .claude/rules/ rule from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create path-scoped rules longer than 50 lines
 - **NEVER** create rules for standard conventions Claude already knows (e.g., "write clean code")
 - **NEVER** use overly broad glob patterns (`**/*`) unless truly global scope is required
 - **EVERY** generated rule MUST have `paths:` YAML frontmatter listing the target glob patterns
 - **EVERY** instruction must be specific and verifiable — not vague guidance
 - **ONE** topic per rule file — do not bundle unrelated instructions
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="conflict-check">
+  Check if a rule file already exists in `.claude/rules/` covering the same topic:
 
-Check if a rule file already exists in `.claude/rules/` covering the same topic:
+  - Same filename (e.g., `.claude/rules/{topic}.md` already exists)
+  - Existing rule with overlapping glob patterns that would create contradiction or duplication
 
-- Same filename (e.g., `.claude/rules/{topic}.md` already exists)
-- Existing rule with overlapping glob patterns that would create contradiction or duplication
+  **If a conflicting or duplicate rule already exists:**
 
-**If a conflicting or duplicate rule already exists:**
+  1. Inform the user: "A rule covering `{topic}` or overlapping glob patterns already exists."
+  2. Suggest using `/agent-customizer:improve-rule` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different topic/pattern scope or use the improve skill.
 
-1. Inform the user: "A rule covering `{topic}` or overlapping glob patterns already exists."
-2. Suggest using `/agent-customizer:improve-rule` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different topic/pattern scope or use the improve skill.
+  **If no conflicting rule exists:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no conflicting rule exists:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Codebase Analysis
+  > Analyze the project to understand existing rules in `.claude/rules/`. Focus on: rule filenames and topics, glob patterns in use, any overlaps or contradictions between rules, gaps where path-scoped rules would add value, and the conventions in CLAUDE.md files that could inform rule content. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in glob pattern scoping.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing rules in `.claude/rules/`. Focus on: rule filenames and topics, glob patterns in use, any overlaps or contradictions between rules, gaps where path-scoped rules would add value, and the conventions in CLAUDE.md files that could inform rule content. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in glob pattern scoping.
+  <PHASE id="2" name="generate-rule">
+  Drop any references from Phase 1. Read these reference documents:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  - `${CLAUDE_SKILL_DIR}/references/rule-authoring-guide.md` — when to use rules, path-scoping, glob syntax, and anti-patterns
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — rule-specific prompting (zero-shot, no examples in rules)
 
-### Phase 2: Generate Rule
+  Read `${CLAUDE_SKILL_DIR}/assets/templates/rule-file.md` and fill its placeholders using:
 
-Drop any references from Phase 1. Read these reference documents:
+  - User requirements for the new rule (topic, target paths, instructions)
+  - Phase 1 analysis output (existing rules, gaps, potential contradictions)
+  - Evidence from the reference files above
 
-- `${CLAUDE_SKILL_DIR}/references/rule-authoring-guide.md` — when to use rules, path-scoping, glob syntax, and anti-patterns
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — rule-specific prompting (zero-shot, no examples in rules)
+  Generate a path-scoped rule:
 
-Read `${CLAUDE_SKILL_DIR}/assets/templates/rule-file.md` and fill its placeholders using:
+  - Include `paths:` YAML frontmatter with specific glob patterns (max 50 lines)
 
-- User requirements for the new rule (topic, target paths, instructions)
-- Phase 1 analysis output (existing rules, gaps, potential contradictions)
-- Evidence from the reference files above
+  In a monorepo, scope glob patterns to the relevant service or package subtree (e.g., `services/api/**/*.go` rather than `**/*.go`). Do not use project-wide language globs (`**/*.go`, `**/*.ts`) when the rule is scoped to a specific service — language-only globs match across every package and defeat path-scoping.
 
-Generate a path-scoped rule:
+  Generate: `.claude/rules/{topic-name}.md`
+  </PHASE>
 
-- Include `paths:` YAML frontmatter with specific glob patterns (max 50 lines)
+  <PHASE id="3" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/rule-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated rule.
 
-In a monorepo, scope glob patterns to the relevant service or package subtree (e.g., `services/api/**/*.go` rather than `**/*.go`). Do not use project-wide language globs (`**/*.go`, `**/*.ts`) when the rule is scoped to a specific service — language-only globs match across every package and defeat path-scoping.
+  The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Additionally, cross-check against ALL existing rule files in `.claude/rules/` for contradictions and overlapping glob patterns. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-Generate: `.claude/rules/{topic-name}.md`
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated rule file
+  2. Cite the evidence from reference files that informed key decisions:
+     - Why this glob pattern (what files it targets and why)
+     - Why each instruction is necessary (what mistakes it prevents)
+     - Why this `paths:` scope is correct for the rule
+  3. Ask for confirmation before writing any files
+  4. On approval, write the rule file to `.claude/rules/{topic-name}.md`
+  </PHASE>
 
-### Phase 3: Self-Validation
+</PROCESS>
 
-Read `${CLAUDE_SKILL_DIR}/references/rule-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated rule.
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Additionally, cross-check against ALL existing rule files in `.claude/rules/` for contradictions and overlapping glob patterns. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete generated rule file
-2. Cite the evidence from reference files that informed key decisions:
-   - Why this glob pattern (what files it targets and why)
-   - Why each instruction is necessary (what mistakes it prevents)
-   - Why this `paths:` scope is correct for the rule
-3. Ask for confirmation before writing any files
-4. On approval, write the rule file to `.claude/rules/{topic-name}.md`
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/rule-validation-criteria.md` and loop the generated rule through every hard limit and quality check until all pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-rule/assets/templates/rule-file.md
+++ b/plugins/agent-customizer/skills/create-rule/assets/templates/rule-file.md
@@ -16,7 +16,5 @@ paths:
 
 # [Topic Name]
 
-*Source: [path/to/source-doc.md] — the document or convention that establishes these rules*
-
 - [Specific, verifiable instruction]
 - [Specific, verifiable instruction]

--- a/plugins/agent-customizer/skills/create-rule/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/create-rule/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/create-rule/references/rule-authoring-guide.md
+++ b/plugins/agent-customizer/skills/create-rule/references/rule-authoring-guide.md
@@ -1,7 +1,6 @@
 # Rule Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code rule files (`.claude/rules/*.md`).
-Source: memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -29,7 +28,6 @@ Rules are instruction files loaded on-demand when Claude reads files matching th
 
 **Rules load into context** when matching files are read, so keep them focused and concise.
 
-*Source: memory/how-claude-remembers-a-project.md lines 123-145; .github/instructions/rules.instructions.md*
 
 ---
 
@@ -48,7 +46,6 @@ Each file should cover **one topic** with a descriptive filename. All `.md` file
 
 For this project, rules should use `paths` frontmatter so they load only when Claude reads matching files. Put always-loaded project guidance in root `CLAUDE.md`, not in `.claude/rules/`.
 
-*Source: memory/how-claude-remembers-a-project.md lines 123-145*
 
 ---
 
@@ -81,7 +78,6 @@ paths:
 ---
 ```
 
-*Source: memory/how-claude-remembers-a-project.md lines 147-186*
 
 ---
 
@@ -98,7 +94,6 @@ paths:
 
 Path-scoped rules trigger when Claude **reads files** matching the pattern, not on every tool use.
 
-*Source: memory/how-claude-remembers-a-project.md lines 166-183*
 
 ---
 
@@ -121,7 +116,6 @@ Path-scoped rules trigger when Claude **reads files** matching the pattern, not 
 
 **No contradictions** — if two rules conflict, Claude may pick one arbitrarily. Review `.claude/rules/` periodically to remove outdated or conflicting instructions.
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; Project convention — `.github/instructions/rules.instructions.md`*
 
 ---
 
@@ -136,4 +130,3 @@ Path-scoped rules trigger when Claude **reads files** matching the pattern, not 
 | Always-loaded rules for rare situations | Context cost on every session | Convert to path-scoped or skill |
 | Rule files exceeding 50 lines | Poor adherence; attention fragmentation | Split into multiple focused files |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 123-145; Project convention — `.github/instructions/rules.instructions.md`*

--- a/plugins/agent-customizer/skills/create-rule/references/rule-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-rule/references/rule-validation-criteria.md
@@ -1,7 +1,6 @@
 # Rule Validation Criteria
 
 Quality checklist for generated and improved `.claude/rules/*.md` rule files.
-Source: memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -9,14 +8,13 @@ Source: memory/how-claude-remembers-a-project.md
 
 Any rule file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 50 lines | Context budget: loaded when matching files read — project convention |
-| YAML frontmatter | Valid YAML if present | memory/how-claude-remembers-a-project.md |
-| `paths:` field | Required; array format; valid glob patterns | memory/how-claude-remembers-a-project.md lines 147-164 |
-| Contradictions with other rules | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 50 lines |
+| YAML frontmatter | Valid YAML if present |
+| `paths:` field | Required; array format; valid glob patterns |
+| Contradictions with other rules | 0 |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 147-164; Project convention — `.github/instructions/rules.instructions.md`*
 
 ---
 

--- a/plugins/agent-customizer/skills/create-skill/SKILL.md
+++ b/plugins/agent-customizer/skills/create-skill/SKILL.md
@@ -29,6 +29,8 @@ Generates a new SKILL.md file with supporting references and templates, grounded
 - **EVERY** skill description must be third-person and include a "Use when..." trigger phrase
 - **EVERY** generated skill must preserve the ethical constraint: persuasion cues support legitimate work only, never safety bypass
 - **EVERY** generated SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** new skill whose output is a human-rich agent-executable artifact (plan, PRD, spec, report, prototype, code-review writeup, custom editor) MUST default to an HTML output template — unless the user explicitly says "generate as markdown" (or equivalent), in which case that override always wins
+- **NEVER** default to HTML for agent-loaded or tooling-locked artifacts (`SKILL.md`, `AGENTS.md`, `CLAUDE.md`, rules files, wiki pages, ADRs, `CONTEXT.md`, `README.md`, commit messages, PR bodies, GitHub issues, code comments) — these are Markdown-mandatory regardless of user request phrasing
 </HARD_RULES>
 
 <PROCESS>
@@ -65,6 +67,14 @@ Generates a new SKILL.md file with supporting references and templates, grounded
 
   Decide skill structure: phases, reference file names, and whether `assets/templates/` is needed.
 
+  **Classify output artifact format.** Read `${CLAUDE_SKILL_DIR}/references/artifact-format-routing.md` and apply its routing table to the new skill being generated:
+
+  1. Identify what kind of artifact the new skill will produce (plan/PRD/spec/report/prototype vs. SKILL.md/rule/ADR/README/etc.).
+  2. Apply the routing table: human-rich agent-executable artifacts default to **HTML**; agent-loaded and tooling-locked artifacts are **Markdown-mandatory**.
+  3. Check for explicit override: if the user said "generate as markdown" (or equivalent), that override wins regardless of artifact type.
+  4. If the verdict is **HTML**: copy `${CLAUDE_SKILL_DIR}/assets/templates/html-artifact-skeleton.html` into the new skill's `assets/templates/` directory (rename to match the artifact type, e.g., `plan.html`). The new skill must instruct its own generation phase to populate the canonical semantic tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`, plus relevant optional tags) inside the HTML `<body>`.
+  5. If the verdict is **Markdown**: use `${CLAUDE_SKILL_DIR}/assets/templates/skill-md.md` or a Markdown template appropriate to the artifact type.
+
   **Apply patterns.** Drop the load-context references above. Read these references:
 
   - `${CLAUDE_SKILL_DIR}/references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
@@ -73,11 +83,12 @@ Generates a new SKILL.md file with supporting references and templates, grounded
   <REFERENCES load="on-demand">
   - skill-authoring-guide.md
   - skill-format-reference.md
+  - artifact-format-routing.md
   - behavioral-guidelines.md
   - prompt-engineering-strategies.md
   </REFERENCES>
 
-  Read `${CLAUDE_SKILL_DIR}/assets/templates/skill-md.md` and fill its placeholders using:
+  Read the chosen output template (HTML skeleton or `skill-md.md`) and fill its placeholders using:
 
   - User requirements for the new skill
   - Phase 1 analysis output (naming conventions, existing patterns, plugin context)
@@ -89,9 +100,7 @@ Generates a new SKILL.md file with supporting references and templates, grounded
 
   1. `SKILL.md` — primary skill file with frontmatter and a body carrying the canonical semantic-tag vocabulary
   2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
-  3. `assets/templates/` — create stub template files if the skill generates output files
-
-     For validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted.
+  3. `assets/templates/` — create the appropriate output template (HTML or Markdown per the routing verdict above); for validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted
   </PHASE>
 
   <PHASE id="3" name="self-validation">

--- a/plugins/agent-customizer/skills/create-skill/SKILL.md
+++ b/plugins/agent-customizer/skills/create-skill/SKILL.md
@@ -7,18 +7,20 @@ description: "Creates new SKILL.md files with references, templates, and frontma
 
 Generates a new SKILL.md file with supporting references and templates, grounded in the docs corpus and project conventions.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new Claude Code skill from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create skills that explain what Claude already knows (language syntax, obvious conventions)
 - **NEVER** inline reference content in SKILL.md body — use the `references/` subdirectory
 - **NEVER** exceed 500 lines in the SKILL.md body
@@ -26,79 +28,89 @@ Generates a new SKILL.md file with supporting references and templates, grounded
 - **EVERY** skill must use `${CLAUDE_SKILL_DIR}` for all bundled file references (not hardcoded paths)
 - **EVERY** skill description must be third-person and include a "Use when..." trigger phrase
 - **EVERY** generated skill must preserve the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** generated SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="name-collision-check">
+  Check if a skill with the same name already exists at:
 
-Check if a skill with the same name already exists at:
+  - `.claude/skills/{requested-name}/SKILL.md`
+  - `plugins/*/skills/{requested-name}/SKILL.md`
 
-- `.claude/skills/{requested-name}/SKILL.md`
-- `plugins/*/skills/{requested-name}/SKILL.md`
+  **If a skill already exists at either location:**
 
-**If a skill already exists at either location:**
+  1. Inform the user: "A skill named `{requested-name}` already exists."
+  2. Suggest using `/agent-customizer:improve-skill` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
 
-1. Inform the user: "A skill named `{requested-name}` already exists."
-2. Suggest using `/agent-customizer:improve-skill` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
+  **If no skill exists with that name:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no skill exists with that name:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Codebase Analysis
+  > Analyze the project to understand existing skills, naming conventions, and integration patterns. Focus on: existing skill directory structure, naming patterns, which skills delegate to agents, plugin conventions in CLAUDE.md files, and any skill that is similar to `{requested-name}` in purpose. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing skills, naming conventions, and integration patterns. Focus on: existing skill directory structure, naming patterns, which skills delegate to agents, plugin conventions in CLAUDE.md files, and any skill that is similar to `{requested-name}` in purpose. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
+  <PHASE id="2" name="generate-skill">
+  **Load context.** Drop any references from Phase 1. Read these references:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  - `${CLAUDE_SKILL_DIR}/references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
+  - `${CLAUDE_SKILL_DIR}/references/skill-format-reference.md` — frontmatter fields, name validation, string substitution variables
 
-### Phase 2: Generate Skill
+  Decide skill structure: phases, reference file names, and whether `assets/templates/` is needed.
 
-#### Phase 2a: Load Context
+  **Apply patterns.** Drop the load-context references above. Read these references:
 
-Drop any references from Phase 1. Read these references:
+  - `${CLAUDE_SKILL_DIR}/references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
 
-- `${CLAUDE_SKILL_DIR}/references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
-- `${CLAUDE_SKILL_DIR}/references/skill-format-reference.md` — frontmatter fields, name validation, string substitution variables
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-format-reference.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-Decide skill structure: phases, reference file names, and whether `assets/templates/` is needed.
+  Read `${CLAUDE_SKILL_DIR}/assets/templates/skill-md.md` and fill its placeholders using:
 
-#### Phase 2b: Apply Patterns
+  - User requirements for the new skill
+  - Phase 1 analysis output (naming conventions, existing patterns, plugin context)
+  - Evidence from the reference files above
 
-Drop Phase 2a references. Read these references:
+  If Phase 1 detects a monorepo or multi-service layout, make the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope. Do not leave multi-service boundaries implicit.
 
-- `${CLAUDE_SKILL_DIR}/references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
+  Generate the complete skill directory structure:
 
-Read `${CLAUDE_SKILL_DIR}/assets/templates/skill-md.md` and fill its placeholders using:
+  1. `SKILL.md` — primary skill file with frontmatter and a body carrying the canonical semantic-tag vocabulary
+  2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
+  3. `assets/templates/` — create stub template files if the skill generates output files
 
-- User requirements for the new skill
-- Phase 1 analysis output (naming conventions, existing patterns, plugin context)
-- Evidence from the reference files above
+     For validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted.
+  </PHASE>
 
-If Phase 1 detects a monorepo or multi-service layout, make the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope. Do not leave multi-service boundaries implicit.
+  <PHASE id="3" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
 
-Generate the complete skill directory structure:
+  If Phase 1 detected a monorepo or multi-service layout, add one extra validation pass: confirm the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope.
 
-1. `SKILL.md` — primary skill file with frontmatter and phase definitions
-2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
-3. `assets/templates/` — create stub template files if the skill generates output files
+  The loop evaluates all hard limits and quality checks — including the canonical semantic-tag strictness tiers — fixes any failures, and re-evaluates: maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-   For validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted.
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates)
+  2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
+  3. Ask for confirmation before writing any files
+  4. On approval, write all files to the target location
+  </PHASE>
 
-### Phase 3: Self-Validation
+</PROCESS>
 
-Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
-
-If Phase 1 detected a monorepo or multi-service layout, add one extra validation pass: confirm the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope.
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates)
-2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
-3. Ask for confirmation before writing any files
-4. On approval, write all files to the target location
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and loop the generated skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/MANIFEST.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/MANIFEST.md
@@ -1,0 +1,27 @@
+# Fixture Corpus — Skill Body Convention
+
+Regression corpus for the canonical semantic-tag strictness tiers defined in
+`references/skill-validation-criteria.md` ("Canonical Semantic-Tag Convention"
+section). Each fixture is a minimal SKILL.md body that exercises exactly one
+validation outcome.
+
+To use: run the validation loop from `skill-validation-criteria.md` against each
+fixture file and confirm the produced verdict matches the **Expected verdict**
+column below. Any mismatch means the strictness-tier text is ambiguous and must
+be tightened — the corpus is the regression test for that clarity.
+
+These fixtures are test data, not real skills. They are not loaded by the
+`create-skill` skill at runtime.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes only | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** — missing mandatory tag |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** — missing mandatory tag |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** — missing mandatory tag |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** — missing mandatory tag |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** — missing mandatory tag |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** — unbalanced tags |
+| `malformed-attribute.md` | `<PHASE>` `name` value missing its quotes | **hard-fail** — malformed attribute syntax |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a non-canonical `mood=` attribute | **warn** — non-canonical attribute name; passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** — alias satisfies the `<HARD_RULES>` check |

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/compliant-baseline.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/compliant-baseline.md
@@ -1,0 +1,39 @@
+---
+name: fixture-compliant-baseline
+description: "Fixture skill exercising the compliant baseline. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. All mandatory tags present, balanced, canonical attributes only. -->
+
+# Fixture Compliant Baseline
+
+One-sentence purpose statement for the baseline fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION>
+Read the validation criteria and loop until all checks pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/malformed-attribute.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/malformed-attribute.md
@@ -1,0 +1,35 @@
+---
+name: fixture-malformed-attribute
+description: "Fixture skill with a malformed PHASE attribute. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The <PHASE> name attribute value is missing its quotes. -->
+
+# Fixture Malformed Attribute
+
+One-sentence purpose statement for the malformed-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name=analysis>
+  DEFECT: the name attribute value above is unquoted — malformed attribute syntax.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-behaviour.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-behaviour.md
@@ -1,0 +1,28 @@
+---
+name: fixture-missing-behaviour
+description: "Fixture skill with the mandatory BEHAVIOUR tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <BEHAVIOUR> tag is absent. -->
+
+# Fixture Missing Behaviour
+
+One-sentence purpose statement for the missing-behaviour fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-hard-rules.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-hard-rules.md
@@ -1,0 +1,30 @@
+---
+name: fixture-missing-hard-rules
+description: "Fixture skill with the mandatory HARD_RULES tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. Both <HARD_RULES> and its <RULES> alias are absent. -->
+
+# Fixture Missing Hard Rules
+
+One-sentence purpose statement for the missing-hard-rules fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-phase.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-phase.md
@@ -1,0 +1,27 @@
+---
+name: fixture-missing-phase
+description: "Fixture skill whose PROCESS contains zero PHASE elements. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is present but contains zero <PHASE> elements. -->
+
+# Fixture Missing Phase
+
+One-sentence purpose statement for the missing-phase fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+The process container holds no phases — this is the defect under test.
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-process.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-process.md
@@ -1,0 +1,23 @@
+---
+name: fixture-missing-process
+description: "Fixture skill with the mandatory PROCESS tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <PROCESS> tag is absent. -->
+
+# Fixture Missing Process
+
+One-sentence purpose statement for the missing-process fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-trigger.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/missing-trigger.md
@@ -1,0 +1,33 @@
+---
+name: fixture-missing-trigger
+description: "Fixture skill with the mandatory TRIGGER tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <TRIGGER> tag is absent. -->
+
+# Fixture Missing Trigger
+
+One-sentence purpose statement for the missing-trigger fixture.
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/non-canonical-attribute.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/non-canonical-attribute.md
@@ -1,0 +1,36 @@
+---
+name: fixture-non-canonical-attribute
+description: "Fixture skill with a non-canonical attribute name. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: warn. <BEHAVIOUR> carries a non-canonical `mood=` attribute; all mandatory tags are present and balanced, so it passes otherwise. -->
+
+# Fixture Non-Canonical Attribute
+
+One-sentence purpose statement for the non-canonical-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical"
+  mood="optimistic">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/rules-alias.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/rules-alias.md
@@ -1,0 +1,35 @@
+---
+name: fixture-rules-alias
+description: "Fixture skill using the legacy RULES alias instead of HARD_RULES. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. Uses the legacy <RULES> tag, which is an accepted alias of <HARD_RULES>; all else compliant. -->
+
+# Fixture Rules Alias
+
+One-sentence purpose statement for the rules-alias fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<RULES>
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-skill/assets/fixtures/unbalanced-tag.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/fixtures/unbalanced-tag.md
@@ -1,0 +1,35 @@
+---
+name: fixture-unbalanced-tag
+description: "Fixture skill with an unbalanced PROCESS tag. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is opened but never closed. -->
+
+# Fixture Unbalanced Tag
+
+One-sentence purpose statement for the unbalanced-tag fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Delegate analysis to the registered evaluator agent.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+<!-- DEFECT: the <PROCESS> opening tag above has no matching </PROCESS> closing tag. -->

--- a/plugins/agent-customizer/skills/create-skill/assets/templates/html-artifact-skeleton.html
+++ b/plugins/agent-customizer/skills/create-skill/assets/templates/html-artifact-skeleton.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{artifact-title}}</title>
+  <style>
+    :root {
+      --color-text:          #1f2937;
+      --color-text-muted:    #4b5563;
+      --color-text-strong:   #111827;
+      --color-bg:            #ffffff;
+      --color-border:        #e5e7eb;
+      --color-code-bg:       #f3f4f6;
+
+      --color-trigger-text:  #374151;
+
+      --color-behaviour-bg:  #f0f4ff;
+      --color-behaviour-bar: #2563eb;
+
+      --color-hardrules-bg:  #fef2f2;
+      --color-hardrules-bar: #dc2626;
+
+      --color-phase-bg:      #fafafa;
+      --color-phase-label:   #111827;
+
+      --color-antipattern-bg:  #fffbeb;
+      --color-antipattern-bar: #d97706;
+
+      --color-output-bg:  #f0fdf4;
+      --color-output-bar: #16a34a;
+
+      --color-validation-bg:  #f5f3ff;
+      --color-validation-bar: #7c3aed;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --color-text:          #e5e7eb;
+        --color-text-muted:    #9ca3af;
+        --color-text-strong:   #f9fafb;
+        --color-bg:            #111827;
+        --color-border:        #374151;
+        --color-code-bg:       #1f2937;
+
+        --color-trigger-text:  #d1d5db;
+
+        --color-behaviour-bg:  #1e2a4a;
+        --color-behaviour-bar: #3b82f6;
+
+        --color-hardrules-bg:  #2d1515;
+        --color-hardrules-bar: #ef4444;
+
+        --color-phase-bg:      #1f2937;
+        --color-phase-label:   #f9fafb;
+
+        --color-antipattern-bg:  #2d2209;
+        --color-antipattern-bar: #f59e0b;
+
+        --color-output-bg:  #052e16;
+        --color-output-bar: #22c55e;
+
+        --color-validation-bg:  #1e1533;
+        --color-validation-bar: #a78bfa;
+      }
+    }
+
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 900px;
+      margin: 2rem auto;
+      padding: 1rem;
+      line-height: 1.6;
+      color: var(--color-text);
+      background: var(--color-bg);
+    }
+
+    BEHAVIOUR, HARD_RULES, PROCESS, PHASE, PREFLIGHT, REFERENCES,
+    EXAMPLE, ANTI_PATTERN, OUTPUT, VALIDATION, TRIGGER {
+      display: block;
+      margin: 1rem 0;
+    }
+
+    TRIGGER {
+      font-style: italic;
+      color: var(--color-trigger-text);
+    }
+
+    BEHAVIOUR {
+      background: var(--color-behaviour-bg);
+      border-left: 4px solid var(--color-behaviour-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    HARD_RULES[priority="hard"] {
+      background: var(--color-hardrules-bg);
+      border-left: 4px solid var(--color-hardrules-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    PROCESS {
+      border-top: 1px solid var(--color-border);
+      padding-top: 1rem;
+    }
+
+    PHASE {
+      background: var(--color-phase-bg);
+      border: 1px solid var(--color-border);
+      padding: 1rem;
+      margin: 0.5rem 0;
+      border-radius: 4px;
+    }
+
+    PHASE::before {
+      content: "Phase " attr(id) " — " attr(name);
+      display: block;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: var(--color-phase-label);
+    }
+
+    ANTI_PATTERN {
+      background: var(--color-antipattern-bg);
+      border-left: 4px solid var(--color-antipattern-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    OUTPUT {
+      background: var(--color-output-bg);
+      border-left: 4px solid var(--color-output-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    VALIDATION {
+      background: var(--color-validation-bg);
+      border-left: 4px solid var(--color-validation-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    code, pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      background: var(--color-code-bg);
+      padding: 0.125rem 0.25rem;
+      border-radius: 3px;
+    }
+
+    pre {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>{{artifact-title}}</h1>
+    <TRIGGER when="...">...</TRIGGER>
+    <BEHAVIOUR avoid="..." always="...">...</BEHAVIOUR>
+    <HARD_RULES priority="hard">...</HARD_RULES>
+    <PROCESS>
+      <PHASE id="1" name="...">...</PHASE>
+    </PROCESS>
+    <OUTPUT format="...">...</OUTPUT>
+    <VALIDATION>...</VALIDATION>
+  </main>
+</body>
+</html>

--- a/plugins/agent-customizer/skills/create-skill/assets/templates/skill-md.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/templates/skill-md.md
@@ -11,8 +11,8 @@ description: "[What this skill does and when to use it. Third person.]"
      Rule: Use ${CLAUDE_SKILL_DIR}/assets/templates/ for output templates
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name the target service/workspace explicitly
-     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
-           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory: <TRIGGER>,
            <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
            Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
            Closed attribute set: avoid=, always=, when=, name=, id=, priority=.

--- a/plugins/agent-customizer/skills/create-skill/assets/templates/skill-md.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/templates/skill-md.md
@@ -11,41 +11,60 @@ description: "[What this skill does and when to use it. Third person.]"
      Rule: Use ${CLAUDE_SKILL_DIR}/assets/templates/ for output templates
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name the target service/workspace explicitly
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
+           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+           <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
+           Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
+           Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: YAML frontmatter is untouched — do NOT duplicate the <TRIGGER> cue into description
 -->
 
 # [Skill Title]
 
 [One-sentence purpose statement]
 
-## Behavioral Guidelines
+<TRIGGER when="[plain-language activation cue — mirror the 'Use when ...' phrase from the description]" />
 
+<BEHAVIOUR
+  avoid="make decisions without surfacing assumptions; add speculative scope"
+  always="surface assumptions first; keep changes surgical">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - [Critical constraint 1]
 - [Critical constraint 2]
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
-<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  <PREFLIGHT name="artifact-collision-check">
+  <!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  </PREFLIGHT>
 
-### Phase 1: [Analysis Phase Name]
-<!-- Delegate to appropriate subagent; if monorepo, record the target service/workspace -->
+  <PHASE id="1" name="[analysis-phase-name]">
+  <!-- Delegate to appropriate subagent; if monorepo, record the target service/workspace -->
+  </PHASE>
 
-### Phase 2: [Generation Phase Name]
-<!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  <PHASE id="2" name="[generation-phase-name]">
+  <!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  </PHASE>
 
-### Phase 3: Self-Validation
-<!-- Read ${CLAUDE_SKILL_DIR}/references/[type]-validation-criteria.md -->
+  <PHASE id="3" name="self-validation">
+  <!-- Read ${CLAUDE_SKILL_DIR}/references/[type]-validation-criteria.md and loop until all checks pass -->
+  </PHASE>
 
-### Phase 4: Present and Write
-<!-- Show artifact with evidence citations, write on approval -->
+  <PHASE id="4" name="present-and-write">
+  <!-- Show artifact with evidence citations, write on approval -->
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+<!-- Read ${CLAUDE_SKILL_DIR}/references/[type]-validation-criteria.md, loop until pass -->
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-skill/references/artifact-format-routing.md
+++ b/plugins/agent-customizer/skills/create-skill/references/artifact-format-routing.md
@@ -1,0 +1,117 @@
+# Artifact Format Routing
+
+Evidence-based routing rule for deciding whether a skill's generated output artifact
+should default to HTML or Markdown.
+Source: wiki/knowledge/skill-body-convention.md (Artifact format routing section),
+CONTEXT.md (HTML-structural body convention — "Artifact format routing" entry),
+wiki/knowledge/html-artifact-effectiveness.md
+
+---
+
+## Routing Table
+
+When `create-skill` generates a new skill, the new skill's output format is
+determined by the artifact kind that new skill produces:
+
+| Artifact kind                                  | Default format | Reason                                            |
+| ---------------------------------------------- | -------------- | ------------------------------------------------- |
+| Plan, PRD, design spec                         | HTML           | Human-rich + agent-executable                     |
+| Report (weekly status, research, explainer)    | HTML           | Human-rich + agent-executable                     |
+| Prototype, custom editor, code-review writeup  | HTML           | Interactivity benefits from HTML                  |
+| `SKILL.md`, subagent `.md`                     | Markdown       | Agent-loaded; spec-mandated                       |
+| `AGENTS.md`, `CLAUDE.md`                       | Markdown       | Agent-loaded; spec-mandated                       |
+| `.claude/rules/*.md`, `.cursor/rules/*.mdc`    | Markdown       | Agent-loaded; spec-mandated                       |
+| `wiki/knowledge/*.md`                          | Markdown       | Agent-loaded by wiki-routing rule                 |
+| `docs/adr/*.md`                                | Markdown       | Tooling-locked (ADR convention)                   |
+| `CONTEXT.md`                                   | Markdown       | Tooling-locked (`grill-with-docs` reads it)       |
+| `README.md`                                    | Markdown       | Tooling-locked (npm/GitHub renderers)             |
+| Commit message, PR body, GitHub issue          | Markdown       | Tooling-locked (GitHub renderers)                 |
+| Code comments                                  | Markdown-ish   | Tooling-locked (compiler/linter parses)           |
+
+Explicit user override (`generate as markdown`) always wins over the default.
+
+---
+
+## How to classify
+
+During Phase 2 (generate-skill), before choosing the output template:
+
+1. **Identify the output artifact kind** — ask: "What does this new skill produce?
+   A plan/PRD/spec/report? Or a platform config file (SKILL.md, rule, ADR)?"
+
+2. **Apply the routing table above.** The left column describes the artifact kind;
+   the Default format column gives the verdict.
+
+3. **Check for explicit override.** If the user said "generate as markdown" (or
+   equivalent phrasing like "output markdown", "use .md", "markdown format"), the
+   override wins regardless of the routing table verdict.
+
+4. **Act on the verdict:**
+   - **HTML default** → use `${CLAUDE_SKILL_DIR}/assets/templates/html-artifact-skeleton.html`
+     as the output template for the new skill. Instruct the new skill to carry the
+     canonical semantic tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>`
+     with one or more `<PHASE id name>`, plus relevant optional tags `<OUTPUT>`,
+     `<VALIDATION>`) inside the HTML `<body>`. Copy or reference the skeleton into
+     the new skill's `assets/templates/` directory.
+   - **Markdown default** → use the standard `${CLAUDE_SKILL_DIR}/assets/templates/skill-md.md`
+     template (or a Markdown template appropriate to the artifact type).
+   - **Explicit override** → apply the user's stated format regardless of the table.
+
+---
+
+## HTML skeleton location
+
+The HTML baseline skeleton lives at:
+
+```
+${CLAUDE_SKILL_DIR}/assets/templates/html-artifact-skeleton.html
+```
+
+It is a valid HTML5 document with:
+- `<meta charset>` and `<meta name="viewport">`
+- Scoped CSS targeting each semantic tag (`BEHAVIOUR`, `HARD_RULES`, `PHASE`, `OUTPUT`,
+  `VALIDATION`, `ANTI_PATTERN`, etc.) with adaptive colors (light and dark mode via
+  CSS custom properties and `@media (prefers-color-scheme: dark)`)
+- Placeholder `{{artifact-title}}` in `<title>` and `<h1>`
+- A `<main>` block containing the canonical semantic-tag scaffold
+
+When generating a new HTML-defaulting skill, copy this skeleton into the new skill's
+`assets/templates/` directory (e.g., as `<artifact-type>.html`). Replace
+`{{artifact-title}}` with the artifact name appropriate to the new skill.
+
+---
+
+## Canonical semantic tags in HTML artifacts
+
+Generated HTML artifacts MUST carry the canonical semantic tags inside the HTML body.
+The same vocabulary that governs `SKILL.md` bodies applies:
+
+**Mandatory tags (HTML artifact)**:
+- `<TRIGGER when="...">` — plain-language activation context
+- `<BEHAVIOUR avoid="..." always="...">` — behavioural guidelines
+- `<HARD_RULES priority="hard">` — inviolable constraints
+- `<PROCESS>` containing at least one `<PHASE id="N" name="...">` — ordered execution steps
+
+**Optional tags (HTML artifact)**:
+- `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`.
+
+These tags are valid HTML5 — browsers treat unknown elements as inline by default;
+the CSS in the skeleton promotes each to `display: block` with semantic styling.
+
+---
+
+## Why HTML for human-rich artifacts
+
+HTML artifacts serve two consumers: humans (CSS layout, diagrams, interactive controls)
+and the next LLM session (parseable semantic-tag structure). The dual-consumer design
+is why this project's HTML artifacts embed canonical semantic tags — the same parse
+target serves both.
+
+Markdown past ~100 lines stops being read; rich visualisations get faked with ASCII;
+HTML renders natively in any browser without extra tooling. For agent-loaded and
+tooling-locked files the tradeoffs reverse: spec compliance, diffability, and
+renderer compatibility make Markdown mandatory.
+
+Source: wiki/knowledge/html-artifact-effectiveness.md (Core argument, Where HTML wins)

--- a/plugins/agent-customizer/skills/create-skill/references/artifact-format-routing.md
+++ b/plugins/agent-customizer/skills/create-skill/references/artifact-format-routing.md
@@ -2,9 +2,6 @@
 
 Evidence-based routing rule for deciding whether a skill's generated output artifact
 should default to HTML or Markdown.
-Source: wiki/knowledge/skill-body-convention.md (Artifact format routing section),
-CONTEXT.md (HTML-structural body convention — "Artifact format routing" entry),
-wiki/knowledge/html-artifact-effectiveness.md
 
 ---
 
@@ -113,5 +110,3 @@ Markdown past ~100 lines stops being read; rich visualisations get faked with AS
 HTML renders natively in any browser without extra tooling. For agent-loaded and
 tooling-locked files the tradeoffs reverse: spec compliance, diffability, and
 renderer compatibility make Markdown mandatory.
-
-Source: wiki/knowledge/html-artifact-effectiveness.md (Core argument, Where HTML wins)

--- a/plugins/agent-customizer/skills/create-skill/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/create-skill/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/create-skill/references/skill-authoring-guide.md
+++ b/plugins/agent-customizer/skills/create-skill/references/skill-authoring-guide.md
@@ -1,7 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code skills (SKILL.md files).
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -50,7 +49,6 @@ Analogy: Claude as a robot on a path — narrow bridge (low freedom) vs. open fi
 | Sonnet | Clear and efficient? (balanced) |
 | Opus | Avoid over-explaining? (may need less) |
 
-*Source: skills/skill-authoring-best-practices.md lines 11-145*
 
 ---
 
@@ -82,7 +80,6 @@ my-skill/
 | `hooks` | No | Hooks scoped to this skill's lifecycle |
 | `argument-hint` | No | Autocomplete hint, e.g. `[issue-number]` |
 
-*Source: skills/extend-claude-with-skills.md lines 169-199*
 
 ---
 
@@ -98,7 +95,6 @@ my-skill/
 
 Include: (1) what it does, (2) when to use it, (3) specific trigger terms for matching.
 
-*Source: skills/skill-authoring-best-practices.md lines 168-250*
 
 ---
 
@@ -118,7 +114,6 @@ Load only the references needed for each phase, not all at once.
 
 Keep SKILL.md under 500 lines. Move detailed reference material to separate files. Reference supporting files explicitly so Claude knows what they contain.
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300; skills/extend-claude-with-skills.md lines 223-246*
 
 ---
 
@@ -132,7 +127,6 @@ Keep SKILL.md under 500 lines. Move detailed reference material to separate file
 
 Use `disable-model-invocation: true` for workflows with side effects (commit, deploy, send-message). Use `user-invocable: false` for background knowledge Claude should apply but users shouldn't invoke directly.
 
-*Source: skills/extend-claude-with-skills.md lines 248-283*
 
 ---
 
@@ -147,4 +141,3 @@ Use `disable-model-invocation: true` for workflows with side effects (commit, de
 | Over-explaining for Opus | Patronizing + token waste | Trust the model; provide minimal scaffolding |
 | Contradictions between phases | Claude picks one arbitrarily | Review all phases for consistency |
 
-*Source: skills/skill-authoring-best-practices.md lines 800-1100*

--- a/plugins/agent-customizer/skills/create-skill/references/skill-format-reference.md
+++ b/plugins/agent-customizer/skills/create-skill/references/skill-format-reference.md
@@ -1,7 +1,6 @@
 # Skill Format Reference
 
 Technical specification for SKILL.md format, directory structure, variables, and discovery.
-Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-skills.md
 
 ---
 
@@ -45,7 +44,6 @@ Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-
 | `agent` | Subagent type when `context: fork` (e.g., `Explore`, `Plan`, `general-purpose`) |
 | `hooks` | Hooks scoped to this skill's lifecycle (see hooks documentation) |
 
-*Source: skills/research-claude-code-skills-format.md lines 90-130; skills/extend-claude-with-skills.md lines 183-198*
 
 ---
 
@@ -57,7 +55,6 @@ Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-
 - Must NOT contain consecutive `--`
 - Must match the parent directory name
 
-*Source: skills/research-claude-code-skills-format.md lines 103-108*
 
 ---
 
@@ -84,7 +81,6 @@ Dynamic context injection with `!` prefix runs shell commands before skill loads
 - Current branch: !`git branch --show-current`
 ```
 
-*Source: skills/extend-claude-with-skills.md lines 201-210; skills/research-claude-code-skills-format.md lines 126-149*
 
 ---
 
@@ -109,7 +105,6 @@ my-skill/
 - `references/` files load only when skill phases explicitly read them
 - `scripts/` files are executed, not loaded into context
 
-*Source: skills/research-claude-code-skills-format.md lines 153-186; skills/extend-claude-with-skills.md lines 100-115*
 
 ---
 
@@ -123,7 +118,6 @@ my-skill/
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to `references/` subdirectory. Explicitly reference supporting files from SKILL.md so Claude knows what to load and when.
 
-*Source: skills/research-claude-code-skills-format.md lines 172-186*
 
 ---
 
@@ -138,4 +132,3 @@ Keep SKILL.md under **500 lines**. Move detailed reference material to `referenc
 
 Priority: enterprise > personal > project. Plugin skills use `plugin-name:skill-name` namespace — no conflicts.
 
-*Source: skills/extend-claude-with-skills.md lines 85-97; skills/research-claude-code-skills-format.md lines 189-200*

--- a/plugins/agent-customizer/skills/create-skill/references/skill-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-skill/references/skill-validation-criteria.md
@@ -1,7 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`, `wiki/knowledge/skill-body-convention.md`
 
 ---
 
@@ -20,16 +19,15 @@ Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skil
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
-| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags |
+| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
 
 ---
 

--- a/plugins/agent-customizer/skills/create-skill/references/skill-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-skill/references/skill-validation-criteria.md
@@ -1,7 +1,18 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`, `wiki/knowledge/skill-body-convention.md`
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
@@ -19,6 +30,38 @@ Any skill violating these criteria must be fixed before proceeding:
 | Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
 
 *Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X")
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|-------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
 ---
 
@@ -40,6 +83,9 @@ Any skill violating these criteria must be fixed before proceeding:
 - [ ] Plugin skill body contains no inline bash analysis commands — analysis must be delegated to registered agents (applies to skills in `plugins/*/skills/`)
 - [ ] Standalone skill body includes explicit bash commands for each analysis step (applies to skills in `skills/`)
 - [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-best-practices.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
 
 ---
 
@@ -62,10 +108,30 @@ Any skill violating these criteria must be fixed before proceeding:
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above
+1. Evaluate the skill against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
-3. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing skills when ALL criteria pass
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The fixture corpus at `${CLAUDE_SKILL_DIR}/assets/fixtures/` is the regression test for the strictness tiers. Each fixture is annotated in `assets/fixtures/MANIFEST.md` with its expected verdict. Running the validation loop against the corpus MUST produce exactly the verdict below for each fixture — any deviation means the strictness-tier text above is ambiguous and must be tightened.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check) |

--- a/plugins/agent-customizer/skills/create-subagent/SKILL.md
+++ b/plugins/agent-customizer/skills/create-subagent/SKILL.md
@@ -5,111 +5,122 @@ description: "Creates new subagent definitions with YAML frontmatter grounded in
 
 # Create Subagent
 
-Generates a new subagent definition with correct YAML frontmatter, minimal tool restrictions, and a structured system prompt grounded in the docs corpus.
+Generates a new subagent definition with correct YAML frontmatter, minimal tool restrictions, and a structured body grounded in the docs corpus.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new Claude Code subagent from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create subagents with generic system prompts ("you are a helpful AI assistant")
 - **NEVER** grant write tools (`Edit`, `Write`) to read-only analysis or review agents; allow `Bash` only for explicitly read-only commands when needed
 - **NEVER** set `maxTurns` > 30 without explicit justification in the system prompt
 - **EVERY** subagent must include: role definition, process steps, output format, and self-verification instructions
 - **EVERY** `description` must include specific "Use when..." trigger phrases so Claude routes correctly
+- **EVERY** generated subagent body must carry the canonical semantic-tag vocabulary (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`); `<TRIGGER>` is optional for subagents
 - **Agents CANNOT spawn other agents** — the Task tool is unavailable at runtime; warn if user requests this
 - Plugin context: `hooks`, `mcpServers`, and `permissionMode` fields are ignored for plugin agents
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="name-collision-check">
+  Check if a subagent with the same name already exists at:
 
-Check if a subagent with the same name already exists at:
+  - `.claude/agents/{requested-name}.md`
+  - `plugins/*/agents/{requested-name}.md`
 
-- `.claude/agents/{requested-name}.md`
-- `plugins/*/agents/{requested-name}.md`
+  **If a subagent already exists with that name:**
 
-**If a subagent already exists with that name:**
+  1. Inform the user: "A subagent named `{requested-name}` already exists."
+  2. Suggest using `/agent-customizer:improve-subagent` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
 
-1. Inform the user: "A subagent named `{requested-name}` already exists."
-2. Suggest using `/agent-customizer:improve-subagent` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
+  **If no subagent exists with that name:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no subagent exists with that name:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Codebase Analysis
+  > Analyze the project to understand existing subagents. Focus on: agent names and roles in `.claude/agents/` and `plugins/*/agents/`, tool restrictions in use, model choices, `maxTurns` values, which skills delegate to which agents, and naming conventions. Flag any agents similar in purpose to `{requested-name}`. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing subagents. Focus on: agent names and roles in `.claude/agents/` and `plugins/*/agents/`, tool restrictions in use, model choices, `maxTurns` values, which skills delegate to which agents, and naming conventions. Flag any agents similar in purpose to `{requested-name}`. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
+  <PHASE id="2" name="generate-subagent">
+  **Load context.** Drop any references from Phase 1. Read these references:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  - `${CLAUDE_SKILL_DIR}/references/subagent-authoring-guide.md` — when to use subagents, system prompt structure, model selection heuristics, tool restriction patterns, anti-patterns
+  - `${CLAUDE_SKILL_DIR}/references/subagent-config-reference.md` — YAML frontmatter fields, valid model IDs, tool allowlist/denylist, orchestration patterns, plugin restrictions
 
-### Phase 2: Generate Subagent
+  Decide model selection, tool restrictions, and target location.
 
-#### Phase 2a: Load Context
+  **Apply patterns.** Drop the load-context references above. Read this reference:
 
-Drop any references from Phase 1. Read these references:
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — subagent-specific prompting (role prompting, structured output, confidence filtering)
 
-- `${CLAUDE_SKILL_DIR}/references/subagent-authoring-guide.md` — when to use subagents, system prompt structure, model selection heuristics, tool restriction patterns, anti-patterns
-- `${CLAUDE_SKILL_DIR}/references/subagent-config-reference.md` — YAML frontmatter fields, valid model IDs, tool allowlist/denylist, orchestration patterns, plugin restrictions
+  <REFERENCES load="on-demand">
+  - subagent-authoring-guide.md
+  - subagent-config-reference.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-Decide model selection, tool restrictions, and target location.
+  Read `${CLAUDE_SKILL_DIR}/assets/templates/subagent-definition.md` and fill its placeholders using:
 
-#### Phase 2b: Apply Patterns
+  - User requirements for the new subagent (role, purpose, tools needed)
+  - Phase 1 analysis output (existing agents, naming conventions, delegation patterns)
+  - Decisions from Phase 2a (model, tools, target location)
 
-Drop Phase 2a references. Read this reference:
+  Apply model selection heuristic:
 
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — subagent-specific prompting (role prompting, structured output, confidence filtering)
+  - `haiku` — narrow read-only lookup agents with no structured judgment, policy evaluation, or config review
+  - `sonnet` — standard analysis, review, and configuration-inspection agents (default for most subagents)
+  - `opus` — complex multi-step reasoning only (requires explicit justification)
 
-Read `${CLAUDE_SKILL_DIR}/assets/templates/subagent-definition.md` and fill its placeholders using:
+  Unless the user explicitly asks for a cheaper exploration agent, choose `sonnet` for any agent that inspects configuration, evaluates compliance, or produces structured findings.
 
-- User requirements for the new subagent (role, purpose, tools needed)
-- Phase 1 analysis output (existing agents, naming conventions, delegation patterns)
-- Decisions from Phase 2a (model, tools, target location)
+  If Phase 1 detects a monorepo or multi-service layout, make the generated system prompt name the relevant services, workspaces, and scope boundaries the agent should inspect. Do not leave multi-service targets implicit.
 
-Apply model selection heuristic:
+  Determine target location:
 
-- `haiku` — narrow read-only lookup agents with no structured judgment, policy evaluation, or config review
-- `sonnet` — standard analysis, review, and configuration-inspection agents (default for most subagents)
-- `opus` — complex multi-step reasoning only (requires explicit justification)
+  - `.claude/agents/{name}.md` — project-level agent (accessible everywhere)
+  - `plugins/{plugin}/agents/{name}.md` — plugin-scoped agent (restricted to plugin context)
+  </PHASE>
 
-Unless the user explicitly asks for a cheaper exploration agent, choose `sonnet` for any agent that inspects configuration, evaluates compliance, or produces structured findings.
+  <PHASE id="3" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated subagent definition.
 
-If Phase 1 detects a monorepo or multi-service layout, make the generated system prompt name the relevant services, workspaces, and scope boundaries the agent should inspect. Do not leave multi-service targets implicit.
+  In addition to the shared criteria, enforce two scenario-sensitive checks before proceeding:
 
-Determine target location:
+  - Treat `sonnet` as the default for configuration inspection, compliance review, and other structured analysis agents unless the user explicitly asks for a cheaper exploration agent
+  - If Phase 1 detected a monorepo or multi-service layout, confirm the generated prompt names the relevant services, workspaces, or scope boundaries explicitly
 
-- `.claude/agents/{name}.md` — project-level agent (accessible everywhere)
-- `plugins/{plugin}/agents/{name}.md` — plugin-scoped agent (restricted to plugin context)
+  The loop evaluates all hard limits, quality checks, and canonical semantic-tag strictness tiers — fixing any failures and re-evaluating — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-### Phase 3: Self-Validation
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated subagent definition
+  2. Cite the evidence from reference files that informed key decisions:
+     - Why this model was chosen (heuristic applied)
+     - Why these tools are included/excluded (principle of least privilege)
+     - What the output format enforces and why
+  3. If the user requested plugin-restricted fields (`hooks`, `mcpServers`, `permissionMode`), warn that these fields are ignored in plugin context
+  4. Ask for confirmation before writing any files
+  5. On approval, write the subagent definition to the target location
+  </PHASE>
 
-Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated subagent definition.
+</PROCESS>
 
-In addition to the shared criteria, enforce two scenario-sensitive checks before proceeding:
-
-- Treat `sonnet` as the default for configuration inspection, compliance review, and other structured analysis agents unless the user explicitly asks for a cheaper exploration agent
-- If Phase 1 detected a monorepo or multi-service layout, confirm the generated prompt names the relevant services, workspaces, or scope boundaries explicitly
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete generated subagent definition
-2. Cite the evidence from reference files that informed key decisions:
-   - Why this model was chosen (heuristic applied)
-   - Why these tools are included/excluded (principle of least privilege)
-   - What the output format enforces and why
-3. If the user requested plugin-restricted fields (`hooks`, `mcpServers`, `permissionMode`), warn that these fields are ignored in plugin context
-4. Ask for confirmation before writing any files
-5. On approval, write the subagent definition to the target location
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and loop the generated subagent through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/MANIFEST.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/MANIFEST.md
@@ -1,0 +1,33 @@
+# Fixture Corpus — Subagent Body Convention
+
+Regression corpus for the canonical semantic-tag strictness tiers defined in
+`references/subagent-validation-criteria.md` ("Canonical Semantic-Tag Convention"
+section). Each fixture is a minimal subagent definition body that exercises exactly
+one validation outcome.
+
+The subagent variant of the convention differs from the skill variant in one
+critical respect: `<TRIGGER>` is **optional** for subagents (they are spawned by
+skills, not user-invoked). Its absence is silent — never a finding. All other
+mandatory tags (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`) are
+hard-fail when absent, same as for skills.
+
+To use: run the validation loop from `subagent-validation-criteria.md` against
+each fixture file and confirm the produced verdict matches the **Expected verdict**
+column below. Any mismatch means the strictness-tier text is ambiguous and must
+be tightened — the corpus is the regression test for that clarity.
+
+These fixtures are test data, not real subagents. They are not loaded by the
+`create-subagent` skill at runtime.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-with-trigger.md` | None — all mandatory tags present, `<TRIGGER>` also present, balanced, canonical attributes only | **pass** |
+| `compliant-without-trigger.md` | `<TRIGGER>` absent (subagent variant — optional) | **pass** — `<TRIGGER>` absence is silent for subagents |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** — missing mandatory tag |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** — missing mandatory tag |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** — missing mandatory tag |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** — missing mandatory tag |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** — unbalanced tags |
+| `malformed-attribute.md` | `<PHASE>` `name` value missing its quotes | **hard-fail** — malformed attribute syntax |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a non-canonical `mood=` attribute | **warn** — non-canonical attribute name; passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** — alias satisfies the `<HARD_RULES>` check |

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/compliant-with-trigger.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/compliant-with-trigger.md
@@ -1,0 +1,42 @@
+---
+name: fixture-compliant-with-trigger
+description: "Fixture subagent exercising the compliant baseline with TRIGGER present. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. All mandatory tags present, <TRIGGER> also present, balanced, canonical attributes only. -->
+
+# Fixture Compliant With Trigger
+
+One-sentence identity statement for the compliant-with-trigger fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>
+
+<OUTPUT>
+Return findings as a structured list with file paths and descriptions.
+</OUTPUT>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/compliant-without-trigger.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/compliant-without-trigger.md
@@ -1,0 +1,40 @@
+---
+name: fixture-compliant-without-trigger
+description: "Fixture subagent exercising the compliant baseline with TRIGGER absent. Use when validating the subagent-specific TRIGGER-optional variant."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. <TRIGGER> is absent — for subagents this is SILENT (not a hard-fail). All other mandatory tags are present, balanced, and use canonical attributes only. -->
+
+# Fixture Compliant Without Trigger
+
+One-sentence identity statement for the compliant-without-trigger fixture.
+
+<BEHAVIOUR
+  avoid="modifying files; surfacing low-confidence findings"
+  always="cite evidence; report in structured format">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>
+
+<OUTPUT>
+Return findings as a structured list with file paths and descriptions.
+</OUTPUT>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/malformed-attribute.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/malformed-attribute.md
@@ -1,0 +1,36 @@
+---
+name: fixture-malformed-attribute
+description: "Fixture subagent with a malformed PHASE attribute. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The <PHASE> name attribute value is missing its quotes. -->
+
+# Fixture Malformed Attribute
+
+One-sentence identity statement for the malformed-attribute fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name=analysis>
+  DEFECT: the name attribute value above is unquoted — malformed attribute syntax.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-behaviour.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-behaviour.md
@@ -1,0 +1,29 @@
+---
+name: fixture-missing-behaviour
+description: "Fixture subagent with the mandatory BEHAVIOUR tag absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <BEHAVIOUR> tag is absent. -->
+
+# Fixture Missing Behaviour
+
+One-sentence identity statement for the missing-behaviour fixture.
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-hard-rules.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-hard-rules.md
@@ -1,0 +1,31 @@
+---
+name: fixture-missing-hard-rules
+description: "Fixture subagent with both HARD_RULES and RULES absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. Both <HARD_RULES> and the <RULES> alias are absent. -->
+
+# Fixture Missing Hard Rules
+
+One-sentence identity statement for the missing-hard-rules fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-phase.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-phase.md
@@ -1,0 +1,28 @@
+---
+name: fixture-missing-phase
+description: "Fixture subagent with PROCESS present but containing zero PHASE elements. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is present but contains zero <PHASE> elements. -->
+
+# Fixture Missing Phase
+
+One-sentence identity statement for the missing-phase fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+<!-- DEFECT: <PROCESS> is present but contains no <PHASE> elements. -->
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-process.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/missing-process.md
@@ -1,0 +1,24 @@
+---
+name: fixture-missing-process
+description: "Fixture subagent with the mandatory PROCESS tag absent. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <PROCESS> tag is absent. -->
+
+# Fixture Missing Process
+
+One-sentence identity statement for the missing-process fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/non-canonical-attribute.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/non-canonical-attribute.md
@@ -1,0 +1,37 @@
+---
+name: fixture-non-canonical-attribute
+description: "Fixture subagent with a non-canonical attribute name. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: warn. <BEHAVIOUR> carries a non-canonical `mood=` attribute; all mandatory tags are present and balanced, so it passes otherwise. -->
+
+# Fixture Non-Canonical Attribute
+
+One-sentence identity statement for the non-canonical-attribute fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence"
+  mood="optimistic">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/rules-alias.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/rules-alias.md
@@ -1,0 +1,36 @@
+---
+name: fixture-rules-alias
+description: "Fixture subagent using the legacy RULES alias instead of HARD_RULES. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: pass. Uses the legacy <RULES> tag, which is an accepted alias of <HARD_RULES>; all else compliant. -->
+
+# Fixture Rules Alias
+
+One-sentence identity statement for the rules-alias fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<RULES>
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+</PROCESS>

--- a/plugins/agent-customizer/skills/create-subagent/assets/fixtures/unbalanced-tag.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/fixtures/unbalanced-tag.md
@@ -1,0 +1,36 @@
+---
+name: fixture-unbalanced-tag
+description: "Fixture subagent with an unbalanced PROCESS tag. Use when validating the canonical semantic-tag convention."
+tools: Read, Grep, Glob
+model: sonnet
+maxTurns: 15
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is opened but never closed. -->
+
+# Fixture Unbalanced Tag
+
+One-sentence identity statement for the unbalanced-tag fixture.
+
+<BEHAVIOUR
+  avoid="modifying files"
+  always="cite evidence">
+- Do not modify any files — report only.
+- Surface findings with source citations.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER modify files.
+- EVERY finding must cite a specific source or file location.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Scan the target files and collect findings.
+  </PHASE>
+
+  <PHASE id="2" name="compile-output">
+  Format findings into the structured output format.
+  </PHASE>
+
+<!-- DEFECT: the <PROCESS> opening tag above has no matching </PROCESS> closing tag. -->

--- a/plugins/agent-customizer/skills/create-subagent/assets/templates/subagent-definition.md
+++ b/plugins/agent-customizer/skills/create-subagent/assets/templates/subagent-definition.md
@@ -13,41 +13,59 @@ maxTurns: [15 for analysis agents, 20 for evaluator agents]
      Rule: Plugin agents CANNOT use hooks, mcpServers, or permissionMode
      Rule: Agents cannot spawn other agents
      Rule: If scope spans multiple services or workspaces, name them explicitly in the prompt
+     Rule: <TRIGGER> is optional — omit if the subagent is always spawned by skills, not user-invoked
+     Rule: Mandatory body tags: <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with at least one <PHASE id="N" name="X">
 -->
 
 # [Agent Name]
 
 [One-sentence identity statement; name target services/workspaces when scope is multi-service]
 
-## Constraints
+<!-- Optional: include <TRIGGER> if this subagent can also be user-invoked -->
+<!-- <TRIGGER when="[activation condition]" /> -->
 
-- Do not [constraint 1 — typically "modify any files"]
-- Do not [constraint 2 — typically "suggest improvements, only report"]
-- Do not [constraint 3]
-- Do not [constraint 4]
+<BEHAVIOUR
+  avoid="[what to avoid — e.g., modifying files; surfacing low-confidence findings]"
+  always="[what to always do — e.g., cite evidence; report in structured format]">
+- [Behavioural guideline 1]
+- [Behavioural guideline 2]
+- Do not modify any files — report only.
+</BEHAVIOUR>
 
-## Process
+<HARD_RULES priority="hard">
+- **NEVER** [inviolable constraint 1 — e.g., "modify files"]
+- **NEVER** [inviolable constraint 2 — e.g., "spawn other subagents"]
+- **EVERY** finding must cite a specific source or file location
+- **EVERY** output must match the Output Format below exactly
+</HARD_RULES>
 
-### 1. [First Step]
+<PROCESS>
 
-[What to analyze/detect/evaluate]
+  <PHASE id="1" name="[first-step]">
+  [What to analyze/detect/evaluate in this step]
+  </PHASE>
 
-### 2. [Second Step]
+  <PHASE id="2" name="[second-step]">
+  [How to process findings — filtering, categorizing, structuring]
+  </PHASE>
 
-[How to process findings]
+  <PHASE id="3" name="[compile-output]">
+  [How to compile and format the final structured output]
+  </PHASE>
 
-### 3. [Third Step]
+</PROCESS>
 
-[How to compile output]
-
-## Output Format
+<OUTPUT>
 
 ```
 [Exact structure the agent must return — headers, tables, sections]
 ```
 
-## Self-Verification
+</OUTPUT>
 
-1. [Check 1]
-2. [Check 2]
-3. [Check 3]
+<VALIDATION>
+Before returning output, verify:
+1. [Self-check 1 — e.g., "All findings cite a file path or source doc"]
+2. [Self-check 2 — e.g., "No files were modified"]
+3. [Self-check 3 — e.g., "Output matches the required format exactly"]
+</VALIDATION>

--- a/plugins/agent-customizer/skills/create-subagent/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/create-subagent/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/create-subagent/references/subagent-authoring-guide.md
+++ b/plugins/agent-customizer/skills/create-subagent/references/subagent-authoring-guide.md
@@ -1,7 +1,6 @@
 # Subagent Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code subagent definitions.
-Source: subagents/research-subagent-best-practices.md, subagents/creating-custom-subagents.md
 
 ---
 
@@ -21,7 +20,6 @@ Source: subagents/research-subagent-best-practices.md, subagents/creating-custom
 
 Subagents are context firewalls. They encapsulate exploration work — glob output, grep noise, evaluator scans — in an isolated window so it never reaches the parent context. Only the condensed, structured result flows back. The orchestrator stays in the smart zone; the subagent absorbs the noise.
 
-*Source: harness-engineering.md*
 
 | Use subagent when | Use inline Claude when | Use hook when |
 |------------------|----------------------|--------------|
@@ -33,7 +31,6 @@ Subagents are context firewalls. They encapsulate exploration work — glob outp
 
 **Subagents cannot spawn other subagents** — prevents infinite nesting.
 
-*Source: subagents/research-subagent-best-practices.md lines 33-55*
 
 ---
 
@@ -66,7 +63,6 @@ maxTurns: 20
 You are a code reviewer specializing in [domain]...
 ```
 
-*Source: subagents/creating-custom-subagents.md lines 151-210*
 
 ---
 
@@ -86,7 +82,6 @@ Effective subagent system prompts follow this 5-part pattern:
 - Include trigger phrases ("use proactively when...", "use when editing...")
 - Avoid generic descriptions ("helps with code")
 
-*Source: subagents/research-subagent-best-practices.md lines 73-76, 374-430*
 
 ---
 
@@ -103,7 +98,6 @@ Effective subagent system prompts follow this 5-part pattern:
 
 **Rule of thumb**: Opus for architecture decisions, Sonnet for everything else, Haiku for read-only exploration only.
 
-*Source: subagents/research-subagent-best-practices.md lines 318-355*
 
 ---
 
@@ -129,7 +123,6 @@ If both defined: denylist applied first, then allowlist resolves against remaini
 - Explorers: `Read, Grep, Glob, Bash(readonly commands)`
 - Full-capability (rare): all tools — justify explicitly
 
-*Source: subagents/creating-custom-subagents.md lines 245-295*
 
 ---
 
@@ -146,7 +139,6 @@ If both defined: denylist applied first, then allowlist resolves against remaini
 | maxTurns > 30 | Runaway agents | Cap at 20-30 for most tasks |
 | Vague system prompt | Inconsistent behavior | Add role, process, output format |
 
-*Source: subagents/research-subagent-best-practices.md lines 791-819*
 
 ---
 
@@ -167,4 +159,3 @@ Consolidate similar issues. Prioritize by: CRITICAL (bugs/security) > HIGH > MED
 
 This pattern significantly reduces noise and keeps output actionable.
 
-*Source: subagents/research-subagent-best-practices.md lines 463-475*

--- a/plugins/agent-customizer/skills/create-subagent/references/subagent-config-reference.md
+++ b/plugins/agent-customizer/skills/create-subagent/references/subagent-config-reference.md
@@ -1,7 +1,6 @@
 # Subagent Config Reference
 
 Complete YAML frontmatter specification, model IDs, and orchestration patterns for subagents.
-Source: subagents/creating-custom-subagents.md, subagents/claude-orchestrate-of-claude-code-sessions.md
 
 ---
 
@@ -37,7 +36,6 @@ Only `name` and `description` are required. All others have sensible defaults.
 | `effort` | No | Inherit | `low`, `medium`, `high`, `max` (Opus 4.6 only) |
 | `isolation` | No | None | `worktree` = isolated git worktree; auto-cleanup if no changes |
 
-*Source: subagents/creating-custom-subagents.md lines 213-232*
 
 ---
 
@@ -54,7 +52,6 @@ Only `name` and `description` are required. All others have sensible defaults.
 
 Full model IDs (e.g., `claude-opus-4-6`, `claude-sonnet-4-6`) also accepted.
 
-*Source: subagents/creating-custom-subagents.md lines 234-241*
 
 ---
 
@@ -91,7 +88,6 @@ Standard patterns from community (read-only reviewers dominate):
 - Explorer: `tools: Read, Grep, Glob, Bash`
 - Full-access (rare): omit `tools` and `disallowedTools`
 
-*Source: subagents/creating-custom-subagents.md lines 243-275*
 
 ---
 
@@ -116,7 +112,6 @@ Main → (delegate) → Researcher agent → (report) → Main → (delegate) �
 **Parallel decomposition:**
 Spawn multiple independent subagents simultaneously. Main aggregates results.
 
-*Source: subagents/creating-custom-subagents.md lines 619-637*
 
 ---
 
@@ -129,7 +124,6 @@ These limitations are enforced by the runtime:
 - **Subagents do not inherit parent skills** — must be explicitly listed in `skills` field (full content injected)
 - **`maxTurns` applies per invocation** — project convention: 15 for analysis agents, 20 for evaluator agents; values outside 15–20 require explicit justification
 
-*Source: subagents/creating-custom-subagents.md lines 210-212; subagents/research-subagent-best-practices.md lines 36-42*
 
 ---
 
@@ -143,4 +137,3 @@ Plugin subagents (from installed plugins) have additional restrictions for secur
 
 To use these fields with a plugin agent: copy the agent file to `.claude/agents/` or `~/.claude/agents/`.
 
-*Source: subagents/creating-custom-subagents.md lines 187-189*

--- a/plugins/agent-customizer/skills/create-subagent/references/subagent-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-subagent/references/subagent-validation-criteria.md
@@ -1,7 +1,18 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Claude Code subagent definitions.
-Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md
+Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md, `wiki/knowledge/skill-body-convention.md`
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
@@ -22,6 +33,41 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 ---
 
+## Canonical Semantic-Tag Convention
+
+The subagent body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the subagent body MUST contain all of these):
+
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Subagent-specific variant**: `<TRIGGER>` is OPTIONAL for subagents (they are spawned by skills, not user-invoked). Its absence is **silent** — never a finding.
+
+**Optional tags** (absence is silent — never a finding): `<TRIGGER>`, `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of `<TRIGGER>` or any other optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
+
+---
+
 ## Quality Checks (All must pass)
 
 - [ ] `description` specific enough for automatic delegation (includes trigger phrases)
@@ -31,8 +77,11 @@ Any subagent violating these criteria must be fixed before proceeding:
 - [ ] Delegation trigger language is normal ("use when..."), not aggressive ("CRITICAL: MUST always...")
 - [ ] No instructions telling subagent to spawn other subagents (runtime blocks this)
 - [ ] System prompt is task-specific, not generic ("you are a helpful AI")
-- [ ] Evidence citations present: system prompt references source docs for domain-specific constraints (e.g., "per creating-custom-subagents.md")
-- [ ] Prompt engineering strategy applied: system prompt uses role prompting (single-sentence role), structured output format, and confidence filtering per prompt-engineering-strategies.md. **Note:** For evaluation agents that mandate explicit evidence citations per finding (a stricter guarantee), the evidence requirement satisfies the confidence filtering criterion.
+- [ ] Evidence citations present: system prompt references source docs for domain-specific constraints
+- [ ] Prompt engineering strategy applied: system prompt uses role prompting, structured output format, and confidence filtering per prompt-engineering-strategies.md
+- [ ] Canonical semantic tags present: `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched — `name`, `description`, `tools`, `model`, `maxTurns` fields per Anthropic subagent spec
 
 ---
 
@@ -48,6 +97,7 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 - [ ] `maxTurns` not increased beyond 20 without justification
 - [ ] Scope of subagent not broadened (single-purpose agents are better than general-purpose)
+- [ ] Reference file ≤200 line limit not violated; >100-line files have a `## Contents` TOC
 
 ---
 
@@ -55,10 +105,30 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 Execute this loop for each generated or improved subagent:
 
-1. Evaluate the subagent against ALL criteria above
+1. Evaluate the subagent against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
-3. If ANY criterion fails: identify the specific failure, fix the subagent, restart evaluation
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing subagents when ALL criteria pass
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the subagent, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing subagents when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The fixture corpus at `${CLAUDE_SKILL_DIR}/assets/fixtures/` is the regression test for the strictness tiers. Each fixture is annotated in `assets/fixtures/MANIFEST.md` with its expected verdict. Running the validation loop against the corpus MUST produce exactly the verdict below for each fixture — any deviation means the strictness-tier text above is ambiguous and must be tightened.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-with-trigger.md` | None — all mandatory tags present, `<TRIGGER>` also present, balanced, canonical attributes | **pass** |
+| `compliant-without-trigger.md` | `<TRIGGER>` absent (subagent variant — optional) | **pass** (silence on optional tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check) |

--- a/plugins/agent-customizer/skills/create-subagent/references/subagent-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-subagent/references/subagent-validation-criteria.md
@@ -1,7 +1,6 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Claude Code subagent definitions.
-Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md, `wiki/knowledge/skill-body-convention.md`
 
 ---
 
@@ -20,16 +19,15 @@ Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best
 
 Any subagent violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | subagents/creating-custom-subagents.md |
-| `name` field | Lowercase letters and hyphens only | subagents/creating-custom-subagents.md lines 217-220 |
-| `description` field | Present and non-empty | subagents/creating-custom-subagents.md lines 217-220 |
-| `model` field | Recognized alias or full model ID | subagents/creating-custom-subagents.md lines 234-241 |
-| `maxTurns` | 15 for analysis agents; 20 for evaluators; values outside 15–20 require justification | Project convention — `.claude/rules/agent-files.md` |
-| System prompt | Not empty; task-specific | subagents/creating-custom-subagents.md lines 199-212 |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens only |
+| `description` field | Present and non-empty |
+| `model` field | Recognized alias or full model ID |
+| `maxTurns` | 15 for analysis agents; 20 for evaluators; values outside 15–20 require justification |
+| System prompt | Not empty; task-specific |
 
-*Source: subagents/creating-custom-subagents.md lines 213-232; subagents/research-subagent-best-practices.md lines 33-55*
 
 ---
 
@@ -64,7 +62,6 @@ The subagent body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-hook/references/hook-authoring-guide.md
+++ b/plugins/agent-customizer/skills/improve-hook/references/hook-authoring-guide.md
@@ -1,7 +1,6 @@
 # Hook Authoring Guide
 
 Evidence-based guidance for creating Claude Code hooks that enforce deterministic behavior.
-Source: hooks/automate-workflow-with-hooks.md, hooks/claude-hook-reference-doc.md
 
 ---
 
@@ -30,7 +29,6 @@ Hooks provide **deterministic control** — they always fire, regardless of LLM 
 
 Examples: auto-formatting after edits, blocking destructive commands, sending notifications, auditing config changes.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 1-13*
 
 ---
 
@@ -62,7 +60,6 @@ Level 3: **Handler** — what to run when matched
 
 Omit `matcher` or use `""` / `"*"` to match all occurrences.
 
-*Source: hooks/claude-hook-reference-doc.md lines 132-141*
 
 ---
 
@@ -83,7 +80,6 @@ Omit `matcher` or use `""` / `"*"` to match all occurrences.
 
 **Use `http`** for centralizing audit trails across projects or sending to external services.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 569-625; hooks/claude-hook-reference-doc.md lines 249-257*
 
 ---
 
@@ -107,7 +103,6 @@ The `matcher` field is a **regex string** filtering on different fields per even
 
 MCP tools follow pattern `mcp__<server>__<tool>` — use `mcp__server__.*` to match all tools from a server.
 
-*Source: hooks/claude-hook-reference-doc.md lines 162-203*
 
 ---
 
@@ -122,7 +117,6 @@ MCP tools follow pattern `mcp__<server>__<tool>` — use `mcp__server__.*` to ma
 | Skill/agent frontmatter | While component active | Yes |
 | Managed policy settings | Organization-wide | Yes, admin-controlled |
 
-*Source: hooks/automate-workflow-with-hooks.md lines 552-565*
 
 ---
 
@@ -142,13 +136,11 @@ For **command** hooks:
 
 For **prompt/agent** hooks — return JSON `{"ok": true/false, "reason": "..."}`. When `ok: false`, Claude receives `reason` as its next instruction.
 
-*Source: hooks/automate-workflow-with-hooks.md lines ~393-420; hooks/claude-hook-reference-doc.md lines 80-88*
 
 ### Hook Output Discipline
 
 **Golden rule of hook output: success silent, failure verbose.** Stdout/stderr from hooks is injected into Claude's context. A passing typecheck or 4,000-line test log on every PostToolUse pushes the smart zone into the dumb zone. Emit nothing on success; emit specific error traces only on failure.
 
-*Source: harness-engineering.md*
 
 ---
 
@@ -162,4 +154,3 @@ For **prompt/agent** hooks — return JSON `{"ok": true/false, "reason": "..."}`
 
 Test with `--debug` to see hook execution details, including which hooks matched, exit codes, and output.
 
-*Source: hooks/claude-hook-reference-doc.md lines 2050-2065*

--- a/plugins/agent-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
@@ -1,8 +1,6 @@
 # Hook Evaluation Criteria
 
 Scoring rubric for assessing existing Claude Code hook configurations before improvement.
-Source: hooks/claude-hook-reference-doc.md, hooks/automate-workflow-with-hooks.md
-
 ---
 
 ## Contents
@@ -19,17 +17,16 @@ Source: hooks/claude-hook-reference-doc.md, hooks/automate-workflow-with-hooks.m
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| JSON configuration | Valid JSON, no syntax errors | hooks/claude-hook-reference-doc.md |
-| Event name | From recognized 22-event list | hooks/claude-hook-reference-doc.md lines 22-46 |
-| Handler type | `command`, `http`, `prompt`, or `agent` | hooks/claude-hook-reference-doc.md lines 249-257 |
-| Matcher field | Valid regex string or empty | hooks/claude-hook-reference-doc.md lines 162-179 |
-| Command path | Absolute script paths must resolve to an existing executable; relative workspace paths (e.g., `.claude/hooks/*.sh`, `scripts/`) are plausible and must not be flagged INVALID | hooks/automate-workflow-with-hooks.md |
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON configuration | Valid JSON, no syntax errors |
+| Event name | From recognized 22-event list |
+| Handler type | `command`, `http`, `prompt`, or `agent` |
+| Matcher field | Valid regex string or empty |
+| Command path | Absolute script paths must resolve to an existing executable; relative workspace paths (e.g., `.claude/hooks/*.sh`, `scripts/`) are plausible and must not be flagged INVALID |
 
 A hook configuration violating any hard limit is flagged **INVALID** regardless of intent.
 
-*Source: hooks/claude-hook-reference-doc.md lines 132-200*
 
 ---
 
@@ -37,7 +34,6 @@ A hook configuration violating any hard limit is flagged **INVALID** regardless 
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -52,7 +48,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Hook commands that always exit 0 (never block) | Observation-only hooks should use PostToolUse, not PreToolUse |
 | Sensitive data in `command` string of settings.json | Use environment variables instead |
 
-*Source: hooks/automate-workflow-with-hooks.md lines 569-625*
 
 ---
 
@@ -65,7 +60,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Hardcoded absolute paths to scripts that don't exist | Verify each absolute `command` script path exists; relative paths (not starting with `/`) are treated as plausible and are not a staleness indicator *(staleness-evaluation heuristic only; Phase 4 validation uses a stricter existence check — see hook-validation-criteria.md)* |
 | Outdated matcher values (e.g., old session end reasons) | Verify against current matcher value lists |
 
-*Source: hooks/claude-hook-reference-doc.md lines 162-179*
 
 ---
 
@@ -79,7 +73,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Security posture appropriate? | Hook validates before allowing | Hook only logs, never blocks |
 | Hook type appropriate for task? | `command` for deterministic, `prompt` for judgment | `agent` for a simple grep check |
 
-*Source: hooks/automate-workflow-with-hooks.md lines 1-13*
 
 ---
 
@@ -94,7 +87,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Handler Efficiency | Right type for each task | Some oversized handlers | Agent hooks for trivial tasks |
 | **Overall** | | | |
 
-*Source: hooks/claude-hook-reference-doc.md lines 249-257*
 
 > **UNCERTAIN classification**: When the `command` handler references an external script that cannot be read from the repository, classify Error Handling as **UNCERTAIN** (not Bad) — exit-code behavior cannot be verified from the hook configuration alone. Report it as a gap rather than a violation.
 

--- a/plugins/agent-customizer/skills/improve-hook/references/hook-events-reference.md
+++ b/plugins/agent-customizer/skills/improve-hook/references/hook-events-reference.md
@@ -1,7 +1,6 @@
 # Hook Events Reference
 
 Complete reference for all 22 Claude Code hook events: triggers, matcher fields, and input/output schemas.
-Source: hooks/claude-hook-reference-doc.md
 
 ---
 
@@ -42,7 +41,6 @@ Source: hooks/claude-hook-reference-doc.md
 | `Elicitation` | When MCP server requests input | Yes |
 | `ElicitationResult` | After user responds to MCP elicitation | Yes |
 
-*Source: hooks/claude-hook-reference-doc.md lines 22-46*
 
 ---
 
@@ -62,7 +60,6 @@ Source: hooks/claude-hook-reference-doc.md
 | `Elicitation`, `ElicitationResult` | MCP server name | your configured server names |
 | No matcher | always fires | `UserPromptSubmit`, `Stop`, `TeammateIdle`, `TaskCompleted`, `WorktreeCreate`, `WorktreeRemove` |
 
-*Source: hooks/claude-hook-reference-doc.md lines 162-179*
 
 ---
 
@@ -115,7 +112,6 @@ Source: hooks/claude-hook-reference-doc.md
 
 **Agent-specific fields:** `type`, `prompt` (required), `timeout` (optional, default 60s)
 
-*Source: hooks/claude-hook-reference-doc.md lines 258-310*
 
 ---
 
@@ -131,7 +127,6 @@ Source: hooks/claude-hook-reference-doc.md
 The 8 agentic loop events that support all handler types:
 `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `UserPromptSubmit`, `Stop`, `SubagentStop`, `TaskCompleted`
 
-*Source: hooks/claude-hook-reference-doc.md lines 249-257*
 
 ---
 
@@ -165,4 +160,3 @@ Inject dynamic context at session start:
 
 Stdout from the hook is injected as additional context.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 70-200*

--- a/plugins/agent-customizer/skills/improve-hook/references/hook-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-hook/references/hook-validation-criteria.md
@@ -1,23 +1,19 @@
 # Hook Validation Criteria
 
 Quality checklist for generated and improved Claude Code hook configurations.
-Source: hooks/claude-hook-reference-doc.md, hooks/automate-workflow-with-hooks.md
-
 ---
 
 ## Hard Limits (Auto-fail if violated)
 
 Any hook violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| JSON structure | Valid JSON; no syntax errors | hooks/claude-hook-reference-doc.md |
-| Event name | From recognized 22-event list | hooks/claude-hook-reference-doc.md lines 22-46 |
-| Handler type | `command`, `http`, `prompt`, or `agent` only | hooks/claude-hook-reference-doc.md lines 249-257 |
-| `command` path | Script file exists and is executable *(validation-phase check; during staleness evaluation, relative paths are treated as plausible — see hook-evaluation-criteria.md)* | hooks/automate-workflow-with-hooks.md |
-| Exit code behavior | Exit 2 effect is event-dependent — see full table in hook reference | Blocks execution on exit 2: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop, TeammateIdle, TaskCompleted, ConfigChange, Elicitation, ElicitationResult. Any non-zero exit code fails creation (not just exit 2): WorktreeCreate. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, Notification, SubagentStart, SessionStart, SessionEnd, PreCompact, PostCompact. Failures logged in debug mode only (not shown to user): WorktreeRemove. Exit code ignored: StopFailure, InstructionsLoaded. |
-
-*Source: hooks/claude-hook-reference-doc.md "Exit code 2 behavior per event" table*
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON structure | Valid JSON; no syntax errors |
+| Event name | From recognized 22-event list |
+| Handler type | `command`, `http`, `prompt`, or `agent` only |
+| `command` path | Script file exists and is executable *(validation-phase check; during staleness evaluation, relative paths are treated as plausible — see hook-evaluation-criteria.md)* |
+| Exit code behavior | Exit 2 effect is event-dependent — see full table in hook reference. Blocks execution on exit 2: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop, TeammateIdle, TaskCompleted, ConfigChange, Elicitation, ElicitationResult. Any non-zero exit code fails creation (not just exit 2): WorktreeCreate. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, Notification, SubagentStart, SessionStart, SessionEnd, PreCompact, PostCompact. Failures logged in debug mode only (not shown to user): WorktreeRemove. Exit code ignored: StopFailure, InstructionsLoaded. |
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-hook/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/improve-hook/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/improve-rule/assets/templates/rule-file.md
+++ b/plugins/agent-customizer/skills/improve-rule/assets/templates/rule-file.md
@@ -16,7 +16,5 @@ paths:
 
 # [Topic Name]
 
-*Source: [path/to/source-doc.md] — the document or convention that establishes these rules*
-
 - [Specific, verifiable instruction]
 - [Specific, verifiable instruction]

--- a/plugins/agent-customizer/skills/improve-rule/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/improve-rule/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/improve-rule/references/rule-authoring-guide.md
+++ b/plugins/agent-customizer/skills/improve-rule/references/rule-authoring-guide.md
@@ -1,8 +1,6 @@
 # Rule Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code rule files (`.claude/rules/*.md`).
-Source: memory/how-claude-remembers-a-project.md
-
 ---
 
 ## Contents
@@ -29,7 +27,6 @@ Rules are instruction files loaded on-demand when Claude reads files matching th
 
 **Rules load into context** when matching files are read, so keep them focused and concise.
 
-*Source: memory/how-claude-remembers-a-project.md lines 123-145; .github/instructions/rules.instructions.md*
 
 ---
 
@@ -48,7 +45,6 @@ Each file should cover **one topic** with a descriptive filename. All `.md` file
 
 For this project, rules should use `paths` frontmatter so they load only when Claude reads matching files. Put always-loaded project guidance in root `CLAUDE.md`, not in `.claude/rules/`.
 
-*Source: memory/how-claude-remembers-a-project.md lines 123-145*
 
 ---
 
@@ -81,7 +77,6 @@ paths:
 ---
 ```
 
-*Source: memory/how-claude-remembers-a-project.md lines 147-186*
 
 ---
 
@@ -98,7 +93,6 @@ paths:
 
 Path-scoped rules trigger when Claude **reads files** matching the pattern, not on every tool use.
 
-*Source: memory/how-claude-remembers-a-project.md lines 166-183*
 
 ---
 
@@ -121,7 +115,6 @@ Path-scoped rules trigger when Claude **reads files** matching the pattern, not 
 
 **No contradictions** — if two rules conflict, Claude may pick one arbitrarily. Review `.claude/rules/` periodically to remove outdated or conflicting instructions.
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; Project convention — `.github/instructions/rules.instructions.md`*
 
 ---
 
@@ -136,4 +129,3 @@ Path-scoped rules trigger when Claude **reads files** matching the pattern, not 
 | Always-loaded rules for rare situations | Context cost on every session | Convert to path-scoped or skill |
 | Rule files exceeding 50 lines | Poor adherence; attention fragmentation | Split into multiple focused files |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 123-145; Project convention — `.github/instructions/rules.instructions.md`*

--- a/plugins/agent-customizer/skills/improve-rule/references/rule-evaluation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-rule/references/rule-evaluation-criteria.md
@@ -1,8 +1,6 @@
 # Rule Evaluation Criteria
 
 Scoring rubric for assessing existing `.claude/rules/*.md` rule files before improvement.
-Source: memory/how-claude-remembers-a-project.md
-
 ---
 
 ## Contents
@@ -19,16 +17,15 @@ Source: memory/how-claude-remembers-a-project.md
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rules | `paths:` array present | memory/how-claude-remembers-a-project.md lines 147-164 |
-| Rules | ≤ 50 lines | Context budget: loaded when matching files read — project convention |
-| YAML frontmatter | Valid YAML if present | memory/how-claude-remembers-a-project.md |
-| Instructions | Actionable and verifiable | memory/how-claude-remembers-a-project.md lines 61-75 |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rules | `paths:` array present |
+| Rules | ≤ 50 lines |
+| YAML frontmatter | Valid YAML if present |
+| Instructions | Actionable and verifiable |
 
 A rule file violating any hard limit is flagged **OVER LIMIT** or **INVALID**.
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 123-145; Project convention — `.github/instructions/rules.instructions.md`*
 
 ---
 
@@ -36,7 +33,6 @@ A rule file violating any hard limit is flagged **OVER LIMIT** or **INVALID**.
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -51,7 +47,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Long explanations or tutorials | Rules are instructions, not documentation |
 | Examples in rules | Token waste; be specific instead |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75*
 
 ---
 
@@ -64,7 +59,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Instructions for conventions no longer used | Check if convention is still in use |
 | Paths pointing to deleted or moved directories | Verify directory paths exist |
 
-*Source: memory/how-claude-remembers-a-project.md lines 147-164*
 
 ---
 
@@ -78,7 +72,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | No overlap with other rules? | Each rule file covers distinct domain | Same instruction in 3 rule files |
 | Rule scope narrow enough for the token cost? | Specific globs for real target files | Missing `paths:` or broad scope |
 
-*Source: memory/how-claude-remembers-a-project.md lines 123-145*
 
 ---
 
@@ -93,7 +86,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Consistency | 0 contradictions across files | 1 contradiction | 2+ contradictions |
 | **Overall** | | | |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 123-145*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-rule/references/rule-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-rule/references/rule-validation-criteria.md
@@ -1,22 +1,19 @@
 # Rule Validation Criteria
 
 Quality checklist for generated and improved `.claude/rules/*.md` rule files.
-Source: memory/how-claude-remembers-a-project.md
-
 ---
 
 ## Hard Limits (Auto-fail if violated)
 
 Any rule file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 50 lines | Context budget: loaded when matching files read — project convention |
-| YAML frontmatter | Valid YAML if present | memory/how-claude-remembers-a-project.md |
-| `paths:` field | Required; array format; valid glob patterns | memory/how-claude-remembers-a-project.md lines 147-164 |
-| Contradictions with other rules | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 50 lines |
+| YAML frontmatter | Valid YAML if present |
+| `paths:` field | Required; array format; valid glob patterns |
+| Contradictions with other rules | 0 |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 147-164; Project convention — `.github/instructions/rules.instructions.md`*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-skill/SKILL.md
+++ b/plugins/agent-customizer/skills/improve-skill/SKILL.md
@@ -7,18 +7,20 @@ description: "Evaluates and optimizes existing SKILL.md files against evidence-b
 
 Evaluate an existing SKILL.md file against evidence-based quality criteria and apply improvements to optimize token usage, reduce bloat, and align with proven patterns.
 
-## Behavioral Guidelines
+<TRIGGER when="improving or auditing an existing Claude Code skill" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **ALWAYS** evaluate before modifying — never change files without analysis
 - **ALWAYS** present changes to the user before applying them
 - **NEVER** remove evidence-grounded references or citations
@@ -26,98 +28,113 @@ Evaluate an existing SKILL.md file against evidence-based quality criteria and a
 - **NEVER** exceed 500 lines in SKILL.md or 200 lines in reference files after improvements
 - **PRESERVE** all genuinely useful skill phases and instructions — only remove waste
 - **PRESERVE** or strengthen the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** improved SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** tag-vocabulary violation found in the target skill must be reported with the specific tag name, line reference, and strictness tier (hard-fail / warn / informational) before proposing a fix
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="skill-exists-check">
+  Check if a skill exists at:
 
-Check if a skill exists at:
+  - The user-provided path
+  - `.claude/skills/{name}/SKILL.md`
+  - `plugins/*/skills/{name}/SKILL.md`
 
-- The user-provided path
-- `.claude/skills/{name}/SKILL.md`
-- `plugins/*/skills/{name}/SKILL.md`
+  **If no skill found:**
 
-**If no skill found:**
+  1. Inform the user: "No skill found at the specified path."
+  2. Suggest using `/agent-customizer:create-skill` to create a new one instead.
+  3. **STOP**
 
-1. Inform the user: "No skill found at the specified path."
-2. Suggest using `/agent-customizer:create-skill` to create a new one instead.
-3. **STOP**
+  **If skill found:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If skill found:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="evaluate">
+  Delegate to the `skill-evaluator` agent with this task:
 
-### Phase 1: Evaluate
+  > Evaluate the skill at `{target-path}`. Read the SKILL.md and all files in the skill directory. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter valid), structural quality (progressive disclosure, phase structure, reference loading), and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW) and quality scores per dimension.
 
-Delegate to the `skill-evaluator` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Evaluate the skill at `{target-path}`. Read the SKILL.md and all files in the skill directory. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter valid), structural quality (progressive disclosure, phase structure, reference loading), and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW) and quality scores per dimension.
+  <PHASE id="2" name="codebase-context">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  > Analyze the project to understand the context around the skill being improved. Focus on: which agents the skill delegates to and whether those agents still exist, naming conventions for similar skills, any other skills that overlap in purpose, and the plugin structure.
 
-### Phase 2: Codebase Context
+  Wait for it to complete and parse its structured output.
+  </PHASE>
 
-Delegate to the `artifact-analyzer` agent with this task:
+  <PHASE id="3" name="generate-improvement-plan">
+  #### Phase 3a: Diagnose
 
-> Analyze the project to understand the context around the skill being improved. Focus on: which agents the skill delegates to and whether those agents still exist, naming conventions for similar skills, any other skills that overlap in purpose, and the plugin structure.
+  Drop Phases 1–2 references. Read:
 
-Wait for it to complete and parse its structured output.
+  - `${CLAUDE_SKILL_DIR}/references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
+  - `${CLAUDE_SKILL_DIR}/references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
 
-### Phase 3: Generate Improvement Plan
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-evaluation-criteria.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-#### Phase 3a: Diagnose
+  Identify issues from both agent reports. Do not write the plan yet.
 
-Drop Phases 1–2 references. Read:
+  #### Phase 3b: Plan
 
-- `${CLAUDE_SKILL_DIR}/references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
-- `${CLAUDE_SKILL_DIR}/references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
+  Drop Phase 3a references. Read:
 
-Identify issues from both agent reports. Do not write the plan yet.
+  - `${CLAUDE_SKILL_DIR}/references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — skill-specific prompting strategies
 
-#### Phase 3b: Plan
+  Create improvement plan: **Removals** (bloat: inlined content, over-specified instructions; stale: broken agent refs, removed tools; duplicates); **Refactoring** (progressive disclosure, phase consolidation, reference paths); **Additions** (missing sections — suggest Hard Rules/Preflight only for user-facing skills, not analysis-only). If all categories yield zero items, conclude "No improvements needed" and proceed to Phase 5.
+  </PHASE>
 
-Drop Phase 3a references. Read:
+  <PHASE id="4" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
 
-- `${CLAUDE_SKILL_DIR}/references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — skill-specific prompting strategies
+  For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+  </PHASE>
 
-Create improvement plan: **Removals** (bloat: inlined content, over-specified instructions; stale: broken agent refs, removed tools; duplicates); **Refactoring** (progressive disclosure, phase consolidation, reference paths); **Additions** (missing sections — suggest Hard Rules/Preflight only for user-facing skills, not analysis-only). If all categories yield zero items, conclude "No improvements needed" and proceed to Phase 5.
+  <PHASE id="5" name="present-and-apply">
+  1. Show a summary overview of all improvements found, grouped by category:
+     - **Removals**: X items (bloat: X, stale: X, duplicates: X)
+     - **Refactoring**: X items (progressive disclosure: X, phase structure: X, reference paths: X)
+     - **Additions**: X items
 
-### Phase 4: Self-Validation
+  2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
 
-Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
+     **WHAT**: The specific content and its current location (file:lines)
+     **WHY**: Evidence-based justification with source reference
+     **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
+     **OPTIONS**:
+     - **Option A** (recommended): Primary action
+     - **Option B**: Alternative action
+     - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
 
-For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+     Wait for the user to select an option for each suggestion before proceeding to the next.
+     If the user selects "Keep as-is", preserve the content in its exact current location.
 
-### Phase 5: Present and Apply
+  3. After all suggestions are reviewed, show aggregate token impact analysis:
+     - **Total lines**: before → after
+     - **Removed tokens**: total waste eliminated
+     - **Deferred suggestions**: X items kept as-is
 
-1. Show a summary overview of all improvements found, grouped by category:
-   - **Removals**: X items (bloat: X, stale: X, duplicates: X)
-   - **Refactoring**: X items (progressive disclosure: X, phase structure: X, reference paths: X)
-   - **Additions**: X items
+  4. Apply ONLY the approved changes (options A or B selections).
 
-2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+  5. Report final metrics:
+     - Lines before → after
+     - Files affected
+     - Estimated token savings per session
+     - Suggestions applied: X of Y (Z deferred)
+  </PHASE>
 
-   **WHAT**: The specific content and its current location (file:lines)
-   **WHY**: Evidence-based justification with source reference
-   **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
-   **OPTIONS**:
-   - **Option A** (recommended): Primary action
-   - **Option B**: Alternative action
-   - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
+</PROCESS>
 
-   Wait for the user to select an option for each suggestion before proceeding to the next.
-   If the user selects "Keep as-is", preserve the content in its exact current location.
-
-3. After all suggestions are reviewed, show aggregate token impact analysis:
-   - **Total lines**: before → after
-   - **Removed tokens**: total waste eliminated
-   - **Deferred suggestions**: X items kept as-is
-
-4. Apply ONLY the approved changes (options A or B selections).
-
-5. Report final metrics:
-   - Lines before → after
-   - Files affected
-   - Estimated token savings per session
-   - Suggestions applied: X of Y (Z deferred)
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/skill-validation-criteria.md` and loop the improved skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/improve-skill/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/prompt-engineering-strategies.md
@@ -1,8 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
-
 ---
 
 ## Contents
@@ -24,7 +22,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 - **Describe desired behavior, not prohibited behavior** — prefer "smooth flowing prose" over "do not use markdown".
 - **Behavioral discipline & safe persuasion** — see `behavioral-guidelines.md` for the four principles and seven persuasion patterns; both apply here verbatim.
 
-*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -32,7 +29,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 
 For SKILL.md authoring: role prompting on the opening line, zero-shot for most phases, few-shot examples reserved for phases with strict output format, XML structuring for multi-section bodies, self-check in the final phase, parallel tool calls in multi-step phases. Chain-of-thought is avoided in skill bodies because it slows execution.
 
-*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160.*
 
 ---
 
@@ -45,7 +41,6 @@ For SKILL.md authoring: role prompting on the opening line, zero-shot for most p
 - Make constraints concrete (scope limits, output shape, stop conditions); keep each phase ≤10 lines with depth in references.
 - Final phase self-check: verify all criteria in `skill-validation-criteria.md`, including Karpathy-style discipline and the persuasion ethical constraint.
 
-*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80. Hooks/rules/subagents recommendations are out of scope for improve-skill — see the broader strategies doc.*
 
 ---
 
@@ -53,7 +48,6 @@ For SKILL.md authoring: role prompting on the opening line, zero-shot for most p
 
 Avoid these prompting anti-patterns: aggressive triggers ("CRITICAL: You MUST always..."), vague instructions ("be thorough"), few-shot examples in rules (token waste on every session), over-explaining what the model already knows, prescriptive step-by-step plans (use "think thoroughly" instead), contradictory instructions across phases, and burying critical rules in the middle of long contexts (lost-in-the-middle effect — keep them in the first/last 20%).
 
-*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -61,4 +55,3 @@ Avoid these prompting anti-patterns: aggressive triggers ("CRITICAL: You MUST al
 
 Every token competes with conversation history. Apply the deletion test from `skill-evaluation-criteria.md` to every instruction; prefer pointers to detailed content over inlining; reserve progressive disclosure for long artifacts (skill bodies, subagent prompts) and zero-shot for short ones (rules, validation criteria).
 
-*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*

--- a/plugins/agent-customizer/skills/improve-skill/references/skill-authoring-guide.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/skill-authoring-guide.md
@@ -1,8 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code skills (SKILL.md files).
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
-
 ---
 
 ## Contents
@@ -25,7 +23,6 @@ Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skil
 
 **Test with all models you plan to use** — Haiku may need more detail, Sonnet should run cleanly, Opus may need less to avoid over-explanation.
 
-*Source: skills/skill-authoring-best-practices.md lines 11-145*
 
 ---
 
@@ -47,7 +44,6 @@ Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skil
 
 Directory layout (`SKILL.md` + `references/`, `assets/templates/`, `scripts/`) and platform extensions detail live in `skill-format-reference.md`.
 
-*Source: skills/extend-claude-with-skills.md lines 169-199*
 
 ---
 
@@ -57,7 +53,6 @@ Directory layout (`SKILL.md` + `references/`, `assets/templates/`, `scripts/`) a
 
 **Descriptions** — write in third person ("Processes Excel files...", not "I can help you..." or "You can use this..."). Include (1) what it does, (2) when to use it, (3) specific trigger terms for matching.
 
-*Source: skills/skill-authoring-best-practices.md lines 168-250*
 
 ---
 
@@ -65,7 +60,6 @@ Directory layout (`SKILL.md` + `references/`, `assets/templates/`, `scripts/`) a
 
 SKILL.md is the index; detailed content lives in supporting files loaded on demand. Apply two patterns: (1) reference the bundled guide material from each phase rather than inlining its content, and (2) load only the references needed for the current phase, not all at once. Loading-model levels are tabulated in `skill-format-reference.md` § Progressive Disclosure Loading Model.
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300; skills/extend-claude-with-skills.md lines 223-246*
 
 ---
 
@@ -73,7 +67,6 @@ SKILL.md is the index; detailed content lives in supporting files loaded on dema
 
 Default: both user and Claude can invoke; description always loaded. `disable-model-invocation: true` makes the skill user-only and removes the description from context — use it for side-effect workflows (commit, deploy, send-message). `user-invocable: false` hides the skill from `/` while keeping it available to Claude — use it for background knowledge.
 
-*Source: skills/extend-claude-with-skills.md lines 248-283*
 
 ---
 
@@ -81,4 +74,3 @@ Default: both user and Claude can invoke; description always loaded. `disable-mo
 
 Avoid generic descriptions ("helps with data" — be specific about what + when), inlining all reference content in SKILL.md (move to `references/`), and hardcoded file paths (use `${CLAUDE_SKILL_DIR}` for bundled files). General prompting anti-patterns (vague instructions, contradictions, lost-in-the-middle) live in `prompt-engineering-strategies.md`.
 
-*Source: skills/skill-authoring-best-practices.md lines 800-1100*

--- a/plugins/agent-customizer/skills/improve-skill/references/skill-evaluation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/skill-evaluation-criteria.md
@@ -1,8 +1,6 @@
 # Skill Evaluation Criteria
 
 Scoring rubric for assessing existing SKILL.md files before improvement.
-Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
-
 ---
 
 ## Contents
@@ -19,18 +17,17 @@ Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present, non-empty, ≤ 1024 chars | Required for skill discovery and Agent Skills spec |
-| `name` field | Present, non-empty, 1-64 chars, kebab-case | Agent Skills specification |
-| Phase structure | At least one clear phase defined | Anthropic skill authoring patterns |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present, non-empty, ≤ 1024 chars |
+| `name` field | Present, non-empty, 1-64 chars, kebab-case |
+| Phase structure | At least one clear phase defined |
 
 A skill violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
 
-*Source: skills/skill-authoring-best-practices.md line 259; `.claude/rules/reference-files.md`*
 
 ---
 
@@ -38,7 +35,6 @@ A skill violating any hard limit is flagged **OVER LIMIT** regardless of content
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If no, flag for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — content that looks helpful but adds no decision value is the failure mode. The deletion test separates signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -46,7 +42,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 
 Flag as bloat: detailed reference content inlined in SKILL.md (should be in `references/`); all references loaded in phase 1 instead of progressively; inline bash analysis in a plugin skill body (must delegate to registered agents); redundant phase instructions; over-specified tool restrictions for simple tasks; explanations of standard practices the model already knows; hardcoded project-specific paths instead of `${CLAUDE_SKILL_DIR}`.
 
-*Source: skills/skill-authoring-best-practices.md lines 11-60*
 
 ---
 
@@ -54,7 +49,6 @@ Flag as bloat: detailed reference content inlined in SKILL.md (should be in `ref
 
 Detect staleness via: deprecated frontmatter field names, references to removed features/tools, outdated model names (use aliases `haiku`/`sonnet`/`opus`), hardcoded file paths that no longer exist, and redundant explicit defaults like `user-invocable: true`.
 
-*Source: skills/skill-authoring-best-practices.md lines 146-167*
 
 ---
 
@@ -62,7 +56,6 @@ Detect staleness via: deprecated frontmatter field names, references to removed 
 
 Good: SKILL.md stays focused on phase overview with file references; each phase loads only its relevant references; supporting files are cited explicitly so Claude knows what to load; body stays ≤500 lines. Bad: monolithic SKILL.md with all guidance inlined, phase 1 loading every reference, files that exist but are never referenced.
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300*
 
 ---
 
@@ -70,7 +63,6 @@ Good: SKILL.md stays focused on phase overview with file references; each phase 
 
 Score each of the five dimensions on a 1–10 scale; 8–10 indicates clean execution, 4–7 mixed, 1–3 bad. Dimensions: **Conciseness** (SKILL.md ≤500 lines, minimal bloat), **Accuracy** (zero stale references), **Progressive Disclosure** (references loaded per-phase, not upfront), **Description Quality** (specific what + when + trigger terms), **Evidence Grounding** (sources cited per phase). Aggregate to an Overall score and call out the dominant remediation theme.
 
-*Source: Evaluating-AGENTS-paper.md lines 1-100*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-skill/references/skill-format-reference.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/skill-format-reference.md
@@ -1,8 +1,6 @@
 # Skill Format Reference
 
 Technical specification for SKILL.md format, directory structure, variables, and discovery.
-Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-skills.md
-
 ---
 
 ## Contents
@@ -31,7 +29,6 @@ The Agent Skills open-standard fields and Claude Code platform extensions are ta
 - Must NOT contain consecutive `--`
 - Must match the parent directory name
 
-*Source: skills/research-claude-code-skills-format.md lines 103-108*
 
 ---
 
@@ -39,7 +36,6 @@ The Agent Skills open-standard fields and Claude Code platform extensions are ta
 
 Skill body variables: `$ARGUMENTS` (all invocation args), `$ARGUMENTS[N]` / `$N` (specific arg by 0-based index), `${CLAUDE_SESSION_ID}` (for logging), `${CLAUDE_SKILL_DIR}` (skill directory — always use this for bundled file references, never hardcoded paths). Dynamic context with the `!` prefix runs shell commands at load time, e.g. `- Current branch: !` + `` `git branch --show-current` ``.
 
-*Source: skills/extend-claude-with-skills.md lines 201-210; skills/research-claude-code-skills-format.md lines 126-149*
 
 ---
 
@@ -47,7 +43,6 @@ Skill body variables: `$ARGUMENTS` (all invocation args), `$ARGUMENTS[N]` / `$N`
 
 A skill directory contains `SKILL.md` (required entry point), `references/` for on-demand reference docs, `assets/templates/` for output templates, optional `examples.md`, and optional `scripts/` for executables (executed, not loaded into context). `references/` files load only when skill phases explicitly read them.
 
-*Source: skills/research-claude-code-skills-format.md lines 153-186; skills/extend-claude-with-skills.md lines 100-115*
 
 ---
 
@@ -61,7 +56,6 @@ A skill directory contains `SKILL.md` (required entry point), `references/` for 
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to `references/` subdirectory. Explicitly reference supporting files from SKILL.md so Claude knows what to load and when.
 
-*Source: skills/research-claude-code-skills-format.md lines 172-186*
 
 ---
 
@@ -76,4 +70,3 @@ Keep SKILL.md under **500 lines**. Move detailed reference material to `referenc
 
 Priority: enterprise > personal > project. Plugin skills use `plugin-name:skill-name` namespace — no conflicts.
 
-*Source: skills/extend-claude-with-skills.md lines 85-97; skills/research-claude-code-skills-format.md lines 189-200*

--- a/plugins/agent-customizer/skills/improve-skill/references/skill-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/skill-validation-criteria.md
@@ -1,8 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`, `wiki/knowledge/skill-body-convention.md`
-
 ---
 
 ## Contents
@@ -20,16 +18,15 @@ Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skil
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
-| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags |
+| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-skill/references/skill-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/skill-validation-criteria.md
@@ -1,35 +1,130 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`, `wiki/knowledge/skill-body-convention.md`
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
 ## Hard Limits (Auto-fail if violated)
 
-Apply the canonical Hard Limits Table from `skill-evaluation-criteria.md` (body length, reference length, TOC requirement, frontmatter `description`/`name`, phase-structure thresholds), plus this validation-only addition:
+Any skill violating these criteria must be fixed before proceeding:
 
 | Criterion | Threshold | Source |
 |-----------|-----------|--------|
+| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
+| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
+| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
+| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
+| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
 | Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+
+*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X")
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. Report it as a `<HARD_RULES>` alias candidate (informational), not as a violation. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+| **Informational** | Legacy `<RULES>` tag present — alias for `<HARD_RULES>` | Surface as alias candidate; do not fail or warn |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+### Structured violation report format
+
+When evaluating a target skill body, report every finding using this format:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+[HARD-FAIL] Missing mandatory tag: <TRIGGER> — required for skills
+[HARD-FAIL] Unbalanced tag: <PROCESS> opened at line 42, no closing tag found
+[HARD-FAIL] Malformed attribute: <PHASE id=1 name="x"> — attribute value `1` missing quotes
+[WARN]      Non-canonical attribute: <BEHAVIOUR mood="high"> — `mood` is outside the closed set
+[INFO]      Legacy alias: <RULES> at line 20 — satisfies <HARD_RULES> check; candidate for organic retrofit to <HARD_RULES>
+──────────────────────────────────
+Result: HARD-FAIL (3 blocking violations, 1 warning, 1 informational)
+```
+
+A compliant target produces:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+No violations found.
+──────────────────────────────────
+Result: PASS
+```
 
 ---
 
 ## Quality Checks (All must pass)
 
-**Structure**: self-validation phase reads `references/*validation-criteria.md`; `${CLAUDE_SKILL_DIR}` used for all bundled refs (no hardcoded paths); progressive disclosure applied (references loaded per phase, not upfront); no reference content inlined in SKILL.md body; each phase ≤10 lines with depth in references; reference files cited explicitly.
-
-**Frontmatter**: `description` in third person, includes both what + when to use; `disable-model-invocation: true` set for side-effect workflows (commit, deploy, send).
-
-**Discipline**: behavioral guidelines applied (surface assumptions, simplest path, surgical, validation targets); persuasion cues stay inside the ethical constraint; phase instructions specific and actionable (no "ensure quality").
-
-**Distribution-specific**: plugin skills (`plugins/*/skills/`) delegate analysis to registered agents — no inline bash; standalone skills (`skills/`) include explicit bash commands per analysis step.
-
-**Prompting**: relevant strategy from `prompt-engineering-strategies.md` applied (role prompting for skills, progressive disclosure for phases); evidence citations present for key decisions.
+- [ ] Has a self-validation phase that reads the skill's `references/*validation-criteria.md`
+- [ ] `${CLAUDE_SKILL_DIR}` used for all bundled file references (not hardcoded paths)
+- [ ] `description` written in third person ("Processes..." not "I process..." or "You can use...")
+- [ ] `description` includes what the skill does AND when to use it
+- [ ] Progressive disclosure applied: references loaded per phase, not all upfront
+- [ ] No reference content inlined in SKILL.md body (should be in `references/` subdirectory)
+- [ ] Each phase instruction is concise (≤10 lines); depth lives in reference files
+- [ ] Reference files cited explicitly so Claude knows what to load and when
+- [ ] `disable-model-invocation: true` set for side-effect workflows (commit, deploy, send)
+- [ ] Prompt engineering strategy applied: skill follows relevant strategy from prompt-engineering-strategies.md (role prompting for skills, progressive disclosure for phases)
+- [ ] Behavioral guidelines applied: the skill surfaces assumptions before acting, prefers the simplest adequate path, keeps changes surgical, and defines explicit validation targets
+- [ ] Persuasion cues, if present, stay inside the ethical constraint: they improve compliance with legitimate work only and never weaken safeguards, refusals, or scope boundaries
+- [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
+- [ ] Plugin skill body contains no inline bash analysis commands — analysis must be delegated to registered agents (applies to skills in `plugins/*/skills/`)
+- [ ] Standalone skill body includes explicit bash commands for each analysis step (applies to skills in `skills/`)
+- [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-best-practices.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
 
 ---
 
 ## If This Is an IMPROVE Operation — Also Check
+
+**Canonical Tag Vocabulary:**
+
+- [ ] Target skill body uses all mandatory tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with at least one `<PHASE>`)
+- [ ] All tags in target skill body are balanced (no unmatched open/close)
+- [ ] All attribute syntax in target skill body is well-formed (no missing quotes, no stray `=`)
+- [ ] Non-canonical attributes in target skill body surfaced as warnings (not hard-fails)
+- [ ] Legacy `<RULES>` in target skill body reported as informational alias candidate (not a fail)
 
 **Information Preservation:**
 
@@ -48,10 +143,37 @@ Apply the canonical Hard Limits Table from `skill-evaluation-criteria.md` (body 
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above
+1. Evaluate the skill against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
-3. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing skills when ALL criteria pass
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The strictness tiers above are exercised by a regression corpus shipped with the
+sibling `create-skill` skill at
+`plugins/agent-customizer/skills/create-skill/assets/fixtures/` (see its
+`MANIFEST.md`). `improve-skill` does not ship its own copy — the strictness-tier
+logic is identical, so the `create-skill` corpus is the single regression test
+for both. The table below documents the expected verdict for each fixture so the
+contract is visible here too; running the validation loop against any body MUST
+produce exactly these verdicts.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check); surface informational alias candidate |

--- a/plugins/agent-customizer/skills/improve-subagent/SKILL.md
+++ b/plugins/agent-customizer/skills/improve-subagent/SKILL.md
@@ -7,129 +7,146 @@ description: "Evaluates and optimizes existing subagent definitions against evid
 
 Evaluate an existing subagent definition against evidence-based quality criteria and apply improvements to tighten tool restrictions, fix model selection, and strengthen system prompts.
 
-## Behavioral Guidelines
+<TRIGGER when="improving or auditing an existing Claude Code subagent definition" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **ALWAYS** evaluate before modifying — never change subagents without analysis
 - **ALWAYS** present changes to the user before applying them
 - **NEVER** loosen tool restrictions without explicit rationale
 - **NEVER** downgrade model without confirming the task doesn't require current model capabilities
 - **NEVER** increase maxTurns beyond 20 without justification; never exceed 30 under any circumstances
 - **PRESERVE** specialized domain knowledge in system prompts — only remove generic waste
-</RULES>
+- **EVERY** improved subagent body must carry the canonical semantic-tag vocabulary (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`); `<TRIGGER>` is optional for subagents
+- **EVERY** tag-vocabulary violation found in the target subagent must be reported with the specific tag name, line reference, and strictness tier (hard-fail / warn / informational) before proposing a fix
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="subagent-exists-check">
+  Check if a subagent exists at:
 
-Check if a subagent exists at:
+  - The user-provided path
+  - `.claude/agents/{name}.md`
+  - `plugins/*/agents/{name}.md`
 
-- The user-provided path
-- `.claude/agents/{name}.md`
-- `plugins/*/agents/{name}.md`
+  **If no subagent found:**
 
-**If no subagent found:**
+  1. Inform the user: "No subagent found at the specified path."
+  2. Suggest using `/agent-customizer:create-subagent` to create a new one instead.
+  3. **STOP**
 
-1. Inform the user: "No subagent found at the specified path."
-2. Suggest using `/agent-customizer:create-subagent` to create a new one instead.
-3. **STOP**
+  **If subagent found:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If subagent found:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="evaluate">
+  Delegate to the `subagent-evaluator` agent with this task:
 
-### Phase 1: Evaluate
+  > Evaluate the subagent definition at `{target-path}`. Check YAML frontmatter validity, required fields (name, description, model, maxTurns), name format (lowercase+hyphens), model appropriateness for task, tool restriction (minimum-necessary principle), system prompt structure (role, process, output format, self-verification), and description specificity for routing. Return structured results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
 
-Delegate to the `subagent-evaluator` agent with this task:
+  - If the user provides a specific agent file → scope to that file.
+  - If no specific file → evaluate ALL agents in `.claude/agents/` and `plugins/*/agents/`.
 
-> Evaluate the subagent definition at `{target-path}`. Check YAML frontmatter validity, required fields (name, description, model, maxTurns), name format (lowercase+hyphens), model appropriateness for task, tool restriction (minimum-necessary principle), system prompt structure (role, process, output format, self-verification), and description specificity for routing. Return structured results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-- If the user provides a specific agent file → scope to that file.
-- If no specific file → evaluate ALL agents in `.claude/agents/` and `plugins/*/agents/`.
+  <PHASE id="2" name="codebase-context">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  > Analyze the project to understand the context around subagent definitions. Focus on: all agents and their roles, which skills delegate to which agents, tool restrictions in use, model choices across agents, any agents with similar purposes (potential consolidation), and naming conventions.
 
-### Phase 2: Codebase Context
+  Wait for it to complete and parse its structured output.
+  </PHASE>
 
-Delegate to the `artifact-analyzer` agent with this task:
+  <PHASE id="3" name="generate-improvement-plan">
+  #### Phase 3a: Diagnose
 
-> Analyze the project to understand the context around subagent definitions. Focus on: all agents and their roles, which skills delegate to which agents, tool restrictions in use, model choices across agents, any agents with similar purposes (potential consolidation), and naming conventions.
+  Drop any references from Phases 1–2. Read these references:
 
-Wait for it to complete and parse its structured output.
+  - `${CLAUDE_SKILL_DIR}/references/subagent-authoring-guide.md` — when to use subagents, system prompt structure, model selection, tool restriction, anti-patterns
+  - `${CLAUDE_SKILL_DIR}/references/subagent-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
 
-### Phase 3: Generate Improvement Plan
+  <REFERENCES load="on-demand">
+  - subagent-authoring-guide.md
+  - subagent-evaluation-criteria.md
+  - subagent-config-reference.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-#### Phase 3a: Diagnose
+  Identify all issues from both agent reports: generic boilerplate, model mismatches, overtriggering, missing output format. Do not yet write the full improvement plan.
 
-Drop any references from Phases 1–2. Read these references:
+  #### Phase 3b: Plan
 
-- `${CLAUDE_SKILL_DIR}/references/subagent-authoring-guide.md` — when to use subagents, system prompt structure, model selection, tool restriction, anti-patterns
-- `${CLAUDE_SKILL_DIR}/references/subagent-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
+  Drop Phase 3a references. Read these references:
 
-Identify all issues from both agent reports: generic boilerplate, model mismatches, overtriggering, missing output format. Do not yet write the full improvement plan.
+  - `${CLAUDE_SKILL_DIR}/references/subagent-config-reference.md` — YAML frontmatter fields, model IDs, orchestration patterns, plugin restrictions
+  - `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — subagent-specific prompting
 
-#### Phase 3b: Plan
+  Based on Phase 3a findings, create improvement plan with categories:
 
-Drop Phase 3a references. Read these references:
+  1. **Removals** — generic system prompt boilerplate, overtriggering language, redundant instructions
+  2. **Refactoring** — tighten tool list to minimum-necessary, fix model selection, add structured output format, improve description for routing specificity
+  3. **Additions** — missing self-verification section, missing explicit output format, missing constraints block
 
-- `${CLAUDE_SKILL_DIR}/references/subagent-config-reference.md` — YAML frontmatter fields, model IDs, orchestration patterns, plugin restrictions
-- `${CLAUDE_SKILL_DIR}/references/prompt-engineering-strategies.md` — subagent-specific prompting
+  If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  </PHASE>
 
-Based on Phase 3a findings, create improvement plan with categories:
+  <PHASE id="4" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved subagent definition.
 
-1. **Removals** — generic system prompt boilerplate, overtriggering language, redundant instructions
-2. **Refactoring** — tighten tool list to minimum-necessary, fix model selection, add structured output format, improve description for routing specificity
-3. **Additions** — missing self-verification section, missing explicit output format, missing constraints block
+  For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+  </PHASE>
 
-If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  <PHASE id="5" name="present-and-apply">
+  1. Show a summary overview of all improvements found, grouped by category:
+     - **Removals**: X items (generic boilerplate: X, overtriggering: X)
+     - **Refactoring**: X items (tool restrictions: X, model: X, description: X, output format: X)
+     - **Additions**: X items (self-verification: X, output format: X)
 
-### Phase 4: Self-Validation
+  2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
 
-Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved subagent definition.
+     **WHAT**: The specific content and its current location (file:lines)
+     **WHY**: Evidence-based justification with source reference
+     **TOKEN IMPACT**: Estimated tokens saved per invocation
+     **OPTIONS**:
+     - **Option A** (recommended): Primary action
+     - **Option B**: Alternative action
+     - **Option C**: Keep as-is
 
-For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+     Wait for the user to select an option for each suggestion before proceeding to the next.
 
-### Phase 5: Present and Apply
+     For tool restriction changes, show before/after tool lists.
+     For model changes, cite the selection heuristic (haiku for exploration, sonnet for analysis, opus for complex reasoning).
+     For system prompt rewrites, show diff of the prompt sections.
+     Warn if the agent is referenced by skills — list which skills delegate to it.
 
-1. Show a summary overview of all improvements found, grouped by category:
-   - **Removals**: X items (generic boilerplate: X, overtriggering: X)
-   - **Refactoring**: X items (tool restrictions: X, model: X, description: X, output format: X)
-   - **Additions**: X items (self-verification: X, output format: X)
+  3. After all suggestions are reviewed, show aggregate impact:
+     - **System prompt lines**: before → after
+     - **Tool count**: before → after
+     - **Deferred suggestions**: X items kept as-is
 
-2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+  4. Apply ONLY the approved changes.
+     - Warn if plugin restrictions apply (no hooks/mcpServers/permissionMode in plugin agents).
 
-   **WHAT**: The specific content and its current location (file:lines)
-   **WHY**: Evidence-based justification with source reference
-   **TOKEN IMPACT**: Estimated tokens saved per invocation
-   **OPTIONS**:
-   - **Option A** (recommended): Primary action
-   - **Option B**: Alternative action
-   - **Option C**: Keep as-is
+  5. Report final metrics:
+     - Lines before → after
+     - Tools before → after
+     - Suggestions applied: X of Y (Z deferred)
+  </PHASE>
 
-   Wait for the user to select an option for each suggestion before proceeding to the next.
+</PROCESS>
 
-   For tool restriction changes, show before/after tool lists.
-   For model changes, cite the selection heuristic (haiku for exploration, sonnet for analysis, opus for complex reasoning).
-   For system prompt rewrites, show diff of the prompt sections.
-   Warn if the agent is referenced by skills — list which skills delegate to it.
-
-3. After all suggestions are reviewed, show aggregate impact:
-   - **System prompt lines**: before → after
-   - **Tool count**: before → after
-   - **Deferred suggestions**: X items kept as-is
-
-4. Apply ONLY the approved changes.
-   - Warn if plugin restrictions apply (no hooks/mcpServers/permissionMode in plugin agents).
-
-5. Report final metrics:
-   - Lines before → after
-   - Tools before → after
-   - Suggestions applied: X of Y (Z deferred)
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/subagent-validation-criteria.md` and loop the improved subagent through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/agent-customizer/skills/improve-subagent/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/improve-subagent/references/subagent-authoring-guide.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/subagent-authoring-guide.md
@@ -1,7 +1,6 @@
 # Subagent Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code subagent definitions.
-Source: subagents/research-subagent-best-practices.md, subagents/creating-custom-subagents.md
 
 ---
 
@@ -21,7 +20,6 @@ Source: subagents/research-subagent-best-practices.md, subagents/creating-custom
 
 Subagents are context firewalls. They encapsulate exploration work — glob output, grep noise, evaluator scans — in an isolated window so it never reaches the parent context. Only the condensed, structured result flows back. The orchestrator stays in the smart zone; the subagent absorbs the noise.
 
-*Source: harness-engineering.md*
 
 | Use subagent when | Use inline Claude when | Use hook when |
 |------------------|----------------------|--------------|
@@ -33,7 +31,6 @@ Subagents are context firewalls. They encapsulate exploration work — glob outp
 
 **Subagents cannot spawn other subagents** — prevents infinite nesting.
 
-*Source: subagents/research-subagent-best-practices.md lines 33-55*
 
 ---
 
@@ -66,7 +63,6 @@ maxTurns: 20
 You are a code reviewer specializing in [domain]...
 ```
 
-*Source: subagents/creating-custom-subagents.md lines 151-210*
 
 ---
 
@@ -86,7 +82,6 @@ Effective subagent system prompts follow this 5-part pattern:
 - Include trigger phrases ("use proactively when...", "use when editing...")
 - Avoid generic descriptions ("helps with code")
 
-*Source: subagents/research-subagent-best-practices.md lines 73-76, 374-430*
 
 ---
 
@@ -103,7 +98,6 @@ Effective subagent system prompts follow this 5-part pattern:
 
 **Rule of thumb**: Opus for architecture decisions, Sonnet for everything else, Haiku for read-only exploration only.
 
-*Source: subagents/research-subagent-best-practices.md lines 318-355*
 
 ---
 
@@ -129,7 +123,6 @@ If both defined: denylist applied first, then allowlist resolves against remaini
 - Explorers: `Read, Grep, Glob, Bash(readonly commands)`
 - Full-capability (rare): all tools — justify explicitly
 
-*Source: subagents/creating-custom-subagents.md lines 245-295*
 
 ---
 
@@ -146,7 +139,6 @@ If both defined: denylist applied first, then allowlist resolves against remaini
 | maxTurns > 30 | Runaway agents | Cap at 20-30 for most tasks |
 | Vague system prompt | Inconsistent behavior | Add role, process, output format |
 
-*Source: subagents/research-subagent-best-practices.md lines 791-819*
 
 ---
 
@@ -167,4 +159,3 @@ Consolidate similar issues. Prioritize by: CRITICAL (bugs/security) > HIGH > MED
 
 This pattern significantly reduces noise and keeps output actionable.
 
-*Source: subagents/research-subagent-best-practices.md lines 463-475*

--- a/plugins/agent-customizer/skills/improve-subagent/references/subagent-config-reference.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/subagent-config-reference.md
@@ -1,7 +1,6 @@
 # Subagent Config Reference
 
 Complete YAML frontmatter specification, model IDs, and orchestration patterns for subagents.
-Source: subagents/creating-custom-subagents.md, subagents/claude-orchestrate-of-claude-code-sessions.md
 
 ---
 
@@ -37,7 +36,6 @@ Only `name` and `description` are required. All others have sensible defaults.
 | `effort` | No | Inherit | `low`, `medium`, `high`, `max` (Opus 4.6 only) |
 | `isolation` | No | None | `worktree` = isolated git worktree; auto-cleanup if no changes |
 
-*Source: subagents/creating-custom-subagents.md lines 213-232*
 
 ---
 
@@ -54,7 +52,6 @@ Only `name` and `description` are required. All others have sensible defaults.
 
 Full model IDs (e.g., `claude-opus-4-6`, `claude-sonnet-4-6`) also accepted.
 
-*Source: subagents/creating-custom-subagents.md lines 234-241*
 
 ---
 
@@ -91,7 +88,6 @@ Standard patterns from community (read-only reviewers dominate):
 - Explorer: `tools: Read, Grep, Glob, Bash`
 - Full-access (rare): omit `tools` and `disallowedTools`
 
-*Source: subagents/creating-custom-subagents.md lines 243-275*
 
 ---
 
@@ -116,7 +112,6 @@ Main → (delegate) → Researcher agent → (report) → Main → (delegate) �
 **Parallel decomposition:**
 Spawn multiple independent subagents simultaneously. Main aggregates results.
 
-*Source: subagents/creating-custom-subagents.md lines 619-637*
 
 ---
 
@@ -129,7 +124,6 @@ These limitations are enforced by the runtime:
 - **Subagents do not inherit parent skills** — must be explicitly listed in `skills` field (full content injected)
 - **`maxTurns` applies per invocation** — project convention: 15 for analysis agents, 20 for evaluator agents; values outside 15–20 require explicit justification
 
-*Source: subagents/creating-custom-subagents.md lines 210-212; subagents/research-subagent-best-practices.md lines 36-42*
 
 ---
 
@@ -143,4 +137,3 @@ Plugin subagents (from installed plugins) have additional restrictions for secur
 
 To use these fields with a plugin agent: copy the agent file to `.claude/agents/` or `~/.claude/agents/`.
 
-*Source: subagents/creating-custom-subagents.md lines 187-189*

--- a/plugins/agent-customizer/skills/improve-subagent/references/subagent-evaluation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/subagent-evaluation-criteria.md
@@ -1,8 +1,6 @@
 # Subagent Evaluation Criteria
 
 Scoring rubric for assessing existing Claude Code subagent definitions before improvement.
-Source: subagents/research-subagent-best-practices.md, subagents/creating-custom-subagents.md
-
 ---
 
 ## Contents
@@ -19,17 +17,16 @@ Source: subagents/research-subagent-best-practices.md, subagents/creating-custom
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| `name` field | Present; lowercase letters and hyphens only | subagents/creating-custom-subagents.md lines 217-220 |
-| `description` field | Present, non-empty, specific | subagents/creating-custom-subagents.md lines 217-220 |
-| `model` field | Recognized alias or full model ID | subagents/creating-custom-subagents.md lines 234-241 |
-| `maxTurns` | 15–20 for most tasks; values outside 15–20 require justification | Project convention — `.claude/rules/agent-files.md` |
-| System prompt (markdown body) | Present and task-specific | subagents/creating-custom-subagents.md lines 199-212 |
+| Criterion | Threshold |
+|-----------|-----------|
+| `name` field | Present; lowercase letters and hyphens only |
+| `description` field | Present, non-empty, specific |
+| `model` field | Recognized alias or full model ID |
+| `maxTurns` | 15–20 for most tasks; values outside 15–20 require justification |
+| System prompt (markdown body) | Present and task-specific |
 
 A subagent violating any hard limit is flagged **INVALID** regardless of other quality.
 
-*Source: subagents/creating-custom-subagents.md lines 213-232*
 
 ---
 
@@ -37,7 +34,6 @@ A subagent violating any hard limit is flagged **INVALID** regardless of other q
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -52,7 +48,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Duplicate subagent with same purpose as built-in | Explore/Plan built-ins cover exploration; don't recreate |
 | Aggressive delegation language ("CRITICAL: MUST use") | Overtriggering; normal language preferred |
 
-*Source: subagents/research-subagent-best-practices.md lines 152-180*
 
 ---
 
@@ -65,7 +60,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | `allowedTools` field (old format) | Current field name is `tools` (allowlist) |
 | Tasks spawning other subagents | Runtime blocks this; remove nested spawn instructions |
 
-*Source: subagents/creating-custom-subagents.md lines 213-232*
 
 ---
 
@@ -79,7 +73,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Description specific enough for routing? | Triggers specified; "use proactively when..." | Generic description; poor delegation |
 | Context isolation justified? | Subagent prevents context pollution | Subagent used when inline works |
 
-*Source: subagents/research-subagent-best-practices.md lines 33-55*
 
 ---
 
@@ -94,7 +87,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Context Isolation | Subagent use justified; prevents pollution | Questionable necessity | Duplicates inline capability |
 | **Overall** | | | |
 
-*Source: subagents/research-subagent-best-practices.md lines 92-146*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
@@ -1,7 +1,18 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Claude Code subagent definitions.
-Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md
+Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md, `wiki/knowledge/skill-body-convention.md`
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
@@ -22,6 +33,70 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 ---
 
+## Canonical Semantic-Tag Convention
+
+The subagent body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the subagent body MUST contain all of these):
+
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Subagent-specific variant**: `<TRIGGER>` is OPTIONAL for subagents (they are spawned by skills, not user-invoked). Its absence is **silent** — never a finding.
+
+**Optional tags** (absence is silent — never a finding): `<TRIGGER>`, `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. Report it as a `<HARD_RULES>` alias candidate (informational), not as a violation. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of `<TRIGGER>` or any other optional tag | No finding; proceed |
+| **Informational** | Legacy `<RULES>` tag present — alias for `<HARD_RULES>` | Surface as alias candidate; do not fail or warn |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
+
+### Structured violation report format
+
+When evaluating a target subagent body, report every finding using this format:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+[HARD-FAIL] Missing mandatory tag: <BEHAVIOUR> — required for subagents
+[HARD-FAIL] Unbalanced tag: <PROCESS> opened at line 35, no closing tag found
+[HARD-FAIL] Malformed attribute: <PHASE id=1 name="x"> — attribute value `1` missing quotes
+[WARN]      Non-canonical attribute: <BEHAVIOUR mood="high"> — `mood` is outside the closed set
+[INFO]      Legacy alias: <RULES> at line 18 — satisfies <HARD_RULES> check; candidate for organic retrofit to <HARD_RULES>
+──────────────────────────────────
+Result: HARD-FAIL (3 blocking violations, 1 warning, 1 informational)
+```
+
+A compliant target produces:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+No violations found.
+──────────────────────────────────
+Result: PASS
+```
+
+Note: `<TRIGGER>` absent in a subagent body is NOT a violation — it produces no report entry.
+
+---
+
 ## Quality Checks (All must pass)
 
 - [ ] `description` specific enough for automatic delegation (includes trigger phrases)
@@ -31,12 +106,23 @@ Any subagent violating these criteria must be fixed before proceeding:
 - [ ] Delegation trigger language is normal ("use when..."), not aggressive ("CRITICAL: MUST always...")
 - [ ] No instructions telling subagent to spawn other subagents (runtime blocks this)
 - [ ] System prompt is task-specific, not generic ("you are a helpful AI")
-- [ ] Evidence citations present: system prompt references source docs for domain-specific constraints (e.g., "per creating-custom-subagents.md")
-- [ ] Prompt engineering strategy applied: system prompt uses role prompting (single-sentence role), structured output format, and confidence filtering per prompt-engineering-strategies.md. **Note:** For evaluation agents that mandate explicit evidence citations per finding (a stricter guarantee), the evidence requirement satisfies the confidence filtering criterion.
+- [ ] Evidence citations present: system prompt references source docs for domain-specific constraints
+- [ ] Prompt engineering strategy applied: system prompt uses role prompting, structured output format, and confidence filtering per prompt-engineering-strategies.md
+- [ ] Canonical semantic tags present: `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched — `name`, `description`, `tools`, `model`, `maxTurns` fields per Anthropic subagent spec
 
 ---
 
 ## If This Is an IMPROVE Operation — Also Check
+
+**Canonical Tag Vocabulary:**
+
+- [ ] Target subagent body uses all mandatory tags (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with at least one `<PHASE>`); `<TRIGGER>` absence is silent — not a finding
+- [ ] All tags in target subagent body are balanced (no unmatched open/close)
+- [ ] All attribute syntax in target subagent body is well-formed (no missing quotes, no stray `=`)
+- [ ] Non-canonical attributes in target subagent body surfaced as warnings (not hard-fails)
+- [ ] Legacy `<RULES>` in target subagent body reported as informational alias candidate (not a fail)
 
 **Information Preservation:**
 
@@ -48,6 +134,7 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 - [ ] `maxTurns` not increased beyond 20 without justification
 - [ ] Scope of subagent not broadened (single-purpose agents are better than general-purpose)
+- [ ] Reference file ≤200 line limit not violated; >100-line files have a `## Contents` TOC
 
 ---
 
@@ -55,10 +142,37 @@ Any subagent violating these criteria must be fixed before proceeding:
 
 Execute this loop for each generated or improved subagent:
 
-1. Evaluate the subagent against ALL criteria above
+1. Evaluate the subagent against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
-3. If ANY criterion fails: identify the specific failure, fix the subagent, restart evaluation
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing subagents when ALL criteria pass
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the subagent, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing subagents when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The strictness tiers above are exercised by a regression corpus shipped with the
+sibling `create-subagent` skill at
+`plugins/agent-customizer/skills/create-subagent/assets/fixtures/` (see its
+`MANIFEST.md`). `improve-subagent` does not ship its own copy — the
+strictness-tier logic is identical, so the `create-subagent` corpus is the single
+regression test for both. The table below documents the expected verdict for each
+fixture so the contract is visible here too; running the validation loop against
+any body MUST produce exactly these verdicts.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-with-trigger.md` | None — all mandatory tags present, `<TRIGGER>` also present, balanced, canonical attributes | **pass** |
+| `compliant-without-trigger.md` | `<TRIGGER>` absent (subagent variant — optional) | **pass** (silence on optional tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check); surface informational alias candidate |

--- a/plugins/agent-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
@@ -1,8 +1,6 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Claude Code subagent definitions.
-Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md, `wiki/knowledge/skill-body-convention.md`
-
 ---
 
 ## Contents
@@ -20,16 +18,15 @@ Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best
 
 Any subagent violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | subagents/creating-custom-subagents.md |
-| `name` field | Lowercase letters and hyphens only | subagents/creating-custom-subagents.md lines 217-220 |
-| `description` field | Present and non-empty | subagents/creating-custom-subagents.md lines 217-220 |
-| `model` field | Recognized alias or full model ID | subagents/creating-custom-subagents.md lines 234-241 |
-| `maxTurns` | 15 for analysis agents; 20 for evaluators; values outside 15–20 require justification | Project convention — `.claude/rules/agent-files.md` |
-| System prompt | Not empty; task-specific | subagents/creating-custom-subagents.md lines 199-212 |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens only |
+| `description` field | Present and non-empty |
+| `model` field | Recognized alias or full model ID |
+| `maxTurns` | 15 for analysis agents; 20 for evaluators; values outside 15–20 require justification |
+| System prompt | Not empty; task-specific |
 
-*Source: subagents/creating-custom-subagents.md lines 213-232; subagents/research-subagent-best-practices.md lines 33-55*
 
 ---
 
@@ -65,7 +62,6 @@ The subagent body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ### Structured violation report format
 

--- a/plugins/agents-initializer/.claude-plugin/plugin.json
+++ b/plugins/agents-initializer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-initializer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Evidence-based AGENTS.md and CLAUDE.md initializer and optimizer. Generates minimal, scoped configuration files following progressive disclosure principles — based on the ETH Zurich 'Evaluating AGENTS.md' study and Anthropic's context engineering best practices.",
   "author": {
     "name": "rodrigorjsf"

--- a/plugins/agents-initializer/agents/file-evaluator.md
+++ b/plugins/agents-initializer/agents/file-evaluator.md
@@ -21,25 +21,25 @@ You are a configuration file quality specialist. Analyze existing AGENTS.md or C
 
 ### Hard Limits
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions" |
-| No contradictions | 0 conflicts | Anthropic: "Claude may pick one arbitrarily" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| No contradictions | 0 conflicts |
 
 ### Bloat Indicators
 
 Each of these wastes tokens without improving agent performance:
 
-| Indicator | Why It's Bloat | Source |
-|-----------|---------------|--------|
-| Directory/file structure listings | "Not effective at providing repository overview" | Evaluating AGENTS.md (ETH Zurich) |
-| Standard language conventions | Agent already knows these from training | Anthropic Best Practices |
-| Vague instructions ("write clean code") | Not actionable, wastes attention budget | a-guide-to-agents.md |
-| Codebase overview paragraphs | Increases steps without improving navigation | Evaluating AGENTS.md |
-| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it correctly, delete it" |
-| Duplicated information across files | Wastes tokens on every request | Context engineering research |
-| **Architectural path trap** | Lists of paths WITH behavioral constraints (e.g., `services/ must not import from routes/`) are **not** directory listings — flag only pure path listings with no rules attached | Evaluating AGENTS.md |
+| Indicator | Why It's Bloat |
+|-----------|---------------|
+| Directory/file structure listings | "Not effective at providing repository overview" |
+| Standard language conventions | Agent already knows these from training |
+| Vague instructions ("write clean code") | Not actionable, wastes attention budget |
+| Codebase overview paragraphs | Increases steps without improving navigation |
+| Obvious tool usage ("use git for version control") | Agent already knows this |
+| Duplicated information across files | Wastes tokens on every request |
+| **Architectural path trap** | Lists of paths WITH behavioral constraints (e.g., `services/ must not import from routes/`) are **not** directory listings — flag only pure path listings with no rules attached |
 
 ### Staleness Indicators
 

--- a/plugins/agents-initializer/skills/improve-agents/references/automation-mechanism-comparison.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/automation-mechanism-comparison.md
@@ -1,7 +1,6 @@
 # Automation Mechanism Comparison
 
 Routing instructions to on-demand automation mechanisms.
-Source: context-aware-improve-optimization.prd.md, analysis-automate-workflow-with-hooks.md, analysis-skill-authoring-best-practices.md, analysis-how-claude-remembers-a-project.md.
 
 Load `automation-token-impact.md` only when Phase 1 flags an instruction block as a migration candidate.
 
@@ -21,7 +20,6 @@ Stop at the first match:
 8. Context-heavy isolated analysis → skill (`context: fork`)
 9. None of the above → keep in current location; reassess next cycle
 
-*Source: context-aware-improve-optimization.prd.md lines 346-358*
 
 ---
 
@@ -42,7 +40,6 @@ Stop at the first match:
 
 Hook events: `PreToolUse` (block via `hookSpecificOutput.permissionDecision`), `PostToolUse`, `Stop`, `SessionStart`, `UserPromptSubmit`, plus 17 others. Path-scoped rules accept negation: `paths: ["src/**/*.ts", "!src/**/*.test.ts"]`.
 
-*Source: analysis-automate-workflow-with-hooks.md lines 21-130, 433-445*
 
 ---
 
@@ -50,4 +47,3 @@ Hook events: `PreToolUse` (block via `hookSpecificOutput.permissionDecision`), `
 
 Skills, path-scoped rules — plugin and standalone. Hooks, subagents — plugin only (require Claude Code). Auto memory — mention only. Filter to supported mechanisms before generating suggestions.
 
-*Source: DESIGN-GUIDELINES.md Guideline 11*

--- a/plugins/agents-initializer/skills/improve-agents/references/automation-token-impact.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/automation-token-impact.md
@@ -2,7 +2,6 @@
 
 Migration-candidate signals and token-impact estimation.
 Load only when Phase 1 flags an instruction block as a migration candidate.
-Source: context-aware-improve-optimization.prd.md, analysis-evaluating-agents-paper.md, research-context-engineering-comprehensive.md.
 
 For mechanism comparison and decision flowchart, see `automation-mechanism-comparison.md`.
 
@@ -19,7 +18,6 @@ For mechanism comparison and decision flowchart, see `automation-mechanism-compa
 - Duplicated across 2+ files → consolidate to single source
 - Version numbers / team names / release info (high-churn) → DELETE or replace with memory pointer
 
-*Source: analysis-evaluating-agents-paper.md lines 36-52; Anthropic Best Practices*
 
 ---
 
@@ -37,4 +35,3 @@ For mechanism comparison and decision flowchart, see `automation-mechanism-compa
 
 Present token-impact estimates alongside migration recommendations.
 
-*Source: research-context-engineering-comprehensive.md; analysis-skill-authoring-best-practices.md lines 19-46; DESIGN-GUIDELINES.md Guideline 10.*

--- a/plugins/agents-initializer/skills/improve-agents/references/context-optimization.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Token-budget and attention guidance for AGENTS.md / CLAUDE.md files.
-Source: research-context-engineering-comprehensive.md.
 
 Hard limits live in `validation-criteria.md`. Bloated files cause Claude to ignore actual instructions. (Anthropic Best Practices)
 
@@ -17,16 +16,13 @@ Place the most important instructions in the first 20% and last 20% of each file
 
 Apply the deletion test: "Would removing this cause the agent to make mistakes? If not, cut it." Full include/exclude categories: see `what-not-to-include.md`. **Specificity goldilocks**: ✅ "Use 2-space indentation"; "Run `npm test` before committing"; "API handlers live in `src/api/handlers/`". ❌ "Format code properly"; "Test your changes"; "Keep files organized".
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ## Context Poisoning Vectors
 
 Detect and remove: stale file paths; contradictions (drop the weaker rule); over-specification (rules already followed; delete or convert to hook); failed-approach accumulation (defensive rules added after incidents); high-churn data (versions, file counts, team names). Treat CLAUDE.md like code: review when things go wrong, prune regularly. (Anthropic Best Practices)
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ## JIT Documentation
 
 Move from always-consumed to on-demand: skills (description loaded; body on invocation), path-scoped rules (load on file match), subdirectory configs (load when working there), `@path/to/import` (expands when parent loads), domain docs in `docs/` (agent navigates when relevant). Maintain lightweight identifiers; load data into context at runtime. (Anthropic Engineering: Effective Context Engineering)
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*

--- a/plugins/agents-initializer/skills/improve-agents/references/evaluation-criteria.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Evaluation Criteria
 
 Scoring rubric for assessing existing AGENTS.md / CLAUDE.md files before improvement. IMPROVE skills only.
-Source: file-evaluator.md, research-context-engineering-comprehensive.md.
 
 The canonical Hard Limits Table, Bloat Indicators, Staleness Indicators, Progressive Disclosure Assessment, Quality Score Rubric, and Evaluation Output Template all live in `agents/file-evaluator.md` (the subagent that produces the structured evaluation report). The Migration Candidate Indicators table lives in `automation-token-impact.md`. This file holds only criteria specific to the IMPROVE workflow.
 
@@ -11,7 +10,6 @@ Goldilocks: ✅ specific and actionable: "Use 2-space indentation"; ❌ too vagu
 
 **Config-enforcement distinction**: rules already enforced by config files ("Strict mode" with `tsconfig.json` `"strict": true`) → DELETE. Project decisions not in config ("Use `unknown` over `any`; validate with `zod`") → keep.
 
-*Source: research-context-engineering-comprehensive.md lines 131-134*
 
 ## Calibrated Improvement Mode
 

--- a/plugins/agents-initializer/skills/improve-agents/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Where AGENTS.md / CLAUDE.md content lives by load timing.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md.
 
 For anti-patterns, see `what-not-to-include.md` § Common Traps. For validation thresholds, see `validation-criteria.md`.
 
@@ -9,7 +8,6 @@ For anti-patterns, see `what-not-to-include.md` § Common Traps. For validation 
 
 **Root AGENTS.md / CLAUDE.md** — every task; always loaded. **Domain file** — one domain (TypeScript, testing); on-demand. **Subdirectory AGENTS.md / CLAUDE.md** — one package or area; on-demand. **`.claude/rules/` path-scoped** — file patterns; on-demand. **Skill** — workflow agent invokes explicitly; on-demand.
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ## Root File Requirements
 
@@ -19,13 +17,11 @@ Root files contain only: (1) one-sentence project description; (2) package manag
 
 **Root**: monorepo purpose, package navigation, shared tooling — never package-specific tech stacks. **Package**: package purpose, specific tech stack, package conventions — never cross-repo decisions. The agent sees all merged files. In large monorepos, use `claudeMdExcludes` in `.claude/settings.local.json` (glob patterns; absolute paths; arrays merge across settings layers; managed policy files cannot be excluded).
 
-*Source: a-guide-to-agents.md; memory/how-claude-remembers-a-project.md lines 243-260*
 
 ## Extraction Triggers
 
 Extract a section to a separate domain file when 3+ distinct rules AND 10+ lines, or when irrelevant to most sessions. Prefer pointers ("For TypeScript conventions, see docs/TYPESCRIPT.md") over inlining. Workflows go to skills.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ## CLAUDE.md Hierarchy
 
@@ -35,7 +31,6 @@ Loading by scope: org-wide managed policy (MDM) and personal `~/.claude/CLAUDE.m
 
 **Load order** — Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory files load only when Claude reads files there.
 
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
 
 ## AGENTS.md Notes
 

--- a/plugins/agents-initializer/skills/improve-agents/references/validation-criteria.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md / CLAUDE.md files.
-Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-evaluator.md:23-59.
 
 ---
 

--- a/plugins/agents-initializer/skills/improve-agents/references/what-not-to-include.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/what-not-to-include.md
@@ -1,13 +1,11 @@
 # What NOT to Include
 
 Exclusion guide for AGENTS.md and CLAUDE.md.
-Sources: ETH Zurich (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md.
 
 ## Exclusions
 
 Exclude: directory/file structure listings; standard language conventions; codebase overview paragraphs (increase exploration without improving navigation — ETH); vague guidance ("write clean code"); file path references (paths churn and poison context); everything in one file (~150-200 instruction attention budget); obvious tooling ("use git"); duplicates; version numbers / release names; long explanations or tutorials; detailed API documentation (link out); anything inferable from code; hook-enforced behaviors — migrate to a hook.
 
-*Source: init-agents/SKILL.md:106-116; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/plugins/agents-initializer/skills/improve-claude/references/automation-mechanism-comparison.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/automation-mechanism-comparison.md
@@ -1,7 +1,6 @@
 # Automation Mechanism Comparison
 
 Routing instructions to on-demand automation mechanisms.
-Source: context-aware-improve-optimization.prd.md, analysis-automate-workflow-with-hooks.md, analysis-skill-authoring-best-practices.md, analysis-how-claude-remembers-a-project.md.
 
 Load `automation-token-impact.md` only when Phase 1 flags an instruction block as a migration candidate.
 
@@ -21,7 +20,6 @@ Stop at the first match:
 8. Context-heavy isolated analysis → skill (`context: fork`)
 9. None of the above → keep in current location; reassess next cycle
 
-*Source: context-aware-improve-optimization.prd.md lines 346-358*
 
 ---
 
@@ -42,7 +40,6 @@ Stop at the first match:
 
 Hook events: `PreToolUse` (block via `hookSpecificOutput.permissionDecision`), `PostToolUse`, `Stop`, `SessionStart`, `UserPromptSubmit`, plus 17 others. Path-scoped rules accept negation: `paths: ["src/**/*.ts", "!src/**/*.test.ts"]`.
 
-*Source: analysis-automate-workflow-with-hooks.md lines 21-130, 433-445*
 
 ---
 
@@ -50,4 +47,3 @@ Hook events: `PreToolUse` (block via `hookSpecificOutput.permissionDecision`), `
 
 Skills, path-scoped rules — plugin and standalone. Hooks, subagents — plugin only (require Claude Code). Auto memory — mention only. Filter to supported mechanisms before generating suggestions.
 
-*Source: DESIGN-GUIDELINES.md Guideline 11*

--- a/plugins/agents-initializer/skills/improve-claude/references/automation-token-impact.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/automation-token-impact.md
@@ -2,7 +2,6 @@
 
 Migration-candidate signals and token-impact estimation.
 Load only when Phase 1 flags an instruction block as a migration candidate.
-Source: context-aware-improve-optimization.prd.md, analysis-evaluating-agents-paper.md, research-context-engineering-comprehensive.md.
 
 For mechanism comparison and decision flowchart, see `automation-mechanism-comparison.md`.
 
@@ -19,7 +18,6 @@ For mechanism comparison and decision flowchart, see `automation-mechanism-compa
 - Duplicated across 2+ files → consolidate to single source
 - Version numbers / team names / release info (high-churn) → DELETE or replace with memory pointer
 
-*Source: analysis-evaluating-agents-paper.md lines 36-52; Anthropic Best Practices*
 
 ---
 
@@ -37,4 +35,3 @@ For mechanism comparison and decision flowchart, see `automation-mechanism-compa
 
 Present token-impact estimates alongside migration recommendations.
 
-*Source: research-context-engineering-comprehensive.md; analysis-skill-authoring-best-practices.md lines 19-46; DESIGN-GUIDELINES.md Guideline 10.*

--- a/plugins/agents-initializer/skills/improve-claude/references/claude-rules-system.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/claude-rules-system.md
@@ -1,7 +1,6 @@
 # Claude Rules System
 
 `.claude/rules/` and CLAUDE.md hierarchy. Claude Code-specific.
-Sources: research-claude-code-skills-format.md, research-context-engineering-comprehensive.md, init-claude/SKILL.md, memory/how-claude-remembers-a-project.md.
 
 ## Loading Behavior
 

--- a/plugins/agents-initializer/skills/improve-claude/references/context-optimization.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Token-budget and attention guidance for AGENTS.md / CLAUDE.md files.
-Source: research-context-engineering-comprehensive.md.
 
 Hard limits live in `validation-criteria.md`. Bloated files cause Claude to ignore actual instructions. (Anthropic Best Practices)
 
@@ -17,16 +16,13 @@ Place the most important instructions in the first 20% and last 20% of each file
 
 Apply the deletion test: "Would removing this cause the agent to make mistakes? If not, cut it." Full include/exclude categories: see `what-not-to-include.md`. **Specificity goldilocks**: ✅ "Use 2-space indentation"; "Run `npm test` before committing"; "API handlers live in `src/api/handlers/`". ❌ "Format code properly"; "Test your changes"; "Keep files organized".
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ## Context Poisoning Vectors
 
 Detect and remove: stale file paths; contradictions (drop the weaker rule); over-specification (rules already followed; delete or convert to hook); failed-approach accumulation (defensive rules added after incidents); high-churn data (versions, file counts, team names). Treat CLAUDE.md like code: review when things go wrong, prune regularly. (Anthropic Best Practices)
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ## JIT Documentation
 
 Move from always-consumed to on-demand: skills (description loaded; body on invocation), path-scoped rules (load on file match), subdirectory configs (load when working there), `@path/to/import` (expands when parent loads), domain docs in `docs/` (agent navigates when relevant). Maintain lightweight identifiers; load data into context at runtime. (Anthropic Engineering: Effective Context Engineering)
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*

--- a/plugins/agents-initializer/skills/improve-claude/references/evaluation-criteria.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Evaluation Criteria
 
 Scoring rubric for assessing existing AGENTS.md / CLAUDE.md files before improvement. IMPROVE skills only.
-Source: file-evaluator.md, research-context-engineering-comprehensive.md.
 
 The canonical Hard Limits Table, Bloat Indicators, Staleness Indicators, Progressive Disclosure Assessment, Quality Score Rubric, and Evaluation Output Template all live in `agents/file-evaluator.md` (the subagent that produces the structured evaluation report). The Migration Candidate Indicators table lives in `automation-token-impact.md`. This file holds only criteria specific to the IMPROVE workflow.
 
@@ -11,7 +10,6 @@ Goldilocks: ✅ specific and actionable: "Use 2-space indentation"; ❌ too vagu
 
 **Config-enforcement distinction**: rules already enforced by config files ("Strict mode" with `tsconfig.json` `"strict": true`) → DELETE. Project decisions not in config ("Use `unknown` over `any`; validate with `zod`") → keep.
 
-*Source: research-context-engineering-comprehensive.md lines 131-134*
 
 ## Calibrated Improvement Mode
 

--- a/plugins/agents-initializer/skills/improve-claude/references/improvement-card-template.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/improvement-card-template.md
@@ -1,6 +1,6 @@
 # Improvement Card Template
 
-Phase 5 output format. Source: improve-agents/SKILL.md:151-160.
+Phase 5 output format.
 
 ---
 

--- a/plugins/agents-initializer/skills/improve-claude/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Where AGENTS.md / CLAUDE.md content lives by load timing.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md.
 
 For anti-patterns, see `what-not-to-include.md` § Common Traps. For validation thresholds, see `validation-criteria.md`.
 
@@ -9,7 +8,6 @@ For anti-patterns, see `what-not-to-include.md` § Common Traps. For validation 
 
 **Root AGENTS.md / CLAUDE.md** — every task; always loaded. **Domain file** — one domain (TypeScript, testing); on-demand. **Subdirectory AGENTS.md / CLAUDE.md** — one package or area; on-demand. **`.claude/rules/` path-scoped** — file patterns; on-demand. **Skill** — workflow agent invokes explicitly; on-demand.
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ## Root File Requirements
 
@@ -19,13 +17,11 @@ Root files contain only: (1) one-sentence project description; (2) package manag
 
 **Root**: monorepo purpose, package navigation, shared tooling — never package-specific tech stacks. **Package**: package purpose, specific tech stack, package conventions — never cross-repo decisions. The agent sees all merged files. In large monorepos, use `claudeMdExcludes` in `.claude/settings.local.json` (glob patterns; absolute paths; arrays merge across settings layers; managed policy files cannot be excluded).
 
-*Source: a-guide-to-agents.md; memory/how-claude-remembers-a-project.md lines 243-260*
 
 ## Extraction Triggers
 
 Extract a section to a separate domain file when 3+ distinct rules AND 10+ lines, or when irrelevant to most sessions. Prefer pointers ("For TypeScript conventions, see docs/TYPESCRIPT.md") over inlining. Workflows go to skills.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ## CLAUDE.md Hierarchy
 
@@ -35,7 +31,6 @@ Loading by scope: org-wide managed policy (MDM) and personal `~/.claude/CLAUDE.m
 
 **Load order** — Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory files load only when Claude reads files there.
 
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
 
 ## AGENTS.md Notes
 

--- a/plugins/agents-initializer/skills/improve-claude/references/validation-criteria.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md / CLAUDE.md files.
-Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-evaluator.md:23-59.
 
 ---
 

--- a/plugins/agents-initializer/skills/improve-claude/references/what-not-to-include.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/what-not-to-include.md
@@ -1,13 +1,11 @@
 # What NOT to Include
 
 Exclusion guide for AGENTS.md and CLAUDE.md.
-Sources: ETH Zurich (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md.
 
 ## Exclusions
 
 Exclude: directory/file structure listings; standard language conventions; codebase overview paragraphs (increase exploration without improving navigation — ETH); vague guidance ("write clean code"); file path references (paths churn and poison context); everything in one file (~150-200 instruction attention budget); obvious tooling ("use git"); duplicates; version numbers / release names; long explanations or tutorials; detailed API documentation (link out); anything inferable from code; hook-enforced behaviors — migrate to a hook.
 
-*Source: init-agents/SKILL.md:106-116; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/plugins/agents-initializer/skills/init-agents/references/context-optimization.md
+++ b/plugins/agents-initializer/skills/init-agents/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Evidence-based instructions for managing token budgets and attention in agent configuration files.
-Source: research-context-engineering-comprehensive.md
 
 ---
 
@@ -13,17 +12,16 @@ Source: research-context-engineering-comprehensive.md
 - Quality over quantity checklist (include/exclude decision table)
 - Context poisoning vectors (detection and removal)
 - JIT documentation patterns (on-demand loading strategies)
-- Key citations
 
 ---
 
 ## Hard Limits
 
-| Limit | Value | Source |
-|-------|-------|--------|
-| Lines per configuration file | ≤ 200 | Anthropic Docs: "Target under 200 lines per CLAUDE.md file." |
-| Instructions per file | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
-| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily." |
+| Limit | Value |
+|-------|-------|
+| Lines per configuration file | ≤ 200 |
+| Instructions per file | ≤ 150-200 |
+| Contradictions between files | 0 |
 
 > "Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"
 > — Anthropic Best Practices
@@ -79,7 +77,6 @@ For each instruction line, ask: **"Would removing this cause the agent to make m
 - ✅ "Run `npm test` before committing" vs. ❌ "Test your changes"
 - ✅ "API handlers live in `src/api/handlers/`" vs. ❌ "Keep files organized"
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -97,7 +94,6 @@ Detect and remove these before generating or improving configuration files:
 
 > "Treat CLAUDE.md like code: review it when things go wrong, prune it regularly." — Anthropic Best Practices
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -116,17 +112,6 @@ Use these patterns to move content from always-consumed to on-demand locations:
 > "Rather than pre-processing all relevant data up front, agents maintain lightweight identifiers and use these references to dynamically load data into context at runtime."
 > — Anthropic Engineering: Effective Context Engineering
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*
 
 ---
 
-## Key Citations
-
-| Claim | Source |
-|-------|--------|
-| ≤200 lines per file | Agent Skills Standard |
-| ~150-200 instruction limit | HumanLayer (Kyle) via a-guide-to-agents.md |
-| n² attention constraint / context rot | Anthropic Engineering Blog |
-| Lost-in-the-middle effect | Liu et al., arXiv:2307.03172 |
-| Quality over quantity heuristic | Anthropic Best Practices |
-| JIT documentation strategy | Anthropic Engineering: Effective Context Engineering |

--- a/plugins/agents-initializer/skills/init-agents/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/init-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -30,7 +29,6 @@ When deciding where to place content, use this table:
 | `.claude/rules/` (path-scoped) | Specific to certain file patterns | On-demand when files match |
 | Skill | A workflow the agent should invoke explicitly | On-demand when invoked |
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -74,7 +72,6 @@ See each package's AGENTS.md for specific guidelines.
 
 Patterns match absolute paths with glob syntax. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded.
 
-*Source: memory/how-claude-remembers-a-project.md lines 243-260*
 
 ---
 
@@ -105,7 +102,6 @@ docs/
 
 **Use skills for workflows** — agents invoke skills only when needed, keeping base context minimal.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ---
 
@@ -125,7 +121,6 @@ docs/
 
 **Load order**: Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory CLAUDE.md files load on-demand only when Claude reads files in that directory — not at launch.
 
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
 
 ---
 

--- a/plugins/agents-initializer/skills/init-agents/references/validation-criteria.md
+++ b/plugins/agents-initializer/skills/init-agents/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md / CLAUDE.md files.
-Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
 
 ---
 
@@ -9,13 +8,13 @@ Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-e
 
 Any file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "~150-200 instructions with reasonable consistency" |
-| Contradictions (within or between files) | 0 | Anthropic: "Claude may pick one arbitrarily" |
-| Language-specific rules in root | 0 | Domain rules belong in separate files |
-| Stale file path references | 0 | "File paths change constantly... actively poisons context" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| Contradictions (within or between files) | 0 |
+| Language-specific rules in root | 0 |
+| Stale file path references | 0 |
 
 ## Recommended Targets (Advisory)
 

--- a/plugins/agents-initializer/skills/init-agents/references/what-not-to-include.md
+++ b/plugins/agents-initializer/skills/init-agents/references/what-not-to-include.md
@@ -1,29 +1,27 @@
 # What NOT to Include
 
 Evidence-based exclusion table for AGENTS.md and CLAUDE.md content.
-Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md, hooks/automate-workflow-with-hooks.md
 
 ---
 
 ## Exclusion Evidence Table
 
-| Content Type | Why to Exclude | Evidence Quote | Source |
-|-------------|----------------|---------------|--------|
-| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" | ETH Zurich: Evaluating AGENTS.md |
-| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" | Anthropic Best Practices |
-| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" | ETH Zurich: Evaluating AGENTS.md |
-| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | a-guide-to-agents.md |
-| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | a-guide-to-agents.md |
-| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | a-guide-to-agents.md |
-| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
-| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" | research-context-engineering-comprehensive.md |
-| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Anthropic Best Practices |
-| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" | Anthropic Best Practices |
-| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; config file instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | "Hooks provide deterministic control over Claude Code's behavior, ensuring certain actions always happen rather than relying on the LLM" | Anthropic Hooks Guide |
+| Content Type | Why to Exclude | Evidence Quote |
+|-------------|----------------|---------------|
+| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" |
+| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" |
+| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" |
+| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" |
+| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" |
+| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" |
+| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" |
+| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) |
+| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column |
+| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" |
+| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; config file instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | "Hooks provide deterministic control over Claude Code's behavior, ensuring certain actions always happen rather than relying on the LLM" |
 
-*Source: init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/plugins/agents-initializer/skills/init-claude/SKILL.md
+++ b/plugins/agents-initializer/skills/init-claude/SKILL.md
@@ -18,18 +18,20 @@ Claude Code's configuration hierarchy enables powerful progressive disclosure:
 - **`.claude/rules/`** — path-scoped rules triggered only when matching files are read
 - **Domain files** — referenced via progressive disclosure pointers
 
-## Behavioral Guidelines
+<TRIGGER when="initializing CLAUDE.md hierarchy for a project" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** generate a single file with everything — use hierarchical progressive disclosure
 - **NEVER** include directory/file structure listings (research proves these don't help agents navigate)
 - **NEVER** include obvious language conventions the model already knows
@@ -39,79 +41,85 @@ Claude Code's configuration hierarchy enables powerful progressive disclosure:
 - Scope CLAUDE.md target: **10-30 lines**
 - `.claude/rules/` files: **focused, path-scoped, one topic per file**
 - Domain files: only when non-standard patterns are detected
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="existing-file-check">
+  Check if `CLAUDE.md` exists in the current working directory.
 
-Check if `CLAUDE.md` exists in the current working directory.
+  **If it already exists:**
 
-**If it already exists:**
+  1. Inform the user: "CLAUDE.md already exists in this project. Switching to the improve workflow to optimize your existing configuration."
+  2. Invoke the `improve-claude` skill and follow its complete process.
+  3. **STOP** — do not proceed to Phase 1 or any subsequent phase of this init skill.
 
-1. Inform the user: "CLAUDE.md already exists in this project. Switching to the improve workflow to optimize your existing configuration."
-2. Invoke the `improve-claude` skill and follow its complete process.
-3. **STOP** — do not proceed to Phase 1 or any subsequent phase of this init skill.
+  **If it does not exist:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If it does not exist:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Delegate to the `codebase-analyzer` agent with this task:
 
-### Phase 1: Codebase Analysis
+  > Analyze the project at the current working directory. Return ONLY non-standard, non-obvious information that would cause Claude to make mistakes if it didn't know them. Be ruthlessly minimal.
 
-Delegate to the `codebase-analyzer` agent with this task:
+  The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
+  Require the parsed output to surface non-default config overrides, repo-wide critical constraints, and any cross-scope prerequisites needed for the root file.
+  </PHASE>
 
-> Analyze the project at the current working directory. Return ONLY non-standard, non-obvious information that would cause Claude to make mistakes if it didn't know them. Be ruthlessly minimal.
+  <PHASE id="2" name="scope-detection">
+  Delegate to the `scope-detector` agent with this task:
 
-The agent runs on Sonnet with read-only tools (Read, Grep, Glob, Bash) in an isolated context. Wait for it to complete and parse its structured output.
-Require the parsed output to surface non-default config overrides, repo-wide critical constraints, and any cross-scope prerequisites needed for the root file.
+  > Detect scopes in the project at the current working directory. Only flag scopes with genuinely different tooling or conventions. A simple single-package project should have ZERO additional scopes. Also identify areas that would benefit from path-scoped .claude/rules/ files. Check shared/library packages in monorepos — even utility packages may need their own scope if they have unique constraints (e.g., zero-dependency rules, dual exports, conditional imports).
 
-### Phase 2: Scope Detection
+  Wait for it to complete and parse its structured output.
+  Require the parsed output to state explicitly when a simple single-package project needs zero additional scopes.
+  </PHASE>
 
-Delegate to the `scope-detector` agent with this task:
+  <PHASE id="3" name="generate-files">
+  #### Phase 3a: Hierarchy Decisions
 
-> Detect scopes in the project at the current working directory. Only flag scopes with genuinely different tooling or conventions. A simple single-package project should have ZERO additional scopes. Also identify areas that would benefit from path-scoped .claude/rules/ files. Check shared/library packages in monorepos — even utility packages may need their own scope if they have unique constraints (e.g., zero-dependency rules, dual exports, conditional imports).
+  Drop Phases 1–2 references. Read:
 
-Wait for it to complete and parse its structured output.
-Require the parsed output to state explicitly when a simple single-package project needs zero additional scopes.
+  - `${CLAUDE_SKILL_DIR}/references/progressive-disclosure-guide.md` — hierarchy decisions and loading tiers
+  - `${CLAUDE_SKILL_DIR}/references/what-not-to-include.md` — content exclusion criteria
 
-### Phase 3: Generate Files
+  Decide which file types to generate and what content belongs in each tier.
 
-#### Phase 3a: Hierarchy Decisions
+  #### Phase 3b: Generate Files
 
-Drop Phases 1–2 references. Read:
+  Drop Phase 3a references. Read:
 
-- `${CLAUDE_SKILL_DIR}/references/progressive-disclosure-guide.md` — hierarchy decisions and loading tiers
-- `${CLAUDE_SKILL_DIR}/references/what-not-to-include.md` — content exclusion criteria
+  - `${CLAUDE_SKILL_DIR}/references/context-optimization.md` — token budget guidelines
+  - `${CLAUDE_SKILL_DIR}/references/claude-rules-system.md` — .claude/rules/ conventions and path-scoping
 
-Decide which file types to generate and what content belongs in each tier.
+  Generate the file hierarchy:
 
-#### Phase 3b: Generate Files
+  **Root CLAUDE.md** — Read `${CLAUDE_SKILL_DIR}/assets/templates/root-claude-md.md`. Fill placeholders. Remove empty sections. Target: 15-40 lines.
 
-Drop Phase 3a references. Read:
+  **Subdirectory CLAUDE.md (per detected scope)** — If scopes detected, read `${CLAUDE_SKILL_DIR}/assets/templates/scoped-claude-md.md`. Only scope-specific content differing from root.
 
-- `${CLAUDE_SKILL_DIR}/references/context-optimization.md` — token budget guidelines
-- `${CLAUDE_SKILL_DIR}/references/claude-rules-system.md` — .claude/rules/ conventions and path-scoping
+  **`.claude/rules/` Files (Path-Scoped Rules)** — If file-pattern-specific rules detected, read `${CLAUDE_SKILL_DIR}/assets/templates/claude-rule.md`. Consult `claude-rules-system.md` (already loaded) for when to create rules files vs using CLAUDE.md, path-scoping conventions, and convention vs domain-critical rule categories.
 
-Generate the file hierarchy:
+  **Domain Files** — If non-standard domain patterns detected, read `${CLAUDE_SKILL_DIR}/assets/templates/domain-doc.md`.
+  </PHASE>
 
-**Root CLAUDE.md** — Read `${CLAUDE_SKILL_DIR}/assets/templates/root-claude-md.md`. Fill placeholders. Remove empty sections. Target: 15-40 lines.
+  <PHASE id="4" name="self-validation">
+  Read `${CLAUDE_SKILL_DIR}/references/validation-criteria.md` and execute its **Validation Loop Instructions** against every generated file. Check general criteria AND CLAUDE.md-specific structural checks (path-scoping, minimal always-loaded content). For init flows, treat the Hard Rules size targets (root 15-40 lines, scoped 10-30 lines) as required validation gates — if a monorepo root exceeds target, move scope-specific detail into subdirectory CLAUDE.md, rules, or domain files and rerun. Maximum 3 iterations.
+  </PHASE>
 
-**Subdirectory CLAUDE.md (per detected scope)** — If scopes detected, read `${CLAUDE_SKILL_DIR}/assets/templates/scoped-claude-md.md`. Only scope-specific content differing from root.
+  <PHASE id="5" name="present-and-write">
+  1. Show the user ALL generated files with their content before writing
+  2. Explain briefly why each file exists and what evidence supports its content
+  3. Include a concise validation summary: iteration count, final root line count, scoped file count, and any fixes made during self-validation
+  4. Highlight which files are always-loaded (root CLAUDE.md) vs on-demand (subdirectory, rules)
+  5. Ask for confirmation before writing files
+  6. Write all files to the project
+  7. Create `.claude/rules/` directory if generating rules files
+  </PHASE>
 
-**`.claude/rules/` Files (Path-Scoped Rules)** — If file-pattern-specific rules detected, read `${CLAUDE_SKILL_DIR}/assets/templates/claude-rule.md`. Consult `claude-rules-system.md` (already loaded) for when to create rules files vs using CLAUDE.md, path-scoping conventions, and convention vs domain-critical rule categories.
+</PROCESS>
 
-**Domain Files** — If non-standard domain patterns detected, read `${CLAUDE_SKILL_DIR}/assets/templates/domain-doc.md`.
-
-### Phase 4: Self-Validation
-
-Read `${CLAUDE_SKILL_DIR}/references/validation-criteria.md` and execute its **Validation Loop Instructions** against every generated file. Check general criteria AND CLAUDE.md-specific structural checks (path-scoping, minimal always-loaded content). For init flows, treat the Hard Rules size targets (root 15-40 lines, scoped 10-30 lines) as required validation gates — if a monorepo root exceeds target, move scope-specific detail into subdirectory CLAUDE.md, rules, or domain files and rerun. Maximum 3 iterations.
-
-### Phase 5: Present and Write
-
-1. Show the user ALL generated files with their content before writing
-2. Explain briefly why each file exists and what evidence supports its content
-3. Include a concise validation summary: iteration count, final root line count, scoped file count, and any fixes made during self-validation
-4. Highlight which files are always-loaded (root CLAUDE.md) vs on-demand (subdirectory, rules)
-5. Ask for confirmation before writing files
-6. Write all files to the project
-7. Create `.claude/rules/` directory if generating rules files
+<VALIDATION loop="max-iterations:3">
+Read `${CLAUDE_SKILL_DIR}/references/validation-criteria.md` and loop every generated file through all hard limits, quality checks, and CLAUDE.md-specific structural checks until all pass.
+</VALIDATION>

--- a/plugins/agents-initializer/skills/init-claude/references/claude-rules-system.md
+++ b/plugins/agents-initializer/skills/init-claude/references/claude-rules-system.md
@@ -2,7 +2,6 @@
 
 Instructions for generating and improving `.claude/rules/` and CLAUDE.md hierarchy.
 Claude Code-specific — not applicable to AGENTS.md skills.
-Sources: research-claude-code-skills-format.md, research-context-engineering-comprehensive.md, init-claude/SKILL.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -24,7 +23,6 @@ Sources: research-claude-code-skills-format.md, research-context-engineering-com
 
 `claudeMdExcludes` (in `.claude/settings.local.json`) skips irrelevant ancestor CLAUDE.md files in large monorepos.
 
-*Source: memory/how-claude-remembers-a-project.md lines 243-260; research-context-engineering-comprehensive.md:181-208*
 
 ---
 
@@ -45,7 +43,6 @@ paths:
 
 Rules **without** `paths:` frontmatter load unconditionally at session start (always consumed).
 
-*Source: research-context-engineering-comprehensive.md lines 181-196*
 
 ---
 
@@ -53,7 +50,6 @@ Rules **without** `paths:` frontmatter load unconditionally at session start (al
 
 Two categories warrant a `.claude/rules/` file: (1) **convention rules** — file-pattern-specific coding conventions (style rules for `**/*.ts`, `**/*.test.ts`; framework-specific patterns like route handlers or migration scripts), only when non-obvious enough to cause mistakes; (2) **domain-critical rules** — security, privacy, or compliance triggered by sensitive file patterns.
 
-*Source: init-claude/SKILL.md:118-136*
 
 ---
 
@@ -67,7 +63,6 @@ Project-wide general conventions belong in root `CLAUDE.md`; scope-wide conventi
 
 `.claude/rules/` holds one file per topic with descriptive filenames (e.g., `code-style.md`, `testing.md` with `paths: ["**/*.test.*"]`, `security.md` with `paths: ["src/api/**"]`); subdirectories like `frontend/react.md` group rules by domain. Files are discovered recursively. Symlinks are supported for cross-project sharing (circular symlinks handled gracefully). User-level rules (`~/.claude/rules/`) apply to all projects but project rules take precedence.
 
-*Source: research-context-engineering-comprehensive.md lines 284-305*
 
 ---
 
@@ -81,4 +76,3 @@ Relevant to every task → root `./CLAUDE.md`. Relevant to one area/package → 
 
 When placing new content, prefer this priority order: (1) path-scoped `.claude/rules/` file → (2) subdirectory `CLAUDE.md` → (3) domain doc (`docs/TESTING.md`) → (4) skill → (5) only if truly needed every task, root `CLAUDE.md`. The 5-scope CLAUDE.md hierarchy table (Managed/CLI/Local/Project/User) lives in `progressive-disclosure-guide.md`.
 
-*Source: research-context-engineering-comprehensive.md lines 259-282*

--- a/plugins/agents-initializer/skills/init-claude/references/context-optimization.md
+++ b/plugins/agents-initializer/skills/init-claude/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Evidence-based instructions for managing token budgets and attention in agent configuration files.
-Source: research-context-engineering-comprehensive.md
 
 ---
 
@@ -38,7 +37,6 @@ Place the most important instructions in the first 20% and last 20% of each conf
 
 Apply the deletion test: "Would removing this cause the agent to make mistakes? If not, cut it." Full include/exclude categories are tabulated in `what-not-to-include.md`. **Specificity goldilocks**: ✅ concrete project-specific rules ("Use 2-space indentation", "Run `npm test` before committing", "API handlers live in `src/api/handlers/`") — ❌ vague directives ("Format code properly", "Test your changes", "Keep files organized").
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -46,7 +44,6 @@ Apply the deletion test: "Would removing this cause the agent to make mistakes? 
 
 Detect and remove: stale file paths (check existence; remove or update), contradictions (compare across files; drop the weaker rule), over-specification (rules the agent already follows; delete or convert to a hook), failed-approach accumulation (defensive rules added after incidents that should not be needed), high-churn information (version numbers, file counts, team names — remove or replace with a pointer). Treat CLAUDE.md like code: review when things go wrong, prune regularly. (Anthropic Best Practices)
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -54,6 +51,5 @@ Detect and remove: stale file paths (check existence; remove or update), contrad
 
 Move content from always-consumed to on-demand locations: skills (description at start, full body on invocation), path-scoped rules (load when matching files are read), subdirectory config files (load when working in that directory), `@path/to/import` (expands when parent loads, controlled), domain docs in `docs/` (agent navigates when relevant). Rather than pre-processing all data up front, agents maintain lightweight identifiers and load data into context at runtime. (Anthropic Engineering: Effective Context Engineering)
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*
 
 ---

--- a/plugins/agents-initializer/skills/init-claude/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/init-claude/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md.
 
 ---
 
@@ -22,7 +21,6 @@ For anti-patterns to detect and remove (ball-of-mud growth, auto-generated init 
 
 Place content based on what's relevant when. **Root AGENTS.md / CLAUDE.md**: relevant to every task, always loaded. **Separate domain file**: relevant to one domain (TypeScript, testing, API design), on-demand. **Subdirectory AGENTS.md / CLAUDE.md**: specific to one package or area, on-demand when working there. **`.claude/rules/` path-scoped**: specific to certain file patterns, on-demand when files match. **Skill**: a workflow the agent invokes explicitly, on-demand.
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -39,7 +37,6 @@ Generate root files with only these elements: (1) one-sentence project descripti
 
 Don't overload any level — the agent sees all merged files in its context. In large monorepos, use `claudeMdExcludes` in `.claude/settings.local.json` to skip irrelevant ancestor CLAUDE.md files (glob patterns match absolute paths; arrays merge across settings layers; managed policy files cannot be excluded).
 
-*Source: a-guide-to-agents.md; memory/how-claude-remembers-a-project.md lines 243-260*
 
 ---
 
@@ -47,7 +44,6 @@ Don't overload any level — the agent sees all merged files in its context. In 
 
 Apply when content exceeds root-file scope. **Extraction trigger**: extract a section to a separate domain file when it has 3+ distinct rules AND spans 10+ lines, or when the topic is irrelevant to most work sessions. **Move domain rules to separate files**: prefer "For TypeScript conventions, see docs/TYPESCRIPT.md" over inlining domain rules. **Nest hierarchically**: domain docs reference each other rather than the root inlining everything. **Use skills for workflows** — agents invoke them only when needed, keeping base context minimal.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ---
 
@@ -59,7 +55,6 @@ Loading by scope: org-wide managed policy (MDM) and personal `~/.claude/CLAUDE.m
 
 **Load order** — Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory files load on-demand only when Claude reads files in that directory.
 
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
 
 ---
 

--- a/plugins/agents-initializer/skills/init-claude/references/validation-criteria.md
+++ b/plugins/agents-initializer/skills/init-claude/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md / CLAUDE.md files.
-Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
 
 ---
 

--- a/plugins/agents-initializer/skills/init-claude/references/what-not-to-include.md
+++ b/plugins/agents-initializer/skills/init-claude/references/what-not-to-include.md
@@ -1,7 +1,6 @@
 # What NOT to Include
 
 Evidence-based exclusion guide for AGENTS.md and CLAUDE.md.
-Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md.
 
 ---
 
@@ -9,7 +8,6 @@ Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-gu
 
 Exclude these categories: directory/file structure listings (agents use grep/glob; static lists go stale — ETH Zurich); standard language conventions (already in training data); codebase overview paragraphs (increase exploration steps without improving navigation — ETH Zurich); vague guidance like "write clean code" (not actionable — wastes attention); file path references (paths change constantly and actively poison context); everything in one file (exceeds the ~150-200 instruction attention budget); obvious tooling ("use git for version control"); duplicated information across files (wastes tokens per request, creates contradictions); version numbers / release names (high-churn, stale instantly); long explanations or tutorials (context is for instructions, not education); detailed API documentation (link out instead); anything inferable from code; hook-enforced behaviors (formatting, file blocking, notifications) — migrate to a hook for deterministic enforcement at zero context cost.
 
-*Source: init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/plugins/cursor-customizer/agents/rule-evaluator.md
+++ b/plugins/cursor-customizer/agents/rule-evaluator.md
@@ -21,14 +21,14 @@ You are a Cursor rule quality assessment specialist. Analyze either a specific `
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
-| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
-| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` | docs/cursor/rules/rules.md — Rule file format |
-| Banned frontmatter key | A `paths` key MUST NOT appear in frontmatter | Cross-platform leakage: a `paths` frontmatter key belongs to a different platform's convention and is invalid here |
-| Contradictions with other rules | 0 | Industry Research: conflicting instructions cause inconsistent model behavior |
-| Stale file path references | 0 | Industry Research: stale paths poison context |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 200 lines |
+| YAML frontmatter | Valid YAML |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` |
+| Banned frontmatter key | A `paths` key MUST NOT appear in frontmatter |
+| Contradictions with other rules | 0 |
+| Stale file path references | 0 |
 
 ### Quality Checks
 

--- a/plugins/cursor-customizer/agents/skill-evaluator.md
+++ b/plugins/cursor-customizer/agents/skill-evaluator.md
@@ -21,13 +21,13 @@ You are a Cursor skill quality assessment specialist. Analyze the target SKILL.m
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
-| Reference files | ≤ 200 lines each | reference-files convention |
-| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags | Agent Skills specification |
-| `name` field format | Present, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder | Agent Skills specification |
-| Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags |
+| `name` field format | Present, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder |
+| Contradictions between phases | 0 |
 
 ### Structural Checks
 

--- a/plugins/cursor-customizer/agents/subagent-evaluator.md
+++ b/plugins/cursor-customizer/agents/subagent-evaluator.md
@@ -21,15 +21,15 @@ You are a Cursor subagent definition quality assessment specialist. Analyze the 
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | Cursor subagents documentation (file format) |
-| `name` field | Lowercase letters and hyphens only | Cursor subagents documentation (configuration fields) |
-| `description` field | Present, non-empty, ≤1024 characters | Cursor subagents documentation (configuration fields) |
-| `model` field | Set to `inherit` | ADR-0002 product-strict frontmatter contract |
-| `readonly` field | Set to `true` | ADR-0002 product-strict frontmatter contract |
-| Frontmatter key set | Exactly `name`, `description`, `model`, `readonly` — nothing else | ADR-0002 product-strict frontmatter contract |
-| System prompt | Not empty; task-specific | Cursor subagents documentation (best practices) |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens only |
+| `description` field | Present, non-empty, ≤1024 characters |
+| `model` field | Set to `inherit` |
+| `readonly` field | Set to `true` |
+| Frontmatter key set | Exactly `name`, `description`, `model`, `readonly` — nothing else |
+| System prompt | Not empty; task-specific |
 
 ### Quality Checks
 

--- a/plugins/cursor-customizer/skills/create-hook/references/hook-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/hook-authoring-guide.md
@@ -1,7 +1,6 @@
 # Hook Authoring Guide
 
 Evidence-based guidance for creating Cursor hooks that enforce deterministic behavior.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -30,7 +29,6 @@ Hooks provide **deterministic control** — they always fire, regardless of mode
 
 Examples: auto-formatting after edits, blocking destructive shell commands, sending notifications, auditing config changes, redacting secrets before file reads.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hooks" introduction*
 
 ---
 
@@ -58,7 +56,6 @@ Level 2: **Hook definition** — at minimum a `command`; optionally `type`, `mat
 
 Omit `matcher` to fire on every occurrence of the event.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration file"*
 
 ---
 
@@ -83,7 +80,6 @@ Omit `matcher` to fire on every occurrence of the event.
 
 Prompt hooks return a structured `{ ok: boolean, reason?: string }` response. The `$ARGUMENTS` placeholder in the prompt is auto-replaced with the hook input JSON.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
 
 ---
 
@@ -102,7 +98,6 @@ The `matcher` field is a **regex string**. Which field it filters depends on the
 
 Matchers on `beforeSubmitPrompt`, `stop`, `afterAgentResponse`, and `afterAgentThought` are matched against fixed literal values documented in the Cursor hooks guide; in practice these matchers add no filtering value and may be omitted.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
 
 ---
 
@@ -119,7 +114,6 @@ Priority order (highest to lowest): Enterprise → Team → Project → User. Al
 
 For project hooks, write paths relative to the project root (e.g., `.cursor/hooks/script.sh`). For user hooks, write paths relative to `~/.cursor/` (e.g., `./hooks/script.sh`).
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
 
 ---
 
@@ -141,7 +135,6 @@ To make a security-critical hook **fail closed** instead, set `"failClosed": tru
 
 For **prompt** hooks: the LLM returns `{ ok: boolean, reason?: string }`. When `ok: false`, the action is denied and `reason` is surfaced to the user.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Per-Script Configuration Options"*
 
 ---
 
@@ -157,4 +150,3 @@ For **prompt** hooks: the LLM returns `{ ok: boolean, reason?: string }`. When `
 
 Use the Hooks tab in Cursor Settings to confirm hooks are loaded and to inspect execution traces.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Troubleshooting", "Environment Variables"*

--- a/plugins/cursor-customizer/skills/create-hook/references/hook-events-reference.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/hook-events-reference.md
@@ -1,7 +1,6 @@
 # Hook Events Reference
 
 Complete reference for Cursor's native hook events: triggers, matcher fields, and handler-type support.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -49,7 +48,6 @@ Cursor exposes two families of hook events: Agent (Cmd+K / Agent Chat) and Tab (
 | `beforeTabFileRead` | Before Tab reads a file for inline completions | Yes (`permission: "deny"`) |
 | `afterTabFileEdit` | After Tab edits a file | No |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Agent and Tab Support"*
 
 ---
 
@@ -72,7 +70,6 @@ The `matcher` is a regex string. The field it matches against depends on the eve
 
 For MCP tool filtering on `preToolUse`/`postToolUse`/`postToolUseFailure`, use the `MCP:<tool_name>` format.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
 
 ---
 
@@ -109,7 +106,6 @@ Cursor hooks live in a `hooks.json` file at the project or user scope. The top l
 
 **Prompt-hook fields:** add `"type": "prompt"` and a `"prompt": "<natural-language criterion>"` field; an optional `"model"` field overrides the default fast model. The prompt receives the hook input via the auto-replaced `$ARGUMENTS` placeholder.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
 
 ---
 
@@ -122,7 +118,6 @@ Cursor hooks live in a `hooks.json` file at the project or user scope. The top l
 
 Unlike some agent platforms, Cursor exposes only these two handler types — there is no separate `http` or `agent` handler. Use `command` for deterministic checks; reserve `prompt` for cases where natural-language judgment is genuinely required.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
 
 ---
 
@@ -158,4 +153,3 @@ Inject dynamic context at session start:
 
 The script's stdout JSON may include `additional_context` to add to the conversation's initial system context.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Examples" and "Hook events"*

--- a/plugins/cursor-customizer/skills/create-hook/references/hook-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/hook-validation-criteria.md
@@ -1,7 +1,6 @@
 # Hook Validation Criteria
 
 Quality checklist for generated and improved Cursor hook configurations.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -28,7 +27,6 @@ Any hook violating these criteria must be fixed before proceeding:
 | Matcher applicability | Matcher set only on events whose matcher field is documented in `hook-events-reference.md` |
 | Exit-code semantics | `0` = success, `2` = block; other non-zero exits fail open by default — security-critical blocking hooks must set `failClosed: true` |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Configuration", "Per-Script Configuration Options"*
 
 ---
 

--- a/plugins/cursor-customizer/skills/create-hook/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/create-rule/SKILL.md
+++ b/plugins/cursor-customizer/skills/create-rule/SKILL.md
@@ -7,18 +7,20 @@ description: "Creates a new .cursor/rules/*.mdc rule grounded in the docs corpus
 
 Generates a new `.cursor/rules/*.mdc` rule with the correct activation-mode frontmatter and minimal, specific instructions grounded in the Cursor docs corpus.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new .cursor/rules/*.mdc rule from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create rules longer than 200 lines
 - **NEVER** create rules for standard conventions the agent already knows (e.g., "write clean code")
 - **NEVER** use overly broad globs (`**/*`) on auto-attached rules unless truly global scope is required
@@ -27,74 +29,80 @@ Generates a new `.cursor/rules/*.mdc` rule with the correct activation-mode fron
 - **EVERY** generated rule MUST set exactly one well-formed activation mode (always / globs / description)
 - **EVERY** instruction must be specific and verifiable — not vague guidance
 - **ONE** concern per rule file — do not bundle unrelated instructions
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="conflict-check">
+  Confirm the project is already initialized for Cursor (`.cursor/rules/` directory exists or the user is creating the first rule). Then check for conflicts:
 
-Confirm the project is already initialized for Cursor (`.cursor/rules/` directory exists or the user is creating the first rule). Then check for conflicts:
+  - Same filename (e.g., `.cursor/rules/{topic}.mdc` already exists)
+  - Existing rule with overlapping globs that would create contradiction or duplication
+  - Existing rule covering the same topic via `description:`-mode
 
-- Same filename (e.g., `.cursor/rules/{topic}.mdc` already exists)
-- Existing rule with overlapping globs that would create contradiction or duplication
-- Existing rule covering the same topic via `description:`-mode
+  **If a conflicting or duplicate rule already exists:**
 
-**If a conflicting or duplicate rule already exists:**
+  1. Inform the user: "A rule covering `{topic}` or overlapping globs already exists."
+  2. Suggest using `/cursor-customizer:improve-rule` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different topic/scope or use the improve skill.
 
-1. Inform the user: "A rule covering `{topic}` or overlapping globs already exists."
-2. Suggest using `/cursor-customizer:improve-rule` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different topic/scope or use the improve skill.
+  **If no conflicting rule exists:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no conflicting rule exists:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="project-context-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Project Context Analysis
+  > Analyze the project to understand existing rules in `.cursor/rules/`. Focus on: rule filenames and topics, activation modes in use, glob patterns in use, any overlaps or contradictions between rules, gaps where a rule would add value, and the conventions in any present `AGENTS.md` files that could inform rule content. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in glob scoping.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The agent runs in an isolated context with read-only access. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing rules in `.cursor/rules/`. Focus on: rule filenames and topics, activation modes in use, glob patterns in use, any overlaps or contradictions between rules, gaps where a rule would add value, and the conventions in any present `AGENTS.md` files that could inform rule content. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in glob scoping.
+  <PHASE id="2" name="activation-mode-selection-and-generation">
+  Before generating, read these reference documents:
 
-The agent runs in an isolated context with read-only access. Wait for it to complete and parse its structured output.
+  - `references/rule-authoring-guide.md` — when to use rules, frontmatter contract, the four activation modes, glob syntax, and anti-patterns
+  - `references/prompt-engineering-strategies.md` — rule-specific prompting (zero-shot, no examples in rules)
 
-### Phase 2: Activation-Mode Selection and Generation
+  Map the user's intent to one activation mode using the rules-authoring guide:
 
-Before generating, read these reference documents:
+  - **Critical tooling / project-wide constraint** → `alwaysApply: true` → read `assets/templates/cursor-rule-always.mdc`
+  - **Pattern-relative convention** (test files, generated code, monorepo packages, sensitive-handler files) → `globs:` → read `assets/templates/cursor-rule-globs.mdc`
+  - **Cross-cutting / domain topic the agent should pull in by name** (authentication, observability, accessibility, API design) → `description:` → read `assets/templates/cursor-rule-description.mdc`
 
-- `references/rule-authoring-guide.md` — when to use rules, frontmatter contract, the four activation modes, glob syntax, and anti-patterns
-- `references/prompt-engineering-strategies.md` — rule-specific prompting (zero-shot, no examples in rules)
+  Fill the chosen template's placeholders using:
 
-Map the user's intent to one activation mode using the rules-authoring guide:
+  - User requirements for the new rule (topic, target globs or description sentence, instructions)
+  - Phase 1 analysis output (existing rules, gaps, potential contradictions)
+  - Evidence from the reference files above
 
-- **Critical tooling / project-wide constraint** → `alwaysApply: true` → read `assets/templates/cursor-rule-always.mdc`
-- **Pattern-relative convention** (test files, generated code, monorepo packages, sensitive-handler files) → `globs:` → read `assets/templates/cursor-rule-globs.mdc`
-- **Cross-cutting / domain topic the agent should pull in by name** (authentication, observability, accessibility, API design) → `description:` → read `assets/templates/cursor-rule-description.mdc`
+  Generate a single rule:
 
-Fill the chosen template's placeholders using:
+  - Frontmatter contains ONLY the three permitted fields and matches the chosen activation mode
+  - Body ≤ 200 lines (significantly shorter for `alwaysApply: true` — every line loads on every conversation)
+  - In a monorepo with `globs:`-mode, scope the glob to the relevant package subtree (e.g., `services/api/**/*.go`), not a language-only glob (`**/*.go`)
 
-- User requirements for the new rule (topic, target globs or description sentence, instructions)
-- Phase 1 analysis output (existing rules, gaps, potential contradictions)
-- Evidence from the reference files above
+  Write target: `.cursor/rules/{topic-name}.mdc` (kebab-case).
+  </PHASE>
 
-Generate a single rule:
+  <PHASE id="3" name="self-validation">
+  Read `references/rule-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated rule.
 
-- Frontmatter contains ONLY the three permitted fields and matches the chosen activation mode
-- Body ≤ 200 lines (significantly shorter for `alwaysApply: true` — every line loads on every conversation)
-- In a monorepo with `globs:`-mode, scope the glob to the relevant package subtree (e.g., `services/api/**/*.go`), not a language-only glob (`**/*.go`)
+  The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Failed checks re-enter Phase 2's generation step. Additionally, cross-check against ALL existing rule files in `.cursor/rules/` for contradictions and overlapping globs. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-Write target: `.cursor/rules/{topic-name}.mdc` (kebab-case).
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated rule file
+  2. Cite the evidence from reference files that informed key decisions:
+     - Why this activation mode (what content nature drove the choice)
+     - Why this glob pattern or description sentence (what scope it targets and why)
+     - Why each instruction is necessary (what mistake it prevents)
+  3. Ask for confirmation before writing any files
+  4. On approval, write the rule file to `.cursor/rules/{topic-name}.mdc`
+  </PHASE>
 
-### Phase 3: Self-Validation
+</PROCESS>
 
-Read `references/rule-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated rule.
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Failed checks re-enter Phase 2's generation step. Additionally, cross-check against ALL existing rule files in `.cursor/rules/` for contradictions and overlapping globs. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete generated rule file
-2. Cite the evidence from reference files that informed key decisions:
-   - Why this activation mode (what content nature drove the choice)
-   - Why this glob pattern or description sentence (what scope it targets and why)
-   - Why each instruction is necessary (what mistake it prevents)
-3. Ask for confirmation before writing any files
-4. On approval, write the rule file to `.cursor/rules/{topic-name}.mdc`
+<VALIDATION loop="max-iterations:3">
+Read `references/rule-validation-criteria.md` and loop the generated rule through every hard limit and quality check until all pass.
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/create-rule/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/create-rule/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/create-rule/references/rule-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/create-rule/references/rule-authoring-guide.md
@@ -1,7 +1,6 @@
 # Rule Authoring Guide
 
 Evidence-based guidance for creating effective Cursor rule files (`.cursor/rules/*.mdc`).
-Source: docs/cursor/rules/rules.md (Cursor official documentation)
 
 ---
 
@@ -31,7 +30,6 @@ Rules are markdown files placed in `.cursor/rules/`. Their contents are included
 | Conventions apply to a file pattern or topic | Side effects must always happen | Multi-phase workflows are required |
 | Domain expertise scoped to a path or topic | No agent judgment is required | Rich, progressive-disclosure references are needed |
 
-*Source: docs/cursor/rules/rules.md — How rules work, Project rules*
 
 ---
 
@@ -47,7 +45,6 @@ Rules are markdown files placed in `.cursor/rules/`. Their contents are included
 
 Each file should cover **one topic** with a kebab-case filename. Both `.md` and `.mdc` extensions are recognised; this distribution generates `.mdc` so that frontmatter can specify activation mode.
 
-*Source: docs/cursor/rules/rules.md — Rule file structure*
 
 ---
 
@@ -63,7 +60,6 @@ Cursor rule frontmatter is restricted to **three fields**. No other key is valid
 
 The token used by other agent platforms to scope rules by file pattern is NOT supported here — Cursor uses `globs` for the same role. Any other frontmatter key is invalid and must be removed.
 
-*Source: docs/cursor/rules/rules.md — Rule file format*
 
 ---
 
@@ -85,7 +81,6 @@ Pick the mode that matches the **content's nature**:
 - Agent-requested → cross-cutting / domain content the agent should pull in by name (authentication, observability, accessibility, API design)
 - Manual → templates and reference snippets the user explicitly opts into
 
-*Source: docs/cursor/rules/rules.md — Rule anatomy*
 
 ---
 
@@ -104,7 +99,6 @@ Auto-attached rules trigger when files matching the pattern enter the agent's co
 
 In monorepos, scope globs to the relevant package subtree (e.g., `services/api/**/*.go` rather than `**/*.go`). Language-only globs match across every package and defeat scoping.
 
-*Source: docs/cursor/rules/rules.md — Project rules; Industry Research on monorepo scoping*
 
 ---
 
@@ -129,7 +123,6 @@ In monorepos, scope globs to the relevant package subtree (e.g., `services/api/*
 
 **No contradictions** — if two rules conflict, the agent may pick one inconsistently. Review `.cursor/rules/` periodically to remove outdated or conflicting instructions.
 
-*Source: docs/cursor/rules/rules.md — Best practices*
 
 ---
 
@@ -148,4 +141,3 @@ In monorepos, scope globs to the relevant package subtree (e.g., `services/api/*
 | Rule files exceeding 200 lines | Poor adherence; attention fragmentation | Split into multiple focused files |
 | Mixing activation modes in one file | Activation-mode contract is per file | One activation mode per file |
 
-*Source: docs/cursor/rules/rules.md — What to avoid in rules; Best practices*

--- a/plugins/cursor-customizer/skills/create-rule/references/rule-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-rule/references/rule-validation-criteria.md
@@ -1,7 +1,6 @@
 # Rule Validation Criteria
 
 Quality checklist for generated and improved `.cursor/rules/*.mdc` rule files.
-Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineering-comprehensive.md)
 
 ---
 
@@ -9,17 +8,16 @@ Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineer
 
 Any rule file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
-| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
-| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` are valid; ALL others are AUTO-FAIL | docs/cursor/rules/rules.md — Rule file format |
-| Banned frontmatter key | A `paths` key MUST NOT appear; it belongs to a different platform's convention | Cross-platform leakage check |
-| Activation-mode well-formedness | `alwaysApply: true` must omit `globs`; `globs:` rules must set `alwaysApply: false`; `description:`-only rules must omit `globs` and set `alwaysApply: false` | docs/cursor/rules/rules.md — Rule anatomy |
-| Contradictions with other rules | 0 | Industry Research: conflicting instructions cause inconsistent agent behavior |
-| Stale file path references | 0 | Industry Research: stale paths poison context |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 200 lines |
+| YAML frontmatter | Valid YAML |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` are valid; ALL others are AUTO-FAIL |
+| Banned frontmatter key | A `paths` key MUST NOT appear; it belongs to a different platform's convention |
+| Activation-mode well-formedness | `alwaysApply: true` must omit `globs`; `globs:` rules must set `alwaysApply: false`; `description:`-only rules must omit `globs` and set `alwaysApply: false` |
+| Contradictions with other rules | 0 |
+| Stale file path references | 0 |
 
-*Source: docs/cursor/rules/rules.md — Rule file format, Best practices*
 
 ---
 
@@ -34,7 +32,7 @@ Any rule file violating these criteria must be fixed before proceeding:
 - [ ] No standard language conventions the agent already knows from training
 - [ ] No long explanations or tutorials — rules are instructions, not documentation
 - [ ] Files referenced via `@path/to/file` rather than copied inline where practical
-- [ ] Evidence citations present: rule instructions justify their existence with reference to project conventions or `docs/cursor/`
+- [ ] Evidence citations present: rule instructions justify their existence with reference to project conventions
 - [ ] Prompt engineering strategy applied: rule uses zero-shot imperative instructions only (no examples, no tutorials, no explanations)
 - [ ] Critical instructions appear at the start or end of the rule body, not buried in the middle
 

--- a/plugins/cursor-customizer/skills/create-skill/SKILL.md
+++ b/plugins/cursor-customizer/skills/create-skill/SKILL.md
@@ -7,18 +7,20 @@ description: "Creates new Cursor SKILL.md packages with references, templates, a
 
 Generates a new Cursor SKILL.md package with supporting references and templates, grounded in the Agent Skills open standard and project conventions.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new Cursor skill from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create skills that explain what the agent already knows (language syntax, obvious conventions)
 - **NEVER** inline reference content in SKILL.md body — use the `references/` subdirectory
 - **NEVER** exceed 500 lines in the SKILL.md body
@@ -26,84 +28,108 @@ Generates a new Cursor SKILL.md package with supporting references and templates
 - **EVERY** bundled-path reference inside SKILL.md must use a relative path from the skill root (e.g., `references/foo.md`, `scripts/deploy.sh`)
 - **EVERY** skill description must be third-person, ≤ 1024 chars, and include a "Use when..." trigger phrase
 - **EVERY** generated skill must preserve the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** generated SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** new skill whose output is a human-rich agent-executable artifact (plan, PRD, spec, report, prototype, code-review writeup, custom editor) MUST default to an HTML output template — unless the user explicitly says "generate as markdown" (or equivalent), in which case that override always wins
+- **NEVER** default to HTML for agent-loaded or tooling-locked artifacts (`SKILL.md`, subagent `.md`, `AGENTS.md`, rules files, `README.md`, commit messages, PR bodies, issue bodies, code comments) — these are Markdown-mandatory regardless of user request phrasing
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="name-collision-check">
+  **Default output path.** Per the Cursor distribution default, new skills are written to `.cursor/skills/<name>/SKILL.md`. The Agent Skills standard also recognises `.agents/skills/<name>/SKILL.md` for cross-tool portability across Agent Skills implementations.
 
-#### Default output path
+  Before proceeding, state both options to the user:
 
-Per the Cursor distribution default, new skills are written to `.cursor/skills/<name>/SKILL.md`. The Agent Skills standard also recognises `.agents/skills/<name>/SKILL.md` for cross-tool portability across Agent Skills implementations.
+  - **Default:** `.cursor/skills/<name>/SKILL.md` — Cursor-namespaced; recommended when the skill is Cursor-specific.
+  - **Portable alternative:** `.agents/skills/<name>/SKILL.md` — open-standard; choose when the skill should also be discovered by other Agent Skills implementations.
 
-Before proceeding, state both options to the user:
+  Proceed with the default path unless the user explicitly requests the portable alternative. Do not silently switch paths.
 
-- **Default:** `.cursor/skills/<name>/SKILL.md` — Cursor-namespaced; recommended when the skill is Cursor-specific.
-- **Portable alternative:** `.agents/skills/<name>/SKILL.md` — open-standard; choose when the skill should also be discovered by other Agent Skills implementations.
+  **Name collision check.** Check if a skill with the same name already exists at any of:
 
-Proceed with the default path unless the user explicitly requests the portable alternative. Do not silently switch paths.
+  - `.cursor/skills/{requested-name}/SKILL.md`
+  - `.agents/skills/{requested-name}/SKILL.md`
+  - `~/.cursor/skills/{requested-name}/SKILL.md`
 
-#### Name collision check
+  **If a skill already exists at any of those locations:**
 
-Check if a skill with the same name already exists at any of:
+  1. Inform the user: "A skill named `{requested-name}` already exists."
+  2. Suggest using `/cursor-customizer:improve-skill` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
 
-- `.cursor/skills/{requested-name}/SKILL.md`
-- `.agents/skills/{requested-name}/SKILL.md`
-- `~/.cursor/skills/{requested-name}/SKILL.md`
+  **If no skill exists with that name:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If a skill already exists at any of those locations:**
+  <PHASE id="1" name="project-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-1. Inform the user: "A skill named `{requested-name}` already exists."
-2. Suggest using `/cursor-customizer:improve-skill` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
+  > Analyze the project to understand existing skills, naming conventions, and integration patterns. Focus on: existing skill directory structure under `.cursor/skills/` and `.agents/skills/`, naming patterns, which skills delegate to subagents, project conventions, and any skill that is similar to `{requested-name}` in purpose. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
 
-**If no skill exists with that name:**
-Proceed to Phase 1 below.
+  The agent runs read-only with Cursor-native frontmatter (`model: inherit`, `readonly: true`) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-### Phase 1: Project Analysis
+  <PHASE id="2" name="generate-skill">
+  Before generating, read these reference documents:
 
-Delegate to the `artifact-analyzer` agent with this task:
+  - `references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
+  - `references/skill-format-reference.md` — frontmatter fields, name validation, bundled-path conventions
 
-> Analyze the project to understand existing skills, naming conventions, and integration patterns. Focus on: existing skill directory structure under `.cursor/skills/` and `.agents/skills/`, naming patterns, which skills delegate to subagents, project conventions, and any skill that is similar to `{requested-name}` in purpose. Also identify the project layout: whether this is a monorepo with multiple service packages (indicated by workspace files like `pnpm-workspace.yaml`, a `package.json` with a `workspaces` field, multiple `go.mod` files in subdirectories, or multiple `pyproject.toml` files in subdirectories) or a single-package project, and report any service directory paths for use in scope resolution.
+  Decide skill structure: phases, reference file names, and whether `assets/templates/` is needed.
 
-The agent runs read-only with Cursor-native frontmatter (`model: inherit`, `readonly: true`) in an isolated context. Wait for it to complete and parse its structured output.
+  **Classify output artifact format.** Read `references/artifact-format-routing.md` and apply its routing table to the new skill being generated:
 
-### Phase 2: Generate Skill
+  1. Identify what kind of artifact the new skill will produce (plan/PRD/spec/report/prototype vs. SKILL.md/rule/etc.).
+  2. Apply the routing table: human-rich agent-executable artifacts default to **HTML**; agent-loaded and tooling-locked artifacts are **Markdown-mandatory**.
+  3. Check for explicit override: if the user said "generate as markdown" (or equivalent), that override wins regardless of artifact type.
+  4. If the verdict is **HTML**: copy `assets/templates/html-artifact-skeleton.html` into the new skill's `assets/templates/` directory (rename to match the artifact type, e.g., `plan.html`). The new skill must instruct its own generation phase to populate the canonical semantic tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`, plus relevant optional tags) inside the HTML `<body>`.
+  5. If the verdict is **Markdown**: use `assets/templates/skill-md.md` or a Markdown template appropriate to the artifact type.
 
-Before generating, read these reference documents:
+  Then read these reference documents:
 
-- `references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
-- `references/skill-format-reference.md` — frontmatter fields, name validation, bundled-path conventions
-- `references/behavioral-guidelines.md` — discipline cues and safe persuasion patterns for skills
-- `references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
+  - `references/behavioral-guidelines.md` — discipline cues and safe persuasion patterns for skills
+  - `references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
 
-Read `assets/templates/skill-md.md` and fill its placeholders using:
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-format-reference.md
+  - artifact-format-routing.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-- User requirements for the new skill
-- Phase 1 analysis output (naming conventions, existing patterns, project context)
-- Evidence from the reference files above
+  Read the chosen output template (HTML skeleton or `skill-md.md`) and fill its placeholders using:
 
-If Phase 1 detects a monorepo or multi-service layout, make the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope. Do not leave multi-service boundaries implicit.
+  - User requirements for the new skill
+  - Phase 1 analysis output (naming conventions, existing patterns, project context)
+  - Evidence from the reference files above
 
-Generate the complete skill directory structure:
+  If Phase 1 detects a monorepo or multi-service layout, make the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope. Do not leave multi-service boundaries implicit.
 
-1. `SKILL.md` — primary skill file with Cursor-shaped frontmatter and phase definitions
-2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
-3. `assets/templates/` — create stub template files if the skill generates output files
+  Generate the complete skill directory structure:
 
-   For validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted.
+  1. `SKILL.md` — primary skill file with Cursor-shaped frontmatter and a body carrying the canonical semantic-tag vocabulary
+  2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
+  3. `assets/templates/` — create the appropriate output template (HTML or Markdown per the routing verdict above); for validator-type skills that only report findings without generating output files, `assets/templates/` may be omitted
+  </PHASE>
 
-### Phase 3: Self-Validation
+  <PHASE id="3" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
 
-Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
+  If Phase 1 detected a monorepo or multi-service layout, add one extra validation pass: confirm the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope.
 
-If Phase 1 detected a monorepo or multi-service layout, add one extra validation pass: confirm the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope.
+  The loop evaluates all hard limits and quality checks — including the canonical semantic-tag strictness tiers — fixes any failures, and re-evaluates: maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates), including the resolved output path from the preflight choice
+  2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
+  3. Ask for confirmation before writing any files
+  4. On approval, write all files to the target location
+  </PHASE>
 
-### Phase 4: Present and Write
+</PROCESS>
 
-1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates), including the resolved output path from the preflight choice
-2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
-3. Ask for confirmation before writing any files
-4. On approval, write all files to the target location
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md` and loop the generated skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/create-skill/assets/templates/html-artifact-skeleton.html
+++ b/plugins/cursor-customizer/skills/create-skill/assets/templates/html-artifact-skeleton.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{artifact-title}}</title>
+  <style>
+    :root {
+      --color-text:          #1f2937;
+      --color-text-muted:    #4b5563;
+      --color-text-strong:   #111827;
+      --color-bg:            #ffffff;
+      --color-border:        #e5e7eb;
+      --color-code-bg:       #f3f4f6;
+
+      --color-trigger-text:  #374151;
+
+      --color-behaviour-bg:  #f0f4ff;
+      --color-behaviour-bar: #2563eb;
+
+      --color-hardrules-bg:  #fef2f2;
+      --color-hardrules-bar: #dc2626;
+
+      --color-phase-bg:      #fafafa;
+      --color-phase-label:   #111827;
+
+      --color-antipattern-bg:  #fffbeb;
+      --color-antipattern-bar: #d97706;
+
+      --color-output-bg:  #f0fdf4;
+      --color-output-bar: #16a34a;
+
+      --color-validation-bg:  #f5f3ff;
+      --color-validation-bar: #7c3aed;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --color-text:          #e5e7eb;
+        --color-text-muted:    #9ca3af;
+        --color-text-strong:   #f9fafb;
+        --color-bg:            #111827;
+        --color-border:        #374151;
+        --color-code-bg:       #1f2937;
+
+        --color-trigger-text:  #d1d5db;
+
+        --color-behaviour-bg:  #1e2a4a;
+        --color-behaviour-bar: #3b82f6;
+
+        --color-hardrules-bg:  #2d1515;
+        --color-hardrules-bar: #ef4444;
+
+        --color-phase-bg:      #1f2937;
+        --color-phase-label:   #f9fafb;
+
+        --color-antipattern-bg:  #2d2209;
+        --color-antipattern-bar: #f59e0b;
+
+        --color-output-bg:  #052e16;
+        --color-output-bar: #22c55e;
+
+        --color-validation-bg:  #1e1533;
+        --color-validation-bar: #a78bfa;
+      }
+    }
+
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 900px;
+      margin: 2rem auto;
+      padding: 1rem;
+      line-height: 1.6;
+      color: var(--color-text);
+      background: var(--color-bg);
+    }
+
+    BEHAVIOUR, HARD_RULES, PROCESS, PHASE, PREFLIGHT, REFERENCES,
+    EXAMPLE, ANTI_PATTERN, OUTPUT, VALIDATION, TRIGGER {
+      display: block;
+      margin: 1rem 0;
+    }
+
+    TRIGGER {
+      font-style: italic;
+      color: var(--color-trigger-text);
+    }
+
+    BEHAVIOUR {
+      background: var(--color-behaviour-bg);
+      border-left: 4px solid var(--color-behaviour-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    HARD_RULES[priority="hard"] {
+      background: var(--color-hardrules-bg);
+      border-left: 4px solid var(--color-hardrules-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    PROCESS {
+      border-top: 1px solid var(--color-border);
+      padding-top: 1rem;
+    }
+
+    PHASE {
+      background: var(--color-phase-bg);
+      border: 1px solid var(--color-border);
+      padding: 1rem;
+      margin: 0.5rem 0;
+      border-radius: 4px;
+    }
+
+    PHASE::before {
+      content: "Phase " attr(id) " — " attr(name);
+      display: block;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: var(--color-phase-label);
+    }
+
+    ANTI_PATTERN {
+      background: var(--color-antipattern-bg);
+      border-left: 4px solid var(--color-antipattern-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    OUTPUT {
+      background: var(--color-output-bg);
+      border-left: 4px solid var(--color-output-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    VALIDATION {
+      background: var(--color-validation-bg);
+      border-left: 4px solid var(--color-validation-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    code, pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      background: var(--color-code-bg);
+      padding: 0.125rem 0.25rem;
+      border-radius: 3px;
+    }
+
+    pre {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>{{artifact-title}}</h1>
+    <TRIGGER when="...">...</TRIGGER>
+    <BEHAVIOUR avoid="..." always="...">...</BEHAVIOUR>
+    <HARD_RULES priority="hard">...</HARD_RULES>
+    <PROCESS>
+      <PHASE id="1" name="...">...</PHASE>
+    </PROCESS>
+    <OUTPUT format="...">...</OUTPUT>
+    <VALIDATION>...</VALIDATION>
+  </main>
+</body>
+</html>

--- a/plugins/cursor-customizer/skills/create-skill/assets/templates/skill-md.md
+++ b/plugins/cursor-customizer/skills/create-skill/assets/templates/skill-md.md
@@ -15,43 +15,62 @@ description: "[What this skill does and when to use it. Third person. Include tr
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name
            the target service/workspace explicitly
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
+           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+           <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
+           Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
+           Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: YAML frontmatter is untouched — do NOT duplicate the <TRIGGER> cue into description
 -->
 
 # [Skill Title]
 
 [One-sentence purpose statement.]
 
-## Behavioral Guidelines
+<TRIGGER when="[plain-language activation cue — mirror the 'Use when ...' phrase from the description]" />
 
+<BEHAVIOUR
+  avoid="make decisions without surfacing assumptions; add speculative scope"
+  always="surface assumptions first; keep changes surgical">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - [Critical constraint 1]
 - [Critical constraint 2]
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
-<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  <PREFLIGHT name="artifact-collision-check">
+  <!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  </PREFLIGHT>
 
-### Phase 1: [Analysis Phase Name]
-<!-- Delegate to the appropriate Cursor subagent (model: inherit, readonly: true);
-     if monorepo, record the target service/workspace -->
+  <PHASE id="1" name="[analysis-phase-name]">
+  <!-- Delegate to the appropriate Cursor subagent (model: inherit, readonly: true);
+       if monorepo, record the target service/workspace -->
+  </PHASE>
 
-### Phase 2: [Generation Phase Name]
-<!-- Read references via relative paths (references/[file].md), apply templates,
-     and use project-relative paths/globs for the detected service/workspace -->
+  <PHASE id="2" name="[generation-phase-name]">
+  <!-- Read references via relative paths (references/[file].md), apply templates,
+       and use project-relative paths/globs for the detected service/workspace -->
+  </PHASE>
 
-### Phase 3: Self-Validation
-<!-- Read references/[type]-validation-criteria.md and execute its validation loop -->
+  <PHASE id="3" name="self-validation">
+  <!-- Read references/[type]-validation-criteria.md and loop until all checks pass -->
+  </PHASE>
 
-### Phase 4: Present and Write
-<!-- Show artifact with evidence citations, write on user approval -->
+  <PHASE id="4" name="present-and-write">
+  <!-- Show artifact with evidence citations, write on user approval -->
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+<!-- Read references/[type]-validation-criteria.md, loop until pass -->
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/create-skill/assets/templates/skill-md.md
+++ b/plugins/cursor-customizer/skills/create-skill/assets/templates/skill-md.md
@@ -15,8 +15,8 @@ description: "[What this skill does and when to use it. Third person. Include tr
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name
            the target service/workspace explicitly
-     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
-           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory: <TRIGGER>,
            <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
            Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
            Closed attribute set: avoid=, always=, when=, name=, id=, priority=.

--- a/plugins/cursor-customizer/skills/create-skill/references/artifact-format-routing.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/artifact-format-routing.md
@@ -2,8 +2,6 @@
 
 Evidence-based routing rule for deciding whether a skill's generated output artifact
 should default to HTML or Markdown.
-Source: Agent Skills open standard; project convention on HTML artifacts
-(human-rich + agent-executable dual-consumer design).
 
 ---
 

--- a/plugins/cursor-customizer/skills/create-skill/references/artifact-format-routing.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/artifact-format-routing.md
@@ -1,0 +1,110 @@
+# Artifact Format Routing
+
+Evidence-based routing rule for deciding whether a skill's generated output artifact
+should default to HTML or Markdown.
+Source: Agent Skills open standard; project convention on HTML artifacts
+(human-rich + agent-executable dual-consumer design).
+
+---
+
+## Routing Table
+
+When `create-skill` generates a new skill, the new skill's output format is
+determined by the artifact kind that new skill produces:
+
+| Artifact kind                                  | Default format | Reason                                            |
+| ---------------------------------------------- | -------------- | ------------------------------------------------- |
+| Plan, PRD, design spec                         | HTML           | Human-rich + agent-executable                     |
+| Report (weekly status, research, explainer)    | HTML           | Human-rich + agent-executable                     |
+| Prototype, custom editor, code-review writeup  | HTML           | Interactivity benefits from HTML                  |
+| `SKILL.md`, subagent `.md`                     | Markdown       | Agent-loaded; spec-mandated                       |
+| `AGENTS.md`                                    | Markdown       | Agent-loaded; spec-mandated                       |
+| `.cursor/rules/*.mdc`                          | Markdown       | Agent-loaded; spec-mandated                       |
+| `README.md`                                    | Markdown       | Tooling-locked (npm/repository renderers)         |
+| Commit message, PR body, issue body            | Markdown       | Tooling-locked (repository renderers)             |
+| Code comments                                  | Markdown-ish   | Tooling-locked (compiler/linter parses)           |
+
+Explicit user override (`generate as markdown`) always wins over the default.
+
+---
+
+## How to classify
+
+During Phase 2 (generate-skill), before choosing the output template:
+
+1. **Identify the output artifact kind** — ask: "What does this new skill produce?
+   A plan/PRD/spec/report? Or a platform config file (SKILL.md, rule)?"
+
+2. **Apply the routing table above.** The left column describes the artifact kind;
+   the Default format column gives the verdict.
+
+3. **Check for explicit override.** If the user said "generate as markdown" (or
+   equivalent phrasing like "output markdown", "use .md", "markdown format"), the
+   override wins regardless of the routing table verdict.
+
+4. **Act on the verdict:**
+   - **HTML default** → use `assets/templates/html-artifact-skeleton.html`
+     as the output template for the new skill. Instruct the new skill to carry the
+     canonical semantic tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>`
+     with one or more `<PHASE id name>`, plus relevant optional tags `<OUTPUT>`,
+     `<VALIDATION>`) inside the HTML `<body>`. Copy the skeleton into the new
+     skill's `assets/templates/` directory.
+   - **Markdown default** → use the standard `assets/templates/skill-md.md`
+     template (or a Markdown template appropriate to the artifact type).
+   - **Explicit override** → apply the user's stated format regardless of the table.
+
+---
+
+## HTML skeleton location
+
+The HTML baseline skeleton lives at:
+
+```
+assets/templates/html-artifact-skeleton.html
+```
+
+It is a valid HTML5 document with:
+- `<meta charset>` and `<meta name="viewport">`
+- Scoped CSS targeting each semantic tag (`BEHAVIOUR`, `HARD_RULES`, `PHASE`, `OUTPUT`,
+  `VALIDATION`, `ANTI_PATTERN`, etc.) with adaptive colors (light and dark mode via
+  CSS custom properties and `@media (prefers-color-scheme: dark)`)
+- Placeholder `{{artifact-title}}` in `<title>` and `<h1>`
+- A `<main>` block containing the canonical semantic-tag scaffold
+
+When generating a new HTML-defaulting skill, copy this skeleton into the new skill's
+`assets/templates/` directory (e.g., as `<artifact-type>.html`). Replace
+`{{artifact-title}}` with the artifact name appropriate to the new skill.
+
+---
+
+## Canonical semantic tags in HTML artifacts
+
+Generated HTML artifacts MUST carry the canonical semantic tags inside the HTML body.
+The same vocabulary that governs `SKILL.md` bodies applies:
+
+**Mandatory tags (HTML artifact)**:
+- `<TRIGGER when="...">` — plain-language activation context
+- `<BEHAVIOUR avoid="..." always="...">` — behavioural guidelines
+- `<HARD_RULES priority="hard">` — inviolable constraints
+- `<PROCESS>` containing at least one `<PHASE id="N" name="...">` — ordered execution steps
+
+**Optional tags (HTML artifact)**:
+- `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`.
+
+These tags are valid HTML5 — browsers treat unknown elements as inline by default;
+the CSS in the skeleton promotes each to `display: block` with semantic styling.
+
+---
+
+## Why HTML for human-rich artifacts
+
+HTML artifacts serve two consumers: humans (CSS layout, diagrams, interactive controls)
+and the next agent session (parseable semantic-tag structure). The dual-consumer design
+is why HTML artifacts embed canonical semantic tags — the same parse target serves both.
+
+Markdown past ~100 lines stops being read; rich visualisations get faked with ASCII;
+HTML renders natively in any browser without extra tooling. For agent-loaded and
+tooling-locked files the tradeoffs reverse: spec compliance, diffability, and
+renderer compatibility make Markdown mandatory.

--- a/plugins/cursor-customizer/skills/create-skill/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/create-skill/references/skill-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/skill-authoring-guide.md
@@ -1,7 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating Cursor SKILL.md packages that conform to the Agent Skills open standard.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -40,7 +39,6 @@ Challenge each piece of content:
 
 **Safe persuasion** — use warm-up phases, curated references, explicit limits, and cited standards to improve compliance with legitimate work. Never use persuasion framing to bypass safeguards, refusals, or scope boundaries.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "What are skills?" and "How skills work"*
 
 ---
 
@@ -56,7 +54,6 @@ Cursor automatically discovers skills from these directories at startup:
 
 The agent is presented with available skills and decides when they are relevant based on context. Skills can also be invoked manually by typing `/` in the agent chat and searching for the skill name.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*
 
 ---
 
@@ -74,7 +71,6 @@ my-skill/
 
 Keep `SKILL.md` focused — move detailed reference material into `references/`. The agent loads supporting files progressively, only when the body of `SKILL.md` directs it to.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
 
 ---
 
@@ -93,7 +89,6 @@ Each skill begins with YAML frontmatter. The Agent Skills standard recognises si
 
 No other fields are part of the standard. Adding fields outside this set introduces foreign-platform dialect and breaks portability.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -109,7 +104,6 @@ No other fields are part of the standard. Adding fields outside this set introdu
 
 Include three things in every description: (1) what it does, (2) when to use it, (3) the trigger terms an agent might match against.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Frontmatter fields"*
 
 ---
 
@@ -129,7 +123,6 @@ Each reference file has one job and is cited explicitly from the phase that need
 
 Keep `SKILL.md` under 500 lines. Move detail to `references/`. Reference supporting files explicitly so the agent knows what they contain.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
 
 ---
 
@@ -149,7 +142,6 @@ Do not use string-substitution variables to refer to bundled files; the relative
 
 Scripts can be written in any language the agent can execute (Bash, Python, JavaScript, etc.). They should be self-contained, include helpful error messages, and handle edge cases gracefully.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills"*
 
 ---
 
@@ -159,7 +151,6 @@ By default, skills are automatically applied when the agent determines they are 
 
 Use this for workflows with side effects (commit, deploy, send-message) or for skills the user wants to gate manually.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Disabling automatic invocation"*
 
 ---
 
@@ -175,4 +166,3 @@ Use this for workflows with side effects (commit, deploy, send-message) or for s
 | Contradictions between phases | Agent picks one arbitrarily | Review all phases for consistency |
 | Loading every reference in Phase 1 | Defeats progressive disclosure | Load each reference only in the phase that needs it |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Optional directories"*

--- a/plugins/cursor-customizer/skills/create-skill/references/skill-format-reference.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/skill-format-reference.md
@@ -1,7 +1,6 @@
 # Skill Format Reference
 
 Technical specification for Cursor SKILL.md format, frontmatter, directory structure, and discovery model.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -31,7 +30,6 @@ The Agent Skills standard, as adopted by Cursor, recognises exactly six frontmat
 
 Frontmatter fields outside this set are foreign-platform dialect and must not appear in Cursor SKILL.md files.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -43,7 +41,6 @@ Frontmatter fields outside this set are foreign-platform dialect and must not ap
 - Must NOT contain consecutive `--`
 - Must match the parent directory name exactly
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -65,7 +62,6 @@ Apply the template at assets/templates/config.yaml.
 
 This convention is what the Agent Skills standard guarantees portable across implementations. Do not use string-substitution variables, absolute paths, or project-relative paths for bundled files — relative paths from the skill root are the only portable form.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills" and "Optional directories"*
 
 ---
 
@@ -90,7 +86,6 @@ my-skill/
 - `assets/` files load only when the skill body explicitly directs the agent to use them.
 - `scripts/` files are executed by the agent, not loaded into context.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
 
 ---
 
@@ -104,7 +99,6 @@ my-skill/
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to the `references/` subdirectory. Explicitly reference supporting files from SKILL.md so the agent knows what to load and when.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "How skills work" and "Optional directories"*
 
 ---
 
@@ -120,4 +114,3 @@ Cursor automatically loads skills from these directories:
 
 When the same skill name exists in multiple locations, Cursor's own resolution rules apply. For new skills, choose `.cursor/skills/` when the skill is Cursor-specific and `.agents/skills/` when the skill should also be discoverable by other Agent Skills consumers.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*

--- a/plugins/cursor-customizer/skills/create-skill/references/skill-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/skill-validation-criteria.md
@@ -8,6 +8,7 @@ Source: docs/cursor/skills/agent-skills-guide.md
 ## Contents
 
 - Hard limits (auto-fail if violated)
+- Canonical Semantic-Tag Convention
 - Foreign-platform dialect ban (auto-fail if violated)
 - Quality checks (all must pass)
 - Improve-only checks (information preservation, structural)
@@ -30,6 +31,40 @@ Any skill violating these criteria must be fixed before proceeding:
 | Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
 
 *Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X")
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|-------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 
@@ -63,6 +98,9 @@ The Cursor distribution is product-strict. The skill tree (SKILL.md, references,
 - [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
 - [ ] Plugin skill bodies delegate analysis to registered subagents; no inline bash analysis commands
 - [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-guide.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
 
 ---
 
@@ -85,10 +123,11 @@ The Cursor distribution is product-strict. The skill tree (SKILL.md, references,
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above (hard limits, foreign-dialect ban, quality checks, and IMPROVE-only checks if applicable).
+1. Evaluate the skill against ALL criteria above (hard limits, the **Canonical Semantic-Tag Convention** strictness tiers, foreign-dialect ban, quality checks, and IMPROVE-only checks if applicable).
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference.
-3. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation.
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
-5. Only proceed to writing skills when ALL criteria pass.
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation.
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix.
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass.
 
 **Do not skip criteria for "minor" violations.** Hard limits and the foreign-dialect ban are absolute.

--- a/plugins/cursor-customizer/skills/create-skill/references/skill-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/skill-validation-criteria.md
@@ -1,7 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved Cursor SKILL.md packages.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -20,17 +19,16 @@ Source: docs/cursor/skills/agent-skills-guide.md
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
-| Reference files | ≤ 200 lines each | reference-files convention |
-| Reference files >100 lines | Must include a `## Contents` table of contents | reference-files convention |
-| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags | Agent Skills specification |
-| `name` field | Present, non-empty, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder | Agent Skills specification |
-| Frontmatter fields | Restricted to `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` | Agent Skills specification |
-| Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` table of contents |
+| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags |
+| `name` field | Present, non-empty, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder |
+| Frontmatter fields | Restricted to `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` |
+| Contradictions between phases | 0 |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
 
 ---
 
@@ -64,7 +62,6 @@ The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 

--- a/plugins/cursor-customizer/skills/create-subagent/SKILL.md
+++ b/plugins/cursor-customizer/skills/create-subagent/SKILL.md
@@ -7,18 +7,20 @@ description: "Creates new Cursor subagent definitions with the four-key Cursor-n
 
 Generates a new Cursor subagent definition with the four-key Cursor-native frontmatter, a focused system prompt, and an explicit output format. Output is grounded in the Cursor subagents documentation and ADR-0002 product-strict guarantees.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new Cursor subagent from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** create subagents with generic system prompts ("you are a helpful AI assistant").
 - **NEVER** emit any frontmatter key outside the four allowed: `name`, `description`, `model`, `readonly`.
 - **NEVER** emit a `model` value other than `inherit`.
@@ -27,78 +29,90 @@ Generates a new Cursor subagent definition with the four-key Cursor-native front
 - **EVERY** description must include a specific "Use when..." trigger phrase so Cursor's agent can route correctly.
 - **DESCRIPTION** must be ≤1024 characters; **NAME** must be kebab-case and distinct from every existing project subagent.
 - **PROJECT SUBAGENTS** MUST NOT instruct the subagent to spawn other subagents — return findings to the parent agent only.
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="name-collision-check">
+  Check whether a subagent with the requested name already exists at:
 
-Check whether a subagent with the requested name already exists at:
+  - `.cursor/agents/{requested-name}.md`
+  - `plugins/*/agents/{requested-name}.md`
 
-- `.cursor/agents/{requested-name}.md`
-- `plugins/*/agents/{requested-name}.md`
+  **If a subagent already exists with that name:**
 
-**If a subagent already exists with that name:**
+  1. Inform the user: "A subagent named `{requested-name}` already exists."
+  2. Suggest using `/cursor-customizer:improve-subagent` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
 
-1. Inform the user: "A subagent named `{requested-name}` already exists."
-2. Suggest using `/cursor-customizer:improve-subagent` to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
+  **If no subagent exists with that name:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no subagent exists with that name:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="project-context-analysis">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-### Phase 1: Project Context Analysis
+  > Analyze the project to understand existing Cursor subagents. Focus on: subagent names and roles in `.cursor/agents/` and `plugins/*/agents/`, the description and `readonly` posture of each, which skills delegate to which subagents, and naming conventions. Flag any subagents similar in purpose to `{requested-name}`. Also identify the project layout: whether this is a monorepo with multiple service packages or a single-package project, and report any service directory paths for use in scope resolution.
 
-Delegate to the `artifact-analyzer` agent with this task:
+  The `artifact-analyzer` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Analyze the project to understand existing Cursor subagents. Focus on: subagent names and roles in `.cursor/agents/` and `plugins/*/agents/`, the description and `readonly` posture of each, which skills delegate to which subagents, and naming conventions. Flag any subagents similar in purpose to `{requested-name}`. Also identify the project layout: whether this is a monorepo with multiple service packages or a single-package project, and report any service directory paths for use in scope resolution.
+  <PHASE id="2" name="generate-subagent">
+  Before generating, read these reference documents:
 
-The `artifact-analyzer` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  - `references/subagent-authoring-guide.md` — when to use a subagent, system prompt structure, the four-key frontmatter contract, description-as-routing-signal, anti-patterns, verification-agent pattern.
+  - `references/subagent-config-reference.md` — full Cursor-native frontmatter specification, model field handling, readonly field handling, file locations, orchestration patterns.
+  - `references/prompt-engineering-strategies.md` — subagent-specific prompting (role prompting, structured output, confidence filtering).
 
-### Phase 2: Generate Subagent
+  <REFERENCES load="on-demand">
+  - subagent-authoring-guide.md
+  - subagent-config-reference.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-Before generating, read these reference documents:
+  Read `assets/templates/subagent-definition.md` and fill its placeholders using:
 
-- `references/subagent-authoring-guide.md` — when to use a subagent, system prompt structure, the four-key frontmatter contract, description-as-routing-signal, anti-patterns, verification-agent pattern.
-- `references/subagent-config-reference.md` — full Cursor-native frontmatter specification, model field handling, readonly field handling, file locations, orchestration patterns.
-- `references/prompt-engineering-strategies.md` — subagent-specific prompting (role prompting, structured output, confidence filtering).
+  - User requirements for the new subagent (role, purpose, scope).
+  - Phase 1 analysis output (existing subagents, naming conventions, delegation patterns).
+  - Evidence from the reference files above.
 
-Read `assets/templates/subagent-definition.md` and fill its placeholders using:
+  Frontmatter posture (non-negotiable):
 
-- User requirements for the new subagent (role, purpose, scope).
-- Phase 1 analysis output (existing subagents, naming conventions, delegation patterns).
-- Evidence from the reference files above.
+  - `model: inherit` — the customizer never embeds a literal model alias or specific model ID.
+  - `readonly: true` — generated subagents are analysis and evaluator roles by default; they report findings to the parent agent.
 
-Frontmatter posture (non-negotiable):
+  If Phase 1 detects a monorepo or multi-service layout, make the generated system prompt name the relevant services, workspaces, and scope boundaries the subagent should inspect. Do not leave multi-service targets implicit.
 
-- `model: inherit` — the customizer never embeds a literal model alias or specific model ID.
-- `readonly: true` — generated subagents are analysis and evaluator roles by default; they report findings to the parent agent.
+  Determine target location:
 
-If Phase 1 detects a monorepo or multi-service layout, make the generated system prompt name the relevant services, workspaces, and scope boundaries the subagent should inspect. Do not leave multi-service targets implicit.
+  - `.cursor/agents/{name}.md` — project-level subagent (project scope).
+  - `plugins/{plugin}/agents/{name}.md` — plugin-scoped subagent (restricted to plugin context).
+  </PHASE>
 
-Determine target location:
+  <PHASE id="3" name="self-validation">
+  Read `references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated subagent definition.
 
-- `.cursor/agents/{name}.md` — project-level subagent (project scope).
-- `plugins/{plugin}/agents/{name}.md` — plugin-scoped subagent (restricted to plugin context).
+  In addition to the shared criteria, enforce two scenario-sensitive checks before proceeding:
 
-### Phase 3: Self-Validation
+  - The frontmatter contains exactly the four allowed keys with the required values (`model: inherit`, `readonly: true`). No other key, no other model value, no other readonly value.
+  - If Phase 1 detected a monorepo or multi-service layout, confirm the generated prompt names the relevant services, workspaces, or scope boundaries explicitly.
 
-Read `references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated subagent definition.
+  The loop evaluates all hard limits and quality checks — including the canonical semantic-tag strictness tiers — fixes any failures, and re-evaluates: maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-In addition to the shared criteria, enforce two scenario-sensitive checks before proceeding:
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated subagent definition.
+  2. Cite the evidence from reference files that informed key decisions:
+     - Why this scope and role (heuristic from `subagent-authoring-guide.md`).
+     - Why the description has these triggers (routing signal from the authoring guide).
+     - Why the system prompt has these sections (structure from prompt-engineering strategies).
+  3. If the user requested any frontmatter key outside the allowed four (or any model value other than `inherit`), refuse and cite `subagent-validation-criteria.md`. Offer to translate the request into a Cursor-native form.
+  4. Ask for confirmation before writing any files.
+  5. On approval, write the subagent definition to the target location.
+  </PHASE>
 
-- The frontmatter contains exactly the four allowed keys with the required values (`model: inherit`, `readonly: true`). No other key, no other model value, no other readonly value.
-- If Phase 1 detected a monorepo or multi-service layout, confirm the generated prompt names the relevant services, workspaces, or scope boundaries explicitly.
+</PROCESS>
 
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
-
-### Phase 4: Present and Write
-
-1. Show the user the complete generated subagent definition.
-2. Cite the evidence from reference files that informed key decisions:
-   - Why this scope and role (heuristic from `subagent-authoring-guide.md`).
-   - Why the description has these triggers (routing signal from the authoring guide).
-   - Why the system prompt has these sections (structure from prompt-engineering strategies).
-3. If the user requested any frontmatter key outside the allowed four (or any model value other than `inherit`), refuse and cite `subagent-validation-criteria.md`. Offer to translate the request into a Cursor-native form.
-4. Ask for confirmation before writing any files.
-5. On approval, write the subagent definition to the target location.
+<VALIDATION loop="max-iterations:3">
+Read `references/subagent-validation-criteria.md` and loop the generated subagent through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/create-subagent/assets/templates/subagent-definition.md
+++ b/plugins/cursor-customizer/skills/create-subagent/assets/templates/subagent-definition.md
@@ -11,8 +11,8 @@ readonly: true
      Forbidden: any other frontmatter key; any other model value.
      Rule: Project subagents must not spawn other subagents.
      Rule: name must be kebab-case and distinct from every other subagent name in the project.
-     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
-           (see wiki/knowledge/skill-body-convention.md). Mandatory for subagents:
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory for subagents:
            <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id="N" name="X">.
            Optional: <TRIGGER>, <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>,
            <OUTPUT>, <VALIDATION>. Closed attribute set: avoid=, always=, when=, name=, id=, priority=.

--- a/plugins/cursor-customizer/skills/create-subagent/assets/templates/subagent-definition.md
+++ b/plugins/cursor-customizer/skills/create-subagent/assets/templates/subagent-definition.md
@@ -11,41 +11,64 @@ readonly: true
      Forbidden: any other frontmatter key; any other model value.
      Rule: Project subagents must not spawn other subagents.
      Rule: name must be kebab-case and distinct from every other subagent name in the project.
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
+           (see wiki/knowledge/skill-body-convention.md). Mandatory for subagents:
+           <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id="N" name="X">.
+           Optional: <TRIGGER>, <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>,
+           <OUTPUT>, <VALIDATION>. Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: <TRIGGER> is optional — omit if the subagent is always spawned by skills, not user-invoked.
 -->
 
 # [Agent Name]
 
 You are a [specific role] specializing in [domain]. [One-sentence identity statement; name target services or scope when relevant.]
 
-## Constraints
+<!-- Optional: include <TRIGGER> if this subagent can also be user-invoked -->
+<!-- <TRIGGER when="[activation condition]" /> -->
 
+<BEHAVIOUR
+  avoid="[what to avoid — e.g., modifying files; surfacing low-confidence findings]"
+  always="[what to always do — e.g., cite evidence; report in structured format]">
+- [Behavioural guideline 1]
+- [Behavioural guideline 2]
 - Do not modify any files — only analyze and report.
-- Do not suggest improvements — describe what exists or what fails.
-- Do not spawn other subagents — return findings to the parent agent.
-- Do not [additional constraint specific to this role].
+</BEHAVIOUR>
 
-## Process
+<HARD_RULES priority="hard">
+- **NEVER** modify any files — describe what exists or what fails, do not change it.
+- **NEVER** suggest improvements — report findings only.
+- **NEVER** spawn other subagents — return findings to the parent agent.
+- **EVERY** finding must cite a specific path or line.
+- **EVERY** output must match the Output Format below exactly.
+</HARD_RULES>
 
-### 1. [First Step]
+<PROCESS>
 
-[What to read, detect, or evaluate.]
+  <PHASE id="1" name="[first-step]">
+  [What to read, detect, or evaluate.]
+  </PHASE>
 
-### 2. [Second Step]
+  <PHASE id="2" name="[second-step]">
+  [How to process findings — filtering, categorizing, structuring.]
+  </PHASE>
 
-[How to process findings.]
+  <PHASE id="3" name="[compile-output]">
+  [How to compile and format the final structured output.]
+  </PHASE>
 
-### 3. [Third Step]
+</PROCESS>
 
-[How to compile output.]
-
-## Output Format
+<OUTPUT>
 
 ```
 [Exact structure the agent must return — headers, tables, sections, with concrete labels.]
 ```
 
-## Self-Verification
+</OUTPUT>
 
+<VALIDATION>
+Before returning output, verify:
 1. [Check 1 — every reported finding cites a specific path or line.]
 2. [Check 2 — output matches the format above.]
 3. [Check 3 — no improvement suggestions included; only findings.]
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/create-subagent/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/create-subagent/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/create-subagent/references/subagent-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/create-subagent/references/subagent-authoring-guide.md
@@ -1,7 +1,6 @@
 # Subagent Authoring Guide
 
 Evidence-based guidance for creating effective Cursor subagent definitions.
-Source: docs/cursor/subagents/subagents-guide.md (Cursor subagents documentation; primary attribution); docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -30,7 +29,6 @@ Subagents are for **isolated, specialized work** that should not pollute the par
 
 If the task is single-purpose (generate a changelog, format imports), prefer a skill or slash command — a subagent is overkill.
 
-*Source: docs/cursor/subagents/subagents-guide.md (when to use subagents)*
 
 ---
 
@@ -48,7 +46,6 @@ Project subagents take precedence over user subagents when names conflict.
 
 The customizer generates into the project or plugin paths only.
 
-*Source: docs/cursor/subagents/subagents-guide.md (file locations)*
 
 ---
 
@@ -64,7 +61,6 @@ Effective subagent system prompts follow this 5-part pattern:
 
 Keep prompts focused. Each subagent should have a single clear responsibility — avoid generic "helper" agents.
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices)*
 
 ---
 
@@ -86,7 +82,6 @@ readonly: true
 
 For full schema details and rejection rules, see `subagent-config-reference.md` and `subagent-validation-criteria.md`.
 
-*Source: docs/cursor/subagents/subagents-guide.md (file format, configuration fields); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -102,7 +97,6 @@ The `description` field is the only signal Cursor's agent uses to decide whether
 Bad: "Helps with code." (too generic — Cursor cannot decide when to delegate)
 Good: "Validates completed work. Use after tasks are marked done to confirm implementations are functional."
 
-*Source: docs/cursor/subagents/subagents-guide.md (description field, best practices)*
 
 ---
 
@@ -118,7 +112,6 @@ Good: "Validates completed work. Use after tasks are marked done to confirm impl
 | Generic "you are a helpful AI" prompt | Defeats the purpose of a subagent | Define a specific role and process |
 | Duplicating a slash-command capability | Adds complexity without benefit | Use the slash command directly |
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices — anti-patterns to avoid)*
 
 ---
 
@@ -152,4 +145,3 @@ Do not accept claims at face value. Test everything you can without modifying st
 
 Useful for: validating end-to-end behavior before marking tickets complete; catching partially implemented functionality; ensuring tests actually pass (not just that test files exist).
 
-*Source: docs/cursor/subagents/subagents-guide.md (common patterns — verification agent)*

--- a/plugins/cursor-customizer/skills/create-subagent/references/subagent-config-reference.md
+++ b/plugins/cursor-customizer/skills/create-subagent/references/subagent-config-reference.md
@@ -1,7 +1,6 @@
 # Subagent Config Reference
 
 Cursor-native subagent frontmatter specification, model handling, and orchestration patterns.
-Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -28,7 +27,6 @@ The Cursor-native subagent frontmatter for this distribution uses **exactly four
 | `model` | Yes | `inherit` | Cursor-native: the subagent runs on the same model as the parent agent. The product-strict contract requires this value. |
 | `readonly` | Yes | `true` | Cursor-native: the subagent runs with restricted write permissions (no file edits, no state-changing shell commands). The product-strict contract requires this value for analysis and evaluator subagents. |
 
-*Source: docs/cursor/subagents/subagents-guide.md (configuration fields table); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -43,7 +41,6 @@ For this distribution, **the value MUST be `inherit`**. The `fast` value and any
 
 If a Cursor user explicitly opts into `fast` or a specific model ID for their own hand-edited subagent, the customizer does not block that — but the customizer never generates such a value.
 
-*Source: docs/cursor/subagents/subagents-guide.md (model configuration); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -55,7 +52,6 @@ For this distribution, **the value MUST be `true`** for every generated subagent
 
 If a future workflow requires a subagent that writes files, the customizer prompts the user to confirm and document the rationale before generating such a subagent — but the default and recommended posture is `readonly: true`.
 
-*Source: docs/cursor/subagents/subagents-guide.md (configuration fields table)*
 
 ---
 
@@ -70,7 +66,6 @@ Cursor honors several subagent locations. This customizer generates into the Cur
 
 File naming: kebab-case `.md` filenames matching the subagent's `name` field (e.g., `security-reviewer.md` for `name: security-reviewer`).
 
-*Source: docs/cursor/subagents/subagents-guide.md (file locations)*
 
 ---
 
@@ -88,7 +83,6 @@ File naming: kebab-case `.md` filenames matching the subagent's `name` field (e.
 | Sequential pipeline | Task B depends on Task A's structured output |
 | Parallel decomposition | Independent reads or evaluations that can run concurrently |
 
-*Source: docs/cursor/subagents/subagents-guide.md (using subagents — parallel execution; orchestrator pattern)*
 
 ---
 
@@ -101,7 +95,6 @@ These constraints govern subagents authored by this customizer:
 - **Subagents do not inherit parent skills.** If a subagent needs domain knowledge, encode it in the system prompt.
 - **The frontmatter key set is closed.** Only `name`, `description`, `model`, `readonly` are permitted. Any other key is rejected by validation.
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices, anti-patterns)*
 
 ---
 
@@ -116,4 +109,3 @@ The following frontmatter fields belong to other agent platforms and MUST NOT ap
 
 These rejections are enforced by `subagent-validation-criteria.md` with explicit examples.
 
-*Source: docs/adr/0002-product-strict-research-foundation.md*

--- a/plugins/cursor-customizer/skills/create-subagent/references/subagent-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-subagent/references/subagent-validation-criteria.md
@@ -1,7 +1,6 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Cursor subagent definitions.
-Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -20,15 +19,15 @@ Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-r
 
 Any subagent violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | Cursor subagents documentation (file format) |
-| `name` field | Lowercase letters and hyphens; ≤64 characters | Cursor subagents documentation (configuration fields) |
-| `description` field | Present, non-empty, ≤1024 characters | Cursor subagents documentation (configuration fields) |
-| `model` field | Exactly `inherit` | ADR-0002 product-strict frontmatter contract |
-| `readonly` field | Exactly `true` | ADR-0002 product-strict frontmatter contract |
-| Frontmatter key set | Exactly the four allowed keys — `name`, `description`, `model`, `readonly` | ADR-0002 product-strict frontmatter contract |
-| System prompt | Not empty; task-specific | Cursor subagents documentation (best practices) |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens; ≤64 characters |
+| `description` field | Present, non-empty, ≤1024 characters |
+| `model` field | Exactly `inherit` |
+| `readonly` field | Exactly `true` |
+| Frontmatter key set | Exactly the four allowed keys — `name`, `description`, `model`, `readonly` |
+| System prompt | Not empty; task-specific |
 
 ---
 
@@ -140,7 +139,6 @@ The subagent body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 

--- a/plugins/cursor-customizer/skills/create-subagent/references/subagent-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-subagent/references/subagent-validation-criteria.md
@@ -9,6 +9,7 @@ Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-r
 
 - Hard limits (auto-fail)
 - Allowed frontmatter contract (rejection rules with examples)
+- Canonical Semantic-Tag Convention
 - Quality checks
 - If this is an IMPROVE operation
 - Validation loop instructions
@@ -79,31 +80,13 @@ Required fix: remove the turn-cap key entirely.
 
 A subagent whose `model` value is a literal model name or ID is REJECTED. The `model` value MUST be `inherit`.
 
-Example REJECTED frontmatter (literal alias):
+Example REJECTED `model` values — every one of these is rejected; only `inherit` passes:
 
 ```yaml
----
-name: example-evaluator
-description: "Evaluates things. Use when reviewing artifacts."
-model: sonnet
-readonly: true
----
-```
-
-Example REJECTED frontmatter (other literal aliases):
-
-```yaml
-model: opus
-```
-
-```yaml
-model: haiku
-```
-
-Example REJECTED frontmatter (full model ID prefix):
-
-```yaml
-model: claude-opus-4-6
+model: sonnet          # literal alias
+model: opus            # literal alias
+model: haiku           # literal alias
+model: claude-opus-4-6 # full model ID prefix
 ```
 
 Required fix: set the model value to `inherit`.
@@ -135,6 +118,32 @@ Required fix: remove the extra key.
 
 ---
 
+## Canonical Semantic-Tag Convention
+
+The subagent body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — deterministically.
+
+**Mandatory tags** (the subagent body MUST contain all of these): `<BEHAVIOUR>` (guidelines, posture), `<HARD_RULES>` (inviolable constraints), `<PROCESS>` (container for the ordered phases; MUST contain at least one `<PHASE>`), and `<PHASE id="N" name="X">` (one execution step inside `<PROCESS>`; `id=` mandatory on every `<PHASE>`).
+
+**Optional tags** (absence is silent — never a finding): `<TRIGGER>`, `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`. `<TRIGGER>` is OPTIONAL for subagents because they are spawned by skills, not user-invoked.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | A mandatory tag missing (`<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`); unbalanced tags; malformed attribute syntax (value missing quotes, stray `=`, unterminated quote) | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of `<TRIGGER>` or any other optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
+
+---
+
 ## Quality Checks (All must pass)
 
 - [ ] `description` is action-oriented and includes a specific "Use when..." trigger phrase for delegation routing.
@@ -148,6 +157,9 @@ Required fix: remove the extra key.
 - [ ] No instructions tell the subagent to spawn other subagents (project convention restricts nested launches).
 - [ ] System prompt is task-specific, not generic ("you are a helpful AI").
 - [ ] Prompt engineering strategy applied: role prompting, structured output, and confidence filtering per `prompt-engineering-strategies.md`. For evaluator-type subagents that mandate explicit evidence per finding, the evidence requirement satisfies the confidence-filtering criterion.
+- [ ] Canonical semantic tags present: `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`.
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`.
+- [ ] YAML frontmatter untouched by the convention — the four-key contract (`name`, `description`, `model`, `readonly`) is unchanged.
 
 ---
 
@@ -170,10 +182,11 @@ Required fix: remove the extra key.
 
 Execute this loop for each generated or improved subagent:
 
-1. Evaluate the subagent against ALL criteria above.
+1. Evaluate the subagent against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers.
 2. For improve operations, verify each suggestion in the improvement plan has a WHY field citing a source document — no suggestion may lack a source reference.
-3. If ANY criterion fails: identify the specific failure, fix the subagent, restart evaluation.
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
-5. Only proceed to writing the subagent when ALL criteria pass.
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the subagent, restart evaluation.
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix.
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
+6. Only proceed to writing the subagent when ALL hard-fail and quality criteria pass.
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits. The frontmatter contract is non-negotiable.

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-authoring-guide.md
@@ -1,7 +1,6 @@
 # Hook Authoring Guide
 
 Evidence-based guidance for creating Cursor hooks that enforce deterministic behavior.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -30,7 +29,6 @@ Hooks provide **deterministic control** — they always fire, regardless of mode
 
 Examples: auto-formatting after edits, blocking destructive shell commands, sending notifications, auditing config changes, redacting secrets before file reads.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hooks" introduction*
 
 ---
 
@@ -58,7 +56,6 @@ Level 2: **Hook definition** — at minimum a `command`; optionally `type`, `mat
 
 Omit `matcher` to fire on every occurrence of the event.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration file"*
 
 ---
 
@@ -83,7 +80,6 @@ Omit `matcher` to fire on every occurrence of the event.
 
 Prompt hooks return a structured `{ ok: boolean, reason?: string }` response. The `$ARGUMENTS` placeholder in the prompt is auto-replaced with the hook input JSON.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
 
 ---
 
@@ -102,7 +98,6 @@ The `matcher` field is a **regex string**. Which field it filters depends on the
 
 Matchers on `beforeSubmitPrompt`, `stop`, `afterAgentResponse`, and `afterAgentThought` are matched against fixed literal values documented in the Cursor hooks guide; in practice these matchers add no filtering value and may be omitted.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
 
 ---
 
@@ -119,7 +114,6 @@ Priority order (highest to lowest): Enterprise → Team → Project → User. Al
 
 For project hooks, write paths relative to the project root (e.g., `.cursor/hooks/script.sh`). For user hooks, write paths relative to `~/.cursor/` (e.g., `./hooks/script.sh`).
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
 
 ---
 
@@ -141,7 +135,6 @@ To make a security-critical hook **fail closed** instead, set `"failClosed": tru
 
 For **prompt** hooks: the LLM returns `{ ok: boolean, reason?: string }`. When `ok: false`, the action is denied and `reason` is surfaced to the user.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Per-Script Configuration Options"*
 
 ---
 
@@ -157,4 +150,3 @@ For **prompt** hooks: the LLM returns `{ ok: boolean, reason?: string }`. When `
 
 Use the Hooks tab in Cursor Settings to confirm hooks are loaded and to inspect execution traces.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Troubleshooting", "Environment Variables"*

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Hook Evaluation Criteria
 
 Scoring rubric for assessing existing Cursor hook configurations before improvement.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -29,7 +28,6 @@ Source: docs/cursor/hooks/hooks-guide.md
 
 A hook configuration violating any hard limit is flagged **INVALID** regardless of intent.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration", "Per-Script Configuration Options"*
 
 ---
 
@@ -37,7 +35,6 @@ A hook configuration violating any hard limit is flagged **INVALID** regardless 
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -52,7 +49,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Sensitive data in `command` strings | Use environment variables instead |
 | `failClosed: true` set on non-security-critical hooks | Increases false-deny rate without security benefit |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Examples", "Per-Script Configuration Options"*
 
 ---
 
@@ -66,7 +62,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Outdated subagent-type matcher values | Verify against documented subagent types (`generalPurpose`, `explore`, `shell`) |
 | Matcher set on an event that does not support matchers | Cross-check against `hook-events-reference.md` "Matcher Field by Event Type" |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
 
 ---
 
@@ -80,7 +75,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Security posture appropriate? | Hook validates before allowing; secrets in env vars; stdin variables quoted | Hook only logs, never blocks; secrets hardcoded; unquoted variable expansion |
 | Hook type appropriate for task? | `command` for deterministic, `prompt` for natural-language judgment | `prompt` for a simple regex check |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hook Types", "Command-Based Hooks"*
 
 ---
 
@@ -95,7 +89,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Handler Efficiency | Right type for each task | Some oversized handlers | Prompt hooks for trivial regex tasks |
 | **Overall** | | | |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration", "Hook Types"*
 
 > **UNCERTAIN classification**: When the `command` handler references an external script that cannot be read from the repository, classify Error Handling as **UNCERTAIN** (not Bad) — exit-code behavior cannot be verified from the hook configuration alone. Report it as a gap rather than a violation.
 

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-events-reference.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-events-reference.md
@@ -1,7 +1,6 @@
 # Hook Events Reference
 
 Complete reference for Cursor's native hook events: triggers, matcher fields, and handler-type support.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -49,7 +48,6 @@ Cursor exposes two families of hook events: Agent (Cmd+K / Agent Chat) and Tab (
 | `beforeTabFileRead` | Before Tab reads a file for inline completions | Yes (`permission: "deny"`) |
 | `afterTabFileEdit` | After Tab edits a file | No |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Agent and Tab Support"*
 
 ---
 
@@ -72,7 +70,6 @@ The `matcher` is a regex string. The field it matches against depends on the eve
 
 For MCP tool filtering on `preToolUse`/`postToolUse`/`postToolUseFailure`, use the `MCP:<tool_name>` format.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
 
 ---
 
@@ -109,7 +106,6 @@ Cursor hooks live in a `hooks.json` file at the project or user scope. The top l
 
 **Prompt-hook fields:** add `"type": "prompt"` and a `"prompt": "<natural-language criterion>"` field; an optional `"model"` field overrides the default fast model. The prompt receives the hook input via the auto-replaced `$ARGUMENTS` placeholder.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
 
 ---
 
@@ -122,7 +118,6 @@ Cursor hooks live in a `hooks.json` file at the project or user scope. The top l
 
 Unlike some agent platforms, Cursor exposes only these two handler types — there is no separate `http` or `agent` handler. Use `command` for deterministic checks; reserve `prompt` for cases where natural-language judgment is genuinely required.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
 
 ---
 
@@ -158,4 +153,3 @@ Inject dynamic context at session start:
 
 The script's stdout JSON may include `additional_context` to add to the conversation's initial system context.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Examples" and "Hook events"*

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-validation-criteria.md
@@ -1,7 +1,6 @@
 # Hook Validation Criteria
 
 Quality checklist for generated and improved Cursor hook configurations.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -28,7 +27,6 @@ Any hook violating these criteria must be fixed before proceeding:
 | Matcher applicability | Matcher set only on events whose matcher field is documented in `hook-events-reference.md` |
 | Exit-code semantics | `0` = success, `2` = block; other non-zero exits fail open by default — security-critical blocking hooks must set `failClosed: true` |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Configuration", "Per-Script Configuration Options"*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-hook/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/improve-rule/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/improve-rule/references/rule-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/rule-authoring-guide.md
@@ -1,7 +1,6 @@
 # Rule Authoring Guide
 
 Evidence-based guidance for creating effective Cursor rule files (`.cursor/rules/*.mdc`).
-Source: docs/cursor/rules/rules.md (Cursor official documentation)
 
 ---
 
@@ -31,7 +30,6 @@ Rules are markdown files placed in `.cursor/rules/`. Their contents are included
 | Conventions apply to a file pattern or topic | Side effects must always happen | Multi-phase workflows are required |
 | Domain expertise scoped to a path or topic | No agent judgment is required | Rich, progressive-disclosure references are needed |
 
-*Source: docs/cursor/rules/rules.md — How rules work, Project rules*
 
 ---
 
@@ -47,7 +45,6 @@ Rules are markdown files placed in `.cursor/rules/`. Their contents are included
 
 Each file should cover **one topic** with a kebab-case filename. Both `.md` and `.mdc` extensions are recognised; this distribution generates `.mdc` so that frontmatter can specify activation mode.
 
-*Source: docs/cursor/rules/rules.md — Rule file structure*
 
 ---
 
@@ -63,7 +60,6 @@ Cursor rule frontmatter is restricted to **three fields**. No other key is valid
 
 The token used by other agent platforms to scope rules by file pattern is NOT supported here — Cursor uses `globs` for the same role. Any other frontmatter key is invalid and must be removed.
 
-*Source: docs/cursor/rules/rules.md — Rule file format*
 
 ---
 
@@ -85,7 +81,6 @@ Pick the mode that matches the **content's nature**:
 - Agent-requested → cross-cutting / domain content the agent should pull in by name (authentication, observability, accessibility, API design)
 - Manual → templates and reference snippets the user explicitly opts into
 
-*Source: docs/cursor/rules/rules.md — Rule anatomy*
 
 ---
 
@@ -104,7 +99,6 @@ Auto-attached rules trigger when files matching the pattern enter the agent's co
 
 In monorepos, scope globs to the relevant package subtree (e.g., `services/api/**/*.go` rather than `**/*.go`). Language-only globs match across every package and defeat scoping.
 
-*Source: docs/cursor/rules/rules.md — Project rules; Industry Research on monorepo scoping*
 
 ---
 
@@ -129,7 +123,6 @@ In monorepos, scope globs to the relevant package subtree (e.g., `services/api/*
 
 **No contradictions** — if two rules conflict, the agent may pick one inconsistently. Review `.cursor/rules/` periodically to remove outdated or conflicting instructions.
 
-*Source: docs/cursor/rules/rules.md — Best practices*
 
 ---
 
@@ -148,4 +141,3 @@ In monorepos, scope globs to the relevant package subtree (e.g., `services/api/*
 | Rule files exceeding 200 lines | Poor adherence; attention fragmentation | Split into multiple focused files |
 | Mixing activation modes in one file | Activation-mode contract is per file | One activation mode per file |
 
-*Source: docs/cursor/rules/rules.md — What to avoid in rules; Best practices*

--- a/plugins/cursor-customizer/skills/improve-rule/references/rule-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/rule-evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Rule Evaluation Criteria
 
 Scoring rubric for assessing existing `.cursor/rules/*.mdc` rule files before improvement.
-Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineering-comprehensive.md)
 
 ---
 
@@ -20,18 +19,17 @@ Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineer
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
-| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
-| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` | docs/cursor/rules/rules.md — Rule file format |
-| Banned frontmatter key | `paths` MUST NOT appear | Cross-platform leakage |
-| Activation-mode well-formedness | One of always / globs / description, with the matching field set | docs/cursor/rules/rules.md — Rule anatomy |
-| Instruction actionability | Verifiable, not vague | docs/cursor/rules/rules.md — Best practices |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 200 lines |
+| YAML frontmatter | Valid YAML |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` |
+| Banned frontmatter key | `paths` MUST NOT appear |
+| Activation-mode well-formedness | One of always / globs / description, with the matching field set |
+| Instruction actionability | Verifiable, not vague |
 
 A rule violating any hard limit is flagged **OVER LIMIT** or **INVALID**.
 
-*Source: docs/cursor/rules/rules.md — Best practices, Rule file format*
 
 ---
 
@@ -39,7 +37,6 @@ A rule violating any hard limit is flagged **OVER LIMIT** or **INVALID**.
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -56,7 +53,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Inlined file content that could be `@path/to/file` reference | Token waste; staleness risk |
 | Edge-case instructions for situations that rarely apply | Steals attention from common paths |
 
-*Source: docs/cursor/rules/rules.md — What to avoid in rules*
 
 ---
 
@@ -70,7 +66,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Globs pointing to deleted or moved directories | Verify directory paths exist |
 | `@path/to/file` references to deleted files | Resolve every `@`-reference |
 
-*Source: Industry Research: stale paths poison context*
 
 ---
 
@@ -83,7 +78,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Cross-cutting / domain topic (auth, observability, accessibility) | `description:` | Always-apply, when the agent only needs it on relevant tasks |
 | User-controlled template or snippet | Manual (no frontmatter trigger) | Auto-attached with overly broad globs |
 
-*Source: docs/cursor/rules/rules.md — Rule anatomy*
 
 ---
 
@@ -99,7 +93,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | References instead of inlined file content? | `@components/Button.tsx` | Whole file body pasted into the rule |
 | No overlap with other rules? | Each rule covers a distinct topic | Same instruction in 3 rule files |
 
-*Source: docs/cursor/rules/rules.md — Best practices*
 
 ---
 
@@ -114,7 +107,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Consistency | 0 contradictions across files | 1 contradiction | 2+ contradictions |
 | **Overall** | | | |
 
-*Source: docs/cursor/rules/rules.md — Best practices; Industry Research on context budgets*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-rule/references/rule-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/rule-validation-criteria.md
@@ -1,7 +1,6 @@
 # Rule Validation Criteria
 
 Quality checklist for generated and improved `.cursor/rules/*.mdc` rule files.
-Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineering-comprehensive.md)
 
 ---
 
@@ -9,17 +8,16 @@ Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineer
 
 Any rule file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
-| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
-| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` are valid; ALL others are AUTO-FAIL | docs/cursor/rules/rules.md — Rule file format |
-| Banned frontmatter key | A `paths` key MUST NOT appear; it belongs to a different platform's convention | Cross-platform leakage check |
-| Activation-mode well-formedness | `alwaysApply: true` must omit `globs`; `globs:` rules must set `alwaysApply: false`; `description:`-only rules must omit `globs` and set `alwaysApply: false` | docs/cursor/rules/rules.md — Rule anatomy |
-| Contradictions with other rules | 0 | Industry Research: conflicting instructions cause inconsistent agent behavior |
-| Stale file path references | 0 | Industry Research: stale paths poison context |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 200 lines |
+| YAML frontmatter | Valid YAML |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` are valid; ALL others are AUTO-FAIL |
+| Banned frontmatter key | A `paths` key MUST NOT appear; it belongs to a different platform's convention |
+| Activation-mode well-formedness | `alwaysApply: true` must omit `globs`; `globs:` rules must set `alwaysApply: false`; `description:`-only rules must omit `globs` and set `alwaysApply: false` |
+| Contradictions with other rules | 0 |
+| Stale file path references | 0 |
 
-*Source: docs/cursor/rules/rules.md — Rule file format, Best practices*
 
 ---
 
@@ -34,7 +32,7 @@ Any rule file violating these criteria must be fixed before proceeding:
 - [ ] No standard language conventions the agent already knows from training
 - [ ] No long explanations or tutorials — rules are instructions, not documentation
 - [ ] Files referenced via `@path/to/file` rather than copied inline where practical
-- [ ] Evidence citations present: rule instructions justify their existence with reference to project conventions or `docs/cursor/`
+- [ ] Evidence citations present: rule instructions justify their existence with reference to project conventions
 - [ ] Prompt engineering strategy applied: rule uses zero-shot imperative instructions only (no examples, no tutorials, no explanations)
 - [ ] Critical instructions appear at the start or end of the rule body, not buried in the middle
 

--- a/plugins/cursor-customizer/skills/improve-skill/SKILL.md
+++ b/plugins/cursor-customizer/skills/improve-skill/SKILL.md
@@ -7,18 +7,20 @@ description: "Evaluates and optimizes existing Cursor SKILL.md packages against 
 
 Evaluate an existing Cursor SKILL.md package against evidence-based quality criteria and apply improvements to reduce bloat, eliminate foreign-platform dialect, and align with the Agent Skills standard.
 
-## Behavioral Guidelines
+<TRIGGER when="improving or auditing an existing Cursor skill" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **ALWAYS** evaluate before modifying — never change files without analysis
 - **ALWAYS** present changes to the user before applying them
 - **NEVER** remove evidence-grounded references or citations
@@ -26,96 +28,111 @@ Evaluate an existing Cursor SKILL.md package against evidence-based quality crit
 - **NEVER** exceed 500 lines in SKILL.md or 200 lines in reference files after improvements
 - **PRESERVE** all genuinely useful skill phases and instructions — only remove waste
 - **PRESERVE** or strengthen the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** improved SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** tag-vocabulary violation found in the target skill must be reported with the specific tag name, line reference, and strictness tier (hard-fail / warn / informational) before proposing a fix
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="skill-exists-check">
+  Check if a skill exists at:
 
-Check if a skill exists at:
+  - The user-provided path
+  - `.cursor/skills/{name}/SKILL.md`
+  - `.agents/skills/{name}/SKILL.md`
+  - `~/.cursor/skills/{name}/SKILL.md`
 
-- The user-provided path
-- `.cursor/skills/{name}/SKILL.md`
-- `.agents/skills/{name}/SKILL.md`
-- `~/.cursor/skills/{name}/SKILL.md`
+  **If no skill found:**
 
-**If no skill found:**
+  1. Inform the user: "No skill found at the specified path."
+  2. Suggest using `/cursor-customizer:create-skill` to create a new one instead.
+  3. **STOP**
 
-1. Inform the user: "No skill found at the specified path."
-2. Suggest using `/cursor-customizer:create-skill` to create a new one instead.
-3. **STOP**
+  **If skill found:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If skill found:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="evaluate">
+  Delegate to the `skill-evaluator` agent with this task:
 
-### Phase 1: Evaluate
+  > Evaluate the skill at `{target-path}`. Read the SKILL.md and all files in the skill directory. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter shape valid against the Agent Skills standard), structural quality (progressive disclosure, phase structure, reference loading), canonical semantic-tag convention, foreign-platform dialect, and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
 
-Delegate to the `skill-evaluator` agent with this task:
+  The agent runs read-only with Cursor-native frontmatter (`model: inherit`, `readonly: true`) in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-> Evaluate the skill at `{target-path}`. Read the SKILL.md and all files in the skill directory. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter shape valid against the Agent Skills standard), structural quality (progressive disclosure, phase structure, reference loading), foreign-platform dialect, and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+  <PHASE id="2" name="project-context">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-The agent runs read-only with Cursor-native frontmatter (`model: inherit`, `readonly: true`) in an isolated context. Wait for it to complete and parse its structured output.
+  > Analyze the project to understand the context around the skill being improved. Focus on: which subagents the skill delegates to and whether those subagents still exist, naming conventions for similar skills, any other skills that overlap in purpose, and the project structure under `.cursor/` and `.agents/`.
 
-### Phase 2: Project Context
+  Wait for it to complete and parse its structured output.
+  </PHASE>
 
-Delegate to the `artifact-analyzer` agent with this task:
+  <PHASE id="3" name="generate-improvement-plan">
+  Read these reference documents:
 
-> Analyze the project to understand the context around the skill being improved. Focus on: which subagents the skill delegates to and whether those subagents still exist, naming conventions for similar skills, any other skills that overlap in purpose, and the project structure under `.cursor/` and `.agents/`.
+  - `references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
+  - `references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
+  - `references/behavioral-guidelines.md` — discipline cues and safe persuasion patterns for skills
+  - `references/prompt-engineering-strategies.md` — skill-specific prompting strategies
 
-Wait for it to complete and parse its structured output.
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-evaluation-criteria.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-### Phase 3: Generate Improvement Plan
+  Based on both subagent reports, create an improvement plan with categories:
 
-Read these reference documents:
+  1. **Removals** — bloat (inlined content, over-specified instructions), stale (broken subagent refs, removed tools), duplicates, foreign-platform dialect
+  2. **Refactoring** — progressive disclosure optimization, phase consolidation, bundled-path corrections to relative-from-skill-root form, canonical semantic-tag migration (including `<RULES>` → `<HARD_RULES>`)
+  3. **Additions** — missing sections (self-validation, output format). Only suggest Hard Rules or Preflight if the skill has user-facing interactions or side effects — do NOT suggest them for informational/analysis-only skills that read and report.
 
-- `references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
-- `references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
-- `references/behavioral-guidelines.md` — discipline cues and safe persuasion patterns for skills
-- `references/prompt-engineering-strategies.md` — skill-specific prompting strategies
+  If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  </PHASE>
 
-Based on both subagent reports, create an improvement plan with categories:
+  <PHASE id="4" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
 
-1. **Removals** — bloat (inlined content, over-specified instructions), stale (broken subagent refs, removed tools), duplicates, foreign-platform dialect
-2. **Refactoring** — progressive disclosure optimization, phase consolidation, bundled-path corrections to relative-from-skill-root form
-3. **Additions** — missing sections (self-validation, output format). Only suggest Hard Rules or Preflight if the skill has user-facing interactions or side effects — do NOT suggest them for informational/analysis-only skills that read and report.
+  For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. The loop covers all hard limits, quality checks, and the canonical semantic-tag strictness tiers. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+  </PHASE>
 
-If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  <PHASE id="5" name="present-and-apply">
+  1. Show a summary overview of all improvements found, grouped by category:
+     - **Removals**: X items (bloat: X, stale: X, duplicates: X, foreign dialect: X)
+     - **Refactoring**: X items (progressive disclosure: X, phase structure: X, bundled-path corrections: X)
+     - **Additions**: X items
 
-### Phase 4: Self-Validation
+  2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
 
-Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
+     **WHAT**: The specific content and its current location (file:lines)
+     **WHY**: Evidence-based justification with source reference
+     **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
+     **OPTIONS**:
+     - **Option A** (recommended): Primary action
+     - **Option B**: Alternative action
+     - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
 
-For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+     Wait for the user to select an option for each suggestion before proceeding to the next.
+     If the user selects "Keep as-is", preserve the content in its exact current location.
 
-### Phase 5: Present and Apply
+  3. After all suggestions are reviewed, show aggregate token impact analysis:
+     - **Total lines**: before → after
+     - **Removed tokens**: total waste eliminated
+     - **Deferred suggestions**: X items kept as-is
 
-1. Show a summary overview of all improvements found, grouped by category:
-   - **Removals**: X items (bloat: X, stale: X, duplicates: X, foreign dialect: X)
-   - **Refactoring**: X items (progressive disclosure: X, phase structure: X, bundled-path corrections: X)
-   - **Additions**: X items
+  4. Apply ONLY the approved changes (options A or B selections).
 
-2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+  5. Report final metrics:
+     - Lines before → after
+     - Files affected
+     - Estimated token savings per session
+     - Suggestions applied: X of Y (Z deferred)
+  </PHASE>
 
-   **WHAT**: The specific content and its current location (file:lines)
-   **WHY**: Evidence-based justification with source reference
-   **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
-   **OPTIONS**:
-   - **Option A** (recommended): Primary action
-   - **Option B**: Alternative action
-   - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
+</PROCESS>
 
-   Wait for the user to select an option for each suggestion before proceeding to the next.
-   If the user selects "Keep as-is", preserve the content in its exact current location.
-
-3. After all suggestions are reviewed, show aggregate token impact analysis:
-   - **Total lines**: before → after
-   - **Removed tokens**: total waste eliminated
-   - **Deferred suggestions**: X items kept as-is
-
-4. Apply ONLY the approved changes (options A or B selections).
-
-5. Report final metrics:
-   - Lines before → after
-   - Files affected
-   - Estimated token savings per session
-   - Suggestions applied: X of Y (Z deferred)
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md` and loop the improved skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/improve-skill/assets/templates/skill-md.md
+++ b/plugins/cursor-customizer/skills/improve-skill/assets/templates/skill-md.md
@@ -15,43 +15,62 @@ description: "[What this skill does and when to use it. Third person. Include tr
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name
            the target service/workspace explicitly
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
+           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+           <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
+           Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
+           Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: YAML frontmatter is untouched — do NOT duplicate the <TRIGGER> cue into description
 -->
 
 # [Skill Title]
 
 [One-sentence purpose statement.]
 
-## Behavioral Guidelines
+<TRIGGER when="[plain-language activation cue — mirror the 'Use when ...' phrase from the description]" />
 
+<BEHAVIOUR
+  avoid="make decisions without surfacing assumptions; add speculative scope"
+  always="surface assumptions first; keep changes surgical">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - [Critical constraint 1]
 - [Critical constraint 2]
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
-<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  <PREFLIGHT name="artifact-collision-check">
+  <!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  </PREFLIGHT>
 
-### Phase 1: [Analysis Phase Name]
-<!-- Delegate to the appropriate Cursor subagent (model: inherit, readonly: true);
-     if monorepo, record the target service/workspace -->
+  <PHASE id="1" name="[analysis-phase-name]">
+  <!-- Delegate to the appropriate Cursor subagent (model: inherit, readonly: true);
+       if monorepo, record the target service/workspace -->
+  </PHASE>
 
-### Phase 2: [Generation Phase Name]
-<!-- Read references via relative paths (references/[file].md), apply templates,
-     and use project-relative paths/globs for the detected service/workspace -->
+  <PHASE id="2" name="[generation-phase-name]">
+  <!-- Read references via relative paths (references/[file].md), apply templates,
+       and use project-relative paths/globs for the detected service/workspace -->
+  </PHASE>
 
-### Phase 3: Self-Validation
-<!-- Read references/[type]-validation-criteria.md and execute its validation loop -->
+  <PHASE id="3" name="self-validation">
+  <!-- Read references/[type]-validation-criteria.md and loop until all checks pass -->
+  </PHASE>
 
-### Phase 4: Present and Write
-<!-- Show artifact with evidence citations, write on user approval -->
+  <PHASE id="4" name="present-and-write">
+  <!-- Show artifact with evidence citations, write on user approval -->
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+<!-- Read references/[type]-validation-criteria.md, loop until pass -->
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/improve-skill/assets/templates/skill-md.md
+++ b/plugins/cursor-customizer/skills/improve-skill/assets/templates/skill-md.md
@@ -15,8 +15,8 @@ description: "[What this skill does and when to use it. Third person. Include tr
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name
            the target service/workspace explicitly
-     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
-           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory: <TRIGGER>,
            <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
            Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
            Closed attribute set: avoid=, always=, when=, name=, id=, priority=.

--- a/plugins/cursor-customizer/skills/improve-skill/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-authoring-guide.md
@@ -1,7 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating Cursor SKILL.md packages that conform to the Agent Skills open standard.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -40,7 +39,6 @@ Challenge each piece of content:
 
 **Safe persuasion** — use warm-up phases, curated references, explicit limits, and cited standards to improve compliance with legitimate work. Never use persuasion framing to bypass safeguards, refusals, or scope boundaries.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "What are skills?" and "How skills work"*
 
 ---
 
@@ -56,7 +54,6 @@ Cursor automatically discovers skills from these directories at startup:
 
 The agent is presented with available skills and decides when they are relevant based on context. Skills can also be invoked manually by typing `/` in the agent chat and searching for the skill name.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*
 
 ---
 
@@ -74,7 +71,6 @@ my-skill/
 
 Keep `SKILL.md` focused — move detailed reference material into `references/`. The agent loads supporting files progressively, only when the body of `SKILL.md` directs it to.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
 
 ---
 
@@ -93,7 +89,6 @@ Each skill begins with YAML frontmatter. The Agent Skills standard recognises si
 
 No other fields are part of the standard. Adding fields outside this set introduces foreign-platform dialect and breaks portability.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -109,7 +104,6 @@ No other fields are part of the standard. Adding fields outside this set introdu
 
 Include three things in every description: (1) what it does, (2) when to use it, (3) the trigger terms an agent might match against.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Frontmatter fields"*
 
 ---
 
@@ -129,7 +123,6 @@ Each reference file has one job and is cited explicitly from the phase that need
 
 Keep `SKILL.md` under 500 lines. Move detail to `references/`. Reference supporting files explicitly so the agent knows what they contain.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
 
 ---
 
@@ -149,7 +142,6 @@ Do not use string-substitution variables to refer to bundled files; the relative
 
 Scripts can be written in any language the agent can execute (Bash, Python, JavaScript, etc.). They should be self-contained, include helpful error messages, and handle edge cases gracefully.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills"*
 
 ---
 
@@ -159,7 +151,6 @@ By default, skills are automatically applied when the agent determines they are 
 
 Use this for workflows with side effects (commit, deploy, send-message) or for skills the user wants to gate manually.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Disabling automatic invocation"*
 
 ---
 
@@ -175,4 +166,3 @@ Use this for workflows with side effects (commit, deploy, send-message) or for s
 | Contradictions between phases | Agent picks one arbitrarily | Review all phases for consistency |
 | Loading every reference in Phase 1 | Defeats progressive disclosure | Load each reference only in the phase that needs it |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Optional directories"*

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Skill Evaluation Criteria
 
 Scoring rubric for assessing existing Cursor SKILL.md packages before improvement.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -20,19 +19,18 @@ Source: docs/cursor/skills/agent-skills-guide.md
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
-| Reference files | ≤ 200 lines each | reference-files convention |
-| Reference files >100 lines | Must include a `## Contents` table of contents | reference-files convention |
-| `description` field | Present, non-empty, ≤ 1024 chars | Agent Skills specification |
-| `name` field | Present, non-empty, 1-64 chars, kebab-case, matches parent folder | Agent Skills specification |
-| Frontmatter fields | Restricted to the six recognised by the Agent Skills standard | Agent Skills specification |
-| Phase structure | At least one clear phase defined | Agent Skills authoring patterns |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` table of contents |
+| `description` field | Present, non-empty, ≤ 1024 chars |
+| `name` field | Present, non-empty, 1-64 chars, kebab-case, matches parent folder |
+| Frontmatter fields | Restricted to the six recognised by the Agent Skills standard |
+| Phase structure | At least one clear phase defined |
 
 A skill violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
 
 ---
 
@@ -40,7 +38,6 @@ A skill violating any hard limit is flagged **OVER LIMIT** regardless of content
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -56,7 +53,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Explaining standard practices the agent already knows | Agents are already capable; add only novel context |
 | Hardcoded absolute or project-relative paths for bundled files | Will go stale; bundled paths must be relative to the skill root |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
 
 ---
 
@@ -70,7 +66,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Hardcoded file paths in SKILL.md body | Check that referenced bundled paths actually exist |
 | Foreign-platform dialect | See dedicated section below — auto-fail |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format"*
 
 ---
 
@@ -96,7 +91,6 @@ The Cursor distribution is product-strict. Apply the following allowlists to the
 | Are supporting files referenced explicitly? | "Read the relevant supporting file for this phase" | Files exist but never referenced |
 | Is SKILL.md body under 500 lines? | Clean entry point with external depth | Monolithic, all content inline |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-format-reference.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-format-reference.md
@@ -1,7 +1,6 @@
 # Skill Format Reference
 
 Technical specification for Cursor SKILL.md format, frontmatter, directory structure, and discovery model.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -31,7 +30,6 @@ The Agent Skills standard, as adopted by Cursor, recognises exactly six frontmat
 
 Frontmatter fields outside this set are foreign-platform dialect and must not appear in Cursor SKILL.md files.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -43,7 +41,6 @@ Frontmatter fields outside this set are foreign-platform dialect and must not ap
 - Must NOT contain consecutive `--`
 - Must match the parent directory name exactly
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -65,7 +62,6 @@ Apply the template at assets/templates/config.yaml.
 
 This convention is what the Agent Skills standard guarantees portable across implementations. Do not use string-substitution variables, absolute paths, or project-relative paths for bundled files — relative paths from the skill root are the only portable form.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills" and "Optional directories"*
 
 ---
 
@@ -90,7 +86,6 @@ my-skill/
 - `assets/` files load only when the skill body explicitly directs the agent to use them.
 - `scripts/` files are executed by the agent, not loaded into context.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
 
 ---
 
@@ -104,7 +99,6 @@ my-skill/
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to the `references/` subdirectory. Explicitly reference supporting files from SKILL.md so the agent knows what to load and when.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "How skills work" and "Optional directories"*
 
 ---
 
@@ -120,4 +114,3 @@ Cursor automatically loads skills from these directories:
 
 When the same skill name exists in multiple locations, Cursor's own resolution rules apply. For new skills, choose `.cursor/skills/` when the skill is Cursor-specific and `.agents/skills/` when the skill should also be discoverable by other Agent Skills consumers.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-validation-criteria.md
@@ -8,6 +8,7 @@ Source: docs/cursor/skills/agent-skills-guide.md
 ## Contents
 
 - Hard limits (auto-fail if violated)
+- Canonical Semantic-Tag Convention
 - Foreign-platform dialect ban (auto-fail if violated)
 - Quality checks (all must pass)
 - Improve-only checks (information preservation, structural)
@@ -30,6 +31,40 @@ Any skill violating these criteria must be fixed before proceeding:
 | Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
 
 *Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X")
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|-------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 
@@ -63,6 +98,9 @@ The Cursor distribution is product-strict. The skill tree (SKILL.md, references,
 - [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
 - [ ] Plugin skill bodies delegate analysis to registered subagents; no inline bash analysis commands
 - [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-guide.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
 
 ---
 
@@ -85,10 +123,11 @@ The Cursor distribution is product-strict. The skill tree (SKILL.md, references,
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above (hard limits, foreign-dialect ban, quality checks, and IMPROVE-only checks if applicable).
+1. Evaluate the skill against ALL criteria above (hard limits, the **Canonical Semantic-Tag Convention** strictness tiers, foreign-dialect ban, quality checks, and IMPROVE-only checks if applicable).
 2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference.
-3. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation.
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
-5. Only proceed to writing skills when ALL criteria pass.
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation.
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix.
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass.
 
 **Do not skip criteria for "minor" violations.** Hard limits and the foreign-dialect ban are absolute.

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-validation-criteria.md
@@ -1,7 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved Cursor SKILL.md packages.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -20,17 +19,16 @@ Source: docs/cursor/skills/agent-skills-guide.md
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
-| Reference files | ≤ 200 lines each | reference-files convention |
-| Reference files >100 lines | Must include a `## Contents` table of contents | reference-files convention |
-| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags | Agent Skills specification |
-| `name` field | Present, non-empty, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder | Agent Skills specification |
-| Frontmatter fields | Restricted to `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` | Agent Skills specification |
-| Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` table of contents |
+| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags |
+| `name` field | Present, non-empty, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder |
+| Frontmatter fields | Restricted to `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` |
+| Contradictions between phases | 0 |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
 
 ---
 
@@ -64,7 +62,6 @@ The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-subagent/SKILL.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/SKILL.md
@@ -7,18 +7,20 @@ description: "Evaluates and optimizes existing Cursor subagent definitions again
 
 Evaluate an existing Cursor subagent definition against evidence-based quality criteria and apply improvements to fix frontmatter, sharpen the routing description, and strengthen the system prompt.
 
-## Behavioral Guidelines
+<TRIGGER when="improving or auditing an existing Cursor subagent definition" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **ALWAYS** evaluate before modifying — never change subagents without analysis.
 - **ALWAYS** present changes to the user before applying them.
 - **NEVER** loosen the `readonly` posture (true → false) without explicit user rationale.
@@ -26,102 +28,117 @@ Evaluate an existing Cursor subagent definition against evidence-based quality c
 - **NEVER** change the `model` value to anything other than `inherit`.
 - **NEVER** broaden subagent scope (single-purpose subagents are better than general-purpose).
 - **PRESERVE** specialized domain knowledge in system prompts — only remove generic boilerplate.
-</RULES>
+- **EVERY** improved subagent body must carry the canonical semantic-tag vocabulary (`<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with `<PHASE>`); `<TRIGGER>` is optional for subagents.
+- **EVERY** tag-vocabulary violation found in the target subagent must be reported with the specific tag name, line reference, and strictness tier (hard-fail / warn / informational) before proposing a fix.
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="subagent-exists-check">
+  Check if a subagent exists at:
 
-Check if a subagent exists at:
+  - The user-provided path
+  - `.cursor/agents/{name}.md`
+  - `plugins/*/agents/{name}.md`
 
-- The user-provided path
-- `.cursor/agents/{name}.md`
-- `plugins/*/agents/{name}.md`
+  **If no subagent found:**
 
-**If no subagent found:**
+  1. Inform the user: "No subagent found at the specified path."
+  2. Suggest using `/cursor-customizer:create-subagent` to create a new one instead.
+  3. **STOP**
 
-1. Inform the user: "No subagent found at the specified path."
-2. Suggest using `/cursor-customizer:create-subagent` to create a new one instead.
-3. **STOP**
+  **If subagent found:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If subagent found:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="evaluate">
+  Delegate to the `subagent-evaluator` agent with this task:
 
-### Phase 1: Evaluate
+  > Evaluate the subagent definition at `{target-path}`. Check YAML frontmatter validity, the four-key contract (only `name`, `description`, `model`, `readonly` allowed; `model` must be `inherit`; `readonly` must be `true`), name format (kebab-case, ≤64 characters, distinct from every other project subagent), description specificity for routing (action-oriented, ≤1024 characters, includes a "Use when..." trigger), system prompt structure (role, constraints, process, output format, self-verification), and any instructions that tell the subagent to spawn other subagents (forbidden by project convention). Return structured results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
 
-Delegate to the `subagent-evaluator` agent with this task:
+  - If the user provides a specific subagent file → scope to that file.
+  - If no specific file → evaluate ALL subagents in `.cursor/agents/` and `plugins/*/agents/`.
 
-> Evaluate the subagent definition at `{target-path}`. Check YAML frontmatter validity, the four-key contract (only `name`, `description`, `model`, `readonly` allowed; `model` must be `inherit`; `readonly` must be `true`), name format (kebab-case, ≤64 characters, distinct from every other project subagent), description specificity for routing (action-oriented, ≤1024 characters, includes a "Use when..." trigger), system prompt structure (role, constraints, process, output format, self-verification), and any instructions that tell the subagent to spawn other subagents (forbidden by project convention). Return structured results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+  The `subagent-evaluator` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-- If the user provides a specific subagent file → scope to that file.
-- If no specific file → evaluate ALL subagents in `.cursor/agents/` and `plugins/*/agents/`.
+  <PHASE id="2" name="project-context">
+  Delegate to the `artifact-analyzer` agent with this task:
 
-The `subagent-evaluator` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  > Analyze the project to understand the context around Cursor subagent definitions. Focus on: all subagents in `.cursor/agents/` and `plugins/*/agents/` (name, description, `model`, `readonly`), which skills delegate to which subagents, any subagents with similar purposes (potential consolidation), and naming conventions. Return the structured artifact-inventory output.
 
-### Phase 2: Project Context
+  The `artifact-analyzer` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  </PHASE>
 
-Delegate to the `artifact-analyzer` agent with this task:
+  <PHASE id="3" name="generate-improvement-plan">
+  Read these reference documents:
 
-> Analyze the project to understand the context around Cursor subagent definitions. Focus on: all subagents in `.cursor/agents/` and `plugins/*/agents/` (name, description, `model`, `readonly`), which skills delegate to which subagents, any subagents with similar purposes (potential consolidation), and naming conventions. Return the structured artifact-inventory output.
+  - `references/subagent-authoring-guide.md` — when to use a subagent, system prompt structure, the four-key frontmatter contract, description-as-routing-signal, anti-patterns.
+  - `references/subagent-evaluation-criteria.md` — bloat / staleness indicators, quality rubric.
+  - `references/subagent-config-reference.md` — full Cursor-native frontmatter specification, model and readonly handling, orchestration patterns.
+  - `references/prompt-engineering-strategies.md` — subagent-specific prompting.
 
-The `artifact-analyzer` runs read-only with `model: inherit` in an isolated context. Wait for it to complete and parse its structured output.
+  <REFERENCES load="on-demand">
+  - subagent-authoring-guide.md
+  - subagent-evaluation-criteria.md
+  - subagent-config-reference.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-### Phase 3: Generate Improvement Plan
+  Based on the evaluator output and the reference documents, create an improvement plan with categories:
 
-Read these reference documents:
+  1. **Removals** — generic system prompt boilerplate, overtriggering language, redundant instructions, foreign-platform frontmatter keys.
+  2. **Refactoring** — fix `model` to `inherit`, fix `readonly` to `true`, sharpen description for routing specificity, restructure system prompt sections, tighten name to kebab-case, canonical semantic-tag migration (including `<RULES>` → `<HARD_RULES>`).
+  3. **Additions** — missing self-verification section, missing explicit output format, missing constraints block.
 
-- `references/subagent-authoring-guide.md` — when to use a subagent, system prompt structure, the four-key frontmatter contract, description-as-routing-signal, anti-patterns.
-- `references/subagent-evaluation-criteria.md` — bloat / staleness indicators, quality rubric.
-- `references/subagent-config-reference.md` — full Cursor-native frontmatter specification, model and readonly handling, orchestration patterns.
-- `references/prompt-engineering-strategies.md` — subagent-specific prompting.
+  If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  </PHASE>
 
-Based on the evaluator output and the reference documents, create an improvement plan with categories:
+  <PHASE id="4" name="self-validation">
+  Read `references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved subagent definition.
 
-1. **Removals** — generic system prompt boilerplate, overtriggering language, redundant instructions, foreign-platform frontmatter keys.
-2. **Refactoring** — fix `model` to `inherit`, fix `readonly` to `true`, sharpen description for routing specificity, restructure system prompt sections, tighten name to kebab-case.
-3. **Additions** — missing self-verification section, missing explicit output format, missing constraints block.
+  For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. The loop covers all hard limits, quality checks, and the canonical semantic-tag strictness tiers. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+  </PHASE>
 
-If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  <PHASE id="5" name="present-and-apply">
+  1. Show a summary overview of all improvements found, grouped by category:
+     - **Removals**: X items (foreign frontmatter keys: X, generic boilerplate: X, overtriggering: X)
+     - **Refactoring**: X items (model fix: X, readonly fix: X, description: X, prompt structure: X)
+     - **Additions**: X items (self-verification: X, output format: X, constraints block: X)
 
-### Phase 4: Self-Validation
+  2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
 
-Read `references/subagent-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved subagent definition.
+     **WHAT**: The specific content and its current location (file:lines).
+     **WHY**: Evidence-based justification with source reference.
+     **TOKEN IMPACT**: Estimated tokens saved per invocation.
+     **OPTIONS**:
+     - **Option A** (recommended): Primary action.
+     - **Option B**: Alternative action.
+     - **Option C**: Keep as-is.
 
-For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+     Wait for the user to select an option for each suggestion before proceeding to the next.
 
-### Phase 5: Present and Apply
+     For frontmatter changes, show before/after frontmatter blocks.
+     For description rewrites, show before/after with the routing signal highlighted.
+     For system prompt rewrites, show diff of the prompt sections.
+     Warn if the subagent is referenced by skills — list which skills delegate to it.
 
-1. Show a summary overview of all improvements found, grouped by category:
-   - **Removals**: X items (foreign frontmatter keys: X, generic boilerplate: X, overtriggering: X)
-   - **Refactoring**: X items (model fix: X, readonly fix: X, description: X, prompt structure: X)
-   - **Additions**: X items (self-verification: X, output format: X, constraints block: X)
+  3. After all suggestions are reviewed, show aggregate impact:
+     - **System prompt lines**: before → after.
+     - **Frontmatter keys**: before → after (must converge to the four allowed keys).
+     - **Deferred suggestions**: X items kept as-is.
 
-2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+  4. Apply ONLY the approved changes.
+     - Refuse any approval that would introduce a frontmatter key outside the allowed four, or change `model` away from `inherit`. Surface the conflict to the user and offer to translate into a Cursor-native form.
 
-   **WHAT**: The specific content and its current location (file:lines).
-   **WHY**: Evidence-based justification with source reference.
-   **TOKEN IMPACT**: Estimated tokens saved per invocation.
-   **OPTIONS**:
-   - **Option A** (recommended): Primary action.
-   - **Option B**: Alternative action.
-   - **Option C**: Keep as-is.
+  5. Report final metrics:
+     - Lines before → after.
+     - Frontmatter keys before → after.
+     - Suggestions applied: X of Y (Z deferred).
+  </PHASE>
 
-   Wait for the user to select an option for each suggestion before proceeding to the next.
+</PROCESS>
 
-   For frontmatter changes, show before/after frontmatter blocks.
-   For description rewrites, show before/after with the routing signal highlighted.
-   For system prompt rewrites, show diff of the prompt sections.
-   Warn if the subagent is referenced by skills — list which skills delegate to it.
-
-3. After all suggestions are reviewed, show aggregate impact:
-   - **System prompt lines**: before → after.
-   - **Frontmatter keys**: before → after (must converge to the four allowed keys).
-   - **Deferred suggestions**: X items kept as-is.
-
-4. Apply ONLY the approved changes.
-   - Refuse any approval that would introduce a frontmatter key outside the allowed four, or change `model` away from `inherit`. Surface the conflict to the user and offer to translate into a Cursor-native form.
-
-5. Report final metrics:
-   - Lines before → after.
-   - Frontmatter keys before → after.
-   - Suggestions applied: X of Y (Z deferred).
+<VALIDATION loop="max-iterations:3">
+Read `references/subagent-validation-criteria.md` and loop the improved subagent through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/improve-subagent/assets/templates/subagent-definition.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/assets/templates/subagent-definition.md
@@ -11,8 +11,8 @@ readonly: true
      Forbidden: any other frontmatter key; any other model value.
      Rule: Project subagents must not spawn other subagents.
      Rule: name must be kebab-case and distinct from every other subagent name in the project.
-     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
-           (see wiki/knowledge/skill-body-convention.md). Mandatory for subagents:
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory for subagents:
            <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id="N" name="X">.
            Optional: <TRIGGER>, <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>,
            <OUTPUT>, <VALIDATION>. Closed attribute set: avoid=, always=, when=, name=, id=, priority=.

--- a/plugins/cursor-customizer/skills/improve-subagent/assets/templates/subagent-definition.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/assets/templates/subagent-definition.md
@@ -11,41 +11,64 @@ readonly: true
      Forbidden: any other frontmatter key; any other model value.
      Rule: Project subagents must not spawn other subagents.
      Rule: name must be kebab-case and distinct from every other subagent name in the project.
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
+           (see wiki/knowledge/skill-body-convention.md). Mandatory for subagents:
+           <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id="N" name="X">.
+           Optional: <TRIGGER>, <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>,
+           <OUTPUT>, <VALIDATION>. Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: <TRIGGER> is optional — omit if the subagent is always spawned by skills, not user-invoked.
 -->
 
 # [Agent Name]
 
 You are a [specific role] specializing in [domain]. [One-sentence identity statement; name target services or scope when relevant.]
 
-## Constraints
+<!-- Optional: include <TRIGGER> if this subagent can also be user-invoked -->
+<!-- <TRIGGER when="[activation condition]" /> -->
 
+<BEHAVIOUR
+  avoid="[what to avoid — e.g., modifying files; surfacing low-confidence findings]"
+  always="[what to always do — e.g., cite evidence; report in structured format]">
+- [Behavioural guideline 1]
+- [Behavioural guideline 2]
 - Do not modify any files — only analyze and report.
-- Do not suggest improvements — describe what exists or what fails.
-- Do not spawn other subagents — return findings to the parent agent.
-- Do not [additional constraint specific to this role].
+</BEHAVIOUR>
 
-## Process
+<HARD_RULES priority="hard">
+- **NEVER** modify any files — describe what exists or what fails, do not change it.
+- **NEVER** suggest improvements — report findings only.
+- **NEVER** spawn other subagents — return findings to the parent agent.
+- **EVERY** finding must cite a specific path or line.
+- **EVERY** output must match the Output Format below exactly.
+</HARD_RULES>
 
-### 1. [First Step]
+<PROCESS>
 
-[What to read, detect, or evaluate.]
+  <PHASE id="1" name="[first-step]">
+  [What to read, detect, or evaluate.]
+  </PHASE>
 
-### 2. [Second Step]
+  <PHASE id="2" name="[second-step]">
+  [How to process findings — filtering, categorizing, structuring.]
+  </PHASE>
 
-[How to process findings.]
+  <PHASE id="3" name="[compile-output]">
+  [How to compile and format the final structured output.]
+  </PHASE>
 
-### 3. [Third Step]
+</PROCESS>
 
-[How to compile output.]
-
-## Output Format
+<OUTPUT>
 
 ```
 [Exact structure the agent must return — headers, tables, sections, with concrete labels.]
 ```
 
-## Self-Verification
+</OUTPUT>
 
+<VALIDATION>
+Before returning output, verify:
 1. [Check 1 — every reported finding cites a specific path or line.]
 2. [Check 2 — output matches the format above.]
 3. [Check 3 — no improvement suggestions included; only findings.]
+</VALIDATION>

--- a/plugins/cursor-customizer/skills/improve-subagent/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/improve-subagent/references/subagent-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/subagent-authoring-guide.md
@@ -1,7 +1,6 @@
 # Subagent Authoring Guide
 
 Evidence-based guidance for creating effective Cursor subagent definitions.
-Source: docs/cursor/subagents/subagents-guide.md (Cursor subagents documentation; primary attribution); docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -30,7 +29,6 @@ Subagents are for **isolated, specialized work** that should not pollute the par
 
 If the task is single-purpose (generate a changelog, format imports), prefer a skill or slash command — a subagent is overkill.
 
-*Source: docs/cursor/subagents/subagents-guide.md (when to use subagents)*
 
 ---
 
@@ -48,7 +46,6 @@ Project subagents take precedence over user subagents when names conflict.
 
 The customizer generates into the project or plugin paths only.
 
-*Source: docs/cursor/subagents/subagents-guide.md (file locations)*
 
 ---
 
@@ -64,7 +61,6 @@ Effective subagent system prompts follow this 5-part pattern:
 
 Keep prompts focused. Each subagent should have a single clear responsibility — avoid generic "helper" agents.
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices)*
 
 ---
 
@@ -86,7 +82,6 @@ readonly: true
 
 For full schema details and rejection rules, see `subagent-config-reference.md` and `subagent-validation-criteria.md`.
 
-*Source: docs/cursor/subagents/subagents-guide.md (file format, configuration fields); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -102,7 +97,6 @@ The `description` field is the only signal Cursor's agent uses to decide whether
 Bad: "Helps with code." (too generic — Cursor cannot decide when to delegate)
 Good: "Validates completed work. Use after tasks are marked done to confirm implementations are functional."
 
-*Source: docs/cursor/subagents/subagents-guide.md (description field, best practices)*
 
 ---
 
@@ -118,7 +112,6 @@ Good: "Validates completed work. Use after tasks are marked done to confirm impl
 | Generic "you are a helpful AI" prompt | Defeats the purpose of a subagent | Define a specific role and process |
 | Duplicating a slash-command capability | Adds complexity without benefit | Use the slash command directly |
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices — anti-patterns to avoid)*
 
 ---
 
@@ -152,4 +145,3 @@ Do not accept claims at face value. Test everything you can without modifying st
 
 Useful for: validating end-to-end behavior before marking tickets complete; catching partially implemented functionality; ensuring tests actually pass (not just that test files exist).
 
-*Source: docs/cursor/subagents/subagents-guide.md (common patterns — verification agent)*

--- a/plugins/cursor-customizer/skills/improve-subagent/references/subagent-config-reference.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/subagent-config-reference.md
@@ -1,7 +1,6 @@
 # Subagent Config Reference
 
 Cursor-native subagent frontmatter specification, model handling, and orchestration patterns.
-Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -28,7 +27,6 @@ The Cursor-native subagent frontmatter for this distribution uses **exactly four
 | `model` | Yes | `inherit` | Cursor-native: the subagent runs on the same model as the parent agent. The product-strict contract requires this value. |
 | `readonly` | Yes | `true` | Cursor-native: the subagent runs with restricted write permissions (no file edits, no state-changing shell commands). The product-strict contract requires this value for analysis and evaluator subagents. |
 
-*Source: docs/cursor/subagents/subagents-guide.md (configuration fields table); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -43,7 +41,6 @@ For this distribution, **the value MUST be `inherit`**. The `fast` value and any
 
 If a Cursor user explicitly opts into `fast` or a specific model ID for their own hand-edited subagent, the customizer does not block that — but the customizer never generates such a value.
 
-*Source: docs/cursor/subagents/subagents-guide.md (model configuration); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -55,7 +52,6 @@ For this distribution, **the value MUST be `true`** for every generated subagent
 
 If a future workflow requires a subagent that writes files, the customizer prompts the user to confirm and document the rationale before generating such a subagent — but the default and recommended posture is `readonly: true`.
 
-*Source: docs/cursor/subagents/subagents-guide.md (configuration fields table)*
 
 ---
 
@@ -70,7 +66,6 @@ Cursor honors several subagent locations. This customizer generates into the Cur
 
 File naming: kebab-case `.md` filenames matching the subagent's `name` field (e.g., `security-reviewer.md` for `name: security-reviewer`).
 
-*Source: docs/cursor/subagents/subagents-guide.md (file locations)*
 
 ---
 
@@ -88,7 +83,6 @@ File naming: kebab-case `.md` filenames matching the subagent's `name` field (e.
 | Sequential pipeline | Task B depends on Task A's structured output |
 | Parallel decomposition | Independent reads or evaluations that can run concurrently |
 
-*Source: docs/cursor/subagents/subagents-guide.md (using subagents — parallel execution; orchestrator pattern)*
 
 ---
 
@@ -101,7 +95,6 @@ These constraints govern subagents authored by this customizer:
 - **Subagents do not inherit parent skills.** If a subagent needs domain knowledge, encode it in the system prompt.
 - **The frontmatter key set is closed.** Only `name`, `description`, `model`, `readonly` are permitted. Any other key is rejected by validation.
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices, anti-patterns)*
 
 ---
 
@@ -116,4 +109,3 @@ The following frontmatter fields belong to other agent platforms and MUST NOT ap
 
 These rejections are enforced by `subagent-validation-criteria.md` with explicit examples.
 
-*Source: docs/adr/0002-product-strict-research-foundation.md*

--- a/plugins/cursor-customizer/skills/improve-subagent/references/subagent-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/subagent-evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Subagent Evaluation Criteria
 
 Scoring rubric for assessing existing Cursor subagent definitions before improvement.
-Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -19,18 +18,17 @@ Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-r
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| `name` field | Present; lowercase letters and hyphens only; ≤64 chars | Cursor subagents documentation (configuration fields) |
-| `description` field | Present, non-empty, ≤1024 chars, specific | Cursor subagents documentation (configuration fields) |
-| `model` field | Exactly `inherit` | ADR-0002 product-strict frontmatter contract |
-| `readonly` field | Exactly `true` | ADR-0002 product-strict frontmatter contract |
-| Frontmatter key set | Exactly `name`, `description`, `model`, `readonly` | ADR-0002 product-strict frontmatter contract |
-| System prompt (markdown body) | Present and task-specific | Cursor subagents documentation (best practices) |
+| Criterion | Threshold |
+|-----------|-----------|
+| `name` field | Present; lowercase letters and hyphens only; ≤64 chars |
+| `description` field | Present, non-empty, ≤1024 chars, specific |
+| `model` field | Exactly `inherit` |
+| `readonly` field | Exactly `true` |
+| Frontmatter key set | Exactly `name`, `description`, `model`, `readonly` |
+| System prompt (markdown body) | Present and task-specific |
 
 A subagent violating any hard limit is flagged **INVALID** regardless of other quality.
 
-*Source: docs/cursor/subagents/subagents-guide.md; docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -38,7 +36,6 @@ A subagent violating any hard limit is flagged **INVALID** regardless of other q
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -53,7 +50,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Duplicate subagent with the same purpose as a built-in role | Built-in subagents already cover exploration / shell / browser; do not recreate |
 | Vague "use for general tasks" descriptions | Cursor cannot route to the subagent reliably |
 
-*Source: docs/cursor/subagents/subagents-guide.md (anti-patterns to avoid)*
 
 ---
 
@@ -69,7 +65,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | `readonly` value is missing or `false` for an analysis subagent | Inspect the `readonly` value; analysis subagents must be `true` |
 | Instructions tell the subagent to spawn other subagents | Search the prompt body for nested-launch language; project convention restricts this |
 
-*Source: docs/cursor/subagents/subagents-guide.md (configuration fields, best practices); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -84,7 +79,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Description specific enough for routing? | Triggers specified ("Use when...", "Use after...") | Generic description; poor delegation |
 | Context isolation justified? | Subagent prevents context pollution | Subagent used when a slash command works |
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices)*
 
 ---
 
@@ -99,7 +93,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Context Isolation | Subagent use justified; prevents pollution | Questionable necessity | Duplicates inline capability |
 | **Overall** | | | |
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices, anti-patterns)*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
@@ -1,7 +1,6 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Cursor subagent definitions.
-Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -20,15 +19,15 @@ Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-r
 
 Any subagent violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | Cursor subagents documentation (file format) |
-| `name` field | Lowercase letters and hyphens; ≤64 characters | Cursor subagents documentation (configuration fields) |
-| `description` field | Present, non-empty, ≤1024 characters | Cursor subagents documentation (configuration fields) |
-| `model` field | Exactly `inherit` | ADR-0002 product-strict frontmatter contract |
-| `readonly` field | Exactly `true` | ADR-0002 product-strict frontmatter contract |
-| Frontmatter key set | Exactly the four allowed keys — `name`, `description`, `model`, `readonly` | ADR-0002 product-strict frontmatter contract |
-| System prompt | Not empty; task-specific | Cursor subagents documentation (best practices) |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens; ≤64 characters |
+| `description` field | Present, non-empty, ≤1024 characters |
+| `model` field | Exactly `inherit` |
+| `readonly` field | Exactly `true` |
+| Frontmatter key set | Exactly the four allowed keys — `name`, `description`, `model`, `readonly` |
+| System prompt | Not empty; task-specific |
 
 ---
 
@@ -140,7 +139,6 @@ The subagent body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
@@ -9,6 +9,7 @@ Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-r
 
 - Hard limits (auto-fail)
 - Allowed frontmatter contract (rejection rules with examples)
+- Canonical Semantic-Tag Convention
 - Quality checks
 - If this is an IMPROVE operation
 - Validation loop instructions
@@ -79,31 +80,13 @@ Required fix: remove the turn-cap key entirely.
 
 A subagent whose `model` value is a literal model name or ID is REJECTED. The `model` value MUST be `inherit`.
 
-Example REJECTED frontmatter (literal alias):
+Example REJECTED `model` values — every one of these is rejected; only `inherit` passes:
 
 ```yaml
----
-name: example-evaluator
-description: "Evaluates things. Use when reviewing artifacts."
-model: sonnet
-readonly: true
----
-```
-
-Example REJECTED frontmatter (other literal aliases):
-
-```yaml
-model: opus
-```
-
-```yaml
-model: haiku
-```
-
-Example REJECTED frontmatter (full model ID prefix):
-
-```yaml
-model: claude-opus-4-6
+model: sonnet          # literal alias
+model: opus            # literal alias
+model: haiku           # literal alias
+model: claude-opus-4-6 # full model ID prefix
 ```
 
 Required fix: set the model value to `inherit`.
@@ -135,6 +118,32 @@ Required fix: remove the extra key.
 
 ---
 
+## Canonical Semantic-Tag Convention
+
+The subagent body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — deterministically.
+
+**Mandatory tags** (the subagent body MUST contain all of these): `<BEHAVIOUR>` (guidelines, posture), `<HARD_RULES>` (inviolable constraints), `<PROCESS>` (container for the ordered phases; MUST contain at least one `<PHASE>`), and `<PHASE id="N" name="X">` (one execution step inside `<PROCESS>`; `id=` mandatory on every `<PHASE>`).
+
+**Optional tags** (absence is silent — never a finding): `<TRIGGER>`, `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`. `<TRIGGER>` is OPTIONAL for subagents because they are spawned by skills, not user-invoked.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — neither a warn nor a hard-fail. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | A mandatory tag missing (`<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`); unbalanced tags; malformed attribute syntax (value missing quotes, stray `=`, unterminated quote) | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of `<TRIGGER>` or any other optional tag | No finding; proceed |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
+
+---
+
 ## Quality Checks (All must pass)
 
 - [ ] `description` is action-oriented and includes a specific "Use when..." trigger phrase for delegation routing.
@@ -148,6 +157,9 @@ Required fix: remove the extra key.
 - [ ] No instructions tell the subagent to spawn other subagents (project convention restricts nested launches).
 - [ ] System prompt is task-specific, not generic ("you are a helpful AI").
 - [ ] Prompt engineering strategy applied: role prompting, structured output, and confidence filtering per `prompt-engineering-strategies.md`. For evaluator-type subagents that mandate explicit evidence per finding, the evidence requirement satisfies the confidence-filtering criterion.
+- [ ] Canonical semantic tags present: `<BEHAVIOUR>`, `<HARD_RULES>`, and `<PROCESS>` containing one or more `<PHASE id="N" name="X">`.
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`.
+- [ ] YAML frontmatter untouched by the convention — the four-key contract (`name`, `description`, `model`, `readonly`) is unchanged.
 
 ---
 
@@ -170,10 +182,11 @@ Required fix: remove the extra key.
 
 Execute this loop for each generated or improved subagent:
 
-1. Evaluate the subagent against ALL criteria above.
+1. Evaluate the subagent against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers.
 2. For improve operations, verify each suggestion in the improvement plan has a WHY field citing a source document — no suggestion may lack a source reference.
-3. If ANY criterion fails: identify the specific failure, fix the subagent, restart evaluation.
-4. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
-5. Only proceed to writing the subagent when ALL criteria pass.
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the subagent, restart evaluation.
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix.
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user.
+6. Only proceed to writing the subagent when ALL hard-fail and quality criteria pass.
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits. The frontmatter contract is non-negotiable.

--- a/plugins/cursor-initializer/agents/file-evaluator.md
+++ b/plugins/cursor-initializer/agents/file-evaluator.md
@@ -24,17 +24,17 @@ You are a configuration-file quality specialist for the Cursor distribution. You
 
 ### Hard Limits
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Industry Research: configuration files lose attention beyond this budget |
-| Instruction count | ≤ 150-200 | Industry Research: frontier LLMs reliably follow ~150-200 instructions |
-| Contradictions across rules | 0 | Conflicting instructions cause the agent to choose arbitrarily |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines — configuration files lose attention beyond this budget |
+| Instruction count | ≤ 150-200 — frontier LLMs reliably follow ~150-200 instructions |
+| Contradictions across rules | 0 — conflicting instructions cause the agent to choose arbitrarily |
 
 ### Bloat Indicators
 
-| Indicator | Why It Is Bloat | Source |
-|-----------|-----------------|--------|
-| Directory or file structure listings | Industry Research (ETH "Evaluating AGENTS.md") found these "not effective at providing repository overview" |
+| Indicator | Why It Is Bloat |
+|-----------|-----------------|
+| Directory or file structure listings | "Not effective at providing repository overview" |
 | Standard language conventions | Already known from training data |
 | Vague instructions ("write clean code") | Not actionable; wastes attention budget |
 | Codebase overview paragraphs | Increases steps without improving navigation |

--- a/plugins/cursor-initializer/skills/improve-cursor/references/automation-migration-guide.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/automation-migration-guide.md
@@ -1,7 +1,6 @@
 # Automation Migration Guide
 
 Decision criteria for migrating instructions (including legacy AGENTS.md content the migration sub-flow processes) into on-demand `.cursor/rules/*.mdc` mechanisms.
-Source: context-aware-improve-optimization.prd.md, analysis-automate-workflow-with-hooks.md, analysis-skill-authoring-best-practices.md, analysis-how-claude-remembers-a-project.md.
 
 ---
 
@@ -18,7 +17,6 @@ Stop at the first match:
 7. Heavy, rare, or has side effects → skill (`disable-model-invocation: true`)
 8. None of the above → keep in current location; reassess next cycle
 
-*Source: context-aware-improve-optimization.prd.md lines 346-358*
 
 ---
 
@@ -33,7 +31,6 @@ Stop at the first match:
 - Duplicated across 2+ files → consolidate to single source
 - Version numbers / team names / release info → DELETE or replace with memory pointer
 
-*Source: analysis-evaluating-agents-paper.md lines 36-52, Industry Research*
 
 ---
 
@@ -50,7 +47,6 @@ Stop at the first match:
 
 Hook events: `preToolUse`, `postToolUse`, `postToolUseFailure`, `stop`, `sessionStart`, `beforeShellExecution`. Block by returning `{"decision": "block"}` from a `prompt` hook. `globs:` accepts string or array (e.g., `["src/**/*.ts", "!src/**/*.test.ts"]`).
 
-*Source: analysis-automate-workflow-with-hooks.md lines 21-130, 433-445*
 
 ---
 
@@ -73,4 +69,3 @@ Skills, path-scoped rules — plugin and standalone. Hooks, subagents — plugin
 
 Present token-impact estimates alongside migration recommendations.
 
-*Source: research-context-engineering-comprehensive.md, analysis-skill-authoring-best-practices.md lines 19-46*

--- a/plugins/cursor-initializer/skills/improve-cursor/references/context-optimization.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Token-budget and attention guidance for `.cursor/rules/*.mdc` and AGENTS.md files.
-Source: Industry Research — research-context-engineering-comprehensive.md.
 
 Hard limits live in `validation-criteria.md`. Bloated files cause the model to miss important instructions: if Cursor keeps doing something despite a rule against it, the file is probably too long. (Industry Research)
 
@@ -23,7 +22,6 @@ Place the most important instructions in the first 20% and last 20% of each file
 
 Apply the deletion test: "Would removing this cause the agent to make mistakes? If not, cut it." Full include/exclude categories: see `what-not-to-include.md`. **Specificity goldilocks**: ✅ "Use 2-space indentation"; "Run `npm test` before committing"; "API handlers live in `src/api/handlers/`". ❌ "Format code properly"; "Test your changes"; "Keep files organized".
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -31,7 +29,6 @@ Apply the deletion test: "Would removing this cause the agent to make mistakes? 
 
 Detect and remove: stale file paths (check existence; remove or update); contradictions (drop the weaker rule); over-specification (rules already followed; delete or convert to hook); failed-approach accumulation (defensive rules added after incidents); high-churn data (versions, file counts, team names — remove or replace with a pointer). Treat configuration files like code: review when things go wrong, prune regularly. (Industry Research)
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -39,4 +36,3 @@ Detect and remove: stale file paths (check existence; remove or update); contrad
 
 Move from always-consumed to on-demand: skills (description at start, body on invocation), path-scoped rules (load on file match), subdirectory configs (load when working there), domain docs in `docs/` (agent navigates when relevant). Maintain lightweight identifiers; load data into context at runtime. (Industry Research, Effective Context Engineering)
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 138-208, 451-461*

--- a/plugins/cursor-initializer/skills/improve-cursor/references/cursor-rules-system.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/cursor-rules-system.md
@@ -1,6 +1,6 @@
 # Cursor Rules System
 
-Reference for generating and evaluating `.cursor/rules/` files. Source: [cursor.com/docs/context/rules](https://cursor.com/docs/context/rules).
+Reference for generating and evaluating `.cursor/rules/` files.
 
 ## File Format
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/evaluation-criteria.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Evaluation Criteria
 
 Scoring rubric for assessing existing AGENTS.md files and `.cursor/rules/*` files before improvement. Used by IMPROVE skills only.
-Source: file-evaluator.md, research-context-engineering-comprehensive.md.
 
 The canonical Hard Limits Table, Bloat Indicators, Staleness Indicators, Progressive Disclosure Assessment, Quality Score Rubric, and Evaluation Output Template all live in `agents/file-evaluator.md` (the subagent that produces the structured evaluation report). The Migration Candidate Indicators table lives in `automation-migration-guide.md`. This file holds only the criteria specific to the IMPROVE workflow that aren't already covered by those references.
 
@@ -18,7 +17,6 @@ The canonical Hard Limits Table, Bloat Indicators, Staleness Indicators, Progres
 
 Goldilocks zone — ✅ specific and actionable: "Use 2-space indentation"; ❌ too vague: "Format code properly" (not verifiable); ❌ too specific: "File `src/auth/handlers.ts` handles JWT" (will go stale on a path reference). Standard-command-form examples like "Run `npm test`" are valid form but should still be excluded per `what-not-to-include.md` because the command is the language default.
 
-*Source: research-context-engineering-comprehensive.md lines 131-134*
 
 ---
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Where AGENTS.md and `.cursor/rules/*.mdc` content lives by load timing.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md.
 
 For anti-patterns (ball-of-mud growth, auto-generated init files, everything-in-one-file), see `what-not-to-include.md` § Common Traps. For validation thresholds, see `validation-criteria.md`.
 
@@ -13,7 +12,6 @@ Place content based on what's relevant when. **Root AGENTS.md** — relevant to 
 
 **Borderline tiebreaker (10–15 lines)**: when domain content falls between 10–15 lines, prefer extracting to a separate domain file if it applies to only one domain. Root brevity is more valuable than an additional file.
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -27,7 +25,6 @@ Generate root files with only: (1) one-sentence project description; (2) package
 
 **Root**: monorepo purpose, package navigation, shared tooling — never package-specific tech stacks. **Package**: package purpose, specific tech stack, package-specific conventions — never cross-repo decisions. The agent sees all merged files. In Cursor monorepos, use `.cursor/rules/*.mdc` with narrow `globs:` patterns; keep `alwaysApply: true` rules minimal.
 
-*Source: a-guide-to-agents.md; memory/how-claude-remembers-a-project.md lines 243-260; docs/cursor/rules-and-memory.md*
 
 ---
 
@@ -35,7 +32,6 @@ Generate root files with only: (1) one-sentence project description; (2) package
 
 Extract a section to a separate domain file when it has 3+ distinct rules AND spans 10+ lines, or when irrelevant to most work sessions. Prefer "For TypeScript conventions, see docs/TYPESCRIPT.md" over inlining. Workflows go to skills (agent invokes only when needed).
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ---
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/validation-criteria.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for improved and newly created `.cursor/rules/*.mdc` files, plus the AGENTS.md migration sub-flow output.
-Source: Industry Research (research-context-engineering-comprehensive.md), file-evaluator.md.
 
 ---
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
@@ -1,7 +1,6 @@
 # What NOT to Include
 
 Exclusion guide for AGENTS.md and `.cursor/rules/*.mdc`.
-Sources: Industry Research (ETH "Evaluating context files", a-guide-to-agents.md, hooks/automate-workflow-with-hooks.md).
 
 ---
 
@@ -9,7 +8,6 @@ Sources: Industry Research (ETH "Evaluating context files", a-guide-to-agents.md
 
 Exclude: directory/file structure listings (static lists go stale — ETH); standard language conventions (already in training data); codebase overview paragraphs (increase exploration steps without improving navigation — ETH); vague guidance ("write clean code"); file path references (paths churn and poison context); everything in one file (exceeds ~150-200 instruction attention budget); obvious tooling ("use git for version control"); duplicated information across files; version numbers / release names (high-churn); long explanations or tutorials; detailed API documentation (link out); anything inferable from code; hook-enforced behaviors (formatting, file blocking, notifications) — migrate to a hook.
 
-*Source: Industry Research — research-context-engineering-comprehensive.md:113-121; ETH Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/context-optimization.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Evidence-based instructions for managing token budgets and attention in `.cursor/rules/*.mdc` files.
-Source: Industry Research — research-context-engineering-comprehensive.md
 
 ---
 
@@ -13,17 +12,16 @@ Source: Industry Research — research-context-engineering-comprehensive.md
 - Quality over quantity checklist (include/exclude decision table)
 - Context poisoning vectors (detection and removal)
 - JIT documentation patterns (on-demand loading strategies)
-- Key citations
 
 ---
 
 ## Hard Limits
 
-| Limit | Value | Source |
-|-------|-------|--------|
-| Lines per rule file | ≤ 200 | Industry Research: 200-line target for configuration files in this toolkit |
-| Instructions per file | ≤ 150-200 | Industry Research: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
-| Contradictions between files | 0 | Industry Research: conflicting instructions make the model choose inconsistently. |
+| Limit | Value |
+|-------|-------|
+| Lines per rule file | ≤ 200 — 200-line target for configuration files in this toolkit |
+| Instructions per file | ≤ 150-200 — "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
+| Contradictions between files | 0 — conflicting instructions make the model choose inconsistently. |
 
 > Industry Research generalizes here: bloated configuration files cause the model to miss important instructions.
 > — Industry Research
@@ -79,7 +77,6 @@ For each instruction line, ask: **"Would removing this cause the agent to make m
 - ✅ "Run `npm test` before committing" vs. ❌ "Test your changes"
 - ✅ "API handlers live in `src/api/handlers/`" vs. ❌ "Keep files organized"
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -97,7 +94,6 @@ Detect and remove these before generating or improving rule files:
 
 > Treat configuration files like code: review them when things go wrong, prune them regularly. — Industry Research
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -115,17 +111,6 @@ Use these patterns to move content from always-consumed to on-demand locations:
 > "Rather than pre-processing all relevant data up front, agents maintain lightweight identifiers and use these references to dynamically load data into context at runtime."
 > — Industry Research, Effective Context Engineering
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 138-208, 451-461*
 
 ---
 
-## Key Citations
-
-| Claim | Source |
-|-------|--------|
-| ≤200 lines per file | Industry Research (Agent Skills Standard) |
-| ~150-200 instruction limit | Industry Research (HumanLayer) |
-| n² attention constraint / context rot | Industry Research (Effective Context Engineering) |
-| Lost-in-the-middle effect | Industry Research, Liu et al., arXiv:2307.03172 |
-| Quality over quantity heuristic | Industry Research |
-| JIT documentation strategy | Industry Research, Effective Context Engineering |

--- a/plugins/cursor-initializer/skills/init-cursor/references/cursor-rules-system.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/cursor-rules-system.md
@@ -1,6 +1,6 @@
 # Cursor Rules System
 
-Reference for generating and evaluating `.cursor/rules/` files. Source: Cursor official documentation ([cursor.com/docs/context/rules](https://cursor.com/docs/context/rules)).
+Reference for generating and evaluating `.cursor/rules/` files.
 
 ## File Format
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring `.cursor/rules/*.mdc` hierarchies in Cursor.
-Sources: Industry Research (a-guide-to-agents.md, research-context-engineering-comprehensive.md)
 
 ---
 
@@ -31,7 +30,6 @@ When deciding where content belongs, use this table:
 
 **Borderline tiebreaker (10–15 lines):** When content falls between 10–15 lines, prefer extracting it to a separate `description:`-mode rule if it applies to only one topic. Always-loaded rule brevity is more valuable than the small cost of an additional rule.
 
-*Source: Industry Research — a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -64,7 +62,6 @@ In monorepos, prefer narrow `globs:`-mode rules scoped to package paths over bro
 
 **Monorepo context scoping in Cursor**: In large monorepos, use `.cursor/rules/*.mdc` with narrow `globs:` patterns to limit rules to relevant packages. Rules with `alwaysApply: true` load for every request — keep them minimal.
 
-*Source: Industry Research — memory/how-claude-remembers-a-project.md lines 243-260*
 
 ---
 
@@ -86,7 +83,6 @@ Always use const instead of let. Never use var...
 
 **Use skills for workflows** — agents invoke skills only when needed, keeping base context minimal.
 
-*Source: Industry Research — a-guide-to-agents.md lines 110-163*
 
 ---
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/validation-criteria.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated `.cursor/rules/*.mdc` files.
-Source: Industry Research (research-context-engineering-comprehensive.md), file-evaluator.md
 
 ---
 
@@ -9,13 +8,13 @@ Source: Industry Research (research-context-engineering-comprehensive.md), file-
 
 Any rule file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule file length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
-| Instruction count | ≤ 150-200 | Industry Research: "~150-200 instructions with reasonable consistency" |
-| Contradictions between rules | 0 | Industry Research: conflicting instructions make the model choose inconsistently |
-| Stale file path references | 0 | Industry Research: "File paths change constantly... actively poisons context" |
-| Invalid `.mdc` frontmatter fields | 0 | Only `description`, `alwaysApply`, `globs` are valid |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule file length | ≤ 200 lines — 200-line target for configuration files in this toolkit |
+| Instruction count | ≤ 150-200 — "~150-200 instructions with reasonable consistency" |
+| Contradictions between rules | 0 — conflicting instructions make the model choose inconsistently |
+| Stale file path references | 0 — "File paths change constantly... actively poisons context" |
+| Invalid `.mdc` frontmatter fields | 0 — only `description`, `alwaysApply`, `globs` are valid |
 
 ---
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
@@ -1,29 +1,27 @@
 # What NOT to Include
 
 Evidence-based exclusion table for `.cursor/rules/*.mdc` content.
-Sources: Industry Research (ETH "Evaluating context files", a-guide-to-agents.md, hooks/automate-workflow-with-hooks.md)
 
 ---
 
 ## Exclusion Evidence Table
 
-| Content Type | Why to Exclude | Evidence Quote | Source |
-|-------------|----------------|---------------|--------|
-| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" | Industry Research (ETH) |
-| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" | Industry Research |
-| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" | Industry Research (ETH) |
-| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | Industry Research (a-guide-to-agents.md) |
-| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | Industry Research |
-| Everything in one rule (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | Industry Research |
-| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | Agent already does this correctly without extra instruction | Industry Research |
-| Duplicated information across rules | Consumes tokens on every applicable conversation; creates contradiction risk | "Wastes tokens on every request" | Industry Research |
-| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Industry Research |
-| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Industry Research |
-| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Industry Research |
-| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | Anything the agent can infer by reading code should stay out of configuration files | Industry Research |
-| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; rule instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | Hooks provide deterministic control over agent behavior instead of repeated context instructions | Industry Research (Hooks Guide) |
+| Content Type | Why to Exclude | Evidence Quote |
+|-------------|----------------|----------------|
+| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" |
+| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" |
+| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" |
+| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" |
+| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" |
+| Everything in one rule (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | Agent already does this correctly without extra instruction |
+| Duplicated information across rules | Consumes tokens on every applicable conversation; creates contradiction risk | "Wastes tokens on every request" |
+| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) |
+| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column |
+| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | Anything the agent can infer by reading code should stay out of configuration files |
+| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; rule instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | Hooks provide deterministic control over agent behavior instead of repeated context instructions |
 
-*Source: Industry Research — research-context-engineering-comprehensive.md:113-121; ETH Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -7,81 +7,116 @@ description: "Creates new SKILL.md files with references, templates, and frontma
 
 Generates a new SKILL.md file with supporting references and templates, grounded in the docs corpus and project conventions.
 
-## Behavioral Guidelines
+<TRIGGER when="creating a new skill from scratch" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
-- **NEVER** create skills that explain what Claude already knows (language syntax, obvious conventions)
+<HARD_RULES priority="hard">
+- **NEVER** create skills that explain what the agent already knows (language syntax, obvious conventions)
 - **NEVER** inline reference content in SKILL.md body — use the `references/` subdirectory
 - **NEVER** exceed 500 lines in the SKILL.md body
 - **EVERY** reference file must be ≤ 200 lines with source attribution
 - **EVERY** skill must use relative `references/` paths for all bundled file references (not hardcoded absolute paths)
 - **EVERY** skill description must be third-person and include a "Use when..." trigger phrase
 - **EVERY** generated skill must preserve the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** generated SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** new skill whose output is a human-rich agent-executable artifact (plan, PRD, spec, report, prototype, code-review writeup, custom editor) MUST default to an HTML output template — unless the user explicitly says "generate as markdown" (or equivalent), in which case that override always wins
+- **NEVER** default to HTML for agent-loaded or tooling-locked artifacts (`SKILL.md`, `AGENTS.md`, `README.md`, `CONTEXT.md`, ADR files, commit messages, PR bodies, GitHub issues, code comments) — these are Markdown-mandatory regardless of user request phrasing
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="name-collision-check">
+  Check if a skill with the same name already exists at:
 
-Check if a skill with the same name already exists at:
+  - `skills/{requested-name}/SKILL.md`
 
-- `.claude/skills/{requested-name}/SKILL.md`
-- `plugins/*/skills/{requested-name}/SKILL.md`
+  **If a skill already exists:**
 
-**If a skill already exists at either location:**
+  1. Inform the user: "A skill named `{requested-name}` already exists."
+  2. Suggest using `improve-skill` to evaluate and optimize it instead.
+  3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
 
-1. Inform the user: "A skill named `{requested-name}` already exists."
-2. Suggest using the `improve-skill` skill to evaluate and optimize it instead.
-3. **STOP** — do not proceed. The user should either choose a different name or use the improve skill.
+  **If no skill exists with that name:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If no skill exists with that name:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Read `references/artifact-analyzer.md` and follow its analysis instructions to analyze the project at the current working directory.
 
-### Phase 1: Codebase Analysis
+  Focus on: existing skill directory structure, naming patterns, and any skill that is similar to `{requested-name}` in purpose. Also identify the project layout: whether this is a monorepo with multiple service packages or a single-package project, and report any service directory paths for use in scope resolution.
+  </PHASE>
 
-Read `references/artifact-analyzer.md` and follow its analysis instructions to analyze the project at the current working directory.
+  <PHASE id="2" name="generate-skill">
+  **Load context.** Read these references:
 
-Focus on: existing skill directory structure, naming patterns, and any skill that is similar to `{requested-name}` in purpose.
+  - `references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
+  - `references/skill-format-reference.md` — frontmatter fields, name validation, string substitution variables
 
-### Phase 2: Generate Skill
+  Decide skill structure: phases, reference file names, and whether `assets/templates/` is needed.
 
-Before generating, read these reference documents:
+  **Classify output artifact format.** Read `references/artifact-format-routing.md` and apply its routing table to the new skill being generated:
 
-- `references/skill-authoring-guide.md` — core principles, structure rules, progressive disclosure, anti-patterns
-- `references/skill-format-reference.md` — frontmatter fields, name validation, string substitution variables
-- `references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
-- `references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
+  1. Identify what kind of artifact the new skill will produce (plan/PRD/spec/report/prototype vs. SKILL.md/AGENTS.md/README/etc.).
+  2. Apply the routing table: human-rich agent-executable artifacts default to **HTML**; agent-loaded and tooling-locked artifacts are **Markdown-mandatory**.
+  3. Check for explicit override: if the user said "generate as markdown" (or equivalent), that override wins regardless of artifact type.
+  4. If the verdict is **HTML**: copy `assets/templates/html-artifact-skeleton.html` into the new skill's `assets/templates/` directory (rename to match the artifact type). The new skill must instruct its generation phase to populate the canonical semantic tags inside the HTML `<body>`.
+  5. If the verdict is **Markdown**: use `assets/templates/skill-md.md` or a Markdown template appropriate to the artifact type.
 
-Read `assets/templates/skill-md.md` and fill its placeholders using:
+  **Apply patterns.** Read these references:
 
-- User requirements for the new skill
-- Phase 1 analysis output (naming conventions, existing patterns)
-- Evidence from the reference files above
+  - `references/behavioral-guidelines.md` — behavior and safe persuasion patterns for skills
+  - `references/prompt-engineering-strategies.md` — per-artifact prompting strategies for skills
 
-Generate the complete skill directory structure:
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-format-reference.md
+  - artifact-format-routing.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-1. `SKILL.md` — primary skill file with frontmatter and phase definitions
-2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
-3. `assets/templates/` — create stub template files if the skill generates output files
+  Read the chosen output template (HTML skeleton or `skill-md.md`) and fill its placeholders using:
 
-### Phase 3: Self-Validation
+  - User requirements for the new skill
+  - Phase 1 analysis output (naming conventions, existing patterns)
+  - Evidence from the reference files above
 
-Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
+  If Phase 1 detects a monorepo or multi-service layout, make the generated phases name the target service, package, or workspace explicitly and use project-relative paths or globs for that scope.
 
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  Generate the complete skill directory structure:
 
-### Phase 4: Present and Write
+  1. `SKILL.md` — primary skill file with frontmatter and a body carrying the canonical semantic-tag vocabulary
+  2. `references/` — create only reference files that include initial source attribution sections (no empty stubs without attribution)
+  3. `assets/templates/` — create the appropriate output template (HTML or Markdown per the routing verdict); for validator-type skills that only report findings, `assets/templates/` may be omitted
+  </PHASE>
 
-1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates)
-2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
-3. Ask for confirmation before writing any files
-4. On approval, write all files to the target location
+  <PHASE id="3" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
+
+  If Phase 1 detected a monorepo or multi-service layout, add one extra validation pass: confirm the generated phases name the target service, package, or workspace explicitly.
+
+  The loop evaluates all hard limits, quality checks, and canonical semantic-tag strictness tiers — fixes any failures, and re-evaluates: maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
+
+  <PHASE id="4" name="present-and-write">
+  1. Show the user the complete generated skill directory (SKILL.md + any stub references/templates)
+  2. Cite the evidence from reference files that informed key decisions (frontmatter choices, phase structure, reference selections)
+  3. Ask for confirmation before writing any files
+  4. On approval, write all files to the target location
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md` and loop the generated skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/skills/create-skill/assets/fixtures/MANIFEST.md
+++ b/skills/create-skill/assets/fixtures/MANIFEST.md
@@ -1,0 +1,27 @@
+# Fixture Corpus — Skill Body Convention
+
+Regression corpus for the canonical semantic-tag strictness tiers defined in
+`references/skill-validation-criteria.md` ("Canonical Semantic-Tag Convention"
+section). Each fixture is a minimal SKILL.md body that exercises exactly one
+validation outcome.
+
+To use: run the validation loop from `references/skill-validation-criteria.md` against each
+fixture file and confirm the produced verdict matches the **Expected verdict**
+column below. Any mismatch means the strictness-tier text is ambiguous and must
+be tightened — the corpus is the regression test for that clarity.
+
+These fixtures are test data, not real skills. They are not loaded by the
+`create-skill` skill at runtime.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes only | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** — missing mandatory tag |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** — missing mandatory tag |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** — missing mandatory tag |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** — missing mandatory tag |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** — missing mandatory tag |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** — unbalanced tags |
+| `malformed-attribute.md` | `<PHASE>` `name` value missing its quotes | **hard-fail** — malformed attribute syntax |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a non-canonical `mood=` attribute | **warn** — non-canonical attribute name; passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** — alias satisfies the `<HARD_RULES>` check |

--- a/skills/create-skill/assets/fixtures/compliant-baseline.md
+++ b/skills/create-skill/assets/fixtures/compliant-baseline.md
@@ -1,0 +1,39 @@
+---
+name: fixture-compliant-baseline
+description: "Fixture skill exercising the compliant baseline. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. All mandatory tags present, balanced, canonical attributes only. -->
+
+# Fixture Compliant Baseline
+
+One-sentence purpose statement for the baseline fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION>
+Read the validation criteria and loop until all checks pass.
+</VALIDATION>

--- a/skills/create-skill/assets/fixtures/malformed-attribute.md
+++ b/skills/create-skill/assets/fixtures/malformed-attribute.md
@@ -1,0 +1,35 @@
+---
+name: fixture-malformed-attribute
+description: "Fixture skill with a malformed PHASE attribute. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The <PHASE> name attribute value is missing its quotes. -->
+
+# Fixture Malformed Attribute
+
+One-sentence purpose statement for the malformed-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name=analysis>
+  DEFECT: the name attribute value above is unquoted — malformed attribute syntax.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/missing-behaviour.md
+++ b/skills/create-skill/assets/fixtures/missing-behaviour.md
@@ -1,0 +1,28 @@
+---
+name: fixture-missing-behaviour
+description: "Fixture skill with the mandatory BEHAVIOUR tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <BEHAVIOUR> tag is absent. -->
+
+# Fixture Missing Behaviour
+
+One-sentence purpose statement for the missing-behaviour fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/missing-hard-rules.md
+++ b/skills/create-skill/assets/fixtures/missing-hard-rules.md
@@ -1,0 +1,30 @@
+---
+name: fixture-missing-hard-rules
+description: "Fixture skill with the mandatory HARD_RULES tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. Both <HARD_RULES> and its <RULES> alias are absent. -->
+
+# Fixture Missing Hard Rules
+
+One-sentence purpose statement for the missing-hard-rules fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/missing-phase.md
+++ b/skills/create-skill/assets/fixtures/missing-phase.md
@@ -1,0 +1,27 @@
+---
+name: fixture-missing-phase
+description: "Fixture skill whose PROCESS contains zero PHASE elements. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is present but contains zero <PHASE> elements. -->
+
+# Fixture Missing Phase
+
+One-sentence purpose statement for the missing-phase fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+The process container holds no phases — this is the defect under test.
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/missing-process.md
+++ b/skills/create-skill/assets/fixtures/missing-process.md
@@ -1,0 +1,23 @@
+---
+name: fixture-missing-process
+description: "Fixture skill with the mandatory PROCESS tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <PROCESS> tag is absent. -->
+
+# Fixture Missing Process
+
+One-sentence purpose statement for the missing-process fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>

--- a/skills/create-skill/assets/fixtures/missing-trigger.md
+++ b/skills/create-skill/assets/fixtures/missing-trigger.md
@@ -1,0 +1,33 @@
+---
+name: fixture-missing-trigger
+description: "Fixture skill with the mandatory TRIGGER tag absent. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. The mandatory <TRIGGER> tag is absent. -->
+
+# Fixture Missing Trigger
+
+One-sentence purpose statement for the missing-trigger fixture.
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/non-canonical-attribute.md
+++ b/skills/create-skill/assets/fixtures/non-canonical-attribute.md
@@ -1,0 +1,36 @@
+---
+name: fixture-non-canonical-attribute
+description: "Fixture skill with a non-canonical attribute name. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: warn. <BEHAVIOUR> carries a non-canonical `mood=` attribute; all mandatory tags are present and balanced, so it passes otherwise. -->
+
+# Fixture Non-Canonical Attribute
+
+One-sentence purpose statement for the non-canonical-attribute fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical"
+  mood="optimistic">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/rules-alias.md
+++ b/skills/create-skill/assets/fixtures/rules-alias.md
@@ -1,0 +1,35 @@
+---
+name: fixture-rules-alias
+description: "Fixture skill using the legacy RULES alias instead of HARD_RULES. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: pass. Uses the legacy <RULES> tag, which is an accepted alias of <HARD_RULES>; all else compliant. -->
+
+# Fixture Rules Alias
+
+One-sentence purpose statement for the rules-alias fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<RULES>
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+</PROCESS>

--- a/skills/create-skill/assets/fixtures/unbalanced-tag.md
+++ b/skills/create-skill/assets/fixtures/unbalanced-tag.md
@@ -1,0 +1,35 @@
+---
+name: fixture-unbalanced-tag
+description: "Fixture skill with an unbalanced PROCESS tag. Use when validating the canonical semantic-tag convention."
+---
+<!-- FIXTURE — expected verdict: hard-fail. <PROCESS> is opened but never closed. -->
+
+# Fixture Unbalanced Tag
+
+One-sentence purpose statement for the unbalanced-tag fixture.
+
+<TRIGGER when="validating the canonical semantic-tag convention" />
+
+<BEHAVIOUR
+  avoid="acting before surfacing assumptions"
+  always="keep changes surgical">
+- Surface assumptions first.
+- Prefer the simplest path.
+</BEHAVIOUR>
+
+<HARD_RULES priority="hard">
+- NEVER inline reference content in the SKILL.md body.
+- EVERY skill body stays under 500 lines.
+</HARD_RULES>
+
+<PROCESS>
+
+  <PHASE id="1" name="analysis">
+  Read references/artifact-analyzer.md and follow its analysis instructions.
+  </PHASE>
+
+  <PHASE id="2" name="generate">
+  Read the template, fill the placeholders, generate the directory structure.
+  </PHASE>
+
+<!-- DEFECT: the <PROCESS> opening tag above has no matching </PROCESS> closing tag. -->

--- a/skills/create-skill/assets/templates/html-artifact-skeleton.html
+++ b/skills/create-skill/assets/templates/html-artifact-skeleton.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{artifact-title}}</title>
+  <style>
+    :root {
+      --color-text:          #1f2937;
+      --color-text-muted:    #4b5563;
+      --color-text-strong:   #111827;
+      --color-bg:            #ffffff;
+      --color-border:        #e5e7eb;
+      --color-code-bg:       #f3f4f6;
+
+      --color-trigger-text:  #374151;
+
+      --color-behaviour-bg:  #f0f4ff;
+      --color-behaviour-bar: #2563eb;
+
+      --color-hardrules-bg:  #fef2f2;
+      --color-hardrules-bar: #dc2626;
+
+      --color-phase-bg:      #fafafa;
+      --color-phase-label:   #111827;
+
+      --color-antipattern-bg:  #fffbeb;
+      --color-antipattern-bar: #d97706;
+
+      --color-output-bg:  #f0fdf4;
+      --color-output-bar: #16a34a;
+
+      --color-validation-bg:  #f5f3ff;
+      --color-validation-bar: #7c3aed;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --color-text:          #e5e7eb;
+        --color-text-muted:    #9ca3af;
+        --color-text-strong:   #f9fafb;
+        --color-bg:            #111827;
+        --color-border:        #374151;
+        --color-code-bg:       #1f2937;
+
+        --color-trigger-text:  #d1d5db;
+
+        --color-behaviour-bg:  #1e2a4a;
+        --color-behaviour-bar: #3b82f6;
+
+        --color-hardrules-bg:  #2d1515;
+        --color-hardrules-bar: #ef4444;
+
+        --color-phase-bg:      #1f2937;
+        --color-phase-label:   #f9fafb;
+
+        --color-antipattern-bg:  #2d2209;
+        --color-antipattern-bar: #f59e0b;
+
+        --color-output-bg:  #052e16;
+        --color-output-bar: #22c55e;
+
+        --color-validation-bg:  #1e1533;
+        --color-validation-bar: #a78bfa;
+      }
+    }
+
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 900px;
+      margin: 2rem auto;
+      padding: 1rem;
+      line-height: 1.6;
+      color: var(--color-text);
+      background: var(--color-bg);
+    }
+
+    BEHAVIOUR, HARD_RULES, PROCESS, PHASE, PREFLIGHT, REFERENCES,
+    EXAMPLE, ANTI_PATTERN, OUTPUT, VALIDATION, TRIGGER {
+      display: block;
+      margin: 1rem 0;
+    }
+
+    TRIGGER {
+      font-style: italic;
+      color: var(--color-trigger-text);
+    }
+
+    BEHAVIOUR {
+      background: var(--color-behaviour-bg);
+      border-left: 4px solid var(--color-behaviour-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    HARD_RULES[priority="hard"] {
+      background: var(--color-hardrules-bg);
+      border-left: 4px solid var(--color-hardrules-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    PROCESS {
+      border-top: 1px solid var(--color-border);
+      padding-top: 1rem;
+    }
+
+    PHASE {
+      background: var(--color-phase-bg);
+      border: 1px solid var(--color-border);
+      padding: 1rem;
+      margin: 0.5rem 0;
+      border-radius: 4px;
+    }
+
+    PHASE::before {
+      content: "Phase " attr(id) " — " attr(name);
+      display: block;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: var(--color-phase-label);
+    }
+
+    ANTI_PATTERN {
+      background: var(--color-antipattern-bg);
+      border-left: 4px solid var(--color-antipattern-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    OUTPUT {
+      background: var(--color-output-bg);
+      border-left: 4px solid var(--color-output-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    VALIDATION {
+      background: var(--color-validation-bg);
+      border-left: 4px solid var(--color-validation-bar);
+      padding: 1rem;
+      border-radius: 4px;
+    }
+
+    code, pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      background: var(--color-code-bg);
+      padding: 0.125rem 0.25rem;
+      border-radius: 3px;
+    }
+
+    pre {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>{{artifact-title}}</h1>
+    <TRIGGER when="...">...</TRIGGER>
+    <BEHAVIOUR avoid="..." always="...">...</BEHAVIOUR>
+    <HARD_RULES priority="hard">...</HARD_RULES>
+    <PROCESS>
+      <PHASE id="1" name="...">...</PHASE>
+    </PROCESS>
+    <OUTPUT format="...">...</OUTPUT>
+    <VALIDATION>...</VALIDATION>
+  </main>
+</body>
+</html>

--- a/skills/create-skill/assets/templates/skill-md.md
+++ b/skills/create-skill/assets/templates/skill-md.md
@@ -3,49 +3,70 @@ name: [skill-name-kebab-case]
 description: "[What this skill does and when to use it. Third person.]"
 ---
 <!-- TEMPLATE: SKILL.md Entry Point
-     Placement: .claude/skills/[skill-name]/SKILL.md or plugins/[plugin]/skills/[skill-name]/SKILL.md
+     Placement: skills/[skill-name]/SKILL.md
      Rule: name ≤ 64 chars, lowercase letters/numbers/hyphens only
      Rule: description ≤ 1024 chars, third person, no XML tags
      Rule: Body under 500 lines
-     Rule: Use references/ for evidence-based guidance
-     Rule: Use assets/templates/ for output templates
+     Rule: Use relative references/ paths for evidence-based guidance
+     Rule: Use relative assets/templates/ paths for output templates
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name the target service/workspace explicitly
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory: <TRIGGER>, <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
+           Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
+           Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: YAML frontmatter is untouched — do NOT duplicate the <TRIGGER> cue into description
+     Rule: Standalone skills MUST NOT author hooks, subagents, path-scoped rules, or CLAUDE.md hierarchy
 -->
 
 # [Skill Title]
 
 [One-sentence purpose statement]
 
-## Behavioral Guidelines
+<TRIGGER when="[plain-language activation cue — mirror the 'Use when ...' phrase from the description]" />
 
+<BEHAVIOUR
+  avoid="make decisions without surfacing assumptions; add speculative scope"
+  always="surface assumptions first; keep changes surgical">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - [Critical constraint 1]
 - [Critical constraint 2]
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
-<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  <PREFLIGHT name="artifact-collision-check">
+  <!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  </PREFLIGHT>
 
-### Phase 1: [Analysis Phase Name]
-<!-- Inline analysis steps go here -->
+  <PHASE id="1" name="[analysis-phase-name]">
+  Read `references/artifact-analyzer.md` and follow its analysis instructions.
+  <!-- If monorepo, record the target service/workspace for use in subsequent phases -->
+  </PHASE>
 
-### Phase 2: [Generation Phase Name]
-<!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  <PHASE id="2" name="[generation-phase-name]">
+  <!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  </PHASE>
 
-### Phase 3: Self-Validation
-<!-- Read references/[type]-validation-criteria.md -->
+  <PHASE id="3" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
+  Maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-### Phase 4: Present and Write
-<!-- Show artifact with evidence citations, write on approval -->
+  <PHASE id="4" name="present-and-write">
+  Show artifact with evidence citations. Ask for confirmation. Write on approval.
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md`, loop until all hard limits, quality checks, and canonical semantic-tag strictness tiers pass.
+</VALIDATION>

--- a/skills/create-skill/references/artifact-analyzer.md
+++ b/skills/create-skill/references/artifact-analyzer.md
@@ -1,7 +1,6 @@
 # Artifact Analysis Instructions
 Structured process for inventorying existing Agent Skills artifacts and conventions.
 Used by CREATE and IMPROVE skills for codebase context analysis.
-Source: agents/artifact-analyzer.md
 ---
 
 ## Contents

--- a/skills/create-skill/references/artifact-format-routing.md
+++ b/skills/create-skill/references/artifact-format-routing.md
@@ -1,0 +1,110 @@
+# Artifact Format Routing
+
+Evidence-based routing rule for deciding whether a skill's generated output artifact
+should default to HTML or Markdown.
+Source: Skill body convention (canonical tag vocabulary), HTML artifact effectiveness research
+
+---
+
+## Routing Table
+
+When `create-skill` generates a new skill, the new skill's output format is
+determined by the artifact kind that new skill produces:
+
+| Artifact kind                                  | Default format | Reason                                            |
+| ---------------------------------------------- | -------------- | ------------------------------------------------- |
+| Plan, PRD, design spec                         | HTML           | Human-rich + agent-executable                     |
+| Report (weekly status, research, explainer)    | HTML           | Human-rich + agent-executable                     |
+| Prototype, custom editor, code-review writeup  | HTML           | Interactivity benefits from HTML                  |
+| `SKILL.md`                                     | Markdown       | Agent-loaded; spec-mandated                       |
+| `AGENTS.md`                                    | Markdown       | Agent-loaded; spec-mandated                       |
+| `README.md`                                    | Markdown       | Tooling-locked (npm/GitHub renderers)             |
+| `CONTEXT.md`                                   | Markdown       | Tooling-locked (agent context readers)            |
+| ADR files (`*.md` in `docs/adr/`)              | Markdown       | Tooling-locked (ADR convention)                   |
+| Commit message, PR body, GitHub issue          | Markdown       | Tooling-locked (GitHub renderers)                 |
+| Code comments                                  | Markdown-ish   | Tooling-locked (compiler/linter parses)           |
+
+Explicit user override (`generate as markdown`) always wins over the default.
+
+---
+
+## How to classify
+
+During the generation phase, before choosing the output template:
+
+1. **Identify the output artifact kind** — ask: "What does this new skill produce?
+   A plan/PRD/spec/report? Or a platform config file (SKILL.md, README, ADR)?"
+
+2. **Apply the routing table above.** The left column describes the artifact kind;
+   the Default format column gives the verdict.
+
+3. **Check for explicit override.** If the user said "generate as markdown" (or
+   equivalent phrasing like "output markdown", "use .md", "markdown format"), the
+   override wins regardless of the routing table verdict.
+
+4. **Act on the verdict:**
+   - **HTML default** → use `assets/templates/html-artifact-skeleton.html`
+     as the output template for the new skill. Instruct the new skill to carry the
+     canonical semantic tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>`
+     with one or more `<PHASE id name>`, plus relevant optional tags `<OUTPUT>`,
+     `<VALIDATION>`) inside the HTML `<body>`. Copy the skeleton into
+     the new skill's `assets/templates/` directory.
+   - **Markdown default** → use the standard `assets/templates/skill-md.md`
+     template (or a Markdown template appropriate to the artifact type).
+   - **Explicit override** → apply the user's stated format regardless of the table.
+
+---
+
+## HTML skeleton location
+
+The HTML baseline skeleton lives at:
+
+```
+assets/templates/html-artifact-skeleton.html
+```
+
+It is a valid HTML5 document with:
+- `<meta charset>` and `<meta name="viewport">`
+- Scoped CSS targeting each semantic tag (`BEHAVIOUR`, `HARD_RULES`, `PHASE`, `OUTPUT`,
+  `VALIDATION`, `ANTI_PATTERN`, etc.) with adaptive colors (light and dark mode via
+  CSS custom properties and `@media (prefers-color-scheme: dark)`)
+- Placeholder `{{artifact-title}}` in `<title>` and `<h1>`
+- A `<main>` block containing the canonical semantic-tag scaffold
+
+When generating a new HTML-defaulting skill, copy this skeleton into the new skill's
+`assets/templates/` directory (e.g., as `<artifact-type>.html`). Replace
+`{{artifact-title}}` with the artifact name appropriate to the new skill.
+
+---
+
+## Canonical semantic tags in HTML artifacts
+
+Generated HTML artifacts MUST carry the canonical semantic tags inside the HTML body.
+The same vocabulary that governs `SKILL.md` bodies applies:
+
+**Mandatory tags (HTML artifact)**:
+- `<TRIGGER when="...">` — plain-language activation context
+- `<BEHAVIOUR avoid="..." always="...">` — behavioural guidelines
+- `<HARD_RULES priority="hard">` — inviolable constraints
+- `<PROCESS>` containing at least one `<PHASE id="N" name="...">` — ordered execution steps
+
+**Optional tags (HTML artifact)**:
+- `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`.
+
+These tags are valid HTML5 — browsers treat unknown elements as inline by default;
+the CSS in the skeleton promotes each to `display: block` with semantic styling.
+
+---
+
+## Why HTML for human-rich artifacts
+
+HTML artifacts serve two consumers: humans (CSS layout, diagrams, interactive controls)
+and the next agent session (parseable semantic-tag structure). The dual-consumer design
+is why HTML artifacts embed canonical semantic tags — the same parse target serves both.
+
+Markdown past ~100 lines stops being read; rich visualisations get faked with ASCII;
+HTML renders natively in any browser without extra tooling. For agent-loaded and
+tooling-locked files the tradeoffs reverse: spec compliance, diffability, and
+renderer compatibility make Markdown mandatory.

--- a/skills/create-skill/references/artifact-format-routing.md
+++ b/skills/create-skill/references/artifact-format-routing.md
@@ -2,7 +2,6 @@
 
 Evidence-based routing rule for deciding whether a skill's generated output artifact
 should default to HTML or Markdown.
-Source: Skill body convention (canonical tag vocabulary), HTML artifact effectiveness research
 
 ---
 

--- a/skills/create-skill/references/prompt-engineering-strategies.md
+++ b/skills/create-skill/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with Opus 4.6
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 | Contradictory instructions | Claude picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*

--- a/skills/create-skill/references/skill-authoring-guide.md
+++ b/skills/create-skill/references/skill-authoring-guide.md
@@ -1,7 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code skills (SKILL.md files).
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -50,7 +49,6 @@ Analogy: Claude as a robot on a path — narrow bridge (low freedom) vs. open fi
 | Sonnet | Clear and efficient? (balanced) |
 | Opus | Avoid over-explaining? (may need less) |
 
-*Source: skills/skill-authoring-best-practices.md lines 11-145*
 
 ---
 
@@ -82,7 +80,6 @@ my-skill/
 | `hooks` | No | Hooks scoped to this skill's lifecycle |
 | `argument-hint` | No | Autocomplete hint, e.g. `[issue-number]` |
 
-*Source: skills/extend-claude-with-skills.md lines 169-199*
 
 ---
 
@@ -98,7 +95,6 @@ my-skill/
 
 Include: (1) what it does, (2) when to use it, (3) specific trigger terms for matching.
 
-*Source: skills/skill-authoring-best-practices.md lines 168-250*
 
 ---
 
@@ -118,7 +114,6 @@ Load only the references needed for each phase, not all at once.
 
 Keep SKILL.md under 500 lines. Move detailed reference material to separate files. Reference supporting files explicitly so Claude knows what they contain.
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300; skills/extend-claude-with-skills.md lines 223-246*
 
 ---
 
@@ -132,7 +127,6 @@ Keep SKILL.md under 500 lines. Move detailed reference material to separate file
 
 Use `disable-model-invocation: true` for workflows with side effects (commit, deploy, send-message). Use `user-invocable: false` for background knowledge Claude should apply but users shouldn't invoke directly.
 
-*Source: skills/extend-claude-with-skills.md lines 248-283*
 
 ---
 
@@ -147,4 +141,3 @@ Use `disable-model-invocation: true` for workflows with side effects (commit, de
 | Over-explaining for Opus | Patronizing + token waste | Trust the model; provide minimal scaffolding |
 | Contradictions between phases | Claude picks one arbitrarily | Review all phases for consistency |
 
-*Source: skills/skill-authoring-best-practices.md lines 800-1100*

--- a/skills/create-skill/references/skill-format-reference.md
+++ b/skills/create-skill/references/skill-format-reference.md
@@ -1,7 +1,6 @@
 # Skill Format Reference
 
 Technical specification for SKILL.md format, directory structure, variables, and discovery.
-Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-skills.md
 
 ---
 
@@ -43,7 +42,6 @@ Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-
 - Must NOT contain reserved words: `anthropic`, `claude`
 - Must match the parent directory name
 
-*Source: skills/research-claude-code-skills-format.md lines 103-108*
 
 ---
 
@@ -69,7 +67,6 @@ Dynamic context injection with `!` prefix runs shell commands before skill loads
 - Current branch: !`git branch --show-current`
 ```
 
-*Source: skills/extend-claude-with-skills.md lines 201-210; skills/research-claude-code-skills-format.md lines 126-149*
 
 ---
 
@@ -94,7 +91,6 @@ my-skill/
 - `references/` files load only when skill phases explicitly read them
 - `scripts/` files are executed, not loaded into context
 
-*Source: skills/research-claude-code-skills-format.md lines 153-186; skills/extend-claude-with-skills.md lines 100-115*
 
 ---
 
@@ -108,7 +104,6 @@ my-skill/
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to `references/` subdirectory. Explicitly reference supporting files from SKILL.md so Claude knows what to load and when.
 
-*Source: skills/research-claude-code-skills-format.md lines 172-186*
 
 ---
 
@@ -123,4 +118,3 @@ Keep SKILL.md under **500 lines**. Move detailed reference material to `referenc
 
 Priority: enterprise > personal > project. Plugin skills use `plugin-name:skill-name` namespace — no conflicts.
 
-*Source: skills/extend-claude-with-skills.md lines 85-97; skills/research-claude-code-skills-format.md lines 189-200*

--- a/skills/create-skill/references/skill-validation-criteria.md
+++ b/skills/create-skill/references/skill-validation-criteria.md
@@ -1,7 +1,19 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md,
+karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical tag vocabulary)
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
@@ -12,36 +24,107 @@ Any skill violating these criteria must be fixed before proceeding:
 | Criterion | Threshold | Source |
 |-----------|-----------|--------|
 | SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
+| Reference files | ≤ 200 lines each | Reference files hard limit |
 | Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
 | `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
 | `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Contradictions between phases | 0 | Agent picks arbitrarily when contradictions exist |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
+*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X"); required for skills
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. Report it as a `<HARD_RULES>` alias candidate (informational), not as a violation. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+| **Informational** | Legacy `<RULES>` tag present — alias for `<HARD_RULES>` | Surface as alias candidate; do not fail or warn |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+### Structured violation report format
+
+When evaluating a target skill body, report every finding using this format:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+[HARD-FAIL] Missing mandatory tag: <TRIGGER> — required for skills
+[HARD-FAIL] Unbalanced tag: <PROCESS> opened at line 42, no closing tag found
+[HARD-FAIL] Malformed attribute: <PHASE id=1 name="x"> — attribute value `1` missing quotes
+[WARN]      Non-canonical attribute: <BEHAVIOUR mood="high"> — `mood` is outside the closed set
+[INFO]      Legacy alias: <RULES> at line 20 — satisfies <HARD_RULES> check; candidate for organic retrofit to <HARD_RULES>
+──────────────────────────────────
+Result: HARD-FAIL (3 blocking violations, 1 warning, 1 informational)
+```
+
+A compliant target produces:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+No violations found.
+──────────────────────────────────
+Result: PASS
+```
 
 ---
 
 ## Quality Checks (All must pass)
 
-- [ ] Bundled file references use relative paths within the skill directory (e.g., `references/...` and `assets/templates/...`), not absolute or cross-directory paths
+- [ ] Has a self-validation phase that reads the skill's `references/*validation-criteria.md`
+- [ ] Bundled file references use relative `references/...` and `assets/templates/...` paths — never absolute or cross-directory paths
 - [ ] `description` written in third person ("Processes..." not "I process..." or "You can use...")
 - [ ] `description` includes what the skill does AND when to use it
 - [ ] Progressive disclosure applied: references loaded per phase, not all upfront
 - [ ] No reference content inlined in SKILL.md body (should be in `references/` subdirectory)
 - [ ] Each phase instruction is concise (≤10 lines); depth lives in reference files
-- [ ] Reference files cited explicitly so Claude knows what to load and when
-- [ ] `disable-model-invocation: true` set for side-effect workflows (commit, deploy, send)
+- [ ] Reference files cited explicitly so the agent knows what to load and when
 - [ ] Prompt engineering strategy applied: skill follows relevant strategy from prompt-engineering-strategies.md (role prompting for skills, progressive disclosure for phases)
 - [ ] Behavioral guidelines applied: the skill surfaces assumptions before acting, prefers the simplest adequate path, keeps changes surgical, and defines explicit validation targets
 - [ ] Persuasion cues, if present, stay inside the ethical constraint: they improve compliance with legitimate work only and never weaken safeguards, refusals, or scope boundaries
 - [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
-- [ ] Standalone skill phases include explicit inline bash commands or instructions to read references that contain those commands — no Task-tool delegation.
+- [ ] Standalone skill phases include explicit inline analysis steps or instructions to read references that contain those steps — no subagent delegation
 - [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-best-practices.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
+- [ ] Skill does not author hooks, subagents, path-scoped rules, or CLAUDE.md hierarchy
 
 ---
 
 ## If This Is an IMPROVE Operation — Also Check
+
+**Canonical Tag Vocabulary:**
+
+- [ ] Target skill body uses all mandatory tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with at least one `<PHASE>`)
+- [ ] All tags in target skill body are balanced (no unmatched open/close)
+- [ ] All attribute syntax in target skill body is well-formed (no missing quotes, no stray `=`)
+- [ ] Non-canonical attributes in target skill body surfaced as warnings (not hard-fails)
+- [ ] Legacy `<RULES>` in target skill body reported as informational alias candidate (not a fail)
 
 **Information Preservation:**
 
@@ -60,9 +143,33 @@ Any skill violating these criteria must be fixed before proceeding:
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above
-2. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation
-3. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing skills when ALL criteria pass
+1. Evaluate the skill against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
+2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The fixture corpus at `assets/fixtures/` is the regression test for the strictness tiers.
+Each fixture is annotated in `assets/fixtures/MANIFEST.md` with its expected verdict.
+Running the validation loop against the corpus MUST produce exactly the verdict below —
+any deviation means the strictness-tier text above is ambiguous and must be tightened.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check); surface informational alias candidate |

--- a/skills/create-skill/references/skill-validation-criteria.md
+++ b/skills/create-skill/references/skill-validation-criteria.md
@@ -1,8 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md,
-karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical tag vocabulary)
 
 ---
 
@@ -21,16 +19,15 @@ karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical 
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | Reference files hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
-| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Agent picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags |
+| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199*
 
 ---
 

--- a/skills/improve-agents/references/automation-migration-guide.md
+++ b/skills/improve-agents/references/automation-migration-guide.md
@@ -1,7 +1,6 @@
 # Automation Migration Guide
 
 Decision criteria for migrating instructions from CLAUDE.md/AGENTS.md to on-demand mechanisms.
-Source: context-aware-improve-optimization.prd.md, analysis-skill-authoring-best-practices.md, analysis-how-claude-remembers-a-project.md, research-context-engineering-comprehensive.md
 
 ---
 
@@ -13,7 +12,6 @@ Source: context-aware-improve-optimization.prd.md, analysis-skill-authoring-best
 - Mechanism comparison (context cost, enforcement, best for)
 - Distribution-aware recommendations (plugin vs. standalone)
 - Token impact estimation (savings per mechanism type)
-- Evidence citations
 
 ---
 
@@ -30,7 +28,6 @@ When evaluating an instruction block for migration, follow this decision path:
 7. **Is it domain content for a monorepo package?** → Subdirectory AGENTS.md in that package root
 8. **None of the above?** → Keep in current location; reassess in next improvement cycle
 
-*Source: context-aware-improve-optimization.prd.md lines 346-358*
 
 ---
 
@@ -38,17 +35,16 @@ When evaluating an instruction block for migration, follow this decision path:
 
 Classify each instruction block by content type, then recommend the corresponding mechanism:
 
-| Content Type | Best Mechanism | Evidence Source |
-|---|---|---|
-| Always-applicable universal rules (<5 lines) | AGENTS.md root | research-context-engineering-comprehensive.md |
-| Package or scope-specific conventions (5-50 lines) | Subdirectory AGENTS.md in the relevant package | analysis-how-claude-remembers-a-project.md |
-| Domain knowledge or workflows (50-500 lines) | Skill (`user-invocable: false`) | extend-claude-with-skills.md |
-| Heavy workflows with side effects | Skill (`disable-model-invocation: true`) | extend-claude-with-skills.md |
-| Isolated, context-heavy analysis | Skill (`context: fork`) | extend-claude-with-skills.md |
-| Infrequently-needed deep reference | On-demand reference linked from SKILL.md | analysis-skill-authoring-best-practices.md |
-| Information agents can infer from code | DELETE — do not document | analysis-evaluating-agents-paper.md |
+| Content Type | Best Mechanism |
+|---|---|
+| Always-applicable universal rules (<5 lines) | AGENTS.md root |
+| Package or scope-specific conventions (5-50 lines) | Subdirectory AGENTS.md in the relevant package |
+| Domain knowledge or workflows (50-500 lines) | Skill (`user-invocable: false`) |
+| Heavy workflows with side effects | Skill (`disable-model-invocation: true`) |
+| Isolated, context-heavy analysis | Skill (`context: fork`) |
+| Infrequently-needed deep reference | On-demand reference linked from SKILL.md |
+| Information agents can infer from code | DELETE — do not document |
 
-*Source: context-aware-improve-optimization.prd.md lines 348-358*
 
 ---
 
@@ -65,7 +61,6 @@ Use these signals to identify instructions that should migrate from always-loade
 | Instructions duplicated across files | Consolidation candidate | Same content in 2+ files → single source of truth |
 | Version numbers, team names, release info | DELETE or pointer | High-churn content → remove |
 
-*Source: analysis-evaluating-agents-paper.md lines 36-52, Anthropic Best Practices*
 
 ---
 
@@ -81,7 +76,6 @@ Compare all available on-demand mechanisms when recommending a migration:
 | Subdirectory AGENTS.md | Loaded when agent enters that directory | Scoped to package or subdirectory | Monorepo package-specific conventions |
 | Domain doc (`docs/TOPIC.md`) | Zero (loaded on demand via pointer) | Advisory — referenced from root AGENTS.md | Deep domain content too large for root |
 
-*Source: analysis-skill-authoring-best-practices.md lines 19-46, research-context-engineering-comprehensive.md*
 
 ---
 
@@ -97,7 +91,6 @@ This guide targets the cross-platform AGENTS.md ecosystem. Recommend only mechan
 
 Suggest only the mechanisms listed above. Tool-specific or platform-specific mechanisms are out of scope for AGENTS.md improvement suggestions.
 
-*Source: DESIGN-GUIDELINES.md Guideline 11, project architecture*
 
 ---
 
@@ -116,17 +109,4 @@ Estimate savings when recommending each migration type:
 
 Present token impact estimates alongside migration recommendations to help users prioritize high-impact changes first.
 
-*Source: research-context-engineering-comprehensive.md, analysis-skill-authoring-best-practices.md lines 19-46*
 
----
-
-## Evidence Citations
-
-| Claim | Source |
-|---|---|
-| Codebase overviews do not help agents navigate | analysis-evaluating-agents-paper.md lines 36-41 |
-| Agent obedience turns unnecessary instructions into active cost | analysis-evaluating-agents-paper.md lines 42-52 |
-| Skill startup cost: ~100 tokens for name + description only | analysis-skill-authoring-best-practices.md lines 19-23 |
-| Reference depth: max 1 level from SKILL.md | analysis-skill-authoring-best-practices.md lines 131-143 |
-| ≤200 lines per config file; ~150-200 instruction limit | research-context-engineering-comprehensive.md |
-| Subdirectory AGENTS.md for monorepo scoping | research-context-engineering-comprehensive.md |

--- a/skills/improve-agents/references/codebase-analyzer.md
+++ b/skills/improve-agents/references/codebase-analyzer.md
@@ -1,7 +1,6 @@
 # Codebase Analysis Instructions
 Structured process for detecting project tech stack, tooling, and non-standard patterns.
 Used by INIT and IMPROVE skills for codebase analysis.
-Source: agents/codebase-analyzer.md
 ---
 
 Follow these codebase analysis instructions. Analyze the project at the current working directory and return a structured summary of its technical characteristics. Focus on facts that would cause mistakes if an AI coding agent didn't know them.
@@ -89,7 +88,6 @@ Look for anything unusual that would trip up an agent:
 - Migration workflows that live in app-specific directories rather than a root config file
 - Repository-specific tools mentioned in existing documentation
 
-*Source: agents/codebase-analyzer.md lines 22-82*
 
 ---
 
@@ -127,7 +125,6 @@ Return your analysis in exactly this format:
 
 If a section has nothing non-standard to report, omit it entirely. Shorter is better.
 
-*Source: agents/codebase-analyzer.md lines 83-113*
 
 ---
 
@@ -140,4 +137,3 @@ Before returning results, verify:
 3. Output follows the exact format specified above
 4. Sections with no findings are omitted, not left empty
 
-*Source: agents/codebase-analyzer.md lines 115-122*

--- a/skills/improve-agents/references/context-optimization.md
+++ b/skills/improve-agents/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Evidence-based instructions for managing token budgets and attention in agent configuration files.
-Source: research-context-engineering-comprehensive.md
 
 ---
 
@@ -13,17 +12,16 @@ Source: research-context-engineering-comprehensive.md
 - Quality over quantity checklist (include/exclude decision table)
 - Context poisoning vectors (detection and removal)
 - JIT documentation patterns (on-demand loading strategies)
-- Key citations
 
 ---
 
 ## Hard Limits
 
-| Limit | Value | Source |
-|-------|-------|--------|
-| Lines per configuration file | ≤ 200 | Anthropic Docs: "Target under 200 lines per CLAUDE.md file." |
-| Instructions per file | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
-| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily." |
+| Limit | Value |
+|-------|-------|
+| Lines per configuration file | ≤ 200 |
+| Instructions per file | ≤ 150-200 |
+| Contradictions between files | 0 |
 
 > "Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"
 > — Anthropic Best Practices
@@ -79,7 +77,6 @@ For each instruction line, ask: **"Would removing this cause the agent to make m
 - ✅ "Run `npm test` before committing" vs. ❌ "Test your changes"
 - ✅ "API handlers live in `src/api/handlers/`" vs. ❌ "Keep files organized"
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -97,7 +94,6 @@ Detect and remove these before generating or improving configuration files:
 
 > "Treat CLAUDE.md like code: review it when things go wrong, prune it regularly." — Anthropic Best Practices
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -116,17 +112,4 @@ Use these patterns to move content from always-consumed to on-demand locations:
 > "Rather than pre-processing all relevant data up front, agents maintain lightweight identifiers and use these references to dynamically load data into context at runtime."
 > — Anthropic Engineering: Effective Context Engineering
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*
 
----
-
-## Key Citations
-
-| Claim | Source |
-|-------|--------|
-| ≤200 lines per file | Agent Skills Standard |
-| ~150-200 instruction limit | HumanLayer (Kyle) via a-guide-to-agents.md |
-| n² attention constraint / context rot | Anthropic Engineering Blog |
-| Lost-in-the-middle effect | Liu et al., arXiv:2307.03172 |
-| Quality over quantity heuristic | Anthropic Best Practices |
-| JIT documentation strategy | Anthropic Engineering: Effective Context Engineering |

--- a/skills/improve-agents/references/evaluation-criteria.md
+++ b/skills/improve-agents/references/evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Evaluation Criteria
 Scoring rubric for assessing existing AGENTS.md and CLAUDE.md files before improvement.
 Used by IMPROVE skills only.
-Source: file-evaluator.md, research-context-engineering-comprehensive.md
 ---
 
 ## Contents
@@ -20,11 +19,11 @@ Source: file-evaluator.md, research-context-engineering-comprehensive.md
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions" |
-| Contradictions | 0 | Anthropic: "Claude may pick one arbitrarily" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| Contradictions | 0 |
 
 A file violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
 
@@ -34,16 +33,15 @@ A file violating any hard limit is flagged **OVER LIMIT** regardless of content 
 
 Check each line of the file against these indicators:
 
-| Indicator | Why It's Bloat | Source |
-|-----------|---------------|--------|
-| Directory/file structure listings | "Not effective at providing repository overview" | ETH Zurich: Evaluating AGENTS.md |
-| Standard language conventions | Agent already knows from training data | Anthropic Best Practices |
-| Vague instructions ("write clean code") | Not actionable; wastes attention budget | a-guide-to-agents.md |
-| Codebase overview paragraphs | Increases steps without improving navigation | ETH Zurich: Evaluating AGENTS.md |
-| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it, delete it" |
-| Duplicated content across files | Wastes tokens on every request | research-context-engineering-comprehensive.md |
+| Indicator | Why It's Bloat |
+|-----------|---------------|
+| Directory/file structure listings | "Not effective at providing repository overview" |
+| Standard language conventions | Agent already knows from training data |
+| Vague instructions ("write clean code") | Not actionable; wastes attention budget |
+| Codebase overview paragraphs | Increases steps without improving navigation |
+| Obvious tool usage ("use git for version control") | Agent already knows this |
+| Duplicated content across files | Wastes tokens on every request |
 
-*Source: file-evaluator.md lines 30-41*
 
 ---
 
@@ -56,7 +54,6 @@ Check each line of the file against these indicators:
 | Package references to uninstalled deps | Check if mentioned packages are in manifest files |
 | Outdated framework version references | Compare mentioned versions with actual installed versions |
 
-*Source: file-evaluator.md lines 43-50*
 
 ---
 
@@ -69,7 +66,6 @@ Check each line of the file against these indicators:
 | Do subdirectory files exist for distinct scopes? | packages/api/AGENTS.md for API-specific rules | Everything in root |
 | Are pointers provided to detailed docs? | "See docs/TESTING.md" | No cross-references |
 
-*Source: file-evaluator.md lines 52-59*
 
 ---
 
@@ -91,7 +87,6 @@ Every instruction should be in the Goldilocks zone:
 | Enforced by config file | "Strict mode is enabled" (`tsconfig.json` has `"strict": true`) | ❌ DELETE — agent reads the config directly |
 | Project decision not in config | "Use `unknown` over `any`; validate with `zod`" | ✅ Keep — agent cannot infer rationale |
 
-*Source: research-context-engineering-comprehensive.md lines 131-134*
 
 ---
 
@@ -108,7 +103,6 @@ Check each instruction block for migration potential to on-demand mechanisms:
 
 Flag each candidate in the Per-File Issues output under `**Automation Opportunity Issues:**`.
 
-*Source: automation-migration-guide.md lines 58-72*
 
 ---
 
@@ -125,7 +119,6 @@ Score each dimension 1-10 based on observed issues:
 | Consistency | 0 contradictions | 1 contradiction | 2+ contradictions |
 | Automation Opportunity | 0 migration candidates missed | 1-3 potential migrations | 4+ missed migrations |
 
-*Source: file-evaluator.md lines 132-141*
 
 ---
 

--- a/skills/improve-agents/references/file-evaluator.md
+++ b/skills/improve-agents/references/file-evaluator.md
@@ -1,7 +1,6 @@
 # File Evaluation Instructions
 Structured process for evaluating existing AGENTS.md/CLAUDE.md files against evidence-based quality criteria.
 Used by IMPROVE skills for current state analysis.
-Source: agents/file-evaluator.md
 ---
 
 Follow these file evaluation instructions. Analyze existing AGENTS.md or CLAUDE.md files in the project at the current working directory and assess their quality against evidence-based criteria. Identify specific problems with evidence so an improvement skill can act on them.
@@ -29,25 +28,25 @@ Use your environment's file reading and search capabilities to examine the proje
 
 ### Hard Limits
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions" |
-| No contradictions | 0 conflicts | Anthropic: "Claude may pick one arbitrarily" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| No contradictions | 0 conflicts |
 
 ### Bloat Indicators
 
 Each of these wastes tokens without improving agent performance:
 
-| Indicator | Why It's Bloat | Source |
-|-----------|---------------|--------|
-| Directory/file structure listings | "Not effective at providing repository overview" | Evaluating AGENTS.md (ETH Zurich) |
-| Standard language conventions | Agent already knows these from training | Anthropic Best Practices |
-| Vague instructions ("write clean code") | Not actionable, wastes attention budget | a-guide-to-agents.md |
-| Codebase overview paragraphs | Increases steps without improving navigation | Evaluating AGENTS.md |
-| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it correctly, delete it" |
-| Duplicated information across files | Wastes tokens on every request | Context engineering research |
-| **Architectural path trap** | Lists of paths WITH behavioral constraints (e.g., `services/ must not import from routes/`) are **not** directory listings — flag only pure path listings with no rules attached | Evaluating AGENTS.md |
+| Indicator | Why It's Bloat |
+|-----------|---------------|
+| Directory/file structure listings | "Not effective at providing repository overview" |
+| Standard language conventions | Agent already knows these from training |
+| Vague instructions ("write clean code") | Not actionable, wastes attention budget |
+| Codebase overview paragraphs | Increases steps without improving navigation |
+| Obvious tool usage ("use git for version control") | Agent already knows this |
+| Duplicated information across files | Wastes tokens on every request |
+| **Architectural path trap** | Lists of paths WITH behavioral constraints (e.g., `services/ must not import from routes/`) are **not** directory listings — flag only pure path listings with no rules attached |
 
 ### Staleness Indicators
 
@@ -68,7 +67,6 @@ Each of these wastes tokens without improving agent performance:
 | Do subdirectory files exist for distinct scopes? | packages/api/CLAUDE.md for API-specific rules | Everything in root |
 | Are pointers provided to detailed docs? | "See docs/TESTING.md" | No cross-references |
 
-*Source: agents/file-evaluator.md lines 20-59*
 
 ### Automation Opportunity Indicators
 
@@ -83,7 +81,6 @@ Flag instructions that are candidates for migration to on-demand mechanisms:
 | Version numbers, team names, high-churn content | Deletion | `DELETE_CANDIDATE` |
 | Standard default commands (e.g., `npm test`, `cargo build`, `go test ./...`) | Agent knows platform defaults from training | `DELETE_CANDIDATE` |
 
-*Source: automation-migration-guide.md lines 58-72*
 
 ---
 
@@ -116,7 +113,6 @@ For each file found:
 - Are there scopes with distinct tooling that lack their own file?
 - Is the root file overloaded with scope-specific information?
 
-*Source: agents/file-evaluator.md lines 75-102*
 
 ---
 
@@ -178,7 +174,6 @@ Return your analysis in exactly this format:
 | **Overall** | **4** | Needs significant refactoring |
 ```
 
-*Source: agents/file-evaluator.md lines 103-162*
 
 ---
 
@@ -193,4 +188,3 @@ Before returning results, verify:
 5. No improvement suggestions crept in — report only identifies problems
 6. Automation opportunity flags match the indicators table — no false classifications
 
-*Source: agents/file-evaluator.md lines 143-152*

--- a/skills/improve-agents/references/progressive-disclosure-guide.md
+++ b/skills/improve-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md
 
 ---
 
@@ -28,7 +27,6 @@ When deciding where to place content, use this table:
 | Subdirectory AGENTS.md | Specific to one package or area | On-demand when working there |
 | Skill | A workflow the agent should invoke explicitly | On-demand when invoked |
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -64,7 +62,6 @@ See each package's AGENTS.md for specific guidelines.
 > "Don't overload any level. The agent sees all merged files in its context."
 > — a-guide-to-agents.md lines 164-193
 
-*Source: a-guide-to-agents.md lines 164-193*
 
 ---
 
@@ -95,7 +92,6 @@ docs/
 
 **Use skills for workflows** — agents invoke skills only when needed, keeping base context minimal.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ---
 
@@ -112,7 +108,6 @@ docs/
 
 **Merge behavior**: Subdirectory AGENTS.md files merge with root (not replace) — content from both applies when the agent works in that directory.
 
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
 
 ---
 

--- a/skills/improve-agents/references/validation-criteria.md
+++ b/skills/improve-agents/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md / CLAUDE.md files.
-Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
 
 ---
 
@@ -9,13 +8,13 @@ Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-e
 
 Any file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "~150-200 instructions with reasonable consistency" |
-| Contradictions (within or between files) | 0 | Anthropic: "Claude may pick one arbitrarily" |
-| Language-specific rules in root | 0 | Domain rules belong in separate files |
-| Stale file path references | 0 | "File paths change constantly... actively poisons context" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| Contradictions (within or between files) | 0 |
+| Language-specific rules in root | 0 |
+| Stale file path references | 0 |
 
 ## Recommended Targets (Advisory)
 

--- a/skills/improve-agents/references/what-not-to-include.md
+++ b/skills/improve-agents/references/what-not-to-include.md
@@ -1,29 +1,27 @@
 # What NOT to Include
 
 Evidence-based exclusion table for AGENTS.md and CLAUDE.md content.
-Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md, research-context-engineering-comprehensive.md
 
 ---
 
 ## Exclusion Evidence Table
 
-| Content Type | Why to Exclude | Evidence Quote | Source |
-|-------------|----------------|---------------|--------|
-| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" | ETH Zurich: Evaluating AGENTS.md |
-| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" | Anthropic Best Practices |
-| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" | ETH Zurich: Evaluating AGENTS.md |
-| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | a-guide-to-agents.md |
-| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | a-guide-to-agents.md |
-| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | a-guide-to-agents.md |
-| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
-| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" | research-context-engineering-comprehensive.md |
-| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Anthropic Best Practices |
-| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" | Anthropic Best Practices |
-| Tooling-enforced behaviors (formatting, linting, file blocking) | Config files already enforce these deterministically; redundant instructions waste attention budget without adding control | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
+| Content Type | Why to Exclude | Evidence Quote |
+|-------------|----------------|---------------|
+| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" |
+| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" |
+| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" |
+| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" |
+| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" |
+| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" |
+| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" |
+| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) |
+| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column |
+| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" |
+| Tooling-enforced behaviors (formatting, linting, file blocking) | Config files already enforce these deterministically; redundant instructions waste attention budget without adding control | "If Claude already does it correctly, delete it" |
 
-*Source: init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/skills/improve-skill/SKILL.md
+++ b/skills/improve-skill/SKILL.md
@@ -7,18 +7,20 @@ description: "Evaluates and optimizes existing SKILL.md files against evidence-b
 
 Evaluate an existing SKILL.md file against evidence-based quality criteria and apply improvements to optimize token usage, reduce bloat, and align with proven patterns.
 
-## Behavioral Guidelines
+<TRIGGER when="improving or auditing an existing skill" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **ALWAYS** evaluate before modifying — never change files without analysis
 - **ALWAYS** present changes to the user before applying them
 - **NEVER** remove evidence-grounded references or citations
@@ -26,91 +28,105 @@ Evaluate an existing SKILL.md file against evidence-based quality criteria and a
 - **NEVER** exceed 500 lines in SKILL.md or 200 lines in reference files after improvements
 - **PRESERVE** all genuinely useful skill phases and instructions — only remove waste
 - **PRESERVE** or strengthen the ethical constraint: persuasion cues support legitimate work only, never safety bypass
-</RULES>
+- **EVERY** improved SKILL.md body must carry the canonical semantic-tag vocabulary in canonical positions
+- **EVERY** tag-vocabulary violation found in the target skill must be reported with the specific tag name, line reference, and strictness tier (hard-fail / warn / informational) before proposing a fix
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="skill-exists-check">
+  Check if a skill exists at:
 
-Check if a skill exists at:
+  - The user-provided path
+  - `skills/{name}/SKILL.md`
 
-- The user-provided path
-- `.claude/skills/{name}/SKILL.md`
-- `plugins/*/skills/{name}/SKILL.md`
+  **If no skill found:**
 
-**If no skill found:**
+  1. Inform the user: "No skill found at the specified path."
+  2. Suggest using `create-skill` to create a new one instead.
+  3. **STOP**
 
-1. Inform the user: "No skill found at the specified path."
-2. Suggest using the `create-skill` skill to create a new one instead.
-3. **STOP**
+  **If skill found:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If skill found:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="evaluate">
+  Read `references/skill-evaluator.md` and follow its evaluation instructions to evaluate the skill at `{target-path}`. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter valid), structural quality (progressive disclosure, phase structure, reference loading), and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+  </PHASE>
 
-### Phase 1: Evaluate
+  <PHASE id="2" name="codebase-context">
+  Read `references/artifact-analyzer.md` and follow its analysis instructions.
 
-Read `references/skill-evaluator.md` and follow its evaluation instructions to evaluate the skill at `{target-path}`. Check hard limits (body ≤500 lines, references ≤200 lines, frontmatter valid), structural quality (progressive disclosure, phase structure, reference loading), and token efficiency. Return structured evaluation results with severity classifications (AUTO-FAIL/HIGH/MEDIUM/LOW).
+  Focus on: naming conventions for similar skills and any other skills that overlap in purpose.
+  </PHASE>
 
-### Phase 2: Codebase Context
+  <PHASE id="3" name="generate-improvement-plan">
+  Read these reference documents:
 
-Read `references/artifact-analyzer.md` and follow its analysis instructions.
+  - `references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
+  - `references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
+  - `references/behavioral-guidelines.md` — behavior and safe persuasion patterns for skills
+  - `references/prompt-engineering-strategies.md` — skill-specific prompting strategies
 
-Focus on: naming conventions for similar skills and any other skills that overlap in purpose.
+  <REFERENCES load="on-demand">
+  - skill-authoring-guide.md
+  - skill-evaluation-criteria.md
+  - behavioral-guidelines.md
+  - prompt-engineering-strategies.md
+  </REFERENCES>
 
-### Phase 3: Generate Improvement Plan
+  Based on both evaluation and analysis results, create improvement plan with categories:
 
-Read these reference documents:
+  1. **Removals** — bloat (inlined content, over-specified instructions), stale (broken refs, removed tools), duplicates
+  2. **Refactoring** — progressive disclosure optimization, phase consolidation, reference path corrections
+  3. **Additions** — missing sections (canonical tags, preflight check, self-validation, output format). Only suggest Hard Rules or Preflight if the skill has user-facing interactions or side effects — do NOT suggest them for informational/analysis-only skills that read and report.
 
-- `references/skill-authoring-guide.md` — core principles, structure, progressive disclosure, anti-patterns
-- `references/skill-evaluation-criteria.md` — bloat/staleness indicators, quality rubric
-- `references/behavioral-guidelines.md` — Karpathy-aligned behavior and safe persuasion patterns for skills
-- `references/prompt-engineering-strategies.md` — skill-specific prompting strategies
+  If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
 
-Based on both evaluation and analysis results, create improvement plan with categories:
+  **Standalone constraint**: This is the standalone distribution — suggest only skills as improvement targets. Do not suggest creating hooks, subagents, or path-scoped rules (these require host-application plugin infrastructure or are outside the standalone authoring boundary). When evaluation criteria mention hooks or subagents as improvement mechanisms, substitute with the closest available mechanism (a skill for workflow guidance).
+  </PHASE>
 
-1. **Removals** — bloat (inlined content, over-specified instructions), stale (broken agent refs, removed tools), duplicates
-2. **Refactoring** — progressive disclosure optimization, phase consolidation, reference path corrections
-3. **Additions** — missing sections (Hard Rules, preflight check, self-validation, output format). Only suggest Hard Rules or Preflight if the skill has user-facing interactions or side effects — do NOT suggest them for informational/analysis-only skills that read and report.
+  <PHASE id="4" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
 
-If all three categories yield zero items after analysis, conclude: "No improvements needed — artifact is already convention-compliant." and proceed directly to Phase 5 with an empty improvement summary.
+  For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+  </PHASE>
 
-**Standalone constraint**: This is the standalone distribution — suggest only skills and path-scoped rules as improvement targets. Do not suggest creating hooks or subagents (these require Claude Code plugin infrastructure). When evaluation criteria mention hooks or subagents as improvement mechanisms, substitute with the closest available mechanism (a rule for path-scoped enforcement, a skill for workflow guidance).
+  <PHASE id="5" name="present-and-apply">
+  1. Show a summary overview of all improvements found, grouped by category:
+     - **Removals**: X items (bloat: X, stale: X, duplicates: X)
+     - **Refactoring**: X items (progressive disclosure: X, phase structure: X, reference paths: X)
+     - **Additions**: X items
 
-### Phase 4: Self-Validation
+  2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
 
-Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the improved skill.
+     **WHAT**: The specific content and its current location (file:lines)
+     **WHY**: Evidence-based justification with source reference
+     **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
+     **OPTIONS**:
+     - **Option A** (recommended): Primary action
+     - **Option B**: Alternative action
+     - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
 
-For improve operations, also evaluate the **"If This Is an IMPROVE Operation"** section. Maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass.
+     Wait for the user to select an option for each suggestion before proceeding to the next.
+     If the user selects "Keep as-is", preserve the content in its exact current location.
 
-### Phase 5: Present and Apply
+  3. After all suggestions are reviewed, show aggregate token impact analysis:
+     - **Total lines**: before → after
+     - **Removed tokens**: total waste eliminated
+     - **Deferred suggestions**: X items kept as-is
 
-1. Show a summary overview of all improvements found, grouped by category:
-   - **Removals**: X items (bloat: X, stale: X, duplicates: X)
-   - **Refactoring**: X items (progressive disclosure: X, phase structure: X, reference paths: X)
-   - **Additions**: X items
+  4. Apply ONLY the approved changes (options A or B selections).
 
-2. For each suggestion, present a structured card in priority order (Removals → Refactoring → Additions):
+  5. Report final metrics:
+     - Lines before → after
+     - Files affected
+     - Estimated token savings per session
+     - Suggestions applied: X of Y (Z deferred)
+  </PHASE>
 
-   **WHAT**: The specific content and its current location (file:lines)
-   **WHY**: Evidence-based justification with source reference
-   **TOKEN IMPACT**: Estimated tokens saved from always-loaded context
-   **OPTIONS**:
-   - **Option A** (recommended): Primary action
-   - **Option B**: Alternative action
-   - **Option C**: Keep as-is — "Preserve in current location. Trade-off: continues consuming ~X tokens per session"
+</PROCESS>
 
-   Wait for the user to select an option for each suggestion before proceeding to the next.
-   If the user selects "Keep as-is", preserve the content in its exact current location.
-
-3. After all suggestions are reviewed, show aggregate token impact analysis:
-   - **Total lines**: before → after
-   - **Removed tokens**: total waste eliminated
-   - **Deferred suggestions**: X items kept as-is
-
-4. Apply ONLY the approved changes (options A or B selections).
-
-5. Report final metrics:
-   - Lines before → after
-   - Files affected
-   - Estimated token savings per session
-   - Suggestions applied: X of Y (Z deferred)
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md` and loop the improved skill through every hard limit, quality check, and canonical semantic-tag strictness tier until all pass.
+</VALIDATION>

--- a/skills/improve-skill/assets/templates/skill-md.md
+++ b/skills/improve-skill/assets/templates/skill-md.md
@@ -3,49 +3,70 @@ name: [skill-name-kebab-case]
 description: "[What this skill does and when to use it. Third person.]"
 ---
 <!-- TEMPLATE: SKILL.md Entry Point
-     Placement: .claude/skills/[skill-name]/SKILL.md or plugins/[plugin]/skills/[skill-name]/SKILL.md
+     Placement: skills/[skill-name]/SKILL.md
      Rule: name ≤ 64 chars, lowercase letters/numbers/hyphens only
      Rule: description ≤ 1024 chars, third person, no XML tags
      Rule: Body under 500 lines
-     Rule: Use references/ for evidence-based guidance
-     Rule: Use assets/templates/ for output templates
+     Rule: Use relative references/ paths for evidence-based guidance
+     Rule: Use relative assets/templates/ paths for output templates
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name the target service/workspace explicitly
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory: <TRIGGER>, <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
+           Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
+           Closed attribute set: avoid=, always=, when=, name=, id=, priority=.
+     Rule: YAML frontmatter is untouched — do NOT duplicate the <TRIGGER> cue into description
+     Rule: Standalone skills MUST NOT author hooks, subagents, path-scoped rules, or CLAUDE.md hierarchy
 -->
 
 # [Skill Title]
 
 [One-sentence purpose statement]
 
-## Behavioral Guidelines
+<TRIGGER when="[plain-language activation cue — mirror the 'Use when ...' phrase from the description]" />
 
+<BEHAVIOUR
+  avoid="make decisions without surfacing assumptions; add speculative scope"
+  always="surface assumptions first; keep changes surgical">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - [Critical constraint 1]
 - [Critical constraint 2]
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
-<!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  <PREFLIGHT name="artifact-collision-check">
+  <!-- CONDITIONAL: Check if artifact exists — redirect to improve if so -->
+  </PREFLIGHT>
 
-### Phase 1: [Analysis Phase Name]
-<!-- Inline analysis steps go here -->
+  <PHASE id="1" name="[analysis-phase-name]">
+  Read `references/artifact-analyzer.md` and follow its analysis instructions.
+  <!-- If monorepo, record the target service/workspace for use in subsequent phases -->
+  </PHASE>
 
-### Phase 2: [Generation Phase Name]
-<!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  <PHASE id="2" name="[generation-phase-name]">
+  <!-- Read references, apply templates, and use project-relative paths/globs for the detected service/workspace -->
+  </PHASE>
 
-### Phase 3: Self-Validation
-<!-- Read references/[type]-validation-criteria.md -->
+  <PHASE id="3" name="self-validation">
+  Read `references/skill-validation-criteria.md` and execute its **Validation Loop Instructions** against the generated skill.
+  Maximum 3 iterations. Do not proceed to Phase 4 until ALL criteria pass.
+  </PHASE>
 
-### Phase 4: Present and Write
-<!-- Show artifact with evidence citations, write on approval -->
+  <PHASE id="4" name="present-and-write">
+  Show artifact with evidence citations. Ask for confirmation. Write on approval.
+  </PHASE>
+
+</PROCESS>
+
+<VALIDATION loop="max-iterations:3">
+Read `references/skill-validation-criteria.md`, loop until all hard limits, quality checks, and canonical semantic-tag strictness tiers pass.
+</VALIDATION>

--- a/skills/improve-skill/references/artifact-analyzer.md
+++ b/skills/improve-skill/references/artifact-analyzer.md
@@ -1,7 +1,6 @@
 # Artifact Analysis Instructions
 Structured process for inventorying existing Agent Skills artifacts and conventions.
 Used by CREATE and IMPROVE skills for codebase context analysis.
-Source: agents/artifact-analyzer.md
 ---
 
 ## Contents

--- a/skills/improve-skill/references/prompt-engineering-strategies.md
+++ b/skills/improve-skill/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with Opus 4.6
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 | Contradictory instructions | Claude picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*

--- a/skills/improve-skill/references/skill-authoring-guide.md
+++ b/skills/improve-skill/references/skill-authoring-guide.md
@@ -1,7 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code skills (SKILL.md files).
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -50,7 +49,6 @@ Analogy: Claude as a robot on a path — narrow bridge (low freedom) vs. open fi
 | Sonnet | Clear and efficient? (balanced) |
 | Opus | Avoid over-explaining? (may need less) |
 
-*Source: skills/skill-authoring-best-practices.md lines 11-145*
 
 ---
 
@@ -82,7 +80,6 @@ my-skill/
 | `hooks` | No | Hooks scoped to this skill's lifecycle |
 | `argument-hint` | No | Autocomplete hint, e.g. `[issue-number]` |
 
-*Source: skills/extend-claude-with-skills.md lines 169-199*
 
 ---
 
@@ -98,7 +95,6 @@ my-skill/
 
 Include: (1) what it does, (2) when to use it, (3) specific trigger terms for matching.
 
-*Source: skills/skill-authoring-best-practices.md lines 168-250*
 
 ---
 
@@ -118,7 +114,6 @@ Load only the references needed for each phase, not all at once.
 
 Keep SKILL.md under 500 lines. Move detailed reference material to separate files. Reference supporting files explicitly so Claude knows what they contain.
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300; skills/extend-claude-with-skills.md lines 223-246*
 
 ---
 
@@ -132,7 +127,6 @@ Keep SKILL.md under 500 lines. Move detailed reference material to separate file
 
 Use `disable-model-invocation: true` for workflows with side effects (commit, deploy, send-message). Use `user-invocable: false` for background knowledge Claude should apply but users shouldn't invoke directly.
 
-*Source: skills/extend-claude-with-skills.md lines 248-283*
 
 ---
 
@@ -147,4 +141,3 @@ Use `disable-model-invocation: true` for workflows with side effects (commit, de
 | Over-explaining for Opus | Patronizing + token waste | Trust the model; provide minimal scaffolding |
 | Contradictions between phases | Claude picks one arbitrarily | Review all phases for consistency |
 
-*Source: skills/skill-authoring-best-practices.md lines 800-1100*

--- a/skills/improve-skill/references/skill-evaluation-criteria.md
+++ b/skills/improve-skill/references/skill-evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Skill Evaluation Criteria
 
 Scoring rubric for assessing existing SKILL.md files before improvement.
-Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
 
 ---
 
@@ -18,18 +17,17 @@ Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | Reference files hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present, non-empty, ≤ 1024 chars | Required for skill discovery and Agent Skills spec |
-| `name` field | Present, non-empty, 1-64 chars, kebab-case | Agent Skills specification |
-| Phase structure | At least one clear phase defined | Anthropic skill authoring patterns |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present, non-empty, ≤ 1024 chars |
+| `name` field | Present, non-empty, 1-64 chars, kebab-case |
+| Phase structure | At least one clear phase defined |
 
 A skill violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
 
-*Source: skills/skill-authoring-best-practices.md line 259*
 
 ---
 
@@ -44,7 +42,6 @@ A skill violating any hard limit is flagged **OVER LIMIT** regardless of content
 | Explaining standard practices Claude already knows | "Claude is already very smart — add only novel context" |
 | Hardcoded absolute paths (not using relative `references/` paths) | Will go stale; breaks skill portability |
 
-*Source: skills/skill-authoring-best-practices.md lines 11-60*
 
 ---
 
@@ -58,7 +55,6 @@ A skill violating any hard limit is flagged **OVER LIMIT** regardless of content
 | Hardcoded file paths in SKILL.md body | Check if referenced paths actually exist |
 | `user-invocable: true` (was the default, now explicit) | Remove redundant explicit defaults |
 
-*Source: skills/skill-authoring-best-practices.md lines 146-167*
 
 ---
 
@@ -71,7 +67,6 @@ A skill violating any hard limit is flagged **OVER LIMIT** regardless of content
 | Are supporting files referenced explicitly? | "Read references/X.md" | Files exist but never referenced |
 | Is SKILL.md body under 500 lines? | Clean entry point with external depth | Monolithic, all content inline |
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300*
 
 ---
 
@@ -88,7 +83,6 @@ Score each dimension 1–10 based on observed issues:
 | Evidence Grounding | References cited per phase | Some references | No references |
 | **Overall** | | | |
 
-*Source: Evaluating-AGENTS-paper.md lines 1-100*
 
 ---
 

--- a/skills/improve-skill/references/skill-evaluation-criteria.md
+++ b/skills/improve-skill/references/skill-evaluation-criteria.md
@@ -21,7 +21,7 @@ Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
 | Criterion | Threshold | Source |
 |-----------|-----------|--------|
 | SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
+| Reference files | ≤ 200 lines each | Reference files hard limit |
 | Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
 | `description` field | Present, non-empty, ≤ 1024 chars | Required for skill discovery and Agent Skills spec |
 | `name` field | Present, non-empty, 1-64 chars, kebab-case | Agent Skills specification |
@@ -29,7 +29,7 @@ Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
 
 A skill violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
 
-*Source: skills/skill-authoring-best-practices.md line 259; `.claude/rules/reference-files.md`*
+*Source: skills/skill-authoring-best-practices.md line 259*
 
 ---
 

--- a/skills/improve-skill/references/skill-evaluator.md
+++ b/skills/improve-skill/references/skill-evaluator.md
@@ -1,7 +1,6 @@
 # Skill Evaluation Instructions
 Structured process for evaluating SKILL.md files against evidence-based quality criteria.
 Used by IMPROVE-SKILL skill for current state analysis.
-Source: agents/skill-evaluator.md
 ---
 
 ## Contents
@@ -30,13 +29,13 @@ Follow these evaluation instructions. Analyze the target SKILL.md file and evalu
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | reference-files.md rule constraint |
-| `description` field | Present and non-empty | Required for skill discovery |
-| `name` field format | Lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| `description` field | Present and non-empty |
+| `name` field format | Lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
 ### Structural Checks
 

--- a/skills/improve-skill/references/skill-format-reference.md
+++ b/skills/improve-skill/references/skill-format-reference.md
@@ -1,7 +1,6 @@
 # Skill Format Reference
 
 Technical specification for SKILL.md format, directory structure, variables, and discovery.
-Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-skills.md
 
 ---
 
@@ -43,7 +42,6 @@ Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-
 - Must NOT contain reserved words: `anthropic`, `claude`
 - Must match the parent directory name
 
-*Source: skills/research-claude-code-skills-format.md lines 103-108*
 
 ---
 
@@ -69,7 +67,6 @@ Dynamic context injection with `!` prefix runs shell commands before skill loads
 - Current branch: !`git branch --show-current`
 ```
 
-*Source: skills/extend-claude-with-skills.md lines 201-210; skills/research-claude-code-skills-format.md lines 126-149*
 
 ---
 
@@ -94,7 +91,6 @@ my-skill/
 - `references/` files load only when skill phases explicitly read them
 - `scripts/` files are executed, not loaded into context
 
-*Source: skills/research-claude-code-skills-format.md lines 153-186; skills/extend-claude-with-skills.md lines 100-115*
 
 ---
 
@@ -108,7 +104,6 @@ my-skill/
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to `references/` subdirectory. Explicitly reference supporting files from SKILL.md so Claude knows what to load and when.
 
-*Source: skills/research-claude-code-skills-format.md lines 172-186*
 
 ---
 
@@ -123,4 +118,3 @@ Keep SKILL.md under **500 lines**. Move detailed reference material to `referenc
 
 Priority: enterprise > personal > project. Plugin skills use `plugin-name:skill-name` namespace — no conflicts.
 
-*Source: skills/extend-claude-with-skills.md lines 85-97; skills/research-claude-code-skills-format.md lines 189-200*

--- a/skills/improve-skill/references/skill-validation-criteria.md
+++ b/skills/improve-skill/references/skill-validation-criteria.md
@@ -1,7 +1,19 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
+Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md,
+karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical tag vocabulary)
+
+---
+
+## Contents
+
+- Hard Limits (Auto-fail if violated)
+- Canonical Semantic-Tag Convention
+- Quality Checks (All must pass)
+- If This Is an IMPROVE Operation — Also Check
+- Validation Loop Instructions
+- Fixture Corpus Expected Verdicts
 
 ---
 
@@ -12,36 +24,107 @@ Any skill violating these criteria must be fixed before proceeding:
 | Criterion | Threshold | Source |
 |-----------|-----------|--------|
 | SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
+| Reference files | ≤ 200 lines each | Reference files hard limit |
 | Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
 | `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
 | `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Contradictions between phases | 0 | Agent picks arbitrarily when contradictions exist |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
+*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199*
+
+---
+
+## Canonical Semantic-Tag Convention
+
+The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical blocks in the canonical semantic-tag vocabulary. The validator applies three strictness tiers — hard-fail, warn, silent — and produces the same verdict every run.
+
+**Mandatory tags** (the SKILL.md body MUST contain all of these):
+
+- `<TRIGGER>` — plain-language activation cue ("use when X"); required for skills
+- `<BEHAVIOUR>` — behavioural guidelines, mindset, posture
+- `<HARD_RULES>` — inviolable constraints
+- `<PROCESS>` — container for the ordered phases; MUST contain at least one `<PHASE>`
+- `<PHASE id="N" name="X">` — one execution step inside `<PROCESS>`; `id=` is mandatory on every `<PHASE>`
+
+**Optional tags** (absence is silent — never a finding): `<PREFLIGHT>`, `<REFERENCES>`, `<EXAMPLE>`, `<ANTI_PATTERN>`, `<OUTPUT>`, `<VALIDATION>`.
+
+**Closed attribute set**: `avoid=`, `always=`, `when=`, `name=`, `id=`, `priority=`. Any other attribute name is non-canonical.
+
+**Legacy `<RULES>` alias**: a `<RULES>` block satisfies the mandatory `<HARD_RULES>` check exactly as `<HARD_RULES>` does — its presence is neither a warn nor a hard-fail. Report it as a `<HARD_RULES>` alias candidate (informational), not as a violation. No mass rename; migrate each `<RULES>` occurrence to `<HARD_RULES>` only when the file is next touched for other reasons.
+
+### Strictness tiers (apply verbatim — the verdict must be deterministic)
+
+| Tier | Trigger | Action |
+|------|---------|--------|
+| **Hard-fail** | Any mandatory tag missing (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>` or `<RULES>` alias, `<PROCESS>`, or `<PROCESS>` with zero `<PHASE>`) | Stop; fix before proceeding |
+| **Hard-fail** | Unbalanced tags — any opening tag without a matching closing tag, or a close with no open | Stop; fix before proceeding |
+| **Hard-fail** | Malformed attribute syntax — an attribute value missing its quotes, a stray `=`, or an unterminated quote | Stop; fix before proceeding |
+| **Warn** | A non-canonical attribute name (outside `avoid` / `always` / `when` / `name` / `id` / `priority`) — typo guard | Surface a warning; do not block |
+| **Silent** | Absence of any optional tag | No finding; proceed |
+| **Informational** | Legacy `<RULES>` tag present — alias for `<HARD_RULES>` | Surface as alias candidate; do not fail or warn |
+
+A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
+
+### Structured violation report format
+
+When evaluating a target skill body, report every finding using this format:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+[HARD-FAIL] Missing mandatory tag: <TRIGGER> — required for skills
+[HARD-FAIL] Unbalanced tag: <PROCESS> opened at line 42, no closing tag found
+[HARD-FAIL] Malformed attribute: <PHASE id=1 name="x"> — attribute value `1` missing quotes
+[WARN]      Non-canonical attribute: <BEHAVIOUR mood="high"> — `mood` is outside the closed set
+[INFO]      Legacy alias: <RULES> at line 20 — satisfies <HARD_RULES> check; candidate for organic retrofit to <HARD_RULES>
+──────────────────────────────────
+Result: HARD-FAIL (3 blocking violations, 1 warning, 1 informational)
+```
+
+A compliant target produces:
+
+```
+VIOLATION REPORT — <target-path>
+──────────────────────────────────
+No violations found.
+──────────────────────────────────
+Result: PASS
+```
 
 ---
 
 ## Quality Checks (All must pass)
 
-- [ ] Bundled file references use relative `references/` paths (not hardcoded absolute paths)
+- [ ] Has a self-validation phase that reads the skill's `references/*validation-criteria.md`
+- [ ] Bundled file references use relative `references/...` and `assets/templates/...` paths — never absolute or cross-directory paths
 - [ ] `description` written in third person ("Processes..." not "I process..." or "You can use...")
 - [ ] `description` includes what the skill does AND when to use it
 - [ ] Progressive disclosure applied: references loaded per phase, not all upfront
 - [ ] No reference content inlined in SKILL.md body (should be in `references/` subdirectory)
 - [ ] Each phase instruction is concise (≤10 lines); depth lives in reference files
-- [ ] Reference files cited explicitly so Claude knows what to load and when
-- [ ] `disable-model-invocation: true` set for side-effect workflows (commit, deploy, send)
+- [ ] Reference files cited explicitly so the agent knows what to load and when
 - [ ] Prompt engineering strategy applied: skill follows relevant strategy from prompt-engineering-strategies.md (role prompting for skills, progressive disclosure for phases)
 - [ ] Behavioral guidelines applied: the skill surfaces assumptions before acting, prefers the simplest adequate path, keeps changes surgical, and defines explicit validation targets
 - [ ] Persuasion cues, if present, stay inside the ethical constraint: they improve compliance with legitimate work only and never weaken safeguards, refusals, or scope boundaries
 - [ ] Phase instructions are specific and actionable — no vague directives like "ensure quality" or "review for completeness"
-- [ ] Standalone skill phases include explicit inline bash commands or instructions to read references that contain those commands — no Task-tool delegation.
+- [ ] Standalone skill phases include explicit inline analysis steps or instructions to read references that contain those steps — no subagent delegation
 - [ ] Evidence citations present: key decisions reference source docs (e.g., "per skill-authoring-best-practices.md")
+- [ ] Canonical semantic tags present in their canonical positions: `<TRIGGER>` after the title, `<BEHAVIOUR>`, `<HARD_RULES>`, then `<PROCESS>` containing one or more `<PHASE id="N" name="X">`
+- [ ] All semantic tags balanced and use only the closed attribute set (`avoid`, `always`, `when`, `name`, `id`, `priority`); every `<PHASE>` carries an `id=`
+- [ ] YAML frontmatter untouched by the convention — the `<TRIGGER>` cue is not duplicated into the `description` field
+- [ ] Skill does not author hooks, subagents, path-scoped rules, or CLAUDE.md hierarchy
 
 ---
 
 ## If This Is an IMPROVE Operation — Also Check
+
+**Canonical Tag Vocabulary:**
+
+- [ ] Target skill body uses all mandatory tags (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` with at least one `<PHASE>`)
+- [ ] All tags in target skill body are balanced (no unmatched open/close)
+- [ ] All attribute syntax in target skill body is well-formed (no missing quotes, no stray `=`)
+- [ ] Non-canonical attributes in target skill body surfaced as warnings (not hard-fails)
+- [ ] Legacy `<RULES>` in target skill body reported as informational alias candidate (not a fail)
 
 **Information Preservation:**
 
@@ -60,9 +143,36 @@ Any skill violating these criteria must be fixed before proceeding:
 
 Execute this loop for each generated or improved skill:
 
-1. Evaluate the skill against ALL criteria above
-2. If ANY criterion fails: identify the specific failure, fix the skill, restart evaluation
-3. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
-4. Only proceed to writing skills when ALL criteria pass
+1. Evaluate the skill against ALL criteria above, including the **Canonical Semantic-Tag Convention** strictness tiers
+2. **For improve operations:** verify each suggestion in the improvement plan has a WHY field citing a source doc — no suggestion may lack a source reference
+3. If ANY hard-fail criterion fails: identify the specific failure, fix the skill, restart evaluation
+4. Surface every warn-tier finding (non-canonical attribute names) without blocking — the user decides whether to fix
+5. Maximum 3 iterations — if still failing after 3 attempts, surface the remaining issues to the user
+6. Only proceed to writing skills when ALL hard-fail and quality criteria pass
 
 **Do not skip criteria for "minor" violations.** Hard limits are hard limits.
+
+---
+
+## Fixture Corpus Expected Verdicts
+
+The strictness tiers above are exercised by a regression corpus shipped with the
+sibling `create-skill` skill at `skills/create-skill/assets/fixtures/` (see its
+`MANIFEST.md`). `improve-skill` does not ship its own copy — the strictness-tier
+logic is identical, so the `create-skill` corpus is the single regression test
+for both. The table below documents the expected verdict for each fixture so the
+contract is visible here too; running the validation loop against any body MUST
+produce exactly these verdicts.
+
+| Fixture | Defect | Expected verdict |
+|---------|--------|------------------|
+| `compliant-baseline.md` | None — all mandatory tags present, balanced, canonical attributes | **pass** |
+| `missing-trigger.md` | `<TRIGGER>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-behaviour.md` | `<BEHAVIOUR>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-hard-rules.md` | `<HARD_RULES>` and `<RULES>` both absent | **hard-fail** (missing mandatory tag) |
+| `missing-process.md` | `<PROCESS>` absent | **hard-fail** (missing mandatory tag) |
+| `missing-phase.md` | `<PROCESS>` present but contains zero `<PHASE>` | **hard-fail** (missing mandatory tag) |
+| `unbalanced-tag.md` | `<PROCESS>` opened, never closed | **hard-fail** (unbalanced tags) |
+| `malformed-attribute.md` | `<PHASE>` attribute value missing its quotes | **hard-fail** (malformed attribute syntax) |
+| `non-canonical-attribute.md` | `<BEHAVIOUR>` carries a `mood=` attribute | **warn** (non-canonical attribute name) — passes otherwise |
+| `rules-alias.md` | Uses legacy `<RULES>` instead of `<HARD_RULES>`; all else compliant | **pass** (alias satisfies the `<HARD_RULES>` check); surface informational alias candidate |

--- a/skills/improve-skill/references/skill-validation-criteria.md
+++ b/skills/improve-skill/references/skill-validation-criteria.md
@@ -1,8 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md,
-karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical tag vocabulary)
 
 ---
 
@@ -21,16 +19,15 @@ karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical 
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | Reference files hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
-| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Agent picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags |
+| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199*
 
 ---
 

--- a/skills/init-agents/SKILL.md
+++ b/skills/init-agents/SKILL.md
@@ -11,18 +11,20 @@ Generate an evidence-based AGENTS.md file hierarchy for this project. Instead of
 
 Auto-generated comprehensive AGENTS.md files **reduce** agent task success by ~3% while **increasing cost by 20%+**. Developer-written **minimal** files improve success by ~4%. This skill generates files that mimic what an experienced developer would write: only non-obvious tooling and conventions.
 
-## Behavioral Guidelines
+<TRIGGER when="initializing AGENTS.md hierarchy for a project" />
 
+<BEHAVIOUR
+  avoid="acting before naming ambiguities; adding speculative scope; weakening safeguards"
+  always="surface assumptions first; keep changes surgical; define verification targets">
 - **Surface assumptions first** — name ambiguities, tradeoffs, and multiple valid interpretations before acting.
 - **Prefer the simplest path** — solve the task completely without speculative flexibility or extra scope.
 - **Keep changes surgical** — touch only what the task requires, and preserve existing behavior unless the task calls for change.
 - **Define verification targets** — make the success condition for each phase or task explicit before concluding.
 - **Use phased persuasion safely** — use warm-ups, curated references, and explicit constraints to improve compliance with legitimate work.
 - **Never weaken safeguards** — do not use persuasion principles to bypass safety constraints, refusals, or scope boundaries.
+</BEHAVIOUR>
 
-## Hard Rules
-
-<RULES>
+<HARD_RULES priority="hard">
 - **NEVER** generate a single file with everything — use hierarchical progressive disclosure
 - **NEVER** include directory/file structure listings (research proves these don't help agents navigate)
 - **NEVER** include obvious language conventions the model already knows
@@ -31,68 +33,74 @@ Auto-generated comprehensive AGENTS.md files **reduce** agent task success by ~3
 - Root file target: **15-40 lines**
 - Scope files target: **10-30 lines**
 - Domain files: only when non-standard patterns are detected
-</RULES>
+</HARD_RULES>
 
-## Process
+<PROCESS>
 
-### Preflight Check
+  <PREFLIGHT name="existing-file-check">
+  Check if `AGENTS.md` exists in the current working directory.
 
-Check if `AGENTS.md` exists in the current working directory.
+  **If it already exists:**
 
-**If it already exists:**
+  1. Inform the user: "AGENTS.md already exists in this project. Switching to the improve workflow to optimize your existing configuration."
+  2. Invoke the `improve-agents` skill and follow its complete process.
+  3. **STOP** — do not proceed to Phase 1 or any subsequent phase of this init skill.
 
-1. Inform the user: "AGENTS.md already exists in this project. Switching to the improve workflow to optimize your existing configuration."
-2. Invoke the `improve-agents` skill and follow its complete process.
-3. **STOP** — do not proceed to Phase 1 or any subsequent phase of this init skill.
+  **If it does not exist:**
+  Proceed to Phase 1 below.
+  </PREFLIGHT>
 
-**If it does not exist:**
-Proceed to Phase 1 below.
+  <PHASE id="1" name="codebase-analysis">
+  Read `references/codebase-analyzer.md` and follow its codebase analysis instructions to analyze the project at the current working directory.
 
-### Phase 1: Codebase Analysis
+  Focus: Return ONLY non-standard, non-obvious information that would cause an agent to make mistakes if it didn't know them. Be ruthlessly minimal.
+  </PHASE>
 
-Read `references/codebase-analyzer.md` and follow its codebase analysis instructions to analyze the project at the current working directory.
+  <PHASE id="2" name="scope-detection">
+  Read `references/scope-detector.md` and follow its scope detection instructions for the project at the current working directory.
 
-Focus: Return ONLY non-standard, non-obvious information that would cause an agent to make mistakes if it didn't know them. Be ruthlessly minimal.
+  Focus: Only flag scopes with genuinely different tooling or conventions. A simple single-package project should have ZERO additional scopes. Check shared/library packages for unique constraints even if they are not user-facing, and treat repo-internal tooling directories as root/domain-doc candidates unless they truly need their own config file.
+  </PHASE>
 
-### Phase 2: Scope Detection
+  <PHASE id="3" name="generate-files">
+  Before generating, read these reference documents:
 
-Read `references/scope-detector.md` and follow its scope detection instructions for the project at the current working directory.
+  - `references/progressive-disclosure-guide.md` — file hierarchy decisions
+  - `references/what-not-to-include.md` — content exclusion criteria
+  - `references/context-optimization.md` — token budget guidelines
 
-Focus: Only flag scopes with genuinely different tooling or conventions. A simple single-package project should have ZERO additional scopes. Check shared/library packages for unique constraints even if they are not user-facing, and treat repo-internal tooling directories as root/domain-doc candidates unless they truly need their own config file.
+  Using ONLY the information from Phase 1 and Phase 2, generate the file hierarchy:
 
-### Phase 3: Generate Files
+  #### Root AGENTS.md
 
-Before generating, read these reference documents:
+  Read `assets/templates/root-agents-md.md`. Fill its placeholders using ONLY the analysis output from Phase 1 and Phase 2. Follow the HTML comment instructions in the template to determine which sections to include or remove. Remove any section that would be empty. Target: 15-40 lines.
 
-- `references/progressive-disclosure-guide.md` — file hierarchy decisions
-- `references/what-not-to-include.md` — content exclusion criteria
-- `references/context-optimization.md` — token budget guidelines
+  #### Scope AGENTS.md (per detected scope)
 
-Using ONLY the information from Phase 1 and Phase 2, generate the file hierarchy:
+  If scopes were detected, read `assets/templates/scoped-agents-md.md` for each scope. Only include scope-specific content that differs from root.
 
-#### Root AGENTS.md
+  #### Domain Files (only if non-standard patterns detected)
 
-Read `assets/templates/root-agents-md.md`. Fill its placeholders using ONLY the analysis output from Phase 1 and Phase 2. Follow the HTML comment instructions in the template to determine which sections to include or remove. Remove any section that would be empty. Target: 15-40 lines.
+  If the codebase-analyzer identified non-standard domain patterns, read `assets/templates/domain-doc.md` and generate a file per domain.
+  </PHASE>
 
-#### Scope AGENTS.md (per detected scope)
+  <PHASE id="4" name="self-validation">
+  Read `references/validation-criteria.md` and execute its **Validation Loop Instructions** against every generated file.
 
-If scopes were detected, read `assets/templates/scoped-agents-md.md` for each scope. Only include scope-specific content that differs from root.
+  The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass for ALL files.
+  For init flows, treat output-size targets as required validation gates: the root file MUST finish within 15-40 lines and each scoped file MUST finish within 10-30 lines. If a monorepo root exceeds target, move scope-specific detail down or trim non-essential context and rerun the validation loop.
+  </PHASE>
 
-#### Domain Files (only if non-standard patterns detected)
+  <PHASE id="5" name="present-and-write">
+  1. Show the user ALL generated files with their content before writing
+  2. Explain briefly why each file exists and what evidence supports its content
+  3. Include a concise validation summary: iteration count, final root line count, scoped file count, and any fixes made during self-validation
+  4. Ask for confirmation before writing files
+  5. Write all files to the project
+  </PHASE>
 
-If the codebase-analyzer identified non-standard domain patterns, read `assets/templates/domain-doc.md` and generate a file per domain.
+</PROCESS>
 
-### Phase 4: Self-Validation
-
-Read `references/validation-criteria.md` and execute its **Validation Loop Instructions** against every generated file.
-
-The loop evaluates all hard limits and quality checks, fixes any failures, and re-evaluates — maximum 3 iterations. Do not proceed to Phase 5 until ALL criteria pass for ALL files.
-For init flows, treat output-size targets as required validation gates: the root file MUST finish within 15-40 lines and each scoped file MUST finish within 10-30 lines. If a monorepo root exceeds target, move scope-specific detail down or trim non-essential context and rerun the validation loop.
-
-### Phase 5: Present and Write
-
-1. Show the user ALL generated files with their content before writing
-2. Explain briefly why each file exists and what evidence supports its content
-3. Include a concise validation summary: iteration count, final root line count, scoped file count, and any fixes made during self-validation
-4. Ask for confirmation before writing files
-5. Write all files to the project
+<VALIDATION loop="max-iterations:3">
+Read `references/validation-criteria.md` and loop every generated file through all hard limits and quality checks until all pass.
+</VALIDATION>

--- a/skills/init-agents/references/codebase-analyzer.md
+++ b/skills/init-agents/references/codebase-analyzer.md
@@ -1,7 +1,6 @@
 # Codebase Analysis Instructions
 Structured process for detecting project tech stack, tooling, and non-standard patterns.
 Used by INIT and IMPROVE skills for codebase analysis.
-Source: agents/codebase-analyzer.md
 ---
 
 Follow these codebase analysis instructions. Analyze the project at the current working directory and return a structured summary of its technical characteristics. Focus on facts that would cause mistakes if an AI coding agent didn't know them.
@@ -89,7 +88,6 @@ Look for anything unusual that would trip up an agent:
 - Migration workflows that live in app-specific directories rather than a root config file
 - Repository-specific tools mentioned in existing documentation
 
-*Source: agents/codebase-analyzer.md lines 22-82*
 
 ---
 
@@ -127,7 +125,6 @@ Return your analysis in exactly this format:
 
 If a section has nothing non-standard to report, omit it entirely. Shorter is better.
 
-*Source: agents/codebase-analyzer.md lines 83-113*
 
 ---
 
@@ -140,4 +137,3 @@ Before returning results, verify:
 3. Output follows the exact format specified above
 4. Sections with no findings are omitted, not left empty
 
-*Source: agents/codebase-analyzer.md lines 115-122*

--- a/skills/init-agents/references/context-optimization.md
+++ b/skills/init-agents/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Evidence-based instructions for managing token budgets and attention in agent configuration files.
-Source: research-context-engineering-comprehensive.md
 
 ---
 
@@ -13,17 +12,16 @@ Source: research-context-engineering-comprehensive.md
 - Quality over quantity checklist (include/exclude decision table)
 - Context poisoning vectors (detection and removal)
 - JIT documentation patterns (on-demand loading strategies)
-- Key citations
 
 ---
 
 ## Hard Limits
 
-| Limit | Value | Source |
-|-------|-------|--------|
-| Lines per configuration file | ≤ 200 | Anthropic Docs: "Target under 200 lines per CLAUDE.md file." |
-| Instructions per file | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
-| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily." |
+| Limit | Value |
+|-------|-------|
+| Lines per configuration file | ≤ 200 |
+| Instructions per file | ≤ 150-200 |
+| Contradictions between files | 0 |
 
 > "Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"
 > — Anthropic Best Practices
@@ -79,7 +77,6 @@ For each instruction line, ask: **"Would removing this cause the agent to make m
 - ✅ "Run `npm test` before committing" vs. ❌ "Test your changes"
 - ✅ "API handlers live in `src/api/handlers/`" vs. ❌ "Keep files organized"
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -97,7 +94,6 @@ Detect and remove these before generating or improving configuration files:
 
 > "Treat CLAUDE.md like code: review it when things go wrong, prune it regularly." — Anthropic Best Practices
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -114,17 +110,4 @@ Use these patterns to move content from always-consumed to on-demand locations:
 > "Rather than pre-processing all relevant data up front, agents maintain lightweight identifiers and use these references to dynamically load data into context at runtime."
 > — Anthropic Engineering: Effective Context Engineering
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*
 
----
-
-## Key Citations
-
-| Claim | Source |
-|-------|--------|
-| ≤200 lines per file | Agent Skills Standard |
-| ~150-200 instruction limit | HumanLayer (Kyle) via a-guide-to-agents.md |
-| n² attention constraint / context rot | Anthropic Engineering Blog |
-| Lost-in-the-middle effect | Liu et al., arXiv:2307.03172 |
-| Quality over quantity heuristic | Anthropic Best Practices |
-| JIT documentation strategy | Anthropic Engineering: Effective Context Engineering |

--- a/skills/init-agents/references/progressive-disclosure-guide.md
+++ b/skills/init-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md hierarchies.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md
 
 ---
 
@@ -28,7 +27,6 @@ When deciding where to place content, use this table:
 | Subdirectory AGENTS.md | Specific to one package or area | On-demand when working there |
 | Skill | A workflow the agent should invoke explicitly | On-demand when invoked |
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -93,7 +91,6 @@ docs/
 
 **Use skills for workflows** — agents invoke skills only when needed, keeping base context minimal.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ---
 

--- a/skills/init-agents/references/scope-detector.md
+++ b/skills/init-agents/references/scope-detector.md
@@ -1,7 +1,6 @@
 # Scope Detection Instructions
 Structured process for identifying distinct project contexts that need separate configuration files.
 Used by INIT skills for scope detection.
-Source: agents/scope-detector.md
 ---
 
 Follow these scope detection instructions. Identify distinct contexts within the project at the current working directory that would benefit from their own configuration file (AGENTS.md or CLAUDE.md). Each scope represents an area where an agent needs different guidance than the root-level instructions.
@@ -91,7 +90,6 @@ For each identified scope, determine what makes it different:
 - What conventions apply here but not elsewhere?
 - What tech-specific knowledge would an agent need?
 
-*Source: agents/scope-detector.md lines 41-76*
 
 ---
 
@@ -131,7 +129,6 @@ Return your analysis in exactly this format:
 
 If the project is a simple single-package project, report zero additional scopes — the root file is sufficient.
 
-*Source: agents/scope-detector.md lines 77-112*
 
 ---
 
@@ -144,4 +141,3 @@ Before returning results, verify:
 3. The recommended file count is the minimum necessary
 4. Simple projects correctly return zero additional scopes
 
-*Source: agents/scope-detector.md lines 113-121*

--- a/skills/init-agents/references/validation-criteria.md
+++ b/skills/init-agents/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md files.
-Source: improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
 
 ---
 
@@ -9,13 +8,13 @@ Source: improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
 
 Any file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "~150-200 instructions with reasonable consistency" |
-| Contradictions (within or between files) | 0 | Anthropic: "Claude may pick one arbitrarily" |
-| Language-specific rules in root | 0 | Domain rules belong in separate files |
-| Stale file path references | 0 | "File paths change constantly... actively poisons context" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| Contradictions (within or between files) | 0 |
+| Language-specific rules in root | 0 |
+| Stale file path references | 0 |
 
 ## Recommended Targets (Advisory)
 

--- a/skills/init-agents/references/what-not-to-include.md
+++ b/skills/init-agents/references/what-not-to-include.md
@@ -1,28 +1,26 @@
 # What NOT to Include
 
 Evidence-based exclusion table for AGENTS.md content.
-Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md
 
 ---
 
 ## Exclusion Evidence Table
 
-| Content Type | Why to Exclude | Evidence Quote | Source |
-|-------------|----------------|---------------|--------|
-| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" | ETH Zurich: Evaluating AGENTS.md |
-| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" | Anthropic Best Practices |
-| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" | ETH Zurich: Evaluating AGENTS.md |
-| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | a-guide-to-agents.md |
-| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | a-guide-to-agents.md |
-| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | a-guide-to-agents.md |
-| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
-| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" | research-context-engineering-comprehensive.md |
-| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Anthropic Best Practices |
-| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" | Anthropic Best Practices |
+| Content Type | Why to Exclude | Evidence Quote |
+|-------------|----------------|---------------|
+| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" |
+| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" |
+| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" |
+| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" |
+| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" |
+| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" |
+| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" |
+| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) |
+| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column |
+| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" |
 
-*Source: init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 


### PR DESCRIPTION
Autonomous orchestrate run `20260521-201015` — implements PRD #143 (Skill body semantic-tag convention + HTML artifact routing v1) end to end.

## Outcome

All 9 slices **passed** — 0 failed, 0 skipped. Processed in 7 dependency-ordered waves, each slice implemented and reviewed in an isolated worktree, merged into this umbrella branch via squash.

| Slice | Title | Slice PR |
|-------|-------|----------|
| #144 | Skill body convention tracer (create-skill end-to-end) | #171 |
| #145 | HTML artifact routing in create-skill | #172 |
| #146 | Subagent body convention (create-subagent) | #173 |
| #147 | Improve verbs retrofit (improve-skill + improve-subagent) | #174 |
| #148 | Cursor customizer parity (4 meta-skills) | #175 |
| #149 | Standalone parity (create-skill + improve-skill) | #176 |
| #150 | Tier-2 exemplar retrofits (5 skills, 3 distributions) | #177 |
| #151 | Quality-gate content updates (4 skills) | #178 |
| #152 | Marketplace version cascade | #179 |

## What landed

The canonical semantic-tag vocabulary (`<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>`/`<PHASE>`, optional tags) is now applied across the agent-customizer, cursor-customizer, and standalone distributions — meta-skill bodies, authoring templates, validation criteria, fixture corpora, and path-scoped rules. HTML artifact routing ships in create-skill across all three distributions. The four quality-gate skills assert the convention. Version cascade: agent-customizer 0.3.0, agents-initializer 1.1.0, root Claude marketplace 1.4.0.

## Review notes

Each slice commit carries a `Closes #NNN` trailer — merging this PR closes #144–#152. Per-slice reviewers fixed several defects inline before merge (non-canonical attributes, a dangling fixture path, a platform-neutrality reword, a line-limit compaction).

This PR is left **unmerged** for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)