### PR TITLE
Enforce reference-file self-containment (remove external-doc references)

### DIFF
--- a/.claude/rules/reference-files.md
+++ b/.claude/rules/reference-files.md
@@ -2,7 +2,9 @@
 paths:
   - "plugins/agents-initializer/skills/*/references/*.md"
   - "plugins/cursor-initializer/skills/*/references/*.md"
+  - "plugins/cursor-customizer/skills/*/references/*.md"
   - "plugins/agent-customizer/skills/*/references/*.md"
+  - "plugins/orchestrate/skills/*/references/*.md"
   - "skills/*/references/*.md"
 ---
 # Reference File Conventions
@@ -10,7 +12,7 @@ paths:
 - Files over 100 lines MUST include a `## Contents` table of contents after the title block
 - Maximum 200 lines per reference file
 - Content must be framed as "read as instructions" — not as executable scripts
-- Each file must have a clear source attribution (e.g., `Source: docs/research-*.md`)
+- Reference files MUST be self-contained — no `Source:` attribution lines, and no inline citations (file paths, line ranges, or external document names) pointing to documents outside the skill's own bundle; a reference file may only mention sibling files inside its own skill directory
 - Identical-content parity applies only to explicitly shared references and same-platform copies
 - Platform-specific references may reuse filenames when their content is intentionally platform-native
 - No nested references — reference files must not import or reference other reference files

--- a/plugins/agent-customizer/agents/hook-evaluator.md
+++ b/plugins/agent-customizer/agents/hook-evaluator.md
@@ -22,13 +22,13 @@ You are a hook configuration quality assessment specialist. Analyze the target h
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| JSON structure | Valid JSON; no syntax errors | hooks/claude-hook-reference-doc.md |
-| Event name | From recognized event list | hooks/claude-hook-reference-doc.md lines 22-46 |
-| Handler type | `command`, `http`, `prompt`, or `agent` only | hooks/claude-hook-reference-doc.md lines 249-257 |
-| `command` path | Script file exists and is executable | hooks/automate-workflow-with-hooks.md |
-| Exit code behavior | Exit 2 effect is event-dependent | Blocks: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, SessionStart, SessionEnd, PreCompact, PostCompact, Notification. StopFailure ignores exit code entirely. |
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON structure | Valid JSON; no syntax errors |
+| Event name | From recognized event list |
+| Handler type | `command`, `http`, `prompt`, or `agent` only |
+| `command` path | Script file exists and is executable |
+| Exit code behavior | Exit 2 effect is event-dependent. Blocks: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, SessionStart, SessionEnd, PreCompact, PostCompact, Notification. StopFailure ignores exit code entirely. |
 
 ### Valid Hook Event Types
 

--- a/plugins/agent-customizer/agents/rule-evaluator.md
+++ b/plugins/agent-customizer/agents/rule-evaluator.md
@@ -22,12 +22,12 @@ You are a path-scoped rule quality assessment specialist. Analyze either a speci
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 50 lines | Context budget: loaded when matching files read |
-| YAML frontmatter | Valid YAML if present | memory/how-claude-remembers-a-project.md |
-| `paths:` field | Required; array format; valid glob patterns | memory/how-claude-remembers-a-project.md lines 147-164 |
-| Contradictions with other rules | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 50 lines |
+| YAML frontmatter | Valid YAML if present |
+| `paths:` field | Required; array format; valid glob patterns |
+| Contradictions with other rules | 0 |
 
 ### Quality Checks
 

--- a/plugins/agent-customizer/agents/skill-evaluator.md
+++ b/plugins/agent-customizer/agents/skill-evaluator.md
@@ -22,13 +22,13 @@ You are a skill quality assessment specialist. Analyze the target SKILL.md file 
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | reference-files.md rule constraint |
-| `description` field | Present and non-empty | Required for skill discovery |
-| `name` field format | Lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| `description` field | Present and non-empty |
+| `name` field format | Lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
 ### Structural Checks
 

--- a/plugins/agent-customizer/agents/subagent-evaluator.md
+++ b/plugins/agent-customizer/agents/subagent-evaluator.md
@@ -22,14 +22,14 @@ You are a subagent definition quality assessment specialist. Analyze the target 
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | subagents/creating-custom-subagents.md |
-| `name` field | Lowercase letters and hyphens only | subagents/creating-custom-subagents.md lines 217-220 |
-| `description` field | Present and non-empty | subagents/creating-custom-subagents.md lines 217-220 |
-| `model` field | Recognized alias or full model ID | subagents/creating-custom-subagents.md lines 234-241 |
-| `maxTurns` | ≤ 30 (justify if higher) | subagents/research-subagent-best-practices.md |
-| System prompt | Not empty; task-specific | subagents/creating-custom-subagents.md lines 199-212 |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens only |
+| `description` field | Present and non-empty |
+| `model` field | Recognized alias or full model ID |
+| `maxTurns` | ≤ 30 (justify if higher) |
+| System prompt | Not empty; task-specific |
 
 ### Quality Checks
 

--- a/plugins/agent-customizer/skills/create-hook/references/hook-authoring-guide.md
+++ b/plugins/agent-customizer/skills/create-hook/references/hook-authoring-guide.md
@@ -1,7 +1,6 @@
 # Hook Authoring Guide
 
 Evidence-based guidance for creating Claude Code hooks that enforce deterministic behavior.
-Source: hooks/automate-workflow-with-hooks.md, hooks/claude-hook-reference-doc.md
 
 ---
 
@@ -30,7 +29,6 @@ Hooks provide **deterministic control** — they always fire, regardless of LLM 
 
 Examples: auto-formatting after edits, blocking destructive commands, sending notifications, auditing config changes.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 1-13*
 
 ---
 
@@ -62,7 +60,6 @@ Level 3: **Handler** — what to run when matched
 
 Omit `matcher` or use `""` / `"*"` to match all occurrences.
 
-*Source: hooks/claude-hook-reference-doc.md lines 132-141*
 
 ---
 
@@ -83,7 +80,6 @@ Omit `matcher` or use `""` / `"*"` to match all occurrences.
 
 **Use `http`** for centralizing audit trails across projects or sending to external services.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 569-625; hooks/claude-hook-reference-doc.md lines 249-257*
 
 ---
 
@@ -107,7 +103,6 @@ The `matcher` field is a **regex string** filtering on different fields per even
 
 MCP tools follow pattern `mcp__<server>__<tool>` — use `mcp__server__.*` to match all tools from a server.
 
-*Source: hooks/claude-hook-reference-doc.md lines 162-203*
 
 ---
 
@@ -122,7 +117,6 @@ MCP tools follow pattern `mcp__<server>__<tool>` — use `mcp__server__.*` to ma
 | Skill/agent frontmatter | While component active | Yes |
 | Managed policy settings | Organization-wide | Yes, admin-controlled |
 
-*Source: hooks/automate-workflow-with-hooks.md lines 552-565*
 
 ---
 
@@ -142,13 +136,11 @@ For **command** hooks:
 
 For **prompt/agent** hooks — return JSON `{"ok": true/false, "reason": "..."}`. When `ok: false`, Claude receives `reason` as its next instruction.
 
-*Source: hooks/automate-workflow-with-hooks.md lines ~393-420; hooks/claude-hook-reference-doc.md lines 80-88*
 
 ### Hook Output Discipline
 
 **Golden rule of hook output: success silent, failure verbose.** Stdout/stderr from hooks is injected into Claude's context. A passing typecheck or 4,000-line test log on every PostToolUse pushes the smart zone into the dumb zone. Emit nothing on success; emit specific error traces only on failure.
 
-*Source: harness-engineering.md*
 
 ---
 
@@ -162,4 +154,3 @@ For **prompt/agent** hooks — return JSON `{"ok": true/false, "reason": "..."}`
 
 Test with `--debug` to see hook execution details, including which hooks matched, exit codes, and output.
 
-*Source: hooks/claude-hook-reference-doc.md lines 2050-2065*

--- a/plugins/agent-customizer/skills/create-hook/references/hook-events-reference.md
+++ b/plugins/agent-customizer/skills/create-hook/references/hook-events-reference.md
@@ -1,7 +1,6 @@
 # Hook Events Reference
 
 Complete reference for all 22 Claude Code hook events: triggers, matcher fields, and input/output schemas.
-Source: hooks/claude-hook-reference-doc.md
 
 ---
 
@@ -42,7 +41,6 @@ Source: hooks/claude-hook-reference-doc.md
 | `Elicitation` | When MCP server requests input | Yes |
 | `ElicitationResult` | After user responds to MCP elicitation | Yes |
 
-*Source: hooks/claude-hook-reference-doc.md lines 22-46*
 
 ---
 
@@ -62,7 +60,6 @@ Source: hooks/claude-hook-reference-doc.md
 | `Elicitation`, `ElicitationResult` | MCP server name | your configured server names |
 | No matcher | always fires | `UserPromptSubmit`, `Stop`, `TeammateIdle`, `TaskCompleted`, `WorktreeCreate`, `WorktreeRemove` |
 
-*Source: hooks/claude-hook-reference-doc.md lines 162-179*
 
 ---
 
@@ -115,7 +112,6 @@ Source: hooks/claude-hook-reference-doc.md
 
 **Agent-specific fields:** `type`, `prompt` (required), `timeout` (optional, default 60s)
 
-*Source: hooks/claude-hook-reference-doc.md lines 258-310*
 
 ---
 
@@ -131,7 +127,6 @@ Source: hooks/claude-hook-reference-doc.md
 The 8 agentic loop events that support all handler types:
 `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `UserPromptSubmit`, `Stop`, `SubagentStop`, `TaskCompleted`
 
-*Source: hooks/claude-hook-reference-doc.md lines 249-257*
 
 ---
 
@@ -165,4 +160,3 @@ Inject dynamic context at session start:
 
 Stdout from the hook is injected as additional context.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 70-200*

--- a/plugins/agent-customizer/skills/create-hook/references/hook-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-hook/references/hook-validation-criteria.md
@@ -1,7 +1,6 @@
 # Hook Validation Criteria
 
 Quality checklist for generated and improved Claude Code hook configurations.
-Source: hooks/claude-hook-reference-doc.md, hooks/automate-workflow-with-hooks.md
 
 ---
 
@@ -9,15 +8,13 @@ Source: hooks/claude-hook-reference-doc.md, hooks/automate-workflow-with-hooks.m
 
 Any hook violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| JSON structure | Valid JSON; no syntax errors | hooks/claude-hook-reference-doc.md |
-| Event name | From recognized 22-event list | hooks/claude-hook-reference-doc.md lines 22-46 |
-| Handler type | `command`, `http`, `prompt`, or `agent` only | hooks/claude-hook-reference-doc.md lines 249-257 |
-| `command` path | Script file exists and is executable *(validation-phase check; during staleness evaluation, relative paths are treated as plausible — see hook-evaluation-criteria.md)* | hooks/automate-workflow-with-hooks.md |
-| Exit code behavior | Exit 2 effect is event-dependent — see full table in hook reference | Blocks execution on exit 2: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop, TeammateIdle, TaskCompleted, ConfigChange, Elicitation, ElicitationResult. Any non-zero exit code fails creation (not just exit 2): WorktreeCreate. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, Notification, SubagentStart, SessionStart, SessionEnd, PreCompact, PostCompact. Failures logged in debug mode only (not shown to user): WorktreeRemove. Exit code ignored: StopFailure, InstructionsLoaded. |
-
-*Source: hooks/claude-hook-reference-doc.md "Exit code 2 behavior per event" table*
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON structure | Valid JSON; no syntax errors |
+| Event name | From recognized 22-event list |
+| Handler type | `command`, `http`, `prompt`, or `agent` only |
+| `command` path | Script file exists and is executable *(validation-phase check; during staleness evaluation, relative paths are treated as plausible — see hook-evaluation-criteria.md)* |
+| Exit code behavior | Exit 2 effect is event-dependent — see full table in hook reference. Blocks execution on exit 2: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop, TeammateIdle, TaskCompleted, ConfigChange, Elicitation, ElicitationResult. Any non-zero exit code fails creation (not just exit 2): WorktreeCreate. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, Notification, SubagentStart, SessionStart, SessionEnd, PreCompact, PostCompact. Failures logged in debug mode only (not shown to user): WorktreeRemove. Exit code ignored: StopFailure, InstructionsLoaded. |
 
 ---
 

--- a/plugins/agent-customizer/skills/create-hook/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/create-hook/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/create-rule/assets/templates/rule-file.md
+++ b/plugins/agent-customizer/skills/create-rule/assets/templates/rule-file.md
@@ -16,7 +16,5 @@ paths:
 
 # [Topic Name]
 
-*Source: [path/to/source-doc.md] — the document or convention that establishes these rules*
-
 - [Specific, verifiable instruction]
 - [Specific, verifiable instruction]

--- a/plugins/agent-customizer/skills/create-rule/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/create-rule/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/create-rule/references/rule-authoring-guide.md
+++ b/plugins/agent-customizer/skills/create-rule/references/rule-authoring-guide.md
@@ -1,7 +1,6 @@
 # Rule Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code rule files (`.claude/rules/*.md`).
-Source: memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -29,7 +28,6 @@ Rules are instruction files loaded on-demand when Claude reads files matching th
 
 **Rules load into context** when matching files are read, so keep them focused and concise.
 
-*Source: memory/how-claude-remembers-a-project.md lines 123-145; .github/instructions/rules.instructions.md*
 
 ---
 
@@ -48,7 +46,6 @@ Each file should cover **one topic** with a descriptive filename. All `.md` file
 
 For this project, rules should use `paths` frontmatter so they load only when Claude reads matching files. Put always-loaded project guidance in root `CLAUDE.md`, not in `.claude/rules/`.
 
-*Source: memory/how-claude-remembers-a-project.md lines 123-145*
 
 ---
 
@@ -81,7 +78,6 @@ paths:
 ---
 ```
 
-*Source: memory/how-claude-remembers-a-project.md lines 147-186*
 
 ---
 
@@ -98,7 +94,6 @@ paths:
 
 Path-scoped rules trigger when Claude **reads files** matching the pattern, not on every tool use.
 
-*Source: memory/how-claude-remembers-a-project.md lines 166-183*
 
 ---
 
@@ -121,7 +116,6 @@ Path-scoped rules trigger when Claude **reads files** matching the pattern, not 
 
 **No contradictions** — if two rules conflict, Claude may pick one arbitrarily. Review `.claude/rules/` periodically to remove outdated or conflicting instructions.
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; Project convention — `.github/instructions/rules.instructions.md`*
 
 ---
 
@@ -136,4 +130,3 @@ Path-scoped rules trigger when Claude **reads files** matching the pattern, not 
 | Always-loaded rules for rare situations | Context cost on every session | Convert to path-scoped or skill |
 | Rule files exceeding 50 lines | Poor adherence; attention fragmentation | Split into multiple focused files |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 123-145; Project convention — `.github/instructions/rules.instructions.md`*

--- a/plugins/agent-customizer/skills/create-rule/references/rule-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-rule/references/rule-validation-criteria.md
@@ -1,7 +1,6 @@
 # Rule Validation Criteria
 
 Quality checklist for generated and improved `.claude/rules/*.md` rule files.
-Source: memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -9,14 +8,13 @@ Source: memory/how-claude-remembers-a-project.md
 
 Any rule file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 50 lines | Context budget: loaded when matching files read — project convention |
-| YAML frontmatter | Valid YAML if present | memory/how-claude-remembers-a-project.md |
-| `paths:` field | Required; array format; valid glob patterns | memory/how-claude-remembers-a-project.md lines 147-164 |
-| Contradictions with other rules | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 50 lines |
+| YAML frontmatter | Valid YAML if present |
+| `paths:` field | Required; array format; valid glob patterns |
+| Contradictions with other rules | 0 |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 147-164; Project convention — `.github/instructions/rules.instructions.md`*
 
 ---
 

--- a/plugins/agent-customizer/skills/create-skill/assets/templates/skill-md.md
+++ b/plugins/agent-customizer/skills/create-skill/assets/templates/skill-md.md
@@ -11,8 +11,8 @@ description: "[What this skill does and when to use it. Third person.]"
      Rule: Use ${CLAUDE_SKILL_DIR}/assets/templates/ for output templates
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name the target service/workspace explicitly
-     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
-           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory: <TRIGGER>,
            <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
            Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
            Closed attribute set: avoid=, always=, when=, name=, id=, priority=.

--- a/plugins/agent-customizer/skills/create-skill/references/artifact-format-routing.md
+++ b/plugins/agent-customizer/skills/create-skill/references/artifact-format-routing.md
@@ -2,9 +2,6 @@
 
 Evidence-based routing rule for deciding whether a skill's generated output artifact
 should default to HTML or Markdown.
-Source: wiki/knowledge/skill-body-convention.md (Artifact format routing section),
-CONTEXT.md (HTML-structural body convention — "Artifact format routing" entry),
-wiki/knowledge/html-artifact-effectiveness.md
 
 ---
 
@@ -113,5 +110,3 @@ Markdown past ~100 lines stops being read; rich visualisations get faked with AS
 HTML renders natively in any browser without extra tooling. For agent-loaded and
 tooling-locked files the tradeoffs reverse: spec compliance, diffability, and
 renderer compatibility make Markdown mandatory.
-
-Source: wiki/knowledge/html-artifact-effectiveness.md (Core argument, Where HTML wins)

--- a/plugins/agent-customizer/skills/create-skill/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/create-skill/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/create-skill/references/skill-authoring-guide.md
+++ b/plugins/agent-customizer/skills/create-skill/references/skill-authoring-guide.md
@@ -1,7 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code skills (SKILL.md files).
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -50,7 +49,6 @@ Analogy: Claude as a robot on a path — narrow bridge (low freedom) vs. open fi
 | Sonnet | Clear and efficient? (balanced) |
 | Opus | Avoid over-explaining? (may need less) |
 
-*Source: skills/skill-authoring-best-practices.md lines 11-145*
 
 ---
 
@@ -82,7 +80,6 @@ my-skill/
 | `hooks` | No | Hooks scoped to this skill's lifecycle |
 | `argument-hint` | No | Autocomplete hint, e.g. `[issue-number]` |
 
-*Source: skills/extend-claude-with-skills.md lines 169-199*
 
 ---
 
@@ -98,7 +95,6 @@ my-skill/
 
 Include: (1) what it does, (2) when to use it, (3) specific trigger terms for matching.
 
-*Source: skills/skill-authoring-best-practices.md lines 168-250*
 
 ---
 
@@ -118,7 +114,6 @@ Load only the references needed for each phase, not all at once.
 
 Keep SKILL.md under 500 lines. Move detailed reference material to separate files. Reference supporting files explicitly so Claude knows what they contain.
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300; skills/extend-claude-with-skills.md lines 223-246*
 
 ---
 
@@ -132,7 +127,6 @@ Keep SKILL.md under 500 lines. Move detailed reference material to separate file
 
 Use `disable-model-invocation: true` for workflows with side effects (commit, deploy, send-message). Use `user-invocable: false` for background knowledge Claude should apply but users shouldn't invoke directly.
 
-*Source: skills/extend-claude-with-skills.md lines 248-283*
 
 ---
 
@@ -147,4 +141,3 @@ Use `disable-model-invocation: true` for workflows with side effects (commit, de
 | Over-explaining for Opus | Patronizing + token waste | Trust the model; provide minimal scaffolding |
 | Contradictions between phases | Claude picks one arbitrarily | Review all phases for consistency |
 
-*Source: skills/skill-authoring-best-practices.md lines 800-1100*

--- a/plugins/agent-customizer/skills/create-skill/references/skill-format-reference.md
+++ b/plugins/agent-customizer/skills/create-skill/references/skill-format-reference.md
@@ -1,7 +1,6 @@
 # Skill Format Reference
 
 Technical specification for SKILL.md format, directory structure, variables, and discovery.
-Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-skills.md
 
 ---
 
@@ -45,7 +44,6 @@ Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-
 | `agent` | Subagent type when `context: fork` (e.g., `Explore`, `Plan`, `general-purpose`) |
 | `hooks` | Hooks scoped to this skill's lifecycle (see hooks documentation) |
 
-*Source: skills/research-claude-code-skills-format.md lines 90-130; skills/extend-claude-with-skills.md lines 183-198*
 
 ---
 
@@ -57,7 +55,6 @@ Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-
 - Must NOT contain consecutive `--`
 - Must match the parent directory name
 
-*Source: skills/research-claude-code-skills-format.md lines 103-108*
 
 ---
 
@@ -84,7 +81,6 @@ Dynamic context injection with `!` prefix runs shell commands before skill loads
 - Current branch: !`git branch --show-current`
 ```
 
-*Source: skills/extend-claude-with-skills.md lines 201-210; skills/research-claude-code-skills-format.md lines 126-149*
 
 ---
 
@@ -109,7 +105,6 @@ my-skill/
 - `references/` files load only when skill phases explicitly read them
 - `scripts/` files are executed, not loaded into context
 
-*Source: skills/research-claude-code-skills-format.md lines 153-186; skills/extend-claude-with-skills.md lines 100-115*
 
 ---
 
@@ -123,7 +118,6 @@ my-skill/
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to `references/` subdirectory. Explicitly reference supporting files from SKILL.md so Claude knows what to load and when.
 
-*Source: skills/research-claude-code-skills-format.md lines 172-186*
 
 ---
 
@@ -138,4 +132,3 @@ Keep SKILL.md under **500 lines**. Move detailed reference material to `referenc
 
 Priority: enterprise > personal > project. Plugin skills use `plugin-name:skill-name` namespace — no conflicts.
 
-*Source: skills/extend-claude-with-skills.md lines 85-97; skills/research-claude-code-skills-format.md lines 189-200*

--- a/plugins/agent-customizer/skills/create-skill/references/skill-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-skill/references/skill-validation-criteria.md
@@ -1,7 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`, `wiki/knowledge/skill-body-convention.md`
 
 ---
 
@@ -20,16 +19,15 @@ Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skil
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
-| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags |
+| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
 
 ---
 

--- a/plugins/agent-customizer/skills/create-subagent/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/create-subagent/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/create-subagent/references/subagent-authoring-guide.md
+++ b/plugins/agent-customizer/skills/create-subagent/references/subagent-authoring-guide.md
@@ -1,7 +1,6 @@
 # Subagent Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code subagent definitions.
-Source: subagents/research-subagent-best-practices.md, subagents/creating-custom-subagents.md
 
 ---
 
@@ -21,7 +20,6 @@ Source: subagents/research-subagent-best-practices.md, subagents/creating-custom
 
 Subagents are context firewalls. They encapsulate exploration work — glob output, grep noise, evaluator scans — in an isolated window so it never reaches the parent context. Only the condensed, structured result flows back. The orchestrator stays in the smart zone; the subagent absorbs the noise.
 
-*Source: harness-engineering.md*
 
 | Use subagent when | Use inline Claude when | Use hook when |
 |------------------|----------------------|--------------|
@@ -33,7 +31,6 @@ Subagents are context firewalls. They encapsulate exploration work — glob outp
 
 **Subagents cannot spawn other subagents** — prevents infinite nesting.
 
-*Source: subagents/research-subagent-best-practices.md lines 33-55*
 
 ---
 
@@ -66,7 +63,6 @@ maxTurns: 20
 You are a code reviewer specializing in [domain]...
 ```
 
-*Source: subagents/creating-custom-subagents.md lines 151-210*
 
 ---
 
@@ -86,7 +82,6 @@ Effective subagent system prompts follow this 5-part pattern:
 - Include trigger phrases ("use proactively when...", "use when editing...")
 - Avoid generic descriptions ("helps with code")
 
-*Source: subagents/research-subagent-best-practices.md lines 73-76, 374-430*
 
 ---
 
@@ -103,7 +98,6 @@ Effective subagent system prompts follow this 5-part pattern:
 
 **Rule of thumb**: Opus for architecture decisions, Sonnet for everything else, Haiku for read-only exploration only.
 
-*Source: subagents/research-subagent-best-practices.md lines 318-355*
 
 ---
 
@@ -129,7 +123,6 @@ If both defined: denylist applied first, then allowlist resolves against remaini
 - Explorers: `Read, Grep, Glob, Bash(readonly commands)`
 - Full-capability (rare): all tools — justify explicitly
 
-*Source: subagents/creating-custom-subagents.md lines 245-295*
 
 ---
 
@@ -146,7 +139,6 @@ If both defined: denylist applied first, then allowlist resolves against remaini
 | maxTurns > 30 | Runaway agents | Cap at 20-30 for most tasks |
 | Vague system prompt | Inconsistent behavior | Add role, process, output format |
 
-*Source: subagents/research-subagent-best-practices.md lines 791-819*
 
 ---
 
@@ -167,4 +159,3 @@ Consolidate similar issues. Prioritize by: CRITICAL (bugs/security) > HIGH > MED
 
 This pattern significantly reduces noise and keeps output actionable.
 
-*Source: subagents/research-subagent-best-practices.md lines 463-475*

--- a/plugins/agent-customizer/skills/create-subagent/references/subagent-config-reference.md
+++ b/plugins/agent-customizer/skills/create-subagent/references/subagent-config-reference.md
@@ -1,7 +1,6 @@
 # Subagent Config Reference
 
 Complete YAML frontmatter specification, model IDs, and orchestration patterns for subagents.
-Source: subagents/creating-custom-subagents.md, subagents/claude-orchestrate-of-claude-code-sessions.md
 
 ---
 
@@ -37,7 +36,6 @@ Only `name` and `description` are required. All others have sensible defaults.
 | `effort` | No | Inherit | `low`, `medium`, `high`, `max` (Opus 4.6 only) |
 | `isolation` | No | None | `worktree` = isolated git worktree; auto-cleanup if no changes |
 
-*Source: subagents/creating-custom-subagents.md lines 213-232*
 
 ---
 
@@ -54,7 +52,6 @@ Only `name` and `description` are required. All others have sensible defaults.
 
 Full model IDs (e.g., `claude-opus-4-6`, `claude-sonnet-4-6`) also accepted.
 
-*Source: subagents/creating-custom-subagents.md lines 234-241*
 
 ---
 
@@ -91,7 +88,6 @@ Standard patterns from community (read-only reviewers dominate):
 - Explorer: `tools: Read, Grep, Glob, Bash`
 - Full-access (rare): omit `tools` and `disallowedTools`
 
-*Source: subagents/creating-custom-subagents.md lines 243-275*
 
 ---
 
@@ -116,7 +112,6 @@ Main → (delegate) → Researcher agent → (report) → Main → (delegate) �
 **Parallel decomposition:**
 Spawn multiple independent subagents simultaneously. Main aggregates results.
 
-*Source: subagents/creating-custom-subagents.md lines 619-637*
 
 ---
 
@@ -129,7 +124,6 @@ These limitations are enforced by the runtime:
 - **Subagents do not inherit parent skills** — must be explicitly listed in `skills` field (full content injected)
 - **`maxTurns` applies per invocation** — project convention: 15 for analysis agents, 20 for evaluator agents; values outside 15–20 require explicit justification
 
-*Source: subagents/creating-custom-subagents.md lines 210-212; subagents/research-subagent-best-practices.md lines 36-42*
 
 ---
 
@@ -143,4 +137,3 @@ Plugin subagents (from installed plugins) have additional restrictions for secur
 
 To use these fields with a plugin agent: copy the agent file to `.claude/agents/` or `~/.claude/agents/`.
 
-*Source: subagents/creating-custom-subagents.md lines 187-189*

--- a/plugins/agent-customizer/skills/create-subagent/references/subagent-validation-criteria.md
+++ b/plugins/agent-customizer/skills/create-subagent/references/subagent-validation-criteria.md
@@ -1,7 +1,6 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Claude Code subagent definitions.
-Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md, `wiki/knowledge/skill-body-convention.md`
 
 ---
 
@@ -20,16 +19,15 @@ Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best
 
 Any subagent violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | subagents/creating-custom-subagents.md |
-| `name` field | Lowercase letters and hyphens only | subagents/creating-custom-subagents.md lines 217-220 |
-| `description` field | Present and non-empty | subagents/creating-custom-subagents.md lines 217-220 |
-| `model` field | Recognized alias or full model ID | subagents/creating-custom-subagents.md lines 234-241 |
-| `maxTurns` | 15 for analysis agents; 20 for evaluators; values outside 15–20 require justification | Project convention — `.claude/rules/agent-files.md` |
-| System prompt | Not empty; task-specific | subagents/creating-custom-subagents.md lines 199-212 |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens only |
+| `description` field | Present and non-empty |
+| `model` field | Recognized alias or full model ID |
+| `maxTurns` | 15 for analysis agents; 20 for evaluators; values outside 15–20 require justification |
+| System prompt | Not empty; task-specific |
 
-*Source: subagents/creating-custom-subagents.md lines 213-232; subagents/research-subagent-best-practices.md lines 33-55*
 
 ---
 
@@ -64,7 +62,6 @@ The subagent body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-hook/references/hook-authoring-guide.md
+++ b/plugins/agent-customizer/skills/improve-hook/references/hook-authoring-guide.md
@@ -1,7 +1,6 @@
 # Hook Authoring Guide
 
 Evidence-based guidance for creating Claude Code hooks that enforce deterministic behavior.
-Source: hooks/automate-workflow-with-hooks.md, hooks/claude-hook-reference-doc.md
 
 ---
 
@@ -30,7 +29,6 @@ Hooks provide **deterministic control** — they always fire, regardless of LLM 
 
 Examples: auto-formatting after edits, blocking destructive commands, sending notifications, auditing config changes.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 1-13*
 
 ---
 
@@ -62,7 +60,6 @@ Level 3: **Handler** — what to run when matched
 
 Omit `matcher` or use `""` / `"*"` to match all occurrences.
 
-*Source: hooks/claude-hook-reference-doc.md lines 132-141*
 
 ---
 
@@ -83,7 +80,6 @@ Omit `matcher` or use `""` / `"*"` to match all occurrences.
 
 **Use `http`** for centralizing audit trails across projects or sending to external services.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 569-625; hooks/claude-hook-reference-doc.md lines 249-257*
 
 ---
 
@@ -107,7 +103,6 @@ The `matcher` field is a **regex string** filtering on different fields per even
 
 MCP tools follow pattern `mcp__<server>__<tool>` — use `mcp__server__.*` to match all tools from a server.
 
-*Source: hooks/claude-hook-reference-doc.md lines 162-203*
 
 ---
 
@@ -122,7 +117,6 @@ MCP tools follow pattern `mcp__<server>__<tool>` — use `mcp__server__.*` to ma
 | Skill/agent frontmatter | While component active | Yes |
 | Managed policy settings | Organization-wide | Yes, admin-controlled |
 
-*Source: hooks/automate-workflow-with-hooks.md lines 552-565*
 
 ---
 
@@ -142,13 +136,11 @@ For **command** hooks:
 
 For **prompt/agent** hooks — return JSON `{"ok": true/false, "reason": "..."}`. When `ok: false`, Claude receives `reason` as its next instruction.
 
-*Source: hooks/automate-workflow-with-hooks.md lines ~393-420; hooks/claude-hook-reference-doc.md lines 80-88*
 
 ### Hook Output Discipline
 
 **Golden rule of hook output: success silent, failure verbose.** Stdout/stderr from hooks is injected into Claude's context. A passing typecheck or 4,000-line test log on every PostToolUse pushes the smart zone into the dumb zone. Emit nothing on success; emit specific error traces only on failure.
 
-*Source: harness-engineering.md*
 
 ---
 
@@ -162,4 +154,3 @@ For **prompt/agent** hooks — return JSON `{"ok": true/false, "reason": "..."}`
 
 Test with `--debug` to see hook execution details, including which hooks matched, exit codes, and output.
 
-*Source: hooks/claude-hook-reference-doc.md lines 2050-2065*

--- a/plugins/agent-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
@@ -1,8 +1,6 @@
 # Hook Evaluation Criteria
 
 Scoring rubric for assessing existing Claude Code hook configurations before improvement.
-Source: hooks/claude-hook-reference-doc.md, hooks/automate-workflow-with-hooks.md
-
 ---
 
 ## Contents
@@ -19,17 +17,16 @@ Source: hooks/claude-hook-reference-doc.md, hooks/automate-workflow-with-hooks.m
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| JSON configuration | Valid JSON, no syntax errors | hooks/claude-hook-reference-doc.md |
-| Event name | From recognized 22-event list | hooks/claude-hook-reference-doc.md lines 22-46 |
-| Handler type | `command`, `http`, `prompt`, or `agent` | hooks/claude-hook-reference-doc.md lines 249-257 |
-| Matcher field | Valid regex string or empty | hooks/claude-hook-reference-doc.md lines 162-179 |
-| Command path | Absolute script paths must resolve to an existing executable; relative workspace paths (e.g., `.claude/hooks/*.sh`, `scripts/`) are plausible and must not be flagged INVALID | hooks/automate-workflow-with-hooks.md |
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON configuration | Valid JSON, no syntax errors |
+| Event name | From recognized 22-event list |
+| Handler type | `command`, `http`, `prompt`, or `agent` |
+| Matcher field | Valid regex string or empty |
+| Command path | Absolute script paths must resolve to an existing executable; relative workspace paths (e.g., `.claude/hooks/*.sh`, `scripts/`) are plausible and must not be flagged INVALID |
 
 A hook configuration violating any hard limit is flagged **INVALID** regardless of intent.
 
-*Source: hooks/claude-hook-reference-doc.md lines 132-200*
 
 ---
 
@@ -37,7 +34,6 @@ A hook configuration violating any hard limit is flagged **INVALID** regardless 
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -52,7 +48,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Hook commands that always exit 0 (never block) | Observation-only hooks should use PostToolUse, not PreToolUse |
 | Sensitive data in `command` string of settings.json | Use environment variables instead |
 
-*Source: hooks/automate-workflow-with-hooks.md lines 569-625*
 
 ---
 
@@ -65,7 +60,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Hardcoded absolute paths to scripts that don't exist | Verify each absolute `command` script path exists; relative paths (not starting with `/`) are treated as plausible and are not a staleness indicator *(staleness-evaluation heuristic only; Phase 4 validation uses a stricter existence check — see hook-validation-criteria.md)* |
 | Outdated matcher values (e.g., old session end reasons) | Verify against current matcher value lists |
 
-*Source: hooks/claude-hook-reference-doc.md lines 162-179*
 
 ---
 
@@ -79,7 +73,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Security posture appropriate? | Hook validates before allowing | Hook only logs, never blocks |
 | Hook type appropriate for task? | `command` for deterministic, `prompt` for judgment | `agent` for a simple grep check |
 
-*Source: hooks/automate-workflow-with-hooks.md lines 1-13*
 
 ---
 
@@ -94,7 +87,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Handler Efficiency | Right type for each task | Some oversized handlers | Agent hooks for trivial tasks |
 | **Overall** | | | |
 
-*Source: hooks/claude-hook-reference-doc.md lines 249-257*
 
 > **UNCERTAIN classification**: When the `command` handler references an external script that cannot be read from the repository, classify Error Handling as **UNCERTAIN** (not Bad) — exit-code behavior cannot be verified from the hook configuration alone. Report it as a gap rather than a violation.
 

--- a/plugins/agent-customizer/skills/improve-hook/references/hook-events-reference.md
+++ b/plugins/agent-customizer/skills/improve-hook/references/hook-events-reference.md
@@ -1,7 +1,6 @@
 # Hook Events Reference
 
 Complete reference for all 22 Claude Code hook events: triggers, matcher fields, and input/output schemas.
-Source: hooks/claude-hook-reference-doc.md
 
 ---
 
@@ -42,7 +41,6 @@ Source: hooks/claude-hook-reference-doc.md
 | `Elicitation` | When MCP server requests input | Yes |
 | `ElicitationResult` | After user responds to MCP elicitation | Yes |
 
-*Source: hooks/claude-hook-reference-doc.md lines 22-46*
 
 ---
 
@@ -62,7 +60,6 @@ Source: hooks/claude-hook-reference-doc.md
 | `Elicitation`, `ElicitationResult` | MCP server name | your configured server names |
 | No matcher | always fires | `UserPromptSubmit`, `Stop`, `TeammateIdle`, `TaskCompleted`, `WorktreeCreate`, `WorktreeRemove` |
 
-*Source: hooks/claude-hook-reference-doc.md lines 162-179*
 
 ---
 
@@ -115,7 +112,6 @@ Source: hooks/claude-hook-reference-doc.md
 
 **Agent-specific fields:** `type`, `prompt` (required), `timeout` (optional, default 60s)
 
-*Source: hooks/claude-hook-reference-doc.md lines 258-310*
 
 ---
 
@@ -131,7 +127,6 @@ Source: hooks/claude-hook-reference-doc.md
 The 8 agentic loop events that support all handler types:
 `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `UserPromptSubmit`, `Stop`, `SubagentStop`, `TaskCompleted`
 
-*Source: hooks/claude-hook-reference-doc.md lines 249-257*
 
 ---
 
@@ -165,4 +160,3 @@ Inject dynamic context at session start:
 
 Stdout from the hook is injected as additional context.
 
-*Source: hooks/automate-workflow-with-hooks.md lines 70-200*

--- a/plugins/agent-customizer/skills/improve-hook/references/hook-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-hook/references/hook-validation-criteria.md
@@ -1,23 +1,19 @@
 # Hook Validation Criteria
 
 Quality checklist for generated and improved Claude Code hook configurations.
-Source: hooks/claude-hook-reference-doc.md, hooks/automate-workflow-with-hooks.md
-
 ---
 
 ## Hard Limits (Auto-fail if violated)
 
 Any hook violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| JSON structure | Valid JSON; no syntax errors | hooks/claude-hook-reference-doc.md |
-| Event name | From recognized 22-event list | hooks/claude-hook-reference-doc.md lines 22-46 |
-| Handler type | `command`, `http`, `prompt`, or `agent` only | hooks/claude-hook-reference-doc.md lines 249-257 |
-| `command` path | Script file exists and is executable *(validation-phase check; during staleness evaluation, relative paths are treated as plausible — see hook-evaluation-criteria.md)* | hooks/automate-workflow-with-hooks.md |
-| Exit code behavior | Exit 2 effect is event-dependent — see full table in hook reference | Blocks execution on exit 2: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop, TeammateIdle, TaskCompleted, ConfigChange, Elicitation, ElicitationResult. Any non-zero exit code fails creation (not just exit 2): WorktreeCreate. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, Notification, SubagentStart, SessionStart, SessionEnd, PreCompact, PostCompact. Failures logged in debug mode only (not shown to user): WorktreeRemove. Exit code ignored: StopFailure, InstructionsLoaded. |
-
-*Source: hooks/claude-hook-reference-doc.md "Exit code 2 behavior per event" table*
+| Criterion | Threshold |
+|-----------|-----------|
+| JSON structure | Valid JSON; no syntax errors |
+| Event name | From recognized 22-event list |
+| Handler type | `command`, `http`, `prompt`, or `agent` only |
+| `command` path | Script file exists and is executable *(validation-phase check; during staleness evaluation, relative paths are treated as plausible — see hook-evaluation-criteria.md)* |
+| Exit code behavior | Exit 2 effect is event-dependent — see full table in hook reference. Blocks execution on exit 2: PreToolUse, PermissionRequest, UserPromptSubmit, Stop, SubagentStop, TeammateIdle, TaskCompleted, ConfigChange, Elicitation, ElicitationResult. Any non-zero exit code fails creation (not just exit 2): WorktreeCreate. Shows stderr only (non-blocking): PostToolUse, PostToolUseFailure, Notification, SubagentStart, SessionStart, SessionEnd, PreCompact, PostCompact. Failures logged in debug mode only (not shown to user): WorktreeRemove. Exit code ignored: StopFailure, InstructionsLoaded. |
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-hook/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/improve-hook/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/improve-rule/assets/templates/rule-file.md
+++ b/plugins/agent-customizer/skills/improve-rule/assets/templates/rule-file.md
@@ -16,7 +16,5 @@ paths:
 
 # [Topic Name]
 
-*Source: [path/to/source-doc.md] — the document or convention that establishes these rules*
-
 - [Specific, verifiable instruction]
 - [Specific, verifiable instruction]

--- a/plugins/agent-customizer/skills/improve-rule/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/improve-rule/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/improve-rule/references/rule-authoring-guide.md
+++ b/plugins/agent-customizer/skills/improve-rule/references/rule-authoring-guide.md
@@ -1,8 +1,6 @@
 # Rule Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code rule files (`.claude/rules/*.md`).
-Source: memory/how-claude-remembers-a-project.md
-
 ---
 
 ## Contents
@@ -29,7 +27,6 @@ Rules are instruction files loaded on-demand when Claude reads files matching th
 
 **Rules load into context** when matching files are read, so keep them focused and concise.
 
-*Source: memory/how-claude-remembers-a-project.md lines 123-145; .github/instructions/rules.instructions.md*
 
 ---
 
@@ -48,7 +45,6 @@ Each file should cover **one topic** with a descriptive filename. All `.md` file
 
 For this project, rules should use `paths` frontmatter so they load only when Claude reads matching files. Put always-loaded project guidance in root `CLAUDE.md`, not in `.claude/rules/`.
 
-*Source: memory/how-claude-remembers-a-project.md lines 123-145*
 
 ---
 
@@ -81,7 +77,6 @@ paths:
 ---
 ```
 
-*Source: memory/how-claude-remembers-a-project.md lines 147-186*
 
 ---
 
@@ -98,7 +93,6 @@ paths:
 
 Path-scoped rules trigger when Claude **reads files** matching the pattern, not on every tool use.
 
-*Source: memory/how-claude-remembers-a-project.md lines 166-183*
 
 ---
 
@@ -121,7 +115,6 @@ Path-scoped rules trigger when Claude **reads files** matching the pattern, not 
 
 **No contradictions** — if two rules conflict, Claude may pick one arbitrarily. Review `.claude/rules/` periodically to remove outdated or conflicting instructions.
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; Project convention — `.github/instructions/rules.instructions.md`*
 
 ---
 
@@ -136,4 +129,3 @@ Path-scoped rules trigger when Claude **reads files** matching the pattern, not 
 | Always-loaded rules for rare situations | Context cost on every session | Convert to path-scoped or skill |
 | Rule files exceeding 50 lines | Poor adherence; attention fragmentation | Split into multiple focused files |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 123-145; Project convention — `.github/instructions/rules.instructions.md`*

--- a/plugins/agent-customizer/skills/improve-rule/references/rule-evaluation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-rule/references/rule-evaluation-criteria.md
@@ -1,8 +1,6 @@
 # Rule Evaluation Criteria
 
 Scoring rubric for assessing existing `.claude/rules/*.md` rule files before improvement.
-Source: memory/how-claude-remembers-a-project.md
-
 ---
 
 ## Contents
@@ -19,16 +17,15 @@ Source: memory/how-claude-remembers-a-project.md
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rules | `paths:` array present | memory/how-claude-remembers-a-project.md lines 147-164 |
-| Rules | ≤ 50 lines | Context budget: loaded when matching files read — project convention |
-| YAML frontmatter | Valid YAML if present | memory/how-claude-remembers-a-project.md |
-| Instructions | Actionable and verifiable | memory/how-claude-remembers-a-project.md lines 61-75 |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rules | `paths:` array present |
+| Rules | ≤ 50 lines |
+| YAML frontmatter | Valid YAML if present |
+| Instructions | Actionable and verifiable |
 
 A rule file violating any hard limit is flagged **OVER LIMIT** or **INVALID**.
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 123-145; Project convention — `.github/instructions/rules.instructions.md`*
 
 ---
 
@@ -36,7 +33,6 @@ A rule file violating any hard limit is flagged **OVER LIMIT** or **INVALID**.
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -51,7 +47,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Long explanations or tutorials | Rules are instructions, not documentation |
 | Examples in rules | Token waste; be specific instead |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75*
 
 ---
 
@@ -64,7 +59,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Instructions for conventions no longer used | Check if convention is still in use |
 | Paths pointing to deleted or moved directories | Verify directory paths exist |
 
-*Source: memory/how-claude-remembers-a-project.md lines 147-164*
 
 ---
 
@@ -78,7 +72,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | No overlap with other rules? | Each rule file covers distinct domain | Same instruction in 3 rule files |
 | Rule scope narrow enough for the token cost? | Specific globs for real target files | Missing `paths:` or broad scope |
 
-*Source: memory/how-claude-remembers-a-project.md lines 123-145*
 
 ---
 
@@ -93,7 +86,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Consistency | 0 contradictions across files | 1 contradiction | 2+ contradictions |
 | **Overall** | | | |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 123-145*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-rule/references/rule-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-rule/references/rule-validation-criteria.md
@@ -1,22 +1,19 @@
 # Rule Validation Criteria
 
 Quality checklist for generated and improved `.claude/rules/*.md` rule files.
-Source: memory/how-claude-remembers-a-project.md
-
 ---
 
 ## Hard Limits (Auto-fail if violated)
 
 Any rule file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 50 lines | Context budget: loaded when matching files read — project convention |
-| YAML frontmatter | Valid YAML if present | memory/how-claude-remembers-a-project.md |
-| `paths:` field | Required; array format; valid glob patterns | memory/how-claude-remembers-a-project.md lines 147-164 |
-| Contradictions with other rules | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 50 lines |
+| YAML frontmatter | Valid YAML if present |
+| `paths:` field | Required; array format; valid glob patterns |
+| Contradictions with other rules | 0 |
 
-*Source: memory/how-claude-remembers-a-project.md lines 61-75; 147-164; Project convention — `.github/instructions/rules.instructions.md`*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-skill/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/prompt-engineering-strategies.md
@@ -1,8 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
-
 ---
 
 ## Contents
@@ -24,7 +22,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 - **Describe desired behavior, not prohibited behavior** — prefer "smooth flowing prose" over "do not use markdown".
 - **Behavioral discipline & safe persuasion** — see `behavioral-guidelines.md` for the four principles and seven persuasion patterns; both apply here verbatim.
 
-*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -32,7 +29,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 
 For SKILL.md authoring: role prompting on the opening line, zero-shot for most phases, few-shot examples reserved for phases with strict output format, XML structuring for multi-section bodies, self-check in the final phase, parallel tool calls in multi-step phases. Chain-of-thought is avoided in skill bodies because it slows execution.
 
-*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160.*
 
 ---
 
@@ -45,7 +41,6 @@ For SKILL.md authoring: role prompting on the opening line, zero-shot for most p
 - Make constraints concrete (scope limits, output shape, stop conditions); keep each phase ≤10 lines with depth in references.
 - Final phase self-check: verify all criteria in `skill-validation-criteria.md`, including Karpathy-style discipline and the persuasion ethical constraint.
 
-*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80. Hooks/rules/subagents recommendations are out of scope for improve-skill — see the broader strategies doc.*
 
 ---
 
@@ -53,7 +48,6 @@ For SKILL.md authoring: role prompting on the opening line, zero-shot for most p
 
 Avoid these prompting anti-patterns: aggressive triggers ("CRITICAL: You MUST always..."), vague instructions ("be thorough"), few-shot examples in rules (token waste on every session), over-explaining what the model already knows, prescriptive step-by-step plans (use "think thoroughly" instead), contradictory instructions across phases, and burying critical rules in the middle of long contexts (lost-in-the-middle effect — keep them in the first/last 20%).
 
-*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -61,4 +55,3 @@ Avoid these prompting anti-patterns: aggressive triggers ("CRITICAL: You MUST al
 
 Every token competes with conversation history. Apply the deletion test from `skill-evaluation-criteria.md` to every instruction; prefer pointers to detailed content over inlining; reserve progressive disclosure for long artifacts (skill bodies, subagent prompts) and zero-shot for short ones (rules, validation criteria).
 
-*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*

--- a/plugins/agent-customizer/skills/improve-skill/references/skill-authoring-guide.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/skill-authoring-guide.md
@@ -1,8 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code skills (SKILL.md files).
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
-
 ---
 
 ## Contents
@@ -25,7 +23,6 @@ Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skil
 
 **Test with all models you plan to use** — Haiku may need more detail, Sonnet should run cleanly, Opus may need less to avoid over-explanation.
 
-*Source: skills/skill-authoring-best-practices.md lines 11-145*
 
 ---
 
@@ -47,7 +44,6 @@ Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skil
 
 Directory layout (`SKILL.md` + `references/`, `assets/templates/`, `scripts/`) and platform extensions detail live in `skill-format-reference.md`.
 
-*Source: skills/extend-claude-with-skills.md lines 169-199*
 
 ---
 
@@ -57,7 +53,6 @@ Directory layout (`SKILL.md` + `references/`, `assets/templates/`, `scripts/`) a
 
 **Descriptions** — write in third person ("Processes Excel files...", not "I can help you..." or "You can use this..."). Include (1) what it does, (2) when to use it, (3) specific trigger terms for matching.
 
-*Source: skills/skill-authoring-best-practices.md lines 168-250*
 
 ---
 
@@ -65,7 +60,6 @@ Directory layout (`SKILL.md` + `references/`, `assets/templates/`, `scripts/`) a
 
 SKILL.md is the index; detailed content lives in supporting files loaded on demand. Apply two patterns: (1) reference the bundled guide material from each phase rather than inlining its content, and (2) load only the references needed for the current phase, not all at once. Loading-model levels are tabulated in `skill-format-reference.md` § Progressive Disclosure Loading Model.
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300; skills/extend-claude-with-skills.md lines 223-246*
 
 ---
 
@@ -73,7 +67,6 @@ SKILL.md is the index; detailed content lives in supporting files loaded on dema
 
 Default: both user and Claude can invoke; description always loaded. `disable-model-invocation: true` makes the skill user-only and removes the description from context — use it for side-effect workflows (commit, deploy, send-message). `user-invocable: false` hides the skill from `/` while keeping it available to Claude — use it for background knowledge.
 
-*Source: skills/extend-claude-with-skills.md lines 248-283*
 
 ---
 
@@ -81,4 +74,3 @@ Default: both user and Claude can invoke; description always loaded. `disable-mo
 
 Avoid generic descriptions ("helps with data" — be specific about what + when), inlining all reference content in SKILL.md (move to `references/`), and hardcoded file paths (use `${CLAUDE_SKILL_DIR}` for bundled files). General prompting anti-patterns (vague instructions, contradictions, lost-in-the-middle) live in `prompt-engineering-strategies.md`.
 
-*Source: skills/skill-authoring-best-practices.md lines 800-1100*

--- a/plugins/agent-customizer/skills/improve-skill/references/skill-evaluation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/skill-evaluation-criteria.md
@@ -1,8 +1,6 @@
 # Skill Evaluation Criteria
 
 Scoring rubric for assessing existing SKILL.md files before improvement.
-Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
-
 ---
 
 ## Contents
@@ -19,18 +17,17 @@ Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present, non-empty, ≤ 1024 chars | Required for skill discovery and Agent Skills spec |
-| `name` field | Present, non-empty, 1-64 chars, kebab-case | Agent Skills specification |
-| Phase structure | At least one clear phase defined | Anthropic skill authoring patterns |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present, non-empty, ≤ 1024 chars |
+| `name` field | Present, non-empty, 1-64 chars, kebab-case |
+| Phase structure | At least one clear phase defined |
 
 A skill violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
 
-*Source: skills/skill-authoring-best-practices.md line 259; `.claude/rules/reference-files.md`*
 
 ---
 
@@ -38,7 +35,6 @@ A skill violating any hard limit is flagged **OVER LIMIT** regardless of content
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If no, flag for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — content that looks helpful but adds no decision value is the failure mode. The deletion test separates signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -46,7 +42,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 
 Flag as bloat: detailed reference content inlined in SKILL.md (should be in `references/`); all references loaded in phase 1 instead of progressively; inline bash analysis in a plugin skill body (must delegate to registered agents); redundant phase instructions; over-specified tool restrictions for simple tasks; explanations of standard practices the model already knows; hardcoded project-specific paths instead of `${CLAUDE_SKILL_DIR}`.
 
-*Source: skills/skill-authoring-best-practices.md lines 11-60*
 
 ---
 
@@ -54,7 +49,6 @@ Flag as bloat: detailed reference content inlined in SKILL.md (should be in `ref
 
 Detect staleness via: deprecated frontmatter field names, references to removed features/tools, outdated model names (use aliases `haiku`/`sonnet`/`opus`), hardcoded file paths that no longer exist, and redundant explicit defaults like `user-invocable: true`.
 
-*Source: skills/skill-authoring-best-practices.md lines 146-167*
 
 ---
 
@@ -62,7 +56,6 @@ Detect staleness via: deprecated frontmatter field names, references to removed 
 
 Good: SKILL.md stays focused on phase overview with file references; each phase loads only its relevant references; supporting files are cited explicitly so Claude knows what to load; body stays ≤500 lines. Bad: monolithic SKILL.md with all guidance inlined, phase 1 loading every reference, files that exist but are never referenced.
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300*
 
 ---
 
@@ -70,7 +63,6 @@ Good: SKILL.md stays focused on phase overview with file references; each phase 
 
 Score each of the five dimensions on a 1–10 scale; 8–10 indicates clean execution, 4–7 mixed, 1–3 bad. Dimensions: **Conciseness** (SKILL.md ≤500 lines, minimal bloat), **Accuracy** (zero stale references), **Progressive Disclosure** (references loaded per-phase, not upfront), **Description Quality** (specific what + when + trigger terms), **Evidence Grounding** (sources cited per phase). Aggregate to an Overall score and call out the dominant remediation theme.
 
-*Source: Evaluating-AGENTS-paper.md lines 1-100*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-skill/references/skill-format-reference.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/skill-format-reference.md
@@ -1,8 +1,6 @@
 # Skill Format Reference
 
 Technical specification for SKILL.md format, directory structure, variables, and discovery.
-Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-skills.md
-
 ---
 
 ## Contents
@@ -31,7 +29,6 @@ The Agent Skills open-standard fields and Claude Code platform extensions are ta
 - Must NOT contain consecutive `--`
 - Must match the parent directory name
 
-*Source: skills/research-claude-code-skills-format.md lines 103-108*
 
 ---
 
@@ -39,7 +36,6 @@ The Agent Skills open-standard fields and Claude Code platform extensions are ta
 
 Skill body variables: `$ARGUMENTS` (all invocation args), `$ARGUMENTS[N]` / `$N` (specific arg by 0-based index), `${CLAUDE_SESSION_ID}` (for logging), `${CLAUDE_SKILL_DIR}` (skill directory — always use this for bundled file references, never hardcoded paths). Dynamic context with the `!` prefix runs shell commands at load time, e.g. `- Current branch: !` + `` `git branch --show-current` ``.
 
-*Source: skills/extend-claude-with-skills.md lines 201-210; skills/research-claude-code-skills-format.md lines 126-149*
 
 ---
 
@@ -47,7 +43,6 @@ Skill body variables: `$ARGUMENTS` (all invocation args), `$ARGUMENTS[N]` / `$N`
 
 A skill directory contains `SKILL.md` (required entry point), `references/` for on-demand reference docs, `assets/templates/` for output templates, optional `examples.md`, and optional `scripts/` for executables (executed, not loaded into context). `references/` files load only when skill phases explicitly read them.
 
-*Source: skills/research-claude-code-skills-format.md lines 153-186; skills/extend-claude-with-skills.md lines 100-115*
 
 ---
 
@@ -61,7 +56,6 @@ A skill directory contains `SKILL.md` (required entry point), `references/` for 
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to `references/` subdirectory. Explicitly reference supporting files from SKILL.md so Claude knows what to load and when.
 
-*Source: skills/research-claude-code-skills-format.md lines 172-186*
 
 ---
 
@@ -76,4 +70,3 @@ Keep SKILL.md under **500 lines**. Move detailed reference material to `referenc
 
 Priority: enterprise > personal > project. Plugin skills use `plugin-name:skill-name` namespace — no conflicts.
 
-*Source: skills/extend-claude-with-skills.md lines 85-97; skills/research-claude-code-skills-format.md lines 189-200*

--- a/plugins/agent-customizer/skills/improve-skill/references/skill-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-skill/references/skill-validation-criteria.md
@@ -1,8 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`, `wiki/knowledge/skill-body-convention.md`
-
 ---
 
 ## Contents
@@ -20,16 +18,15 @@ Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skil
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | `.claude/rules/reference-files.md` — hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
-| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags |
+| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199; `.claude/rules/reference-files.md`*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-subagent/references/prompt-engineering-strategies.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/agent-customizer/skills/improve-subagent/references/subagent-authoring-guide.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/subagent-authoring-guide.md
@@ -1,7 +1,6 @@
 # Subagent Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code subagent definitions.
-Source: subagents/research-subagent-best-practices.md, subagents/creating-custom-subagents.md
 
 ---
 
@@ -21,7 +20,6 @@ Source: subagents/research-subagent-best-practices.md, subagents/creating-custom
 
 Subagents are context firewalls. They encapsulate exploration work — glob output, grep noise, evaluator scans — in an isolated window so it never reaches the parent context. Only the condensed, structured result flows back. The orchestrator stays in the smart zone; the subagent absorbs the noise.
 
-*Source: harness-engineering.md*
 
 | Use subagent when | Use inline Claude when | Use hook when |
 |------------------|----------------------|--------------|
@@ -33,7 +31,6 @@ Subagents are context firewalls. They encapsulate exploration work — glob outp
 
 **Subagents cannot spawn other subagents** — prevents infinite nesting.
 
-*Source: subagents/research-subagent-best-practices.md lines 33-55*
 
 ---
 
@@ -66,7 +63,6 @@ maxTurns: 20
 You are a code reviewer specializing in [domain]...
 ```
 
-*Source: subagents/creating-custom-subagents.md lines 151-210*
 
 ---
 
@@ -86,7 +82,6 @@ Effective subagent system prompts follow this 5-part pattern:
 - Include trigger phrases ("use proactively when...", "use when editing...")
 - Avoid generic descriptions ("helps with code")
 
-*Source: subagents/research-subagent-best-practices.md lines 73-76, 374-430*
 
 ---
 
@@ -103,7 +98,6 @@ Effective subagent system prompts follow this 5-part pattern:
 
 **Rule of thumb**: Opus for architecture decisions, Sonnet for everything else, Haiku for read-only exploration only.
 
-*Source: subagents/research-subagent-best-practices.md lines 318-355*
 
 ---
 
@@ -129,7 +123,6 @@ If both defined: denylist applied first, then allowlist resolves against remaini
 - Explorers: `Read, Grep, Glob, Bash(readonly commands)`
 - Full-capability (rare): all tools — justify explicitly
 
-*Source: subagents/creating-custom-subagents.md lines 245-295*
 
 ---
 
@@ -146,7 +139,6 @@ If both defined: denylist applied first, then allowlist resolves against remaini
 | maxTurns > 30 | Runaway agents | Cap at 20-30 for most tasks |
 | Vague system prompt | Inconsistent behavior | Add role, process, output format |
 
-*Source: subagents/research-subagent-best-practices.md lines 791-819*
 
 ---
 
@@ -167,4 +159,3 @@ Consolidate similar issues. Prioritize by: CRITICAL (bugs/security) > HIGH > MED
 
 This pattern significantly reduces noise and keeps output actionable.
 
-*Source: subagents/research-subagent-best-practices.md lines 463-475*

--- a/plugins/agent-customizer/skills/improve-subagent/references/subagent-config-reference.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/subagent-config-reference.md
@@ -1,7 +1,6 @@
 # Subagent Config Reference
 
 Complete YAML frontmatter specification, model IDs, and orchestration patterns for subagents.
-Source: subagents/creating-custom-subagents.md, subagents/claude-orchestrate-of-claude-code-sessions.md
 
 ---
 
@@ -37,7 +36,6 @@ Only `name` and `description` are required. All others have sensible defaults.
 | `effort` | No | Inherit | `low`, `medium`, `high`, `max` (Opus 4.6 only) |
 | `isolation` | No | None | `worktree` = isolated git worktree; auto-cleanup if no changes |
 
-*Source: subagents/creating-custom-subagents.md lines 213-232*
 
 ---
 
@@ -54,7 +52,6 @@ Only `name` and `description` are required. All others have sensible defaults.
 
 Full model IDs (e.g., `claude-opus-4-6`, `claude-sonnet-4-6`) also accepted.
 
-*Source: subagents/creating-custom-subagents.md lines 234-241*
 
 ---
 
@@ -91,7 +88,6 @@ Standard patterns from community (read-only reviewers dominate):
 - Explorer: `tools: Read, Grep, Glob, Bash`
 - Full-access (rare): omit `tools` and `disallowedTools`
 
-*Source: subagents/creating-custom-subagents.md lines 243-275*
 
 ---
 
@@ -116,7 +112,6 @@ Main → (delegate) → Researcher agent → (report) → Main → (delegate) �
 **Parallel decomposition:**
 Spawn multiple independent subagents simultaneously. Main aggregates results.
 
-*Source: subagents/creating-custom-subagents.md lines 619-637*
 
 ---
 
@@ -129,7 +124,6 @@ These limitations are enforced by the runtime:
 - **Subagents do not inherit parent skills** — must be explicitly listed in `skills` field (full content injected)
 - **`maxTurns` applies per invocation** — project convention: 15 for analysis agents, 20 for evaluator agents; values outside 15–20 require explicit justification
 
-*Source: subagents/creating-custom-subagents.md lines 210-212; subagents/research-subagent-best-practices.md lines 36-42*
 
 ---
 
@@ -143,4 +137,3 @@ Plugin subagents (from installed plugins) have additional restrictions for secur
 
 To use these fields with a plugin agent: copy the agent file to `.claude/agents/` or `~/.claude/agents/`.
 
-*Source: subagents/creating-custom-subagents.md lines 187-189*

--- a/plugins/agent-customizer/skills/improve-subagent/references/subagent-evaluation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/subagent-evaluation-criteria.md
@@ -1,8 +1,6 @@
 # Subagent Evaluation Criteria
 
 Scoring rubric for assessing existing Claude Code subagent definitions before improvement.
-Source: subagents/research-subagent-best-practices.md, subagents/creating-custom-subagents.md
-
 ---
 
 ## Contents
@@ -19,17 +17,16 @@ Source: subagents/research-subagent-best-practices.md, subagents/creating-custom
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| `name` field | Present; lowercase letters and hyphens only | subagents/creating-custom-subagents.md lines 217-220 |
-| `description` field | Present, non-empty, specific | subagents/creating-custom-subagents.md lines 217-220 |
-| `model` field | Recognized alias or full model ID | subagents/creating-custom-subagents.md lines 234-241 |
-| `maxTurns` | 15–20 for most tasks; values outside 15–20 require justification | Project convention — `.claude/rules/agent-files.md` |
-| System prompt (markdown body) | Present and task-specific | subagents/creating-custom-subagents.md lines 199-212 |
+| Criterion | Threshold |
+|-----------|-----------|
+| `name` field | Present; lowercase letters and hyphens only |
+| `description` field | Present, non-empty, specific |
+| `model` field | Recognized alias or full model ID |
+| `maxTurns` | 15–20 for most tasks; values outside 15–20 require justification |
+| System prompt (markdown body) | Present and task-specific |
 
 A subagent violating any hard limit is flagged **INVALID** regardless of other quality.
 
-*Source: subagents/creating-custom-subagents.md lines 213-232*
 
 ---
 
@@ -37,7 +34,6 @@ A subagent violating any hard limit is flagged **INVALID** regardless of other q
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -52,7 +48,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Duplicate subagent with same purpose as built-in | Explore/Plan built-ins cover exploration; don't recreate |
 | Aggressive delegation language ("CRITICAL: MUST use") | Overtriggering; normal language preferred |
 
-*Source: subagents/research-subagent-best-practices.md lines 152-180*
 
 ---
 
@@ -65,7 +60,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | `allowedTools` field (old format) | Current field name is `tools` (allowlist) |
 | Tasks spawning other subagents | Runtime blocks this; remove nested spawn instructions |
 
-*Source: subagents/creating-custom-subagents.md lines 213-232*
 
 ---
 
@@ -79,7 +73,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Description specific enough for routing? | Triggers specified; "use proactively when..." | Generic description; poor delegation |
 | Context isolation justified? | Subagent prevents context pollution | Subagent used when inline works |
 
-*Source: subagents/research-subagent-best-practices.md lines 33-55*
 
 ---
 
@@ -94,7 +87,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Context Isolation | Subagent use justified; prevents pollution | Questionable necessity | Duplicates inline capability |
 | **Overall** | | | |
 
-*Source: subagents/research-subagent-best-practices.md lines 92-146*
 
 ---
 

--- a/plugins/agent-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
+++ b/plugins/agent-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
@@ -1,8 +1,6 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Claude Code subagent definitions.
-Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best-practices.md, `wiki/knowledge/skill-body-convention.md`
-
 ---
 
 ## Contents
@@ -20,16 +18,15 @@ Source: subagents/creating-custom-subagents.md, subagents/research-subagent-best
 
 Any subagent violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | subagents/creating-custom-subagents.md |
-| `name` field | Lowercase letters and hyphens only | subagents/creating-custom-subagents.md lines 217-220 |
-| `description` field | Present and non-empty | subagents/creating-custom-subagents.md lines 217-220 |
-| `model` field | Recognized alias or full model ID | subagents/creating-custom-subagents.md lines 234-241 |
-| `maxTurns` | 15 for analysis agents; 20 for evaluators; values outside 15–20 require justification | Project convention — `.claude/rules/agent-files.md` |
-| System prompt | Not empty; task-specific | subagents/creating-custom-subagents.md lines 199-212 |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens only |
+| `description` field | Present and non-empty |
+| `model` field | Recognized alias or full model ID |
+| `maxTurns` | 15 for analysis agents; 20 for evaluators; values outside 15–20 require justification |
+| System prompt | Not empty; task-specific |
 
-*Source: subagents/creating-custom-subagents.md lines 213-232; subagents/research-subagent-best-practices.md lines 33-55*
 
 ---
 
@@ -65,7 +62,6 @@ The subagent body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ### Structured violation report format
 

--- a/plugins/agents-initializer/agents/file-evaluator.md
+++ b/plugins/agents-initializer/agents/file-evaluator.md
@@ -21,25 +21,25 @@ You are a configuration file quality specialist. Analyze existing AGENTS.md or C
 
 ### Hard Limits
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions" |
-| No contradictions | 0 conflicts | Anthropic: "Claude may pick one arbitrarily" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| No contradictions | 0 conflicts |
 
 ### Bloat Indicators
 
 Each of these wastes tokens without improving agent performance:
 
-| Indicator | Why It's Bloat | Source |
-|-----------|---------------|--------|
-| Directory/file structure listings | "Not effective at providing repository overview" | Evaluating AGENTS.md (ETH Zurich) |
-| Standard language conventions | Agent already knows these from training | Anthropic Best Practices |
-| Vague instructions ("write clean code") | Not actionable, wastes attention budget | a-guide-to-agents.md |
-| Codebase overview paragraphs | Increases steps without improving navigation | Evaluating AGENTS.md |
-| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it correctly, delete it" |
-| Duplicated information across files | Wastes tokens on every request | Context engineering research |
-| **Architectural path trap** | Lists of paths WITH behavioral constraints (e.g., `services/ must not import from routes/`) are **not** directory listings — flag only pure path listings with no rules attached | Evaluating AGENTS.md |
+| Indicator | Why It's Bloat |
+|-----------|---------------|
+| Directory/file structure listings | "Not effective at providing repository overview" |
+| Standard language conventions | Agent already knows these from training |
+| Vague instructions ("write clean code") | Not actionable, wastes attention budget |
+| Codebase overview paragraphs | Increases steps without improving navigation |
+| Obvious tool usage ("use git for version control") | Agent already knows this |
+| Duplicated information across files | Wastes tokens on every request |
+| **Architectural path trap** | Lists of paths WITH behavioral constraints (e.g., `services/ must not import from routes/`) are **not** directory listings — flag only pure path listings with no rules attached |
 
 ### Staleness Indicators
 

--- a/plugins/agents-initializer/skills/improve-agents/references/automation-mechanism-comparison.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/automation-mechanism-comparison.md
@@ -1,7 +1,6 @@
 # Automation Mechanism Comparison
 
 Routing instructions to on-demand automation mechanisms.
-Source: context-aware-improve-optimization.prd.md, analysis-automate-workflow-with-hooks.md, analysis-skill-authoring-best-practices.md, analysis-how-claude-remembers-a-project.md.
 
 Load `automation-token-impact.md` only when Phase 1 flags an instruction block as a migration candidate.
 
@@ -21,7 +20,6 @@ Stop at the first match:
 8. Context-heavy isolated analysis → skill (`context: fork`)
 9. None of the above → keep in current location; reassess next cycle
 
-*Source: context-aware-improve-optimization.prd.md lines 346-358*
 
 ---
 
@@ -42,7 +40,6 @@ Stop at the first match:
 
 Hook events: `PreToolUse` (block via `hookSpecificOutput.permissionDecision`), `PostToolUse`, `Stop`, `SessionStart`, `UserPromptSubmit`, plus 17 others. Path-scoped rules accept negation: `paths: ["src/**/*.ts", "!src/**/*.test.ts"]`.
 
-*Source: analysis-automate-workflow-with-hooks.md lines 21-130, 433-445*
 
 ---
 
@@ -50,4 +47,3 @@ Hook events: `PreToolUse` (block via `hookSpecificOutput.permissionDecision`), `
 
 Skills, path-scoped rules — plugin and standalone. Hooks, subagents — plugin only (require Claude Code). Auto memory — mention only. Filter to supported mechanisms before generating suggestions.
 
-*Source: DESIGN-GUIDELINES.md Guideline 11*

--- a/plugins/agents-initializer/skills/improve-agents/references/automation-token-impact.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/automation-token-impact.md
@@ -2,7 +2,6 @@
 
 Migration-candidate signals and token-impact estimation.
 Load only when Phase 1 flags an instruction block as a migration candidate.
-Source: context-aware-improve-optimization.prd.md, analysis-evaluating-agents-paper.md, research-context-engineering-comprehensive.md.
 
 For mechanism comparison and decision flowchart, see `automation-mechanism-comparison.md`.
 
@@ -19,7 +18,6 @@ For mechanism comparison and decision flowchart, see `automation-mechanism-compa
 - Duplicated across 2+ files → consolidate to single source
 - Version numbers / team names / release info (high-churn) → DELETE or replace with memory pointer
 
-*Source: analysis-evaluating-agents-paper.md lines 36-52; Anthropic Best Practices*
 
 ---
 
@@ -37,4 +35,3 @@ For mechanism comparison and decision flowchart, see `automation-mechanism-compa
 
 Present token-impact estimates alongside migration recommendations.
 
-*Source: research-context-engineering-comprehensive.md; analysis-skill-authoring-best-practices.md lines 19-46; DESIGN-GUIDELINES.md Guideline 10.*

--- a/plugins/agents-initializer/skills/improve-agents/references/context-optimization.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Token-budget and attention guidance for AGENTS.md / CLAUDE.md files.
-Source: research-context-engineering-comprehensive.md.
 
 Hard limits live in `validation-criteria.md`. Bloated files cause Claude to ignore actual instructions. (Anthropic Best Practices)
 
@@ -17,16 +16,13 @@ Place the most important instructions in the first 20% and last 20% of each file
 
 Apply the deletion test: "Would removing this cause the agent to make mistakes? If not, cut it." Full include/exclude categories: see `what-not-to-include.md`. **Specificity goldilocks**: ✅ "Use 2-space indentation"; "Run `npm test` before committing"; "API handlers live in `src/api/handlers/`". ❌ "Format code properly"; "Test your changes"; "Keep files organized".
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ## Context Poisoning Vectors
 
 Detect and remove: stale file paths; contradictions (drop the weaker rule); over-specification (rules already followed; delete or convert to hook); failed-approach accumulation (defensive rules added after incidents); high-churn data (versions, file counts, team names). Treat CLAUDE.md like code: review when things go wrong, prune regularly. (Anthropic Best Practices)
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ## JIT Documentation
 
 Move from always-consumed to on-demand: skills (description loaded; body on invocation), path-scoped rules (load on file match), subdirectory configs (load when working there), `@path/to/import` (expands when parent loads), domain docs in `docs/` (agent navigates when relevant). Maintain lightweight identifiers; load data into context at runtime. (Anthropic Engineering: Effective Context Engineering)
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*

--- a/plugins/agents-initializer/skills/improve-agents/references/evaluation-criteria.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Evaluation Criteria
 
 Scoring rubric for assessing existing AGENTS.md / CLAUDE.md files before improvement. IMPROVE skills only.
-Source: file-evaluator.md, research-context-engineering-comprehensive.md.
 
 The canonical Hard Limits Table, Bloat Indicators, Staleness Indicators, Progressive Disclosure Assessment, Quality Score Rubric, and Evaluation Output Template all live in `agents/file-evaluator.md` (the subagent that produces the structured evaluation report). The Migration Candidate Indicators table lives in `automation-token-impact.md`. This file holds only criteria specific to the IMPROVE workflow.
 
@@ -11,7 +10,6 @@ Goldilocks: ✅ specific and actionable: "Use 2-space indentation"; ❌ too vagu
 
 **Config-enforcement distinction**: rules already enforced by config files ("Strict mode" with `tsconfig.json` `"strict": true`) → DELETE. Project decisions not in config ("Use `unknown` over `any`; validate with `zod`") → keep.
 
-*Source: research-context-engineering-comprehensive.md lines 131-134*
 
 ## Calibrated Improvement Mode
 

--- a/plugins/agents-initializer/skills/improve-agents/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Where AGENTS.md / CLAUDE.md content lives by load timing.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md.
 
 For anti-patterns, see `what-not-to-include.md` § Common Traps. For validation thresholds, see `validation-criteria.md`.
 
@@ -9,7 +8,6 @@ For anti-patterns, see `what-not-to-include.md` § Common Traps. For validation 
 
 **Root AGENTS.md / CLAUDE.md** — every task; always loaded. **Domain file** — one domain (TypeScript, testing); on-demand. **Subdirectory AGENTS.md / CLAUDE.md** — one package or area; on-demand. **`.claude/rules/` path-scoped** — file patterns; on-demand. **Skill** — workflow agent invokes explicitly; on-demand.
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ## Root File Requirements
 
@@ -19,13 +17,11 @@ Root files contain only: (1) one-sentence project description; (2) package manag
 
 **Root**: monorepo purpose, package navigation, shared tooling — never package-specific tech stacks. **Package**: package purpose, specific tech stack, package conventions — never cross-repo decisions. The agent sees all merged files. In large monorepos, use `claudeMdExcludes` in `.claude/settings.local.json` (glob patterns; absolute paths; arrays merge across settings layers; managed policy files cannot be excluded).
 
-*Source: a-guide-to-agents.md; memory/how-claude-remembers-a-project.md lines 243-260*
 
 ## Extraction Triggers
 
 Extract a section to a separate domain file when 3+ distinct rules AND 10+ lines, or when irrelevant to most sessions. Prefer pointers ("For TypeScript conventions, see docs/TYPESCRIPT.md") over inlining. Workflows go to skills.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ## CLAUDE.md Hierarchy
 
@@ -35,7 +31,6 @@ Loading by scope: org-wide managed policy (MDM) and personal `~/.claude/CLAUDE.m
 
 **Load order** — Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory files load only when Claude reads files there.
 
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
 
 ## AGENTS.md Notes
 

--- a/plugins/agents-initializer/skills/improve-agents/references/validation-criteria.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md / CLAUDE.md files.
-Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-evaluator.md:23-59.
 
 ---
 

--- a/plugins/agents-initializer/skills/improve-agents/references/what-not-to-include.md
+++ b/plugins/agents-initializer/skills/improve-agents/references/what-not-to-include.md
@@ -1,13 +1,11 @@
 # What NOT to Include
 
 Exclusion guide for AGENTS.md and CLAUDE.md.
-Sources: ETH Zurich (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md.
 
 ## Exclusions
 
 Exclude: directory/file structure listings; standard language conventions; codebase overview paragraphs (increase exploration without improving navigation — ETH); vague guidance ("write clean code"); file path references (paths churn and poison context); everything in one file (~150-200 instruction attention budget); obvious tooling ("use git"); duplicates; version numbers / release names; long explanations or tutorials; detailed API documentation (link out); anything inferable from code; hook-enforced behaviors — migrate to a hook.
 
-*Source: init-agents/SKILL.md:106-116; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/plugins/agents-initializer/skills/improve-claude/references/automation-mechanism-comparison.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/automation-mechanism-comparison.md
@@ -1,7 +1,6 @@
 # Automation Mechanism Comparison
 
 Routing instructions to on-demand automation mechanisms.
-Source: context-aware-improve-optimization.prd.md, analysis-automate-workflow-with-hooks.md, analysis-skill-authoring-best-practices.md, analysis-how-claude-remembers-a-project.md.
 
 Load `automation-token-impact.md` only when Phase 1 flags an instruction block as a migration candidate.
 
@@ -21,7 +20,6 @@ Stop at the first match:
 8. Context-heavy isolated analysis → skill (`context: fork`)
 9. None of the above → keep in current location; reassess next cycle
 
-*Source: context-aware-improve-optimization.prd.md lines 346-358*
 
 ---
 
@@ -42,7 +40,6 @@ Stop at the first match:
 
 Hook events: `PreToolUse` (block via `hookSpecificOutput.permissionDecision`), `PostToolUse`, `Stop`, `SessionStart`, `UserPromptSubmit`, plus 17 others. Path-scoped rules accept negation: `paths: ["src/**/*.ts", "!src/**/*.test.ts"]`.
 
-*Source: analysis-automate-workflow-with-hooks.md lines 21-130, 433-445*
 
 ---
 
@@ -50,4 +47,3 @@ Hook events: `PreToolUse` (block via `hookSpecificOutput.permissionDecision`), `
 
 Skills, path-scoped rules — plugin and standalone. Hooks, subagents — plugin only (require Claude Code). Auto memory — mention only. Filter to supported mechanisms before generating suggestions.
 
-*Source: DESIGN-GUIDELINES.md Guideline 11*

--- a/plugins/agents-initializer/skills/improve-claude/references/automation-token-impact.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/automation-token-impact.md
@@ -2,7 +2,6 @@
 
 Migration-candidate signals and token-impact estimation.
 Load only when Phase 1 flags an instruction block as a migration candidate.
-Source: context-aware-improve-optimization.prd.md, analysis-evaluating-agents-paper.md, research-context-engineering-comprehensive.md.
 
 For mechanism comparison and decision flowchart, see `automation-mechanism-comparison.md`.
 
@@ -19,7 +18,6 @@ For mechanism comparison and decision flowchart, see `automation-mechanism-compa
 - Duplicated across 2+ files → consolidate to single source
 - Version numbers / team names / release info (high-churn) → DELETE or replace with memory pointer
 
-*Source: analysis-evaluating-agents-paper.md lines 36-52; Anthropic Best Practices*
 
 ---
 
@@ -37,4 +35,3 @@ For mechanism comparison and decision flowchart, see `automation-mechanism-compa
 
 Present token-impact estimates alongside migration recommendations.
 
-*Source: research-context-engineering-comprehensive.md; analysis-skill-authoring-best-practices.md lines 19-46; DESIGN-GUIDELINES.md Guideline 10.*

--- a/plugins/agents-initializer/skills/improve-claude/references/claude-rules-system.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/claude-rules-system.md
@@ -1,7 +1,6 @@
 # Claude Rules System
 
 `.claude/rules/` and CLAUDE.md hierarchy. Claude Code-specific.
-Sources: research-claude-code-skills-format.md, research-context-engineering-comprehensive.md, init-claude/SKILL.md, memory/how-claude-remembers-a-project.md.
 
 ## Loading Behavior
 

--- a/plugins/agents-initializer/skills/improve-claude/references/context-optimization.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Token-budget and attention guidance for AGENTS.md / CLAUDE.md files.
-Source: research-context-engineering-comprehensive.md.
 
 Hard limits live in `validation-criteria.md`. Bloated files cause Claude to ignore actual instructions. (Anthropic Best Practices)
 
@@ -17,16 +16,13 @@ Place the most important instructions in the first 20% and last 20% of each file
 
 Apply the deletion test: "Would removing this cause the agent to make mistakes? If not, cut it." Full include/exclude categories: see `what-not-to-include.md`. **Specificity goldilocks**: ✅ "Use 2-space indentation"; "Run `npm test` before committing"; "API handlers live in `src/api/handlers/`". ❌ "Format code properly"; "Test your changes"; "Keep files organized".
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ## Context Poisoning Vectors
 
 Detect and remove: stale file paths; contradictions (drop the weaker rule); over-specification (rules already followed; delete or convert to hook); failed-approach accumulation (defensive rules added after incidents); high-churn data (versions, file counts, team names). Treat CLAUDE.md like code: review when things go wrong, prune regularly. (Anthropic Best Practices)
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ## JIT Documentation
 
 Move from always-consumed to on-demand: skills (description loaded; body on invocation), path-scoped rules (load on file match), subdirectory configs (load when working there), `@path/to/import` (expands when parent loads), domain docs in `docs/` (agent navigates when relevant). Maintain lightweight identifiers; load data into context at runtime. (Anthropic Engineering: Effective Context Engineering)
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*

--- a/plugins/agents-initializer/skills/improve-claude/references/evaluation-criteria.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Evaluation Criteria
 
 Scoring rubric for assessing existing AGENTS.md / CLAUDE.md files before improvement. IMPROVE skills only.
-Source: file-evaluator.md, research-context-engineering-comprehensive.md.
 
 The canonical Hard Limits Table, Bloat Indicators, Staleness Indicators, Progressive Disclosure Assessment, Quality Score Rubric, and Evaluation Output Template all live in `agents/file-evaluator.md` (the subagent that produces the structured evaluation report). The Migration Candidate Indicators table lives in `automation-token-impact.md`. This file holds only criteria specific to the IMPROVE workflow.
 
@@ -11,7 +10,6 @@ Goldilocks: ✅ specific and actionable: "Use 2-space indentation"; ❌ too vagu
 
 **Config-enforcement distinction**: rules already enforced by config files ("Strict mode" with `tsconfig.json` `"strict": true`) → DELETE. Project decisions not in config ("Use `unknown` over `any`; validate with `zod`") → keep.
 
-*Source: research-context-engineering-comprehensive.md lines 131-134*
 
 ## Calibrated Improvement Mode
 

--- a/plugins/agents-initializer/skills/improve-claude/references/improvement-card-template.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/improvement-card-template.md
@@ -1,6 +1,6 @@
 # Improvement Card Template
 
-Phase 5 output format. Source: improve-agents/SKILL.md:151-160.
+Phase 5 output format.
 
 ---
 

--- a/plugins/agents-initializer/skills/improve-claude/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Where AGENTS.md / CLAUDE.md content lives by load timing.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md.
 
 For anti-patterns, see `what-not-to-include.md` § Common Traps. For validation thresholds, see `validation-criteria.md`.
 
@@ -9,7 +8,6 @@ For anti-patterns, see `what-not-to-include.md` § Common Traps. For validation 
 
 **Root AGENTS.md / CLAUDE.md** — every task; always loaded. **Domain file** — one domain (TypeScript, testing); on-demand. **Subdirectory AGENTS.md / CLAUDE.md** — one package or area; on-demand. **`.claude/rules/` path-scoped** — file patterns; on-demand. **Skill** — workflow agent invokes explicitly; on-demand.
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ## Root File Requirements
 
@@ -19,13 +17,11 @@ Root files contain only: (1) one-sentence project description; (2) package manag
 
 **Root**: monorepo purpose, package navigation, shared tooling — never package-specific tech stacks. **Package**: package purpose, specific tech stack, package conventions — never cross-repo decisions. The agent sees all merged files. In large monorepos, use `claudeMdExcludes` in `.claude/settings.local.json` (glob patterns; absolute paths; arrays merge across settings layers; managed policy files cannot be excluded).
 
-*Source: a-guide-to-agents.md; memory/how-claude-remembers-a-project.md lines 243-260*
 
 ## Extraction Triggers
 
 Extract a section to a separate domain file when 3+ distinct rules AND 10+ lines, or when irrelevant to most sessions. Prefer pointers ("For TypeScript conventions, see docs/TYPESCRIPT.md") over inlining. Workflows go to skills.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ## CLAUDE.md Hierarchy
 
@@ -35,7 +31,6 @@ Loading by scope: org-wide managed policy (MDM) and personal `~/.claude/CLAUDE.m
 
 **Load order** — Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory files load only when Claude reads files there.
 
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
 
 ## AGENTS.md Notes
 

--- a/plugins/agents-initializer/skills/improve-claude/references/validation-criteria.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md / CLAUDE.md files.
-Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-evaluator.md:23-59.
 
 ---
 

--- a/plugins/agents-initializer/skills/improve-claude/references/what-not-to-include.md
+++ b/plugins/agents-initializer/skills/improve-claude/references/what-not-to-include.md
@@ -1,13 +1,11 @@
 # What NOT to Include
 
 Exclusion guide for AGENTS.md and CLAUDE.md.
-Sources: ETH Zurich (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md.
 
 ## Exclusions
 
 Exclude: directory/file structure listings; standard language conventions; codebase overview paragraphs (increase exploration without improving navigation — ETH); vague guidance ("write clean code"); file path references (paths churn and poison context); everything in one file (~150-200 instruction attention budget); obvious tooling ("use git"); duplicates; version numbers / release names; long explanations or tutorials; detailed API documentation (link out); anything inferable from code; hook-enforced behaviors — migrate to a hook.
 
-*Source: init-agents/SKILL.md:106-116; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/plugins/agents-initializer/skills/init-agents/references/context-optimization.md
+++ b/plugins/agents-initializer/skills/init-agents/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Evidence-based instructions for managing token budgets and attention in agent configuration files.
-Source: research-context-engineering-comprehensive.md
 
 ---
 
@@ -13,17 +12,16 @@ Source: research-context-engineering-comprehensive.md
 - Quality over quantity checklist (include/exclude decision table)
 - Context poisoning vectors (detection and removal)
 - JIT documentation patterns (on-demand loading strategies)
-- Key citations
 
 ---
 
 ## Hard Limits
 
-| Limit | Value | Source |
-|-------|-------|--------|
-| Lines per configuration file | ≤ 200 | Anthropic Docs: "Target under 200 lines per CLAUDE.md file." |
-| Instructions per file | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
-| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily." |
+| Limit | Value |
+|-------|-------|
+| Lines per configuration file | ≤ 200 |
+| Instructions per file | ≤ 150-200 |
+| Contradictions between files | 0 |
 
 > "Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"
 > — Anthropic Best Practices
@@ -79,7 +77,6 @@ For each instruction line, ask: **"Would removing this cause the agent to make m
 - ✅ "Run `npm test` before committing" vs. ❌ "Test your changes"
 - ✅ "API handlers live in `src/api/handlers/`" vs. ❌ "Keep files organized"
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -97,7 +94,6 @@ Detect and remove these before generating or improving configuration files:
 
 > "Treat CLAUDE.md like code: review it when things go wrong, prune it regularly." — Anthropic Best Practices
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -116,17 +112,6 @@ Use these patterns to move content from always-consumed to on-demand locations:
 > "Rather than pre-processing all relevant data up front, agents maintain lightweight identifiers and use these references to dynamically load data into context at runtime."
 > — Anthropic Engineering: Effective Context Engineering
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*
 
 ---
 
-## Key Citations
-
-| Claim | Source |
-|-------|--------|
-| ≤200 lines per file | Agent Skills Standard |
-| ~150-200 instruction limit | HumanLayer (Kyle) via a-guide-to-agents.md |
-| n² attention constraint / context rot | Anthropic Engineering Blog |
-| Lost-in-the-middle effect | Liu et al., arXiv:2307.03172 |
-| Quality over quantity heuristic | Anthropic Best Practices |
-| JIT documentation strategy | Anthropic Engineering: Effective Context Engineering |

--- a/plugins/agents-initializer/skills/init-agents/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/init-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -30,7 +29,6 @@ When deciding where to place content, use this table:
 | `.claude/rules/` (path-scoped) | Specific to certain file patterns | On-demand when files match |
 | Skill | A workflow the agent should invoke explicitly | On-demand when invoked |
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -74,7 +72,6 @@ See each package's AGENTS.md for specific guidelines.
 
 Patterns match absolute paths with glob syntax. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded.
 
-*Source: memory/how-claude-remembers-a-project.md lines 243-260*
 
 ---
 
@@ -105,7 +102,6 @@ docs/
 
 **Use skills for workflows** — agents invoke skills only when needed, keeping base context minimal.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ---
 
@@ -125,7 +121,6 @@ docs/
 
 **Load order**: Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory CLAUDE.md files load on-demand only when Claude reads files in that directory — not at launch.
 
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
 
 ---
 

--- a/plugins/agents-initializer/skills/init-agents/references/validation-criteria.md
+++ b/plugins/agents-initializer/skills/init-agents/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md / CLAUDE.md files.
-Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
 
 ---
 
@@ -9,13 +8,13 @@ Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-e
 
 Any file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "~150-200 instructions with reasonable consistency" |
-| Contradictions (within or between files) | 0 | Anthropic: "Claude may pick one arbitrarily" |
-| Language-specific rules in root | 0 | Domain rules belong in separate files |
-| Stale file path references | 0 | "File paths change constantly... actively poisons context" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| Contradictions (within or between files) | 0 |
+| Language-specific rules in root | 0 |
+| Stale file path references | 0 |
 
 ## Recommended Targets (Advisory)
 

--- a/plugins/agents-initializer/skills/init-agents/references/what-not-to-include.md
+++ b/plugins/agents-initializer/skills/init-agents/references/what-not-to-include.md
@@ -1,29 +1,27 @@
 # What NOT to Include
 
 Evidence-based exclusion table for AGENTS.md and CLAUDE.md content.
-Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md, hooks/automate-workflow-with-hooks.md
 
 ---
 
 ## Exclusion Evidence Table
 
-| Content Type | Why to Exclude | Evidence Quote | Source |
-|-------------|----------------|---------------|--------|
-| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" | ETH Zurich: Evaluating AGENTS.md |
-| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" | Anthropic Best Practices |
-| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" | ETH Zurich: Evaluating AGENTS.md |
-| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | a-guide-to-agents.md |
-| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | a-guide-to-agents.md |
-| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | a-guide-to-agents.md |
-| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
-| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" | research-context-engineering-comprehensive.md |
-| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Anthropic Best Practices |
-| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" | Anthropic Best Practices |
-| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; config file instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | "Hooks provide deterministic control over Claude Code's behavior, ensuring certain actions always happen rather than relying on the LLM" | Anthropic Hooks Guide |
+| Content Type | Why to Exclude | Evidence Quote |
+|-------------|----------------|---------------|
+| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" |
+| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" |
+| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" |
+| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" |
+| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" |
+| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" |
+| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" |
+| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) |
+| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column |
+| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" |
+| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; config file instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | "Hooks provide deterministic control over Claude Code's behavior, ensuring certain actions always happen rather than relying on the LLM" |
 
-*Source: init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/plugins/agents-initializer/skills/init-claude/references/claude-rules-system.md
+++ b/plugins/agents-initializer/skills/init-claude/references/claude-rules-system.md
@@ -2,7 +2,6 @@
 
 Instructions for generating and improving `.claude/rules/` and CLAUDE.md hierarchy.
 Claude Code-specific — not applicable to AGENTS.md skills.
-Sources: research-claude-code-skills-format.md, research-context-engineering-comprehensive.md, init-claude/SKILL.md, memory/how-claude-remembers-a-project.md
 
 ---
 
@@ -24,7 +23,6 @@ Sources: research-claude-code-skills-format.md, research-context-engineering-com
 
 `claudeMdExcludes` (in `.claude/settings.local.json`) skips irrelevant ancestor CLAUDE.md files in large monorepos.
 
-*Source: memory/how-claude-remembers-a-project.md lines 243-260; research-context-engineering-comprehensive.md:181-208*
 
 ---
 
@@ -45,7 +43,6 @@ paths:
 
 Rules **without** `paths:` frontmatter load unconditionally at session start (always consumed).
 
-*Source: research-context-engineering-comprehensive.md lines 181-196*
 
 ---
 
@@ -53,7 +50,6 @@ Rules **without** `paths:` frontmatter load unconditionally at session start (al
 
 Two categories warrant a `.claude/rules/` file: (1) **convention rules** — file-pattern-specific coding conventions (style rules for `**/*.ts`, `**/*.test.ts`; framework-specific patterns like route handlers or migration scripts), only when non-obvious enough to cause mistakes; (2) **domain-critical rules** — security, privacy, or compliance triggered by sensitive file patterns.
 
-*Source: init-claude/SKILL.md:118-136*
 
 ---
 
@@ -67,7 +63,6 @@ Project-wide general conventions belong in root `CLAUDE.md`; scope-wide conventi
 
 `.claude/rules/` holds one file per topic with descriptive filenames (e.g., `code-style.md`, `testing.md` with `paths: ["**/*.test.*"]`, `security.md` with `paths: ["src/api/**"]`); subdirectories like `frontend/react.md` group rules by domain. Files are discovered recursively. Symlinks are supported for cross-project sharing (circular symlinks handled gracefully). User-level rules (`~/.claude/rules/`) apply to all projects but project rules take precedence.
 
-*Source: research-context-engineering-comprehensive.md lines 284-305*
 
 ---
 
@@ -81,4 +76,3 @@ Relevant to every task → root `./CLAUDE.md`. Relevant to one area/package → 
 
 When placing new content, prefer this priority order: (1) path-scoped `.claude/rules/` file → (2) subdirectory `CLAUDE.md` → (3) domain doc (`docs/TESTING.md`) → (4) skill → (5) only if truly needed every task, root `CLAUDE.md`. The 5-scope CLAUDE.md hierarchy table (Managed/CLI/Local/Project/User) lives in `progressive-disclosure-guide.md`.
 
-*Source: research-context-engineering-comprehensive.md lines 259-282*

--- a/plugins/agents-initializer/skills/init-claude/references/context-optimization.md
+++ b/plugins/agents-initializer/skills/init-claude/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Evidence-based instructions for managing token budgets and attention in agent configuration files.
-Source: research-context-engineering-comprehensive.md
 
 ---
 
@@ -38,7 +37,6 @@ Place the most important instructions in the first 20% and last 20% of each conf
 
 Apply the deletion test: "Would removing this cause the agent to make mistakes? If not, cut it." Full include/exclude categories are tabulated in `what-not-to-include.md`. **Specificity goldilocks**: ✅ concrete project-specific rules ("Use 2-space indentation", "Run `npm test` before committing", "API handlers live in `src/api/handlers/`") — ❌ vague directives ("Format code properly", "Test your changes", "Keep files organized").
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -46,7 +44,6 @@ Apply the deletion test: "Would removing this cause the agent to make mistakes? 
 
 Detect and remove: stale file paths (check existence; remove or update), contradictions (compare across files; drop the weaker rule), over-specification (rules the agent already follows; delete or convert to a hook), failed-approach accumulation (defensive rules added after incidents that should not be needed), high-churn information (version numbers, file counts, team names — remove or replace with a pointer). Treat CLAUDE.md like code: review when things go wrong, prune regularly. (Anthropic Best Practices)
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -54,6 +51,5 @@ Detect and remove: stale file paths (check existence; remove or update), contrad
 
 Move content from always-consumed to on-demand locations: skills (description at start, full body on invocation), path-scoped rules (load when matching files are read), subdirectory config files (load when working in that directory), `@path/to/import` (expands when parent loads, controlled), domain docs in `docs/` (agent navigates when relevant). Rather than pre-processing all data up front, agents maintain lightweight identifiers and load data into context at runtime. (Anthropic Engineering: Effective Context Engineering)
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*
 
 ---

--- a/plugins/agents-initializer/skills/init-claude/references/progressive-disclosure-guide.md
+++ b/plugins/agents-initializer/skills/init-claude/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md.
 
 ---
 
@@ -22,7 +21,6 @@ For anti-patterns to detect and remove (ball-of-mud growth, auto-generated init 
 
 Place content based on what's relevant when. **Root AGENTS.md / CLAUDE.md**: relevant to every task, always loaded. **Separate domain file**: relevant to one domain (TypeScript, testing, API design), on-demand. **Subdirectory AGENTS.md / CLAUDE.md**: specific to one package or area, on-demand when working there. **`.claude/rules/` path-scoped**: specific to certain file patterns, on-demand when files match. **Skill**: a workflow the agent invokes explicitly, on-demand.
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -39,7 +37,6 @@ Generate root files with only these elements: (1) one-sentence project descripti
 
 Don't overload any level — the agent sees all merged files in its context. In large monorepos, use `claudeMdExcludes` in `.claude/settings.local.json` to skip irrelevant ancestor CLAUDE.md files (glob patterns match absolute paths; arrays merge across settings layers; managed policy files cannot be excluded).
 
-*Source: a-guide-to-agents.md; memory/how-claude-remembers-a-project.md lines 243-260*
 
 ---
 
@@ -47,7 +44,6 @@ Don't overload any level — the agent sees all merged files in its context. In 
 
 Apply when content exceeds root-file scope. **Extraction trigger**: extract a section to a separate domain file when it has 3+ distinct rules AND spans 10+ lines, or when the topic is irrelevant to most work sessions. **Move domain rules to separate files**: prefer "For TypeScript conventions, see docs/TYPESCRIPT.md" over inlining domain rules. **Nest hierarchically**: domain docs reference each other rather than the root inlining everything. **Use skills for workflows** — agents invoke them only when needed, keeping base context minimal.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ---
 
@@ -59,7 +55,6 @@ Loading by scope: org-wide managed policy (MDM) and personal `~/.claude/CLAUDE.m
 
 **Load order** — Claude Code walks up the directory tree from CWD, loading every ancestor CLAUDE.md at session start. Subdirectory files load on-demand only when Claude reads files in that directory.
 
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
 
 ---
 

--- a/plugins/agents-initializer/skills/init-claude/references/validation-criteria.md
+++ b/plugins/agents-initializer/skills/init-claude/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md / CLAUDE.md files.
-Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
 
 ---
 

--- a/plugins/agents-initializer/skills/init-claude/references/what-not-to-include.md
+++ b/plugins/agents-initializer/skills/init-claude/references/what-not-to-include.md
@@ -1,7 +1,6 @@
 # What NOT to Include
 
 Evidence-based exclusion guide for AGENTS.md and CLAUDE.md.
-Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md.
 
 ---
 
@@ -9,7 +8,6 @@ Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-gu
 
 Exclude these categories: directory/file structure listings (agents use grep/glob; static lists go stale — ETH Zurich); standard language conventions (already in training data); codebase overview paragraphs (increase exploration steps without improving navigation — ETH Zurich); vague guidance like "write clean code" (not actionable — wastes attention); file path references (paths change constantly and actively poison context); everything in one file (exceeds the ~150-200 instruction attention budget); obvious tooling ("use git for version control"); duplicated information across files (wastes tokens per request, creates contradictions); version numbers / release names (high-churn, stale instantly); long explanations or tutorials (context is for instructions, not education); detailed API documentation (link out instead); anything inferable from code; hook-enforced behaviors (formatting, file blocking, notifications) — migrate to a hook for deterministic enforcement at zero context cost.
 
-*Source: init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/plugins/cursor-customizer/agents/rule-evaluator.md
+++ b/plugins/cursor-customizer/agents/rule-evaluator.md
@@ -21,14 +21,14 @@ You are a Cursor rule quality assessment specialist. Analyze either a specific `
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
-| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
-| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` | docs/cursor/rules/rules.md — Rule file format |
-| Banned frontmatter key | A `paths` key MUST NOT appear in frontmatter | Cross-platform leakage: a `paths` frontmatter key belongs to a different platform's convention and is invalid here |
-| Contradictions with other rules | 0 | Industry Research: conflicting instructions cause inconsistent model behavior |
-| Stale file path references | 0 | Industry Research: stale paths poison context |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 200 lines |
+| YAML frontmatter | Valid YAML |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` |
+| Banned frontmatter key | A `paths` key MUST NOT appear in frontmatter |
+| Contradictions with other rules | 0 |
+| Stale file path references | 0 |
 
 ### Quality Checks
 

--- a/plugins/cursor-customizer/agents/skill-evaluator.md
+++ b/plugins/cursor-customizer/agents/skill-evaluator.md
@@ -21,13 +21,13 @@ You are a Cursor skill quality assessment specialist. Analyze the target SKILL.m
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
-| Reference files | ≤ 200 lines each | reference-files convention |
-| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags | Agent Skills specification |
-| `name` field format | Present, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder | Agent Skills specification |
-| Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags |
+| `name` field format | Present, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder |
+| Contradictions between phases | 0 |
 
 ### Structural Checks
 

--- a/plugins/cursor-customizer/agents/subagent-evaluator.md
+++ b/plugins/cursor-customizer/agents/subagent-evaluator.md
@@ -21,15 +21,15 @@ You are a Cursor subagent definition quality assessment specialist. Analyze the 
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | Cursor subagents documentation (file format) |
-| `name` field | Lowercase letters and hyphens only | Cursor subagents documentation (configuration fields) |
-| `description` field | Present, non-empty, ≤1024 characters | Cursor subagents documentation (configuration fields) |
-| `model` field | Set to `inherit` | ADR-0002 product-strict frontmatter contract |
-| `readonly` field | Set to `true` | ADR-0002 product-strict frontmatter contract |
-| Frontmatter key set | Exactly `name`, `description`, `model`, `readonly` — nothing else | ADR-0002 product-strict frontmatter contract |
-| System prompt | Not empty; task-specific | Cursor subagents documentation (best practices) |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens only |
+| `description` field | Present, non-empty, ≤1024 characters |
+| `model` field | Set to `inherit` |
+| `readonly` field | Set to `true` |
+| Frontmatter key set | Exactly `name`, `description`, `model`, `readonly` — nothing else |
+| System prompt | Not empty; task-specific |
 
 ### Quality Checks
 

--- a/plugins/cursor-customizer/skills/create-hook/references/hook-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/hook-authoring-guide.md
@@ -1,7 +1,6 @@
 # Hook Authoring Guide
 
 Evidence-based guidance for creating Cursor hooks that enforce deterministic behavior.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -30,7 +29,6 @@ Hooks provide **deterministic control** — they always fire, regardless of mode
 
 Examples: auto-formatting after edits, blocking destructive shell commands, sending notifications, auditing config changes, redacting secrets before file reads.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hooks" introduction*
 
 ---
 
@@ -58,7 +56,6 @@ Level 2: **Hook definition** — at minimum a `command`; optionally `type`, `mat
 
 Omit `matcher` to fire on every occurrence of the event.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration file"*
 
 ---
 
@@ -83,7 +80,6 @@ Omit `matcher` to fire on every occurrence of the event.
 
 Prompt hooks return a structured `{ ok: boolean, reason?: string }` response. The `$ARGUMENTS` placeholder in the prompt is auto-replaced with the hook input JSON.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
 
 ---
 
@@ -102,7 +98,6 @@ The `matcher` field is a **regex string**. Which field it filters depends on the
 
 Matchers on `beforeSubmitPrompt`, `stop`, `afterAgentResponse`, and `afterAgentThought` are matched against fixed literal values documented in the Cursor hooks guide; in practice these matchers add no filtering value and may be omitted.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
 
 ---
 
@@ -119,7 +114,6 @@ Priority order (highest to lowest): Enterprise → Team → Project → User. Al
 
 For project hooks, write paths relative to the project root (e.g., `.cursor/hooks/script.sh`). For user hooks, write paths relative to `~/.cursor/` (e.g., `./hooks/script.sh`).
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
 
 ---
 
@@ -141,7 +135,6 @@ To make a security-critical hook **fail closed** instead, set `"failClosed": tru
 
 For **prompt** hooks: the LLM returns `{ ok: boolean, reason?: string }`. When `ok: false`, the action is denied and `reason` is surfaced to the user.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Per-Script Configuration Options"*
 
 ---
 
@@ -157,4 +150,3 @@ For **prompt** hooks: the LLM returns `{ ok: boolean, reason?: string }`. When `
 
 Use the Hooks tab in Cursor Settings to confirm hooks are loaded and to inspect execution traces.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Troubleshooting", "Environment Variables"*

--- a/plugins/cursor-customizer/skills/create-hook/references/hook-events-reference.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/hook-events-reference.md
@@ -1,7 +1,6 @@
 # Hook Events Reference
 
 Complete reference for Cursor's native hook events: triggers, matcher fields, and handler-type support.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -49,7 +48,6 @@ Cursor exposes two families of hook events: Agent (Cmd+K / Agent Chat) and Tab (
 | `beforeTabFileRead` | Before Tab reads a file for inline completions | Yes (`permission: "deny"`) |
 | `afterTabFileEdit` | After Tab edits a file | No |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Agent and Tab Support"*
 
 ---
 
@@ -72,7 +70,6 @@ The `matcher` is a regex string. The field it matches against depends on the eve
 
 For MCP tool filtering on `preToolUse`/`postToolUse`/`postToolUseFailure`, use the `MCP:<tool_name>` format.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
 
 ---
 
@@ -109,7 +106,6 @@ Cursor hooks live in a `hooks.json` file at the project or user scope. The top l
 
 **Prompt-hook fields:** add `"type": "prompt"` and a `"prompt": "<natural-language criterion>"` field; an optional `"model"` field overrides the default fast model. The prompt receives the hook input via the auto-replaced `$ARGUMENTS` placeholder.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
 
 ---
 
@@ -122,7 +118,6 @@ Cursor hooks live in a `hooks.json` file at the project or user scope. The top l
 
 Unlike some agent platforms, Cursor exposes only these two handler types — there is no separate `http` or `agent` handler. Use `command` for deterministic checks; reserve `prompt` for cases where natural-language judgment is genuinely required.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
 
 ---
 
@@ -158,4 +153,3 @@ Inject dynamic context at session start:
 
 The script's stdout JSON may include `additional_context` to add to the conversation's initial system context.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Examples" and "Hook events"*

--- a/plugins/cursor-customizer/skills/create-hook/references/hook-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/hook-validation-criteria.md
@@ -1,7 +1,6 @@
 # Hook Validation Criteria
 
 Quality checklist for generated and improved Cursor hook configurations.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -28,7 +27,6 @@ Any hook violating these criteria must be fixed before proceeding:
 | Matcher applicability | Matcher set only on events whose matcher field is documented in `hook-events-reference.md` |
 | Exit-code semantics | `0` = success, `2` = block; other non-zero exits fail open by default — security-critical blocking hooks must set `failClosed: true` |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Configuration", "Per-Script Configuration Options"*
 
 ---
 

--- a/plugins/cursor-customizer/skills/create-hook/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/create-hook/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/create-rule/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/create-rule/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/create-rule/references/rule-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/create-rule/references/rule-authoring-guide.md
@@ -1,7 +1,6 @@
 # Rule Authoring Guide
 
 Evidence-based guidance for creating effective Cursor rule files (`.cursor/rules/*.mdc`).
-Source: docs/cursor/rules/rules.md (Cursor official documentation)
 
 ---
 
@@ -31,7 +30,6 @@ Rules are markdown files placed in `.cursor/rules/`. Their contents are included
 | Conventions apply to a file pattern or topic | Side effects must always happen | Multi-phase workflows are required |
 | Domain expertise scoped to a path or topic | No agent judgment is required | Rich, progressive-disclosure references are needed |
 
-*Source: docs/cursor/rules/rules.md — How rules work, Project rules*
 
 ---
 
@@ -47,7 +45,6 @@ Rules are markdown files placed in `.cursor/rules/`. Their contents are included
 
 Each file should cover **one topic** with a kebab-case filename. Both `.md` and `.mdc` extensions are recognised; this distribution generates `.mdc` so that frontmatter can specify activation mode.
 
-*Source: docs/cursor/rules/rules.md — Rule file structure*
 
 ---
 
@@ -63,7 +60,6 @@ Cursor rule frontmatter is restricted to **three fields**. No other key is valid
 
 The token used by other agent platforms to scope rules by file pattern is NOT supported here — Cursor uses `globs` for the same role. Any other frontmatter key is invalid and must be removed.
 
-*Source: docs/cursor/rules/rules.md — Rule file format*
 
 ---
 
@@ -85,7 +81,6 @@ Pick the mode that matches the **content's nature**:
 - Agent-requested → cross-cutting / domain content the agent should pull in by name (authentication, observability, accessibility, API design)
 - Manual → templates and reference snippets the user explicitly opts into
 
-*Source: docs/cursor/rules/rules.md — Rule anatomy*
 
 ---
 
@@ -104,7 +99,6 @@ Auto-attached rules trigger when files matching the pattern enter the agent's co
 
 In monorepos, scope globs to the relevant package subtree (e.g., `services/api/**/*.go` rather than `**/*.go`). Language-only globs match across every package and defeat scoping.
 
-*Source: docs/cursor/rules/rules.md — Project rules; Industry Research on monorepo scoping*
 
 ---
 
@@ -129,7 +123,6 @@ In monorepos, scope globs to the relevant package subtree (e.g., `services/api/*
 
 **No contradictions** — if two rules conflict, the agent may pick one inconsistently. Review `.cursor/rules/` periodically to remove outdated or conflicting instructions.
 
-*Source: docs/cursor/rules/rules.md — Best practices*
 
 ---
 
@@ -148,4 +141,3 @@ In monorepos, scope globs to the relevant package subtree (e.g., `services/api/*
 | Rule files exceeding 200 lines | Poor adherence; attention fragmentation | Split into multiple focused files |
 | Mixing activation modes in one file | Activation-mode contract is per file | One activation mode per file |
 
-*Source: docs/cursor/rules/rules.md — What to avoid in rules; Best practices*

--- a/plugins/cursor-customizer/skills/create-rule/references/rule-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-rule/references/rule-validation-criteria.md
@@ -1,7 +1,6 @@
 # Rule Validation Criteria
 
 Quality checklist for generated and improved `.cursor/rules/*.mdc` rule files.
-Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineering-comprehensive.md)
 
 ---
 
@@ -9,17 +8,16 @@ Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineer
 
 Any rule file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
-| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
-| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` are valid; ALL others are AUTO-FAIL | docs/cursor/rules/rules.md — Rule file format |
-| Banned frontmatter key | A `paths` key MUST NOT appear; it belongs to a different platform's convention | Cross-platform leakage check |
-| Activation-mode well-formedness | `alwaysApply: true` must omit `globs`; `globs:` rules must set `alwaysApply: false`; `description:`-only rules must omit `globs` and set `alwaysApply: false` | docs/cursor/rules/rules.md — Rule anatomy |
-| Contradictions with other rules | 0 | Industry Research: conflicting instructions cause inconsistent agent behavior |
-| Stale file path references | 0 | Industry Research: stale paths poison context |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 200 lines |
+| YAML frontmatter | Valid YAML |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` are valid; ALL others are AUTO-FAIL |
+| Banned frontmatter key | A `paths` key MUST NOT appear; it belongs to a different platform's convention |
+| Activation-mode well-formedness | `alwaysApply: true` must omit `globs`; `globs:` rules must set `alwaysApply: false`; `description:`-only rules must omit `globs` and set `alwaysApply: false` |
+| Contradictions with other rules | 0 |
+| Stale file path references | 0 |
 
-*Source: docs/cursor/rules/rules.md — Rule file format, Best practices*
 
 ---
 
@@ -34,7 +32,7 @@ Any rule file violating these criteria must be fixed before proceeding:
 - [ ] No standard language conventions the agent already knows from training
 - [ ] No long explanations or tutorials — rules are instructions, not documentation
 - [ ] Files referenced via `@path/to/file` rather than copied inline where practical
-- [ ] Evidence citations present: rule instructions justify their existence with reference to project conventions or `docs/cursor/`
+- [ ] Evidence citations present: rule instructions justify their existence with reference to project conventions
 - [ ] Prompt engineering strategy applied: rule uses zero-shot imperative instructions only (no examples, no tutorials, no explanations)
 - [ ] Critical instructions appear at the start or end of the rule body, not buried in the middle
 

--- a/plugins/cursor-customizer/skills/create-skill/assets/templates/skill-md.md
+++ b/plugins/cursor-customizer/skills/create-skill/assets/templates/skill-md.md
@@ -15,8 +15,8 @@ description: "[What this skill does and when to use it. Third person. Include tr
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name
            the target service/workspace explicitly
-     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
-           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory: <TRIGGER>,
            <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
            Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
            Closed attribute set: avoid=, always=, when=, name=, id=, priority=.

--- a/plugins/cursor-customizer/skills/create-skill/references/artifact-format-routing.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/artifact-format-routing.md
@@ -2,8 +2,6 @@
 
 Evidence-based routing rule for deciding whether a skill's generated output artifact
 should default to HTML or Markdown.
-Source: Agent Skills open standard; project convention on HTML artifacts
-(human-rich + agent-executable dual-consumer design).
 
 ---
 

--- a/plugins/cursor-customizer/skills/create-skill/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/create-skill/references/skill-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/skill-authoring-guide.md
@@ -1,7 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating Cursor SKILL.md packages that conform to the Agent Skills open standard.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -40,7 +39,6 @@ Challenge each piece of content:
 
 **Safe persuasion** — use warm-up phases, curated references, explicit limits, and cited standards to improve compliance with legitimate work. Never use persuasion framing to bypass safeguards, refusals, or scope boundaries.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "What are skills?" and "How skills work"*
 
 ---
 
@@ -56,7 +54,6 @@ Cursor automatically discovers skills from these directories at startup:
 
 The agent is presented with available skills and decides when they are relevant based on context. Skills can also be invoked manually by typing `/` in the agent chat and searching for the skill name.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*
 
 ---
 
@@ -74,7 +71,6 @@ my-skill/
 
 Keep `SKILL.md` focused — move detailed reference material into `references/`. The agent loads supporting files progressively, only when the body of `SKILL.md` directs it to.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
 
 ---
 
@@ -93,7 +89,6 @@ Each skill begins with YAML frontmatter. The Agent Skills standard recognises si
 
 No other fields are part of the standard. Adding fields outside this set introduces foreign-platform dialect and breaks portability.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -109,7 +104,6 @@ No other fields are part of the standard. Adding fields outside this set introdu
 
 Include three things in every description: (1) what it does, (2) when to use it, (3) the trigger terms an agent might match against.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Frontmatter fields"*
 
 ---
 
@@ -129,7 +123,6 @@ Each reference file has one job and is cited explicitly from the phase that need
 
 Keep `SKILL.md` under 500 lines. Move detail to `references/`. Reference supporting files explicitly so the agent knows what they contain.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
 
 ---
 
@@ -149,7 +142,6 @@ Do not use string-substitution variables to refer to bundled files; the relative
 
 Scripts can be written in any language the agent can execute (Bash, Python, JavaScript, etc.). They should be self-contained, include helpful error messages, and handle edge cases gracefully.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills"*
 
 ---
 
@@ -159,7 +151,6 @@ By default, skills are automatically applied when the agent determines they are 
 
 Use this for workflows with side effects (commit, deploy, send-message) or for skills the user wants to gate manually.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Disabling automatic invocation"*
 
 ---
 
@@ -175,4 +166,3 @@ Use this for workflows with side effects (commit, deploy, send-message) or for s
 | Contradictions between phases | Agent picks one arbitrarily | Review all phases for consistency |
 | Loading every reference in Phase 1 | Defeats progressive disclosure | Load each reference only in the phase that needs it |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Optional directories"*

--- a/plugins/cursor-customizer/skills/create-skill/references/skill-format-reference.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/skill-format-reference.md
@@ -1,7 +1,6 @@
 # Skill Format Reference
 
 Technical specification for Cursor SKILL.md format, frontmatter, directory structure, and discovery model.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -31,7 +30,6 @@ The Agent Skills standard, as adopted by Cursor, recognises exactly six frontmat
 
 Frontmatter fields outside this set are foreign-platform dialect and must not appear in Cursor SKILL.md files.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -43,7 +41,6 @@ Frontmatter fields outside this set are foreign-platform dialect and must not ap
 - Must NOT contain consecutive `--`
 - Must match the parent directory name exactly
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -65,7 +62,6 @@ Apply the template at assets/templates/config.yaml.
 
 This convention is what the Agent Skills standard guarantees portable across implementations. Do not use string-substitution variables, absolute paths, or project-relative paths for bundled files — relative paths from the skill root are the only portable form.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills" and "Optional directories"*
 
 ---
 
@@ -90,7 +86,6 @@ my-skill/
 - `assets/` files load only when the skill body explicitly directs the agent to use them.
 - `scripts/` files are executed by the agent, not loaded into context.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
 
 ---
 
@@ -104,7 +99,6 @@ my-skill/
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to the `references/` subdirectory. Explicitly reference supporting files from SKILL.md so the agent knows what to load and when.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "How skills work" and "Optional directories"*
 
 ---
 
@@ -120,4 +114,3 @@ Cursor automatically loads skills from these directories:
 
 When the same skill name exists in multiple locations, Cursor's own resolution rules apply. For new skills, choose `.cursor/skills/` when the skill is Cursor-specific and `.agents/skills/` when the skill should also be discoverable by other Agent Skills consumers.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*

--- a/plugins/cursor-customizer/skills/create-skill/references/skill-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-skill/references/skill-validation-criteria.md
@@ -1,7 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved Cursor SKILL.md packages.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -20,17 +19,16 @@ Source: docs/cursor/skills/agent-skills-guide.md
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
-| Reference files | ≤ 200 lines each | reference-files convention |
-| Reference files >100 lines | Must include a `## Contents` table of contents | reference-files convention |
-| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags | Agent Skills specification |
-| `name` field | Present, non-empty, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder | Agent Skills specification |
-| Frontmatter fields | Restricted to `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` | Agent Skills specification |
-| Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` table of contents |
+| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags |
+| `name` field | Present, non-empty, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder |
+| Frontmatter fields | Restricted to `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` |
+| Contradictions between phases | 0 |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
 
 ---
 
@@ -64,7 +62,6 @@ The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 

--- a/plugins/cursor-customizer/skills/create-subagent/assets/templates/subagent-definition.md
+++ b/plugins/cursor-customizer/skills/create-subagent/assets/templates/subagent-definition.md
@@ -11,8 +11,8 @@ readonly: true
      Forbidden: any other frontmatter key; any other model value.
      Rule: Project subagents must not spawn other subagents.
      Rule: name must be kebab-case and distinct from every other subagent name in the project.
-     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
-           (see wiki/knowledge/skill-body-convention.md). Mandatory for subagents:
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory for subagents:
            <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id="N" name="X">.
            Optional: <TRIGGER>, <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>,
            <OUTPUT>, <VALIDATION>. Closed attribute set: avoid=, always=, when=, name=, id=, priority=.

--- a/plugins/cursor-customizer/skills/create-subagent/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/create-subagent/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/create-subagent/references/subagent-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/create-subagent/references/subagent-authoring-guide.md
@@ -1,7 +1,6 @@
 # Subagent Authoring Guide
 
 Evidence-based guidance for creating effective Cursor subagent definitions.
-Source: docs/cursor/subagents/subagents-guide.md (Cursor subagents documentation; primary attribution); docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -30,7 +29,6 @@ Subagents are for **isolated, specialized work** that should not pollute the par
 
 If the task is single-purpose (generate a changelog, format imports), prefer a skill or slash command — a subagent is overkill.
 
-*Source: docs/cursor/subagents/subagents-guide.md (when to use subagents)*
 
 ---
 
@@ -48,7 +46,6 @@ Project subagents take precedence over user subagents when names conflict.
 
 The customizer generates into the project or plugin paths only.
 
-*Source: docs/cursor/subagents/subagents-guide.md (file locations)*
 
 ---
 
@@ -64,7 +61,6 @@ Effective subagent system prompts follow this 5-part pattern:
 
 Keep prompts focused. Each subagent should have a single clear responsibility — avoid generic "helper" agents.
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices)*
 
 ---
 
@@ -86,7 +82,6 @@ readonly: true
 
 For full schema details and rejection rules, see `subagent-config-reference.md` and `subagent-validation-criteria.md`.
 
-*Source: docs/cursor/subagents/subagents-guide.md (file format, configuration fields); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -102,7 +97,6 @@ The `description` field is the only signal Cursor's agent uses to decide whether
 Bad: "Helps with code." (too generic — Cursor cannot decide when to delegate)
 Good: "Validates completed work. Use after tasks are marked done to confirm implementations are functional."
 
-*Source: docs/cursor/subagents/subagents-guide.md (description field, best practices)*
 
 ---
 
@@ -118,7 +112,6 @@ Good: "Validates completed work. Use after tasks are marked done to confirm impl
 | Generic "you are a helpful AI" prompt | Defeats the purpose of a subagent | Define a specific role and process |
 | Duplicating a slash-command capability | Adds complexity without benefit | Use the slash command directly |
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices — anti-patterns to avoid)*
 
 ---
 
@@ -152,4 +145,3 @@ Do not accept claims at face value. Test everything you can without modifying st
 
 Useful for: validating end-to-end behavior before marking tickets complete; catching partially implemented functionality; ensuring tests actually pass (not just that test files exist).
 
-*Source: docs/cursor/subagents/subagents-guide.md (common patterns — verification agent)*

--- a/plugins/cursor-customizer/skills/create-subagent/references/subagent-config-reference.md
+++ b/plugins/cursor-customizer/skills/create-subagent/references/subagent-config-reference.md
@@ -1,7 +1,6 @@
 # Subagent Config Reference
 
 Cursor-native subagent frontmatter specification, model handling, and orchestration patterns.
-Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -28,7 +27,6 @@ The Cursor-native subagent frontmatter for this distribution uses **exactly four
 | `model` | Yes | `inherit` | Cursor-native: the subagent runs on the same model as the parent agent. The product-strict contract requires this value. |
 | `readonly` | Yes | `true` | Cursor-native: the subagent runs with restricted write permissions (no file edits, no state-changing shell commands). The product-strict contract requires this value for analysis and evaluator subagents. |
 
-*Source: docs/cursor/subagents/subagents-guide.md (configuration fields table); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -43,7 +41,6 @@ For this distribution, **the value MUST be `inherit`**. The `fast` value and any
 
 If a Cursor user explicitly opts into `fast` or a specific model ID for their own hand-edited subagent, the customizer does not block that — but the customizer never generates such a value.
 
-*Source: docs/cursor/subagents/subagents-guide.md (model configuration); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -55,7 +52,6 @@ For this distribution, **the value MUST be `true`** for every generated subagent
 
 If a future workflow requires a subagent that writes files, the customizer prompts the user to confirm and document the rationale before generating such a subagent — but the default and recommended posture is `readonly: true`.
 
-*Source: docs/cursor/subagents/subagents-guide.md (configuration fields table)*
 
 ---
 
@@ -70,7 +66,6 @@ Cursor honors several subagent locations. This customizer generates into the Cur
 
 File naming: kebab-case `.md` filenames matching the subagent's `name` field (e.g., `security-reviewer.md` for `name: security-reviewer`).
 
-*Source: docs/cursor/subagents/subagents-guide.md (file locations)*
 
 ---
 
@@ -88,7 +83,6 @@ File naming: kebab-case `.md` filenames matching the subagent's `name` field (e.
 | Sequential pipeline | Task B depends on Task A's structured output |
 | Parallel decomposition | Independent reads or evaluations that can run concurrently |
 
-*Source: docs/cursor/subagents/subagents-guide.md (using subagents — parallel execution; orchestrator pattern)*
 
 ---
 
@@ -101,7 +95,6 @@ These constraints govern subagents authored by this customizer:
 - **Subagents do not inherit parent skills.** If a subagent needs domain knowledge, encode it in the system prompt.
 - **The frontmatter key set is closed.** Only `name`, `description`, `model`, `readonly` are permitted. Any other key is rejected by validation.
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices, anti-patterns)*
 
 ---
 
@@ -116,4 +109,3 @@ The following frontmatter fields belong to other agent platforms and MUST NOT ap
 
 These rejections are enforced by `subagent-validation-criteria.md` with explicit examples.
 
-*Source: docs/adr/0002-product-strict-research-foundation.md*

--- a/plugins/cursor-customizer/skills/create-subagent/references/subagent-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/create-subagent/references/subagent-validation-criteria.md
@@ -1,7 +1,6 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Cursor subagent definitions.
-Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -20,15 +19,15 @@ Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-r
 
 Any subagent violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | Cursor subagents documentation (file format) |
-| `name` field | Lowercase letters and hyphens; ≤64 characters | Cursor subagents documentation (configuration fields) |
-| `description` field | Present, non-empty, ≤1024 characters | Cursor subagents documentation (configuration fields) |
-| `model` field | Exactly `inherit` | ADR-0002 product-strict frontmatter contract |
-| `readonly` field | Exactly `true` | ADR-0002 product-strict frontmatter contract |
-| Frontmatter key set | Exactly the four allowed keys — `name`, `description`, `model`, `readonly` | ADR-0002 product-strict frontmatter contract |
-| System prompt | Not empty; task-specific | Cursor subagents documentation (best practices) |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens; ≤64 characters |
+| `description` field | Present, non-empty, ≤1024 characters |
+| `model` field | Exactly `inherit` |
+| `readonly` field | Exactly `true` |
+| Frontmatter key set | Exactly the four allowed keys — `name`, `description`, `model`, `readonly` |
+| System prompt | Not empty; task-specific |
 
 ---
 
@@ -140,7 +139,6 @@ The subagent body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-authoring-guide.md
@@ -1,7 +1,6 @@
 # Hook Authoring Guide
 
 Evidence-based guidance for creating Cursor hooks that enforce deterministic behavior.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -30,7 +29,6 @@ Hooks provide **deterministic control** — they always fire, regardless of mode
 
 Examples: auto-formatting after edits, blocking destructive shell commands, sending notifications, auditing config changes, redacting secrets before file reads.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hooks" introduction*
 
 ---
 
@@ -58,7 +56,6 @@ Level 2: **Hook definition** — at minimum a `command`; optionally `type`, `mat
 
 Omit `matcher` to fire on every occurrence of the event.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration file"*
 
 ---
 
@@ -83,7 +80,6 @@ Omit `matcher` to fire on every occurrence of the event.
 
 Prompt hooks return a structured `{ ok: boolean, reason?: string }` response. The `$ARGUMENTS` placeholder in the prompt is auto-replaced with the hook input JSON.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
 
 ---
 
@@ -102,7 +98,6 @@ The `matcher` field is a **regex string**. Which field it filters depends on the
 
 Matchers on `beforeSubmitPrompt`, `stop`, `afterAgentResponse`, and `afterAgentThought` are matched against fixed literal values documented in the Cursor hooks guide; in practice these matchers add no filtering value and may be omitted.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
 
 ---
 
@@ -119,7 +114,6 @@ Priority order (highest to lowest): Enterprise → Team → Project → User. Al
 
 For project hooks, write paths relative to the project root (e.g., `.cursor/hooks/script.sh`). For user hooks, write paths relative to `~/.cursor/` (e.g., `./hooks/script.sh`).
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
 
 ---
 
@@ -141,7 +135,6 @@ To make a security-critical hook **fail closed** instead, set `"failClosed": tru
 
 For **prompt** hooks: the LLM returns `{ ok: boolean, reason?: string }`. When `ok: false`, the action is denied and `reason` is surfaced to the user.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Per-Script Configuration Options"*
 
 ---
 
@@ -157,4 +150,3 @@ For **prompt** hooks: the LLM returns `{ ok: boolean, reason?: string }`. When `
 
 Use the Hooks tab in Cursor Settings to confirm hooks are loaded and to inspect execution traces.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Troubleshooting", "Environment Variables"*

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Hook Evaluation Criteria
 
 Scoring rubric for assessing existing Cursor hook configurations before improvement.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -29,7 +28,6 @@ Source: docs/cursor/hooks/hooks-guide.md
 
 A hook configuration violating any hard limit is flagged **INVALID** regardless of intent.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration", "Per-Script Configuration Options"*
 
 ---
 
@@ -37,7 +35,6 @@ A hook configuration violating any hard limit is flagged **INVALID** regardless 
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -52,7 +49,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Sensitive data in `command` strings | Use environment variables instead |
 | `failClosed: true` set on non-security-critical hooks | Increases false-deny rate without security benefit |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Examples", "Per-Script Configuration Options"*
 
 ---
 
@@ -66,7 +62,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Outdated subagent-type matcher values | Verify against documented subagent types (`generalPurpose`, `explore`, `shell`) |
 | Matcher set on an event that does not support matchers | Cross-check against `hook-events-reference.md` "Matcher Field by Event Type" |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
 
 ---
 
@@ -80,7 +75,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Security posture appropriate? | Hook validates before allowing; secrets in env vars; stdin variables quoted | Hook only logs, never blocks; secrets hardcoded; unquoted variable expansion |
 | Hook type appropriate for task? | `command` for deterministic, `prompt` for natural-language judgment | `prompt` for a simple regex check |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hook Types", "Command-Based Hooks"*
 
 ---
 
@@ -95,7 +89,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Handler Efficiency | Right type for each task | Some oversized handlers | Prompt hooks for trivial regex tasks |
 | **Overall** | | | |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration", "Hook Types"*
 
 > **UNCERTAIN classification**: When the `command` handler references an external script that cannot be read from the repository, classify Error Handling as **UNCERTAIN** (not Bad) — exit-code behavior cannot be verified from the hook configuration alone. Report it as a gap rather than a violation.
 

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-events-reference.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-events-reference.md
@@ -1,7 +1,6 @@
 # Hook Events Reference
 
 Complete reference for Cursor's native hook events: triggers, matcher fields, and handler-type support.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -49,7 +48,6 @@ Cursor exposes two families of hook events: Agent (Cmd+K / Agent Chat) and Tab (
 | `beforeTabFileRead` | Before Tab reads a file for inline completions | Yes (`permission: "deny"`) |
 | `afterTabFileEdit` | After Tab edits a file | No |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Agent and Tab Support"*
 
 ---
 
@@ -72,7 +70,6 @@ The `matcher` is a regex string. The field it matches against depends on the eve
 
 For MCP tool filtering on `preToolUse`/`postToolUse`/`postToolUseFailure`, use the `MCP:<tool_name>` format.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Matcher Configuration"*
 
 ---
 
@@ -109,7 +106,6 @@ Cursor hooks live in a `hooks.json` file at the project or user scope. The top l
 
 **Prompt-hook fields:** add `"type": "prompt"` and a `"prompt": "<natural-language criterion>"` field; an optional `"model"` field overrides the default fast model. The prompt receives the hook input via the auto-replaced `$ARGUMENTS` placeholder.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Configuration"*
 
 ---
 
@@ -122,7 +118,6 @@ Cursor hooks live in a `hooks.json` file at the project or user scope. The top l
 
 Unlike some agent platforms, Cursor exposes only these two handler types — there is no separate `http` or `agent` handler. Use `command` for deterministic checks; reserve `prompt` for cases where natural-language judgment is genuinely required.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Hook Types"*
 
 ---
 
@@ -158,4 +153,3 @@ Inject dynamic context at session start:
 
 The script's stdout JSON may include `additional_context` to add to the conversation's initial system context.
 
-*Source: docs/cursor/hooks/hooks-guide.md "Examples" and "Hook events"*

--- a/plugins/cursor-customizer/skills/improve-hook/references/hook-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/hook-validation-criteria.md
@@ -1,7 +1,6 @@
 # Hook Validation Criteria
 
 Quality checklist for generated and improved Cursor hook configurations.
-Source: docs/cursor/hooks/hooks-guide.md
 
 ---
 
@@ -28,7 +27,6 @@ Any hook violating these criteria must be fixed before proceeding:
 | Matcher applicability | Matcher set only on events whose matcher field is documented in `hook-events-reference.md` |
 | Exit-code semantics | `0` = success, `2` = block; other non-zero exits fail open by default — security-critical blocking hooks must set `failClosed: true` |
 
-*Source: docs/cursor/hooks/hooks-guide.md "Command-Based Hooks", "Configuration", "Per-Script Configuration Options"*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-hook/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/improve-hook/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/improve-rule/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/improve-rule/references/rule-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/rule-authoring-guide.md
@@ -1,7 +1,6 @@
 # Rule Authoring Guide
 
 Evidence-based guidance for creating effective Cursor rule files (`.cursor/rules/*.mdc`).
-Source: docs/cursor/rules/rules.md (Cursor official documentation)
 
 ---
 
@@ -31,7 +30,6 @@ Rules are markdown files placed in `.cursor/rules/`. Their contents are included
 | Conventions apply to a file pattern or topic | Side effects must always happen | Multi-phase workflows are required |
 | Domain expertise scoped to a path or topic | No agent judgment is required | Rich, progressive-disclosure references are needed |
 
-*Source: docs/cursor/rules/rules.md — How rules work, Project rules*
 
 ---
 
@@ -47,7 +45,6 @@ Rules are markdown files placed in `.cursor/rules/`. Their contents are included
 
 Each file should cover **one topic** with a kebab-case filename. Both `.md` and `.mdc` extensions are recognised; this distribution generates `.mdc` so that frontmatter can specify activation mode.
 
-*Source: docs/cursor/rules/rules.md — Rule file structure*
 
 ---
 
@@ -63,7 +60,6 @@ Cursor rule frontmatter is restricted to **three fields**. No other key is valid
 
 The token used by other agent platforms to scope rules by file pattern is NOT supported here — Cursor uses `globs` for the same role. Any other frontmatter key is invalid and must be removed.
 
-*Source: docs/cursor/rules/rules.md — Rule file format*
 
 ---
 
@@ -85,7 +81,6 @@ Pick the mode that matches the **content's nature**:
 - Agent-requested → cross-cutting / domain content the agent should pull in by name (authentication, observability, accessibility, API design)
 - Manual → templates and reference snippets the user explicitly opts into
 
-*Source: docs/cursor/rules/rules.md — Rule anatomy*
 
 ---
 
@@ -104,7 +99,6 @@ Auto-attached rules trigger when files matching the pattern enter the agent's co
 
 In monorepos, scope globs to the relevant package subtree (e.g., `services/api/**/*.go` rather than `**/*.go`). Language-only globs match across every package and defeat scoping.
 
-*Source: docs/cursor/rules/rules.md — Project rules; Industry Research on monorepo scoping*
 
 ---
 
@@ -129,7 +123,6 @@ In monorepos, scope globs to the relevant package subtree (e.g., `services/api/*
 
 **No contradictions** — if two rules conflict, the agent may pick one inconsistently. Review `.cursor/rules/` periodically to remove outdated or conflicting instructions.
 
-*Source: docs/cursor/rules/rules.md — Best practices*
 
 ---
 
@@ -148,4 +141,3 @@ In monorepos, scope globs to the relevant package subtree (e.g., `services/api/*
 | Rule files exceeding 200 lines | Poor adherence; attention fragmentation | Split into multiple focused files |
 | Mixing activation modes in one file | Activation-mode contract is per file | One activation mode per file |
 
-*Source: docs/cursor/rules/rules.md — What to avoid in rules; Best practices*

--- a/plugins/cursor-customizer/skills/improve-rule/references/rule-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/rule-evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Rule Evaluation Criteria
 
 Scoring rubric for assessing existing `.cursor/rules/*.mdc` rule files before improvement.
-Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineering-comprehensive.md)
 
 ---
 
@@ -20,18 +19,17 @@ Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineer
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
-| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
-| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` | docs/cursor/rules/rules.md — Rule file format |
-| Banned frontmatter key | `paths` MUST NOT appear | Cross-platform leakage |
-| Activation-mode well-formedness | One of always / globs / description, with the matching field set | docs/cursor/rules/rules.md — Rule anatomy |
-| Instruction actionability | Verifiable, not vague | docs/cursor/rules/rules.md — Best practices |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 200 lines |
+| YAML frontmatter | Valid YAML |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` |
+| Banned frontmatter key | `paths` MUST NOT appear |
+| Activation-mode well-formedness | One of always / globs / description, with the matching field set |
+| Instruction actionability | Verifiable, not vague |
 
 A rule violating any hard limit is flagged **OVER LIMIT** or **INVALID**.
 
-*Source: docs/cursor/rules/rules.md — Best practices, Rule file format*
 
 ---
 
@@ -39,7 +37,6 @@ A rule violating any hard limit is flagged **OVER LIMIT** or **INVALID**.
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -56,7 +53,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Inlined file content that could be `@path/to/file` reference | Token waste; staleness risk |
 | Edge-case instructions for situations that rarely apply | Steals attention from common paths |
 
-*Source: docs/cursor/rules/rules.md — What to avoid in rules*
 
 ---
 
@@ -70,7 +66,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Globs pointing to deleted or moved directories | Verify directory paths exist |
 | `@path/to/file` references to deleted files | Resolve every `@`-reference |
 
-*Source: Industry Research: stale paths poison context*
 
 ---
 
@@ -83,7 +78,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Cross-cutting / domain topic (auth, observability, accessibility) | `description:` | Always-apply, when the agent only needs it on relevant tasks |
 | User-controlled template or snippet | Manual (no frontmatter trigger) | Auto-attached with overly broad globs |
 
-*Source: docs/cursor/rules/rules.md — Rule anatomy*
 
 ---
 
@@ -99,7 +93,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | References instead of inlined file content? | `@components/Button.tsx` | Whole file body pasted into the rule |
 | No overlap with other rules? | Each rule covers a distinct topic | Same instruction in 3 rule files |
 
-*Source: docs/cursor/rules/rules.md — Best practices*
 
 ---
 
@@ -114,7 +107,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Consistency | 0 contradictions across files | 1 contradiction | 2+ contradictions |
 | **Overall** | | | |
 
-*Source: docs/cursor/rules/rules.md — Best practices; Industry Research on context budgets*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-rule/references/rule-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-rule/references/rule-validation-criteria.md
@@ -1,7 +1,6 @@
 # Rule Validation Criteria
 
 Quality checklist for generated and improved `.cursor/rules/*.mdc` rule files.
-Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineering-comprehensive.md)
 
 ---
 
@@ -9,17 +8,16 @@ Source: docs/cursor/rules/rules.md, Industry Research (research-context-engineer
 
 Any rule file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
-| YAML frontmatter | Valid YAML | docs/cursor/rules/rules.md — Rule anatomy |
-| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` are valid; ALL others are AUTO-FAIL | docs/cursor/rules/rules.md — Rule file format |
-| Banned frontmatter key | A `paths` key MUST NOT appear; it belongs to a different platform's convention | Cross-platform leakage check |
-| Activation-mode well-formedness | `alwaysApply: true` must omit `globs`; `globs:` rules must set `alwaysApply: false`; `description:`-only rules must omit `globs` and set `alwaysApply: false` | docs/cursor/rules/rules.md — Rule anatomy |
-| Contradictions with other rules | 0 | Industry Research: conflicting instructions cause inconsistent agent behavior |
-| Stale file path references | 0 | Industry Research: stale paths poison context |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule length | ≤ 200 lines |
+| YAML frontmatter | Valid YAML |
+| Frontmatter fields | ONLY `description`, `alwaysApply`, `globs` are valid; ALL others are AUTO-FAIL |
+| Banned frontmatter key | A `paths` key MUST NOT appear; it belongs to a different platform's convention |
+| Activation-mode well-formedness | `alwaysApply: true` must omit `globs`; `globs:` rules must set `alwaysApply: false`; `description:`-only rules must omit `globs` and set `alwaysApply: false` |
+| Contradictions with other rules | 0 |
+| Stale file path references | 0 |
 
-*Source: docs/cursor/rules/rules.md — Rule file format, Best practices*
 
 ---
 
@@ -34,7 +32,7 @@ Any rule file violating these criteria must be fixed before proceeding:
 - [ ] No standard language conventions the agent already knows from training
 - [ ] No long explanations or tutorials — rules are instructions, not documentation
 - [ ] Files referenced via `@path/to/file` rather than copied inline where practical
-- [ ] Evidence citations present: rule instructions justify their existence with reference to project conventions or `docs/cursor/`
+- [ ] Evidence citations present: rule instructions justify their existence with reference to project conventions
 - [ ] Prompt engineering strategy applied: rule uses zero-shot imperative instructions only (no examples, no tutorials, no explanations)
 - [ ] Critical instructions appear at the start or end of the rule body, not buried in the middle
 

--- a/plugins/cursor-customizer/skills/improve-skill/assets/templates/skill-md.md
+++ b/plugins/cursor-customizer/skills/improve-skill/assets/templates/skill-md.md
@@ -15,8 +15,8 @@ description: "[What this skill does and when to use it. Third person. Include tr
      Rule: Progressive disclosure — load references per phase, not all upfront
      Rule: If analysis finds a monorepo or multi-service layout, generated phases must name
            the target service/workspace explicitly
-     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
-           (see wiki/knowledge/skill-body-convention.md). Mandatory: <TRIGGER>,
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory: <TRIGGER>,
            <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id name>.
            Optional: <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>, <OUTPUT>, <VALIDATION>.
            Closed attribute set: avoid=, always=, when=, name=, id=, priority=.

--- a/plugins/cursor-customizer/skills/improve-skill/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-authoring-guide.md
@@ -1,7 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating Cursor SKILL.md packages that conform to the Agent Skills open standard.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -40,7 +39,6 @@ Challenge each piece of content:
 
 **Safe persuasion** — use warm-up phases, curated references, explicit limits, and cited standards to improve compliance with legitimate work. Never use persuasion framing to bypass safeguards, refusals, or scope boundaries.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "What are skills?" and "How skills work"*
 
 ---
 
@@ -56,7 +54,6 @@ Cursor automatically discovers skills from these directories at startup:
 
 The agent is presented with available skills and decides when they are relevant based on context. Skills can also be invoked manually by typing `/` in the agent chat and searching for the skill name.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*
 
 ---
 
@@ -74,7 +71,6 @@ my-skill/
 
 Keep `SKILL.md` focused — move detailed reference material into `references/`. The agent loads supporting files progressively, only when the body of `SKILL.md` directs it to.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
 
 ---
 
@@ -93,7 +89,6 @@ Each skill begins with YAML frontmatter. The Agent Skills standard recognises si
 
 No other fields are part of the standard. Adding fields outside this set introduces foreign-platform dialect and breaks portability.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -109,7 +104,6 @@ No other fields are part of the standard. Adding fields outside this set introdu
 
 Include three things in every description: (1) what it does, (2) when to use it, (3) the trigger terms an agent might match against.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Frontmatter fields"*
 
 ---
 
@@ -129,7 +123,6 @@ Each reference file has one job and is cited explicitly from the phase that need
 
 Keep `SKILL.md` under 500 lines. Move detail to `references/`. Reference supporting files explicitly so the agent knows what they contain.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
 
 ---
 
@@ -149,7 +142,6 @@ Do not use string-substitution variables to refer to bundled files; the relative
 
 Scripts can be written in any language the agent can execute (Bash, Python, JavaScript, etc.). They should be self-contained, include helpful error messages, and handle edge cases gracefully.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills"*
 
 ---
 
@@ -159,7 +151,6 @@ By default, skills are automatically applied when the agent determines they are 
 
 Use this for workflows with side effects (commit, deploy, send-message) or for skills the user wants to gate manually.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Disabling automatic invocation"*
 
 ---
 
@@ -175,4 +166,3 @@ Use this for workflows with side effects (commit, deploy, send-message) or for s
 | Contradictions between phases | Agent picks one arbitrarily | Review all phases for consistency |
 | Loading every reference in Phase 1 | Defeats progressive disclosure | Load each reference only in the phase that needs it |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format" and "Optional directories"*

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Skill Evaluation Criteria
 
 Scoring rubric for assessing existing Cursor SKILL.md packages before improvement.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -20,19 +19,18 @@ Source: docs/cursor/skills/agent-skills-guide.md
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
-| Reference files | ≤ 200 lines each | reference-files convention |
-| Reference files >100 lines | Must include a `## Contents` table of contents | reference-files convention |
-| `description` field | Present, non-empty, ≤ 1024 chars | Agent Skills specification |
-| `name` field | Present, non-empty, 1-64 chars, kebab-case, matches parent folder | Agent Skills specification |
-| Frontmatter fields | Restricted to the six recognised by the Agent Skills standard | Agent Skills specification |
-| Phase structure | At least one clear phase defined | Agent Skills authoring patterns |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` table of contents |
+| `description` field | Present, non-empty, ≤ 1024 chars |
+| `name` field | Present, non-empty, 1-64 chars, kebab-case, matches parent folder |
+| Frontmatter fields | Restricted to the six recognised by the Agent Skills standard |
+| Phase structure | At least one clear phase defined |
 
 A skill violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
 
 ---
 
@@ -40,7 +38,6 @@ A skill violating any hard limit is flagged **OVER LIMIT** regardless of content
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -56,7 +53,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Explaining standard practices the agent already knows | Agents are already capable; add only novel context |
 | Hardcoded absolute or project-relative paths for bundled files | Will go stale; bundled paths must be relative to the skill root |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
 
 ---
 
@@ -70,7 +66,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Hardcoded file paths in SKILL.md body | Check that referenced bundled paths actually exist |
 | Foreign-platform dialect | See dedicated section below — auto-fail |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "SKILL.md file format"*
 
 ---
 
@@ -96,7 +91,6 @@ The Cursor distribution is product-strict. Apply the following allowlists to the
 | Are supporting files referenced explicitly? | "Read the relevant supporting file for this phase" | Files exist but never referenced |
 | Is SKILL.md body under 500 lines? | Clean entry point with external depth | Monolithic, all content inline |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Optional directories"*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-format-reference.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-format-reference.md
@@ -1,7 +1,6 @@
 # Skill Format Reference
 
 Technical specification for Cursor SKILL.md format, frontmatter, directory structure, and discovery model.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -31,7 +30,6 @@ The Agent Skills standard, as adopted by Cursor, recognises exactly six frontmat
 
 Frontmatter fields outside this set are foreign-platform dialect and must not appear in Cursor SKILL.md files.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -43,7 +41,6 @@ Frontmatter fields outside this set are foreign-platform dialect and must not ap
 - Must NOT contain consecutive `--`
 - Must match the parent directory name exactly
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields"*
 
 ---
 
@@ -65,7 +62,6 @@ Apply the template at assets/templates/config.yaml.
 
 This convention is what the Agent Skills standard guarantees portable across implementations. Do not use string-substitution variables, absolute paths, or project-relative paths for bundled files — relative paths from the skill root are the only portable form.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Including scripts in skills" and "Optional directories"*
 
 ---
 
@@ -90,7 +86,6 @@ my-skill/
 - `assets/` files load only when the skill body explicitly directs the agent to use them.
 - `scripts/` files are executed by the agent, not loaded into context.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories" and "Optional directories"*
 
 ---
 
@@ -104,7 +99,6 @@ my-skill/
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to the `references/` subdirectory. Explicitly reference supporting files from SKILL.md so the agent knows what to load and when.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "How skills work" and "Optional directories"*
 
 ---
 
@@ -120,4 +114,3 @@ Cursor automatically loads skills from these directories:
 
 When the same skill name exists in multiple locations, Cursor's own resolution rules apply. For new skills, choose `.cursor/skills/` when the skill is Cursor-specific and `.agents/skills/` when the skill should also be discoverable by other Agent Skills consumers.
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Skill directories"*

--- a/plugins/cursor-customizer/skills/improve-skill/references/skill-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-skill/references/skill-validation-criteria.md
@@ -1,7 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved Cursor SKILL.md packages.
-Source: docs/cursor/skills/agent-skills-guide.md
 
 ---
 
@@ -20,17 +19,16 @@ Source: docs/cursor/skills/agent-skills-guide.md
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Agent Skills best practice: keep SKILL.md focused |
-| Reference files | ≤ 200 lines each | reference-files convention |
-| Reference files >100 lines | Must include a `## Contents` table of contents | reference-files convention |
-| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags | Agent Skills specification |
-| `name` field | Present, non-empty, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder | Agent Skills specification |
-| Frontmatter fields | Restricted to `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` | Agent Skills specification |
-| Contradictions between phases | 0 | Agents pick arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` table of contents |
+| `description` field | Present, non-empty, ≤ 1024 chars, no XML tags |
+| `name` field | Present, non-empty, lowercase letters/numbers/hyphens only, max 64 chars, matches parent folder |
+| Frontmatter fields | Restricted to `name`, `description`, `license`, `compatibility`, `metadata`, `disable-model-invocation` |
+| Contradictions between phases | 0 |
 
-*Source: docs/cursor/skills/agent-skills-guide.md "Frontmatter fields" and "Optional directories"*
 
 ---
 
@@ -64,7 +62,6 @@ The SKILL.md body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-subagent/assets/templates/subagent-definition.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/assets/templates/subagent-definition.md
@@ -11,8 +11,8 @@ readonly: true
      Forbidden: any other frontmatter key; any other model value.
      Rule: Project subagents must not spawn other subagents.
      Rule: name must be kebab-case and distinct from every other subagent name in the project.
-     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary
-           (see wiki/knowledge/skill-body-convention.md). Mandatory for subagents:
+     Rule: The body wraps logical blocks in the canonical semantic-tag vocabulary.
+           Mandatory for subagents:
            <BEHAVIOUR>, <HARD_RULES>, <PROCESS> with one or more <PHASE id="N" name="X">.
            Optional: <TRIGGER>, <PREFLIGHT>, <REFERENCES>, <EXAMPLE>, <ANTI_PATTERN>,
            <OUTPUT>, <VALIDATION>. Closed attribute set: avoid=, always=, when=, name=, id=, priority=.

--- a/plugins/cursor-customizer/skills/improve-subagent/references/prompt-engineering-strategies.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, Industry Research (agent prompting best practices), `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: Industry Research (agent prompting best practices) lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; Industry Research (agent prompting best practices) lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with large capable models
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: Industry Research (agent prompting best practices) lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, Industry Research (agent prompting best pra
 | Contradictory instructions | Agent picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: Industry Research (agent prompting best practices) lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; Industry Research (agent prompting best practices) lines 32-50*

--- a/plugins/cursor-customizer/skills/improve-subagent/references/subagent-authoring-guide.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/subagent-authoring-guide.md
@@ -1,7 +1,6 @@
 # Subagent Authoring Guide
 
 Evidence-based guidance for creating effective Cursor subagent definitions.
-Source: docs/cursor/subagents/subagents-guide.md (Cursor subagents documentation; primary attribution); docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -30,7 +29,6 @@ Subagents are for **isolated, specialized work** that should not pollute the par
 
 If the task is single-purpose (generate a changelog, format imports), prefer a skill or slash command — a subagent is overkill.
 
-*Source: docs/cursor/subagents/subagents-guide.md (when to use subagents)*
 
 ---
 
@@ -48,7 +46,6 @@ Project subagents take precedence over user subagents when names conflict.
 
 The customizer generates into the project or plugin paths only.
 
-*Source: docs/cursor/subagents/subagents-guide.md (file locations)*
 
 ---
 
@@ -64,7 +61,6 @@ Effective subagent system prompts follow this 5-part pattern:
 
 Keep prompts focused. Each subagent should have a single clear responsibility — avoid generic "helper" agents.
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices)*
 
 ---
 
@@ -86,7 +82,6 @@ readonly: true
 
 For full schema details and rejection rules, see `subagent-config-reference.md` and `subagent-validation-criteria.md`.
 
-*Source: docs/cursor/subagents/subagents-guide.md (file format, configuration fields); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -102,7 +97,6 @@ The `description` field is the only signal Cursor's agent uses to decide whether
 Bad: "Helps with code." (too generic — Cursor cannot decide when to delegate)
 Good: "Validates completed work. Use after tasks are marked done to confirm implementations are functional."
 
-*Source: docs/cursor/subagents/subagents-guide.md (description field, best practices)*
 
 ---
 
@@ -118,7 +112,6 @@ Good: "Validates completed work. Use after tasks are marked done to confirm impl
 | Generic "you are a helpful AI" prompt | Defeats the purpose of a subagent | Define a specific role and process |
 | Duplicating a slash-command capability | Adds complexity without benefit | Use the slash command directly |
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices — anti-patterns to avoid)*
 
 ---
 
@@ -152,4 +145,3 @@ Do not accept claims at face value. Test everything you can without modifying st
 
 Useful for: validating end-to-end behavior before marking tickets complete; catching partially implemented functionality; ensuring tests actually pass (not just that test files exist).
 
-*Source: docs/cursor/subagents/subagents-guide.md (common patterns — verification agent)*

--- a/plugins/cursor-customizer/skills/improve-subagent/references/subagent-config-reference.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/subagent-config-reference.md
@@ -1,7 +1,6 @@
 # Subagent Config Reference
 
 Cursor-native subagent frontmatter specification, model handling, and orchestration patterns.
-Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -28,7 +27,6 @@ The Cursor-native subagent frontmatter for this distribution uses **exactly four
 | `model` | Yes | `inherit` | Cursor-native: the subagent runs on the same model as the parent agent. The product-strict contract requires this value. |
 | `readonly` | Yes | `true` | Cursor-native: the subagent runs with restricted write permissions (no file edits, no state-changing shell commands). The product-strict contract requires this value for analysis and evaluator subagents. |
 
-*Source: docs/cursor/subagents/subagents-guide.md (configuration fields table); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -43,7 +41,6 @@ For this distribution, **the value MUST be `inherit`**. The `fast` value and any
 
 If a Cursor user explicitly opts into `fast` or a specific model ID for their own hand-edited subagent, the customizer does not block that — but the customizer never generates such a value.
 
-*Source: docs/cursor/subagents/subagents-guide.md (model configuration); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -55,7 +52,6 @@ For this distribution, **the value MUST be `true`** for every generated subagent
 
 If a future workflow requires a subagent that writes files, the customizer prompts the user to confirm and document the rationale before generating such a subagent — but the default and recommended posture is `readonly: true`.
 
-*Source: docs/cursor/subagents/subagents-guide.md (configuration fields table)*
 
 ---
 
@@ -70,7 +66,6 @@ Cursor honors several subagent locations. This customizer generates into the Cur
 
 File naming: kebab-case `.md` filenames matching the subagent's `name` field (e.g., `security-reviewer.md` for `name: security-reviewer`).
 
-*Source: docs/cursor/subagents/subagents-guide.md (file locations)*
 
 ---
 
@@ -88,7 +83,6 @@ File naming: kebab-case `.md` filenames matching the subagent's `name` field (e.
 | Sequential pipeline | Task B depends on Task A's structured output |
 | Parallel decomposition | Independent reads or evaluations that can run concurrently |
 
-*Source: docs/cursor/subagents/subagents-guide.md (using subagents — parallel execution; orchestrator pattern)*
 
 ---
 
@@ -101,7 +95,6 @@ These constraints govern subagents authored by this customizer:
 - **Subagents do not inherit parent skills.** If a subagent needs domain knowledge, encode it in the system prompt.
 - **The frontmatter key set is closed.** Only `name`, `description`, `model`, `readonly` are permitted. Any other key is rejected by validation.
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices, anti-patterns)*
 
 ---
 
@@ -116,4 +109,3 @@ The following frontmatter fields belong to other agent platforms and MUST NOT ap
 
 These rejections are enforced by `subagent-validation-criteria.md` with explicit examples.
 
-*Source: docs/adr/0002-product-strict-research-foundation.md*

--- a/plugins/cursor-customizer/skills/improve-subagent/references/subagent-evaluation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/subagent-evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Subagent Evaluation Criteria
 
 Scoring rubric for assessing existing Cursor subagent definitions before improvement.
-Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -19,18 +18,17 @@ Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-r
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| `name` field | Present; lowercase letters and hyphens only; ≤64 chars | Cursor subagents documentation (configuration fields) |
-| `description` field | Present, non-empty, ≤1024 chars, specific | Cursor subagents documentation (configuration fields) |
-| `model` field | Exactly `inherit` | ADR-0002 product-strict frontmatter contract |
-| `readonly` field | Exactly `true` | ADR-0002 product-strict frontmatter contract |
-| Frontmatter key set | Exactly `name`, `description`, `model`, `readonly` | ADR-0002 product-strict frontmatter contract |
-| System prompt (markdown body) | Present and task-specific | Cursor subagents documentation (best practices) |
+| Criterion | Threshold |
+|-----------|-----------|
+| `name` field | Present; lowercase letters and hyphens only; ≤64 chars |
+| `description` field | Present, non-empty, ≤1024 chars, specific |
+| `model` field | Exactly `inherit` |
+| `readonly` field | Exactly `true` |
+| Frontmatter key set | Exactly `name`, `description`, `model`, `readonly` |
+| System prompt (markdown body) | Present and task-specific |
 
 A subagent violating any hard limit is flagged **INVALID** regardless of other quality.
 
-*Source: docs/cursor/subagents/subagents-guide.md; docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -38,7 +36,6 @@ A subagent violating any hard limit is flagged **INVALID** regardless of other q
 
 For every instruction, line, and reference, ask: **"Would removing this cause the agent to make mistakes?"** If the answer is no, flag it for removal. ETH Zurich (Feb 2026) measured that LLM-generated agent files reduce success rate by ~3% and increase cost by ~20% — the failure mode is content that looks helpful but adds no decision value. The deletion test is the rubric for separating signal from bloat.
 
-*Source: docs/general-llm/Evaluating-AGENTS-paper.pdf*
 
 ---
 
@@ -53,7 +50,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Duplicate subagent with the same purpose as a built-in role | Built-in subagents already cover exploration / shell / browser; do not recreate |
 | Vague "use for general tasks" descriptions | Cursor cannot route to the subagent reliably |
 
-*Source: docs/cursor/subagents/subagents-guide.md (anti-patterns to avoid)*
 
 ---
 
@@ -69,7 +65,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | `readonly` value is missing or `false` for an analysis subagent | Inspect the `readonly` value; analysis subagents must be `true` |
 | Instructions tell the subagent to spawn other subagents | Search the prompt body for nested-launch language; project convention restricts this |
 
-*Source: docs/cursor/subagents/subagents-guide.md (configuration fields, best practices); docs/adr/0002-product-strict-research-foundation.md*
 
 ---
 
@@ -84,7 +79,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Description specific enough for routing? | Triggers specified ("Use when...", "Use after...") | Generic description; poor delegation |
 | Context isolation justified? | Subagent prevents context pollution | Subagent used when a slash command works |
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices)*
 
 ---
 
@@ -99,7 +93,6 @@ For every instruction, line, and reference, ask: **"Would removing this cause th
 | Context Isolation | Subagent use justified; prevents pollution | Questionable necessity | Duplicates inline capability |
 | **Overall** | | | |
 
-*Source: docs/cursor/subagents/subagents-guide.md (best practices, anti-patterns)*
 
 ---
 

--- a/plugins/cursor-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
+++ b/plugins/cursor-customizer/skills/improve-subagent/references/subagent-validation-criteria.md
@@ -1,7 +1,6 @@
 # Subagent Validation Criteria
 
 Quality checklist for generated and improved Cursor subagent definitions.
-Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-research-foundation.md
 
 ---
 
@@ -20,15 +19,15 @@ Source: docs/cursor/subagents/subagents-guide.md, docs/adr/0002-product-strict-r
 
 Any subagent violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| YAML frontmatter | Valid YAML syntax | Cursor subagents documentation (file format) |
-| `name` field | Lowercase letters and hyphens; ≤64 characters | Cursor subagents documentation (configuration fields) |
-| `description` field | Present, non-empty, ≤1024 characters | Cursor subagents documentation (configuration fields) |
-| `model` field | Exactly `inherit` | ADR-0002 product-strict frontmatter contract |
-| `readonly` field | Exactly `true` | ADR-0002 product-strict frontmatter contract |
-| Frontmatter key set | Exactly the four allowed keys — `name`, `description`, `model`, `readonly` | ADR-0002 product-strict frontmatter contract |
-| System prompt | Not empty; task-specific | Cursor subagents documentation (best practices) |
+| Criterion | Threshold |
+|-----------|-----------|
+| YAML frontmatter | Valid YAML syntax |
+| `name` field | Lowercase letters and hyphens; ≤64 characters |
+| `description` field | Present, non-empty, ≤1024 characters |
+| `model` field | Exactly `inherit` |
+| `readonly` field | Exactly `true` |
+| Frontmatter key set | Exactly the four allowed keys — `name`, `description`, `model`, `readonly` |
+| System prompt | Not empty; task-specific |
 
 ---
 
@@ -140,7 +139,6 @@ The subagent body (everything after the YAML frontmatter) MUST wrap its logical 
 
 A self-closing tag (`<TRIGGER ... />`) counts as balanced. `<PHASE>` missing its mandatory `id=` is a hard-fail (a mandatory attribute is absent, not malformed).
 
-*Source: wiki/knowledge/skill-body-convention.md; docs/adr/0007-skill-body-semantic-tag-convention.md*
 
 ---
 

--- a/plugins/cursor-initializer/agents/file-evaluator.md
+++ b/plugins/cursor-initializer/agents/file-evaluator.md
@@ -24,17 +24,17 @@ You are a configuration-file quality specialist for the Cursor distribution. You
 
 ### Hard Limits
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Industry Research: configuration files lose attention beyond this budget |
-| Instruction count | ≤ 150-200 | Industry Research: frontier LLMs reliably follow ~150-200 instructions |
-| Contradictions across rules | 0 | Conflicting instructions cause the agent to choose arbitrarily |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines — configuration files lose attention beyond this budget |
+| Instruction count | ≤ 150-200 — frontier LLMs reliably follow ~150-200 instructions |
+| Contradictions across rules | 0 — conflicting instructions cause the agent to choose arbitrarily |
 
 ### Bloat Indicators
 
-| Indicator | Why It Is Bloat | Source |
-|-----------|-----------------|--------|
-| Directory or file structure listings | Industry Research (ETH "Evaluating AGENTS.md") found these "not effective at providing repository overview" |
+| Indicator | Why It Is Bloat |
+|-----------|-----------------|
+| Directory or file structure listings | "Not effective at providing repository overview" |
 | Standard language conventions | Already known from training data |
 | Vague instructions ("write clean code") | Not actionable; wastes attention budget |
 | Codebase overview paragraphs | Increases steps without improving navigation |

--- a/plugins/cursor-initializer/skills/improve-cursor/references/automation-migration-guide.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/automation-migration-guide.md
@@ -1,7 +1,6 @@
 # Automation Migration Guide
 
 Decision criteria for migrating instructions (including legacy AGENTS.md content the migration sub-flow processes) into on-demand `.cursor/rules/*.mdc` mechanisms.
-Source: context-aware-improve-optimization.prd.md, analysis-automate-workflow-with-hooks.md, analysis-skill-authoring-best-practices.md, analysis-how-claude-remembers-a-project.md.
 
 ---
 
@@ -18,7 +17,6 @@ Stop at the first match:
 7. Heavy, rare, or has side effects → skill (`disable-model-invocation: true`)
 8. None of the above → keep in current location; reassess next cycle
 
-*Source: context-aware-improve-optimization.prd.md lines 346-358*
 
 ---
 
@@ -33,7 +31,6 @@ Stop at the first match:
 - Duplicated across 2+ files → consolidate to single source
 - Version numbers / team names / release info → DELETE or replace with memory pointer
 
-*Source: analysis-evaluating-agents-paper.md lines 36-52, Industry Research*
 
 ---
 
@@ -50,7 +47,6 @@ Stop at the first match:
 
 Hook events: `preToolUse`, `postToolUse`, `postToolUseFailure`, `stop`, `sessionStart`, `beforeShellExecution`. Block by returning `{"decision": "block"}` from a `prompt` hook. `globs:` accepts string or array (e.g., `["src/**/*.ts", "!src/**/*.test.ts"]`).
 
-*Source: analysis-automate-workflow-with-hooks.md lines 21-130, 433-445*
 
 ---
 
@@ -73,4 +69,3 @@ Skills, path-scoped rules — plugin and standalone. Hooks, subagents — plugin
 
 Present token-impact estimates alongside migration recommendations.
 
-*Source: research-context-engineering-comprehensive.md, analysis-skill-authoring-best-practices.md lines 19-46*

--- a/plugins/cursor-initializer/skills/improve-cursor/references/context-optimization.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Token-budget and attention guidance for `.cursor/rules/*.mdc` and AGENTS.md files.
-Source: Industry Research — research-context-engineering-comprehensive.md.
 
 Hard limits live in `validation-criteria.md`. Bloated files cause the model to miss important instructions: if Cursor keeps doing something despite a rule against it, the file is probably too long. (Industry Research)
 
@@ -23,7 +22,6 @@ Place the most important instructions in the first 20% and last 20% of each file
 
 Apply the deletion test: "Would removing this cause the agent to make mistakes? If not, cut it." Full include/exclude categories: see `what-not-to-include.md`. **Specificity goldilocks**: ✅ "Use 2-space indentation"; "Run `npm test` before committing"; "API handlers live in `src/api/handlers/`". ❌ "Format code properly"; "Test your changes"; "Keep files organized".
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -31,7 +29,6 @@ Apply the deletion test: "Would removing this cause the agent to make mistakes? 
 
 Detect and remove: stale file paths (check existence; remove or update); contradictions (drop the weaker rule); over-specification (rules already followed; delete or convert to hook); failed-approach accumulation (defensive rules added after incidents); high-churn data (versions, file counts, team names — remove or replace with a pointer). Treat configuration files like code: review when things go wrong, prune regularly. (Industry Research)
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -39,4 +36,3 @@ Detect and remove: stale file paths (check existence; remove or update); contrad
 
 Move from always-consumed to on-demand: skills (description at start, body on invocation), path-scoped rules (load on file match), subdirectory configs (load when working there), domain docs in `docs/` (agent navigates when relevant). Maintain lightweight identifiers; load data into context at runtime. (Industry Research, Effective Context Engineering)
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 138-208, 451-461*

--- a/plugins/cursor-initializer/skills/improve-cursor/references/cursor-rules-system.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/cursor-rules-system.md
@@ -1,6 +1,6 @@
 # Cursor Rules System
 
-Reference for generating and evaluating `.cursor/rules/` files. Source: [cursor.com/docs/context/rules](https://cursor.com/docs/context/rules).
+Reference for generating and evaluating `.cursor/rules/` files.
 
 ## File Format
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/evaluation-criteria.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Evaluation Criteria
 
 Scoring rubric for assessing existing AGENTS.md files and `.cursor/rules/*` files before improvement. Used by IMPROVE skills only.
-Source: file-evaluator.md, research-context-engineering-comprehensive.md.
 
 The canonical Hard Limits Table, Bloat Indicators, Staleness Indicators, Progressive Disclosure Assessment, Quality Score Rubric, and Evaluation Output Template all live in `agents/file-evaluator.md` (the subagent that produces the structured evaluation report). The Migration Candidate Indicators table lives in `automation-migration-guide.md`. This file holds only the criteria specific to the IMPROVE workflow that aren't already covered by those references.
 
@@ -18,7 +17,6 @@ The canonical Hard Limits Table, Bloat Indicators, Staleness Indicators, Progres
 
 Goldilocks zone — ✅ specific and actionable: "Use 2-space indentation"; ❌ too vague: "Format code properly" (not verifiable); ❌ too specific: "File `src/auth/handlers.ts` handles JWT" (will go stale on a path reference). Standard-command-form examples like "Run `npm test`" are valid form but should still be excluded per `what-not-to-include.md` because the command is the language default.
 
-*Source: research-context-engineering-comprehensive.md lines 131-134*
 
 ---
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Where AGENTS.md and `.cursor/rules/*.mdc` content lives by load timing.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md, memory/how-claude-remembers-a-project.md.
 
 For anti-patterns (ball-of-mud growth, auto-generated init files, everything-in-one-file), see `what-not-to-include.md` § Common Traps. For validation thresholds, see `validation-criteria.md`.
 
@@ -13,7 +12,6 @@ Place content based on what's relevant when. **Root AGENTS.md** — relevant to 
 
 **Borderline tiebreaker (10–15 lines)**: when domain content falls between 10–15 lines, prefer extracting to a separate domain file if it applies to only one domain. Root brevity is more valuable than an additional file.
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -27,7 +25,6 @@ Generate root files with only: (1) one-sentence project description; (2) package
 
 **Root**: monorepo purpose, package navigation, shared tooling — never package-specific tech stacks. **Package**: package purpose, specific tech stack, package-specific conventions — never cross-repo decisions. The agent sees all merged files. In Cursor monorepos, use `.cursor/rules/*.mdc` with narrow `globs:` patterns; keep `alwaysApply: true` rules minimal.
 
-*Source: a-guide-to-agents.md; memory/how-claude-remembers-a-project.md lines 243-260; docs/cursor/rules-and-memory.md*
 
 ---
 
@@ -35,7 +32,6 @@ Generate root files with only: (1) one-sentence project description; (2) package
 
 Extract a section to a separate domain file when it has 3+ distinct rules AND spans 10+ lines, or when irrelevant to most work sessions. Prefer "For TypeScript conventions, see docs/TYPESCRIPT.md" over inlining. Workflows go to skills (agent invokes only when needed).
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ---
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/validation-criteria.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for improved and newly created `.cursor/rules/*.mdc` files, plus the AGENTS.md migration sub-flow output.
-Source: Industry Research (research-context-engineering-comprehensive.md), file-evaluator.md.
 
 ---
 

--- a/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/improve-cursor/references/what-not-to-include.md
@@ -1,7 +1,6 @@
 # What NOT to Include
 
 Exclusion guide for AGENTS.md and `.cursor/rules/*.mdc`.
-Sources: Industry Research (ETH "Evaluating context files", a-guide-to-agents.md, hooks/automate-workflow-with-hooks.md).
 
 ---
 
@@ -9,7 +8,6 @@ Sources: Industry Research (ETH "Evaluating context files", a-guide-to-agents.md
 
 Exclude: directory/file structure listings (static lists go stale — ETH); standard language conventions (already in training data); codebase overview paragraphs (increase exploration steps without improving navigation — ETH); vague guidance ("write clean code"); file path references (paths churn and poison context); everything in one file (exceeds ~150-200 instruction attention budget); obvious tooling ("use git for version control"); duplicated information across files; version numbers / release names (high-churn); long explanations or tutorials; detailed API documentation (link out); anything inferable from code; hook-enforced behaviors (formatting, file blocking, notifications) — migrate to a hook.
 
-*Source: Industry Research — research-context-engineering-comprehensive.md:113-121; ETH Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/context-optimization.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Evidence-based instructions for managing token budgets and attention in `.cursor/rules/*.mdc` files.
-Source: Industry Research — research-context-engineering-comprehensive.md
 
 ---
 
@@ -13,17 +12,16 @@ Source: Industry Research — research-context-engineering-comprehensive.md
 - Quality over quantity checklist (include/exclude decision table)
 - Context poisoning vectors (detection and removal)
 - JIT documentation patterns (on-demand loading strategies)
-- Key citations
 
 ---
 
 ## Hard Limits
 
-| Limit | Value | Source |
-|-------|-------|--------|
-| Lines per rule file | ≤ 200 | Industry Research: 200-line target for configuration files in this toolkit |
-| Instructions per file | ≤ 150-200 | Industry Research: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
-| Contradictions between files | 0 | Industry Research: conflicting instructions make the model choose inconsistently. |
+| Limit | Value |
+|-------|-------|
+| Lines per rule file | ≤ 200 — 200-line target for configuration files in this toolkit |
+| Instructions per file | ≤ 150-200 — "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
+| Contradictions between files | 0 — conflicting instructions make the model choose inconsistently. |
 
 > Industry Research generalizes here: bloated configuration files cause the model to miss important instructions.
 > — Industry Research
@@ -79,7 +77,6 @@ For each instruction line, ask: **"Would removing this cause the agent to make m
 - ✅ "Run `npm test` before committing" vs. ❌ "Test your changes"
 - ✅ "API handlers live in `src/api/handlers/`" vs. ❌ "Keep files organized"
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -97,7 +94,6 @@ Detect and remove these before generating or improving rule files:
 
 > Treat configuration files like code: review them when things go wrong, prune them regularly. — Industry Research
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -115,17 +111,6 @@ Use these patterns to move content from always-consumed to on-demand locations:
 > "Rather than pre-processing all relevant data up front, agents maintain lightweight identifiers and use these references to dynamically load data into context at runtime."
 > — Industry Research, Effective Context Engineering
 
-*Source: Industry Research — research-context-engineering-comprehensive.md lines 138-208, 451-461*
 
 ---
 
-## Key Citations
-
-| Claim | Source |
-|-------|--------|
-| ≤200 lines per file | Industry Research (Agent Skills Standard) |
-| ~150-200 instruction limit | Industry Research (HumanLayer) |
-| n² attention constraint / context rot | Industry Research (Effective Context Engineering) |
-| Lost-in-the-middle effect | Industry Research, Liu et al., arXiv:2307.03172 |
-| Quality over quantity heuristic | Industry Research |
-| JIT documentation strategy | Industry Research, Effective Context Engineering |

--- a/plugins/cursor-initializer/skills/init-cursor/references/cursor-rules-system.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/cursor-rules-system.md
@@ -1,6 +1,6 @@
 # Cursor Rules System
 
-Reference for generating and evaluating `.cursor/rules/` files. Source: Cursor official documentation ([cursor.com/docs/context/rules](https://cursor.com/docs/context/rules)).
+Reference for generating and evaluating `.cursor/rules/` files.
 
 ## File Format
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring `.cursor/rules/*.mdc` hierarchies in Cursor.
-Sources: Industry Research (a-guide-to-agents.md, research-context-engineering-comprehensive.md)
 
 ---
 
@@ -31,7 +30,6 @@ When deciding where content belongs, use this table:
 
 **Borderline tiebreaker (10–15 lines):** When content falls between 10–15 lines, prefer extracting it to a separate `description:`-mode rule if it applies to only one topic. Always-loaded rule brevity is more valuable than the small cost of an additional rule.
 
-*Source: Industry Research — a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -64,7 +62,6 @@ In monorepos, prefer narrow `globs:`-mode rules scoped to package paths over bro
 
 **Monorepo context scoping in Cursor**: In large monorepos, use `.cursor/rules/*.mdc` with narrow `globs:` patterns to limit rules to relevant packages. Rules with `alwaysApply: true` load for every request — keep them minimal.
 
-*Source: Industry Research — memory/how-claude-remembers-a-project.md lines 243-260*
 
 ---
 
@@ -86,7 +83,6 @@ Always use const instead of let. Never use var...
 
 **Use skills for workflows** — agents invoke skills only when needed, keeping base context minimal.
 
-*Source: Industry Research — a-guide-to-agents.md lines 110-163*
 
 ---
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/validation-criteria.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated `.cursor/rules/*.mdc` files.
-Source: Industry Research (research-context-engineering-comprehensive.md), file-evaluator.md
 
 ---
 
@@ -9,13 +8,13 @@ Source: Industry Research (research-context-engineering-comprehensive.md), file-
 
 Any rule file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| Rule file length | ≤ 200 lines | Industry Research: 200-line target for configuration files in this toolkit |
-| Instruction count | ≤ 150-200 | Industry Research: "~150-200 instructions with reasonable consistency" |
-| Contradictions between rules | 0 | Industry Research: conflicting instructions make the model choose inconsistently |
-| Stale file path references | 0 | Industry Research: "File paths change constantly... actively poisons context" |
-| Invalid `.mdc` frontmatter fields | 0 | Only `description`, `alwaysApply`, `globs` are valid |
+| Criterion | Threshold |
+|-----------|-----------|
+| Rule file length | ≤ 200 lines — 200-line target for configuration files in this toolkit |
+| Instruction count | ≤ 150-200 — "~150-200 instructions with reasonable consistency" |
+| Contradictions between rules | 0 — conflicting instructions make the model choose inconsistently |
+| Stale file path references | 0 — "File paths change constantly... actively poisons context" |
+| Invalid `.mdc` frontmatter fields | 0 — only `description`, `alwaysApply`, `globs` are valid |
 
 ---
 

--- a/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
+++ b/plugins/cursor-initializer/skills/init-cursor/references/what-not-to-include.md
@@ -1,29 +1,27 @@
 # What NOT to Include
 
 Evidence-based exclusion table for `.cursor/rules/*.mdc` content.
-Sources: Industry Research (ETH "Evaluating context files", a-guide-to-agents.md, hooks/automate-workflow-with-hooks.md)
 
 ---
 
 ## Exclusion Evidence Table
 
-| Content Type | Why to Exclude | Evidence Quote | Source |
-|-------------|----------------|---------------|--------|
-| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" | Industry Research (ETH) |
-| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" | Industry Research |
-| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" | Industry Research (ETH) |
-| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | Industry Research (a-guide-to-agents.md) |
-| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | Industry Research |
-| Everything in one rule (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | Industry Research |
-| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | Agent already does this correctly without extra instruction | Industry Research |
-| Duplicated information across rules | Consumes tokens on every applicable conversation; creates contradiction risk | "Wastes tokens on every request" | Industry Research |
-| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Industry Research |
-| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Industry Research |
-| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Industry Research |
-| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | Anything the agent can infer by reading code should stay out of configuration files | Industry Research |
-| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; rule instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | Hooks provide deterministic control over agent behavior instead of repeated context instructions | Industry Research (Hooks Guide) |
+| Content Type | Why to Exclude | Evidence Quote |
+|-------------|----------------|----------------|
+| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" |
+| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" |
+| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" |
+| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" |
+| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" |
+| Everything in one rule (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | Agent already does this correctly without extra instruction |
+| Duplicated information across rules | Consumes tokens on every applicable conversation; creates contradiction risk | "Wastes tokens on every request" |
+| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) |
+| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column |
+| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | Anything the agent can infer by reading code should stay out of configuration files |
+| Hook-enforced behaviors (formatting, file blocking, notifications) | Hooks handle these deterministically; rule instructions are redundant and may conflict with hook execution. **Migrate** to hook configuration for zero context cost | Hooks provide deterministic control over agent behavior instead of repeated context instructions |
 
-*Source: Industry Research — research-context-engineering-comprehensive.md:113-121; ETH Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/skills/create-skill/references/artifact-analyzer.md
+++ b/skills/create-skill/references/artifact-analyzer.md
@@ -1,7 +1,6 @@
 # Artifact Analysis Instructions
 Structured process for inventorying existing Agent Skills artifacts and conventions.
 Used by CREATE and IMPROVE skills for codebase context analysis.
-Source: agents/artifact-analyzer.md
 ---
 
 ## Contents

--- a/skills/create-skill/references/artifact-format-routing.md
+++ b/skills/create-skill/references/artifact-format-routing.md
@@ -2,7 +2,6 @@
 
 Evidence-based routing rule for deciding whether a skill's generated output artifact
 should default to HTML or Markdown.
-Source: Skill body convention (canonical tag vocabulary), HTML artifact effectiveness research
 
 ---
 

--- a/skills/create-skill/references/prompt-engineering-strategies.md
+++ b/skills/create-skill/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with Opus 4.6
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 | Contradictory instructions | Claude picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*

--- a/skills/create-skill/references/skill-authoring-guide.md
+++ b/skills/create-skill/references/skill-authoring-guide.md
@@ -1,7 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code skills (SKILL.md files).
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -50,7 +49,6 @@ Analogy: Claude as a robot on a path — narrow bridge (low freedom) vs. open fi
 | Sonnet | Clear and efficient? (balanced) |
 | Opus | Avoid over-explaining? (may need less) |
 
-*Source: skills/skill-authoring-best-practices.md lines 11-145*
 
 ---
 
@@ -82,7 +80,6 @@ my-skill/
 | `hooks` | No | Hooks scoped to this skill's lifecycle |
 | `argument-hint` | No | Autocomplete hint, e.g. `[issue-number]` |
 
-*Source: skills/extend-claude-with-skills.md lines 169-199*
 
 ---
 
@@ -98,7 +95,6 @@ my-skill/
 
 Include: (1) what it does, (2) when to use it, (3) specific trigger terms for matching.
 
-*Source: skills/skill-authoring-best-practices.md lines 168-250*
 
 ---
 
@@ -118,7 +114,6 @@ Load only the references needed for each phase, not all at once.
 
 Keep SKILL.md under 500 lines. Move detailed reference material to separate files. Reference supporting files explicitly so Claude knows what they contain.
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300; skills/extend-claude-with-skills.md lines 223-246*
 
 ---
 
@@ -132,7 +127,6 @@ Keep SKILL.md under 500 lines. Move detailed reference material to separate file
 
 Use `disable-model-invocation: true` for workflows with side effects (commit, deploy, send-message). Use `user-invocable: false` for background knowledge Claude should apply but users shouldn't invoke directly.
 
-*Source: skills/extend-claude-with-skills.md lines 248-283*
 
 ---
 
@@ -147,4 +141,3 @@ Use `disable-model-invocation: true` for workflows with side effects (commit, de
 | Over-explaining for Opus | Patronizing + token waste | Trust the model; provide minimal scaffolding |
 | Contradictions between phases | Claude picks one arbitrarily | Review all phases for consistency |
 
-*Source: skills/skill-authoring-best-practices.md lines 800-1100*

--- a/skills/create-skill/references/skill-format-reference.md
+++ b/skills/create-skill/references/skill-format-reference.md
@@ -1,7 +1,6 @@
 # Skill Format Reference
 
 Technical specification for SKILL.md format, directory structure, variables, and discovery.
-Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-skills.md
 
 ---
 
@@ -43,7 +42,6 @@ Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-
 - Must NOT contain reserved words: `anthropic`, `claude`
 - Must match the parent directory name
 
-*Source: skills/research-claude-code-skills-format.md lines 103-108*
 
 ---
 
@@ -69,7 +67,6 @@ Dynamic context injection with `!` prefix runs shell commands before skill loads
 - Current branch: !`git branch --show-current`
 ```
 
-*Source: skills/extend-claude-with-skills.md lines 201-210; skills/research-claude-code-skills-format.md lines 126-149*
 
 ---
 
@@ -94,7 +91,6 @@ my-skill/
 - `references/` files load only when skill phases explicitly read them
 - `scripts/` files are executed, not loaded into context
 
-*Source: skills/research-claude-code-skills-format.md lines 153-186; skills/extend-claude-with-skills.md lines 100-115*
 
 ---
 
@@ -108,7 +104,6 @@ my-skill/
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to `references/` subdirectory. Explicitly reference supporting files from SKILL.md so Claude knows what to load and when.
 
-*Source: skills/research-claude-code-skills-format.md lines 172-186*
 
 ---
 
@@ -123,4 +118,3 @@ Keep SKILL.md under **500 lines**. Move detailed reference material to `referenc
 
 Priority: enterprise > personal > project. Plugin skills use `plugin-name:skill-name` namespace — no conflicts.
 
-*Source: skills/extend-claude-with-skills.md lines 85-97; skills/research-claude-code-skills-format.md lines 189-200*

--- a/skills/create-skill/references/skill-validation-criteria.md
+++ b/skills/create-skill/references/skill-validation-criteria.md
@@ -1,8 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md,
-karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical tag vocabulary)
 
 ---
 
@@ -21,16 +19,15 @@ karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical 
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | Reference files hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
-| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Agent picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags |
+| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199*
 
 ---
 

--- a/skills/improve-agents/references/automation-migration-guide.md
+++ b/skills/improve-agents/references/automation-migration-guide.md
@@ -1,7 +1,6 @@
 # Automation Migration Guide
 
 Decision criteria for migrating instructions from CLAUDE.md/AGENTS.md to on-demand mechanisms.
-Source: context-aware-improve-optimization.prd.md, analysis-skill-authoring-best-practices.md, analysis-how-claude-remembers-a-project.md, research-context-engineering-comprehensive.md
 
 ---
 
@@ -13,7 +12,6 @@ Source: context-aware-improve-optimization.prd.md, analysis-skill-authoring-best
 - Mechanism comparison (context cost, enforcement, best for)
 - Distribution-aware recommendations (plugin vs. standalone)
 - Token impact estimation (savings per mechanism type)
-- Evidence citations
 
 ---
 
@@ -30,7 +28,6 @@ When evaluating an instruction block for migration, follow this decision path:
 7. **Is it domain content for a monorepo package?** → Subdirectory AGENTS.md in that package root
 8. **None of the above?** → Keep in current location; reassess in next improvement cycle
 
-*Source: context-aware-improve-optimization.prd.md lines 346-358*
 
 ---
 
@@ -38,17 +35,16 @@ When evaluating an instruction block for migration, follow this decision path:
 
 Classify each instruction block by content type, then recommend the corresponding mechanism:
 
-| Content Type | Best Mechanism | Evidence Source |
-|---|---|---|
-| Always-applicable universal rules (<5 lines) | AGENTS.md root | research-context-engineering-comprehensive.md |
-| Package or scope-specific conventions (5-50 lines) | Subdirectory AGENTS.md in the relevant package | analysis-how-claude-remembers-a-project.md |
-| Domain knowledge or workflows (50-500 lines) | Skill (`user-invocable: false`) | extend-claude-with-skills.md |
-| Heavy workflows with side effects | Skill (`disable-model-invocation: true`) | extend-claude-with-skills.md |
-| Isolated, context-heavy analysis | Skill (`context: fork`) | extend-claude-with-skills.md |
-| Infrequently-needed deep reference | On-demand reference linked from SKILL.md | analysis-skill-authoring-best-practices.md |
-| Information agents can infer from code | DELETE — do not document | analysis-evaluating-agents-paper.md |
+| Content Type | Best Mechanism |
+|---|---|
+| Always-applicable universal rules (<5 lines) | AGENTS.md root |
+| Package or scope-specific conventions (5-50 lines) | Subdirectory AGENTS.md in the relevant package |
+| Domain knowledge or workflows (50-500 lines) | Skill (`user-invocable: false`) |
+| Heavy workflows with side effects | Skill (`disable-model-invocation: true`) |
+| Isolated, context-heavy analysis | Skill (`context: fork`) |
+| Infrequently-needed deep reference | On-demand reference linked from SKILL.md |
+| Information agents can infer from code | DELETE — do not document |
 
-*Source: context-aware-improve-optimization.prd.md lines 348-358*
 
 ---
 
@@ -65,7 +61,6 @@ Use these signals to identify instructions that should migrate from always-loade
 | Instructions duplicated across files | Consolidation candidate | Same content in 2+ files → single source of truth |
 | Version numbers, team names, release info | DELETE or pointer | High-churn content → remove |
 
-*Source: analysis-evaluating-agents-paper.md lines 36-52, Anthropic Best Practices*
 
 ---
 
@@ -81,7 +76,6 @@ Compare all available on-demand mechanisms when recommending a migration:
 | Subdirectory AGENTS.md | Loaded when agent enters that directory | Scoped to package or subdirectory | Monorepo package-specific conventions |
 | Domain doc (`docs/TOPIC.md`) | Zero (loaded on demand via pointer) | Advisory — referenced from root AGENTS.md | Deep domain content too large for root |
 
-*Source: analysis-skill-authoring-best-practices.md lines 19-46, research-context-engineering-comprehensive.md*
 
 ---
 
@@ -97,7 +91,6 @@ This guide targets the cross-platform AGENTS.md ecosystem. Recommend only mechan
 
 Suggest only the mechanisms listed above. Tool-specific or platform-specific mechanisms are out of scope for AGENTS.md improvement suggestions.
 
-*Source: DESIGN-GUIDELINES.md Guideline 11, project architecture*
 
 ---
 
@@ -116,17 +109,4 @@ Estimate savings when recommending each migration type:
 
 Present token impact estimates alongside migration recommendations to help users prioritize high-impact changes first.
 
-*Source: research-context-engineering-comprehensive.md, analysis-skill-authoring-best-practices.md lines 19-46*
 
----
-
-## Evidence Citations
-
-| Claim | Source |
-|---|---|
-| Codebase overviews do not help agents navigate | analysis-evaluating-agents-paper.md lines 36-41 |
-| Agent obedience turns unnecessary instructions into active cost | analysis-evaluating-agents-paper.md lines 42-52 |
-| Skill startup cost: ~100 tokens for name + description only | analysis-skill-authoring-best-practices.md lines 19-23 |
-| Reference depth: max 1 level from SKILL.md | analysis-skill-authoring-best-practices.md lines 131-143 |
-| ≤200 lines per config file; ~150-200 instruction limit | research-context-engineering-comprehensive.md |
-| Subdirectory AGENTS.md for monorepo scoping | research-context-engineering-comprehensive.md |

--- a/skills/improve-agents/references/codebase-analyzer.md
+++ b/skills/improve-agents/references/codebase-analyzer.md
@@ -1,7 +1,6 @@
 # Codebase Analysis Instructions
 Structured process for detecting project tech stack, tooling, and non-standard patterns.
 Used by INIT and IMPROVE skills for codebase analysis.
-Source: agents/codebase-analyzer.md
 ---
 
 Follow these codebase analysis instructions. Analyze the project at the current working directory and return a structured summary of its technical characteristics. Focus on facts that would cause mistakes if an AI coding agent didn't know them.
@@ -89,7 +88,6 @@ Look for anything unusual that would trip up an agent:
 - Migration workflows that live in app-specific directories rather than a root config file
 - Repository-specific tools mentioned in existing documentation
 
-*Source: agents/codebase-analyzer.md lines 22-82*
 
 ---
 
@@ -127,7 +125,6 @@ Return your analysis in exactly this format:
 
 If a section has nothing non-standard to report, omit it entirely. Shorter is better.
 
-*Source: agents/codebase-analyzer.md lines 83-113*
 
 ---
 
@@ -140,4 +137,3 @@ Before returning results, verify:
 3. Output follows the exact format specified above
 4. Sections with no findings are omitted, not left empty
 
-*Source: agents/codebase-analyzer.md lines 115-122*

--- a/skills/improve-agents/references/context-optimization.md
+++ b/skills/improve-agents/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Evidence-based instructions for managing token budgets and attention in agent configuration files.
-Source: research-context-engineering-comprehensive.md
 
 ---
 
@@ -13,17 +12,16 @@ Source: research-context-engineering-comprehensive.md
 - Quality over quantity checklist (include/exclude decision table)
 - Context poisoning vectors (detection and removal)
 - JIT documentation patterns (on-demand loading strategies)
-- Key citations
 
 ---
 
 ## Hard Limits
 
-| Limit | Value | Source |
-|-------|-------|--------|
-| Lines per configuration file | ≤ 200 | Anthropic Docs: "Target under 200 lines per CLAUDE.md file." |
-| Instructions per file | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
-| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily." |
+| Limit | Value |
+|-------|-------|
+| Lines per configuration file | ≤ 200 |
+| Instructions per file | ≤ 150-200 |
+| Contradictions between files | 0 |
 
 > "Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"
 > — Anthropic Best Practices
@@ -79,7 +77,6 @@ For each instruction line, ask: **"Would removing this cause the agent to make m
 - ✅ "Run `npm test` before committing" vs. ❌ "Test your changes"
 - ✅ "API handlers live in `src/api/handlers/`" vs. ❌ "Keep files organized"
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -97,7 +94,6 @@ Detect and remove these before generating or improving configuration files:
 
 > "Treat CLAUDE.md like code: review it when things go wrong, prune it regularly." — Anthropic Best Practices
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -116,17 +112,4 @@ Use these patterns to move content from always-consumed to on-demand locations:
 > "Rather than pre-processing all relevant data up front, agents maintain lightweight identifiers and use these references to dynamically load data into context at runtime."
 > — Anthropic Engineering: Effective Context Engineering
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*
 
----
-
-## Key Citations
-
-| Claim | Source |
-|-------|--------|
-| ≤200 lines per file | Agent Skills Standard |
-| ~150-200 instruction limit | HumanLayer (Kyle) via a-guide-to-agents.md |
-| n² attention constraint / context rot | Anthropic Engineering Blog |
-| Lost-in-the-middle effect | Liu et al., arXiv:2307.03172 |
-| Quality over quantity heuristic | Anthropic Best Practices |
-| JIT documentation strategy | Anthropic Engineering: Effective Context Engineering |

--- a/skills/improve-agents/references/evaluation-criteria.md
+++ b/skills/improve-agents/references/evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Evaluation Criteria
 Scoring rubric for assessing existing AGENTS.md and CLAUDE.md files before improvement.
 Used by IMPROVE skills only.
-Source: file-evaluator.md, research-context-engineering-comprehensive.md
 ---
 
 ## Contents
@@ -20,11 +19,11 @@ Source: file-evaluator.md, research-context-engineering-comprehensive.md
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions" |
-| Contradictions | 0 | Anthropic: "Claude may pick one arbitrarily" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| Contradictions | 0 |
 
 A file violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
 
@@ -34,16 +33,15 @@ A file violating any hard limit is flagged **OVER LIMIT** regardless of content 
 
 Check each line of the file against these indicators:
 
-| Indicator | Why It's Bloat | Source |
-|-----------|---------------|--------|
-| Directory/file structure listings | "Not effective at providing repository overview" | ETH Zurich: Evaluating AGENTS.md |
-| Standard language conventions | Agent already knows from training data | Anthropic Best Practices |
-| Vague instructions ("write clean code") | Not actionable; wastes attention budget | a-guide-to-agents.md |
-| Codebase overview paragraphs | Increases steps without improving navigation | ETH Zurich: Evaluating AGENTS.md |
-| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it, delete it" |
-| Duplicated content across files | Wastes tokens on every request | research-context-engineering-comprehensive.md |
+| Indicator | Why It's Bloat |
+|-----------|---------------|
+| Directory/file structure listings | "Not effective at providing repository overview" |
+| Standard language conventions | Agent already knows from training data |
+| Vague instructions ("write clean code") | Not actionable; wastes attention budget |
+| Codebase overview paragraphs | Increases steps without improving navigation |
+| Obvious tool usage ("use git for version control") | Agent already knows this |
+| Duplicated content across files | Wastes tokens on every request |
 
-*Source: file-evaluator.md lines 30-41*
 
 ---
 
@@ -56,7 +54,6 @@ Check each line of the file against these indicators:
 | Package references to uninstalled deps | Check if mentioned packages are in manifest files |
 | Outdated framework version references | Compare mentioned versions with actual installed versions |
 
-*Source: file-evaluator.md lines 43-50*
 
 ---
 
@@ -69,7 +66,6 @@ Check each line of the file against these indicators:
 | Do subdirectory files exist for distinct scopes? | packages/api/AGENTS.md for API-specific rules | Everything in root |
 | Are pointers provided to detailed docs? | "See docs/TESTING.md" | No cross-references |
 
-*Source: file-evaluator.md lines 52-59*
 
 ---
 
@@ -91,7 +87,6 @@ Every instruction should be in the Goldilocks zone:
 | Enforced by config file | "Strict mode is enabled" (`tsconfig.json` has `"strict": true`) | ❌ DELETE — agent reads the config directly |
 | Project decision not in config | "Use `unknown` over `any`; validate with `zod`" | ✅ Keep — agent cannot infer rationale |
 
-*Source: research-context-engineering-comprehensive.md lines 131-134*
 
 ---
 
@@ -108,7 +103,6 @@ Check each instruction block for migration potential to on-demand mechanisms:
 
 Flag each candidate in the Per-File Issues output under `**Automation Opportunity Issues:**`.
 
-*Source: automation-migration-guide.md lines 58-72*
 
 ---
 
@@ -125,7 +119,6 @@ Score each dimension 1-10 based on observed issues:
 | Consistency | 0 contradictions | 1 contradiction | 2+ contradictions |
 | Automation Opportunity | 0 migration candidates missed | 1-3 potential migrations | 4+ missed migrations |
 
-*Source: file-evaluator.md lines 132-141*
 
 ---
 

--- a/skills/improve-agents/references/file-evaluator.md
+++ b/skills/improve-agents/references/file-evaluator.md
@@ -1,7 +1,6 @@
 # File Evaluation Instructions
 Structured process for evaluating existing AGENTS.md/CLAUDE.md files against evidence-based quality criteria.
 Used by IMPROVE skills for current state analysis.
-Source: agents/file-evaluator.md
 ---
 
 Follow these file evaluation instructions. Analyze existing AGENTS.md or CLAUDE.md files in the project at the current working directory and assess their quality against evidence-based criteria. Identify specific problems with evidence so an improvement skill can act on them.
@@ -29,25 +28,25 @@ Use your environment's file reading and search capabilities to examine the proje
 
 ### Hard Limits
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions" |
-| No contradictions | 0 conflicts | Anthropic: "Claude may pick one arbitrarily" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| No contradictions | 0 conflicts |
 
 ### Bloat Indicators
 
 Each of these wastes tokens without improving agent performance:
 
-| Indicator | Why It's Bloat | Source |
-|-----------|---------------|--------|
-| Directory/file structure listings | "Not effective at providing repository overview" | Evaluating AGENTS.md (ETH Zurich) |
-| Standard language conventions | Agent already knows these from training | Anthropic Best Practices |
-| Vague instructions ("write clean code") | Not actionable, wastes attention budget | a-guide-to-agents.md |
-| Codebase overview paragraphs | Increases steps without improving navigation | Evaluating AGENTS.md |
-| Obvious tool usage ("use git for version control") | Agent already knows this | Anthropic: "If Claude already does it correctly, delete it" |
-| Duplicated information across files | Wastes tokens on every request | Context engineering research |
-| **Architectural path trap** | Lists of paths WITH behavioral constraints (e.g., `services/ must not import from routes/`) are **not** directory listings — flag only pure path listings with no rules attached | Evaluating AGENTS.md |
+| Indicator | Why It's Bloat |
+|-----------|---------------|
+| Directory/file structure listings | "Not effective at providing repository overview" |
+| Standard language conventions | Agent already knows these from training |
+| Vague instructions ("write clean code") | Not actionable, wastes attention budget |
+| Codebase overview paragraphs | Increases steps without improving navigation |
+| Obvious tool usage ("use git for version control") | Agent already knows this |
+| Duplicated information across files | Wastes tokens on every request |
+| **Architectural path trap** | Lists of paths WITH behavioral constraints (e.g., `services/ must not import from routes/`) are **not** directory listings — flag only pure path listings with no rules attached |
 
 ### Staleness Indicators
 
@@ -68,7 +67,6 @@ Each of these wastes tokens without improving agent performance:
 | Do subdirectory files exist for distinct scopes? | packages/api/CLAUDE.md for API-specific rules | Everything in root |
 | Are pointers provided to detailed docs? | "See docs/TESTING.md" | No cross-references |
 
-*Source: agents/file-evaluator.md lines 20-59*
 
 ### Automation Opportunity Indicators
 
@@ -83,7 +81,6 @@ Flag instructions that are candidates for migration to on-demand mechanisms:
 | Version numbers, team names, high-churn content | Deletion | `DELETE_CANDIDATE` |
 | Standard default commands (e.g., `npm test`, `cargo build`, `go test ./...`) | Agent knows platform defaults from training | `DELETE_CANDIDATE` |
 
-*Source: automation-migration-guide.md lines 58-72*
 
 ---
 
@@ -116,7 +113,6 @@ For each file found:
 - Are there scopes with distinct tooling that lack their own file?
 - Is the root file overloaded with scope-specific information?
 
-*Source: agents/file-evaluator.md lines 75-102*
 
 ---
 
@@ -178,7 +174,6 @@ Return your analysis in exactly this format:
 | **Overall** | **4** | Needs significant refactoring |
 ```
 
-*Source: agents/file-evaluator.md lines 103-162*
 
 ---
 
@@ -193,4 +188,3 @@ Before returning results, verify:
 5. No improvement suggestions crept in — report only identifies problems
 6. Automation opportunity flags match the indicators table — no false classifications
 
-*Source: agents/file-evaluator.md lines 143-152*

--- a/skills/improve-agents/references/progressive-disclosure-guide.md
+++ b/skills/improve-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md and CLAUDE.md hierarchies.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md
 
 ---
 
@@ -28,7 +27,6 @@ When deciding where to place content, use this table:
 | Subdirectory AGENTS.md | Specific to one package or area | On-demand when working there |
 | Skill | A workflow the agent should invoke explicitly | On-demand when invoked |
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -64,7 +62,6 @@ See each package's AGENTS.md for specific guidelines.
 > "Don't overload any level. The agent sees all merged files in its context."
 > — a-guide-to-agents.md lines 164-193
 
-*Source: a-guide-to-agents.md lines 164-193*
 
 ---
 
@@ -95,7 +92,6 @@ docs/
 
 **Use skills for workflows** — agents invoke skills only when needed, keeping base context minimal.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ---
 
@@ -112,7 +108,6 @@ docs/
 
 **Merge behavior**: Subdirectory AGENTS.md files merge with root (not replace) — content from both applies when the agent works in that directory.
 
-*Source: research-context-engineering-comprehensive.md lines 181-208, 257-305*
 
 ---
 

--- a/skills/improve-agents/references/validation-criteria.md
+++ b/skills/improve-agents/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md / CLAUDE.md files.
-Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
 
 ---
 
@@ -9,13 +8,13 @@ Source: improve-claude/SKILL.md:143-160, improve-agents/SKILL.md:108-122, file-e
 
 Any file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "~150-200 instructions with reasonable consistency" |
-| Contradictions (within or between files) | 0 | Anthropic: "Claude may pick one arbitrarily" |
-| Language-specific rules in root | 0 | Domain rules belong in separate files |
-| Stale file path references | 0 | "File paths change constantly... actively poisons context" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| Contradictions (within or between files) | 0 |
+| Language-specific rules in root | 0 |
+| Stale file path references | 0 |
 
 ## Recommended Targets (Advisory)
 

--- a/skills/improve-agents/references/what-not-to-include.md
+++ b/skills/improve-agents/references/what-not-to-include.md
@@ -1,29 +1,27 @@
 # What NOT to Include
 
 Evidence-based exclusion table for AGENTS.md and CLAUDE.md content.
-Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md, research-context-engineering-comprehensive.md
 
 ---
 
 ## Exclusion Evidence Table
 
-| Content Type | Why to Exclude | Evidence Quote | Source |
-|-------------|----------------|---------------|--------|
-| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" | ETH Zurich: Evaluating AGENTS.md |
-| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" | Anthropic Best Practices |
-| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" | ETH Zurich: Evaluating AGENTS.md |
-| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | a-guide-to-agents.md |
-| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | a-guide-to-agents.md |
-| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | a-guide-to-agents.md |
-| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
-| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" | research-context-engineering-comprehensive.md |
-| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Anthropic Best Practices |
-| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" | Anthropic Best Practices |
-| Tooling-enforced behaviors (formatting, linting, file blocking) | Config files already enforce these deterministically; redundant instructions waste attention budget without adding control | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
+| Content Type | Why to Exclude | Evidence Quote |
+|-------------|----------------|---------------|
+| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" |
+| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" |
+| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" |
+| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" |
+| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" |
+| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" |
+| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" |
+| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) |
+| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column |
+| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" |
+| Tooling-enforced behaviors (formatting, linting, file blocking) | Config files already enforce these deterministically; redundant instructions waste attention budget without adding control | "If Claude already does it correctly, delete it" |
 
-*Source: init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 

--- a/skills/improve-skill/references/artifact-analyzer.md
+++ b/skills/improve-skill/references/artifact-analyzer.md
@@ -1,7 +1,6 @@
 # Artifact Analysis Instructions
 Structured process for inventorying existing Agent Skills artifacts and conventions.
 Used by CREATE and IMPROVE skills for codebase context analysis.
-Source: agents/artifact-analyzer.md
 ---
 
 ## Contents

--- a/skills/improve-skill/references/prompt-engineering-strategies.md
+++ b/skills/improve-skill/references/prompt-engineering-strategies.md
@@ -1,7 +1,6 @@
 # Prompt Engineering Strategies
 
 Evidence-based prompting strategies for artifact authoring, organized by artifact type.
-Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -37,7 +36,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 
 **Safe persuasion only** — use commitment through warm-up phases, reciprocity through curated references, scarcity through explicit limits, and authority/social proof through cited standards. Never use persuasion patterns to bypass safeguards, refusals, or scope boundaries.
 
-*Source: claude-prompting-best-practices.md lines 1-100; prompt-engineering-guide.md lines 1-80; karpathy-guidelines.instructions.md; persuasion-principles.md*
 
 ---
 
@@ -53,7 +51,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 | Self-check instruction | ✅ Final phase | ❌ Not applicable | ❌ Not applicable | ✅ Verification |
 | Parallel tool calls | ✅ Multi-step phases | ❌ Not applicable | ❌ Not applicable | ✅ Independent tasks |
 
-*Source: prompt-engineering-guide.md lines 80-200; claude-prompting-best-practices.md lines 50-160*
 
 ---
 
@@ -94,7 +91,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 - Avoid aggressive trigger language ("CRITICAL: You MUST...") — causes overtriggering with Opus 4.6
 - Use normal delegation language: "Use this tool when..." not "ALWAYS use this tool"
 
-*Source: claude-prompting-best-practices.md lines 373-380; prompt-engineering-guide.md lines 20-80*
 
 ---
 
@@ -110,7 +106,6 @@ Source: prompt-engineering-guide.md, claude-prompting-best-practices.md, `.githu
 | Contradictory instructions | Claude picks one arbitrarily | Audit for conflicts before writing |
 | Instructions buried in the middle | Lost-in-the-middle degradation | Move critical rules to first/last 20% |
 
-*Source: claude-prompting-best-practices.md lines 50-100; prompt-engineering-guide.md lines 100-200*
 
 ---
 
@@ -124,4 +119,3 @@ Every token in an artifact competes with conversation history and other context.
 - Short artifacts (rules, validation criteria) should be zero-shot and minimal
 - Long artifacts (skill bodies, subagent prompts) should use progressive disclosure
 
-*Source: karpathy-guidelines.instructions.md; claude-prompting-best-practices.md lines 32-50*

--- a/skills/improve-skill/references/skill-authoring-guide.md
+++ b/skills/improve-skill/references/skill-authoring-guide.md
@@ -1,7 +1,6 @@
 # Skill Authoring Guide
 
 Evidence-based guidance for creating effective Claude Code skills (SKILL.md files).
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md, `.github/instructions/karpathy-guidelines.instructions.md`, `docs/general-llm/persuasion-principles.md`
 
 ---
 
@@ -50,7 +49,6 @@ Analogy: Claude as a robot on a path — narrow bridge (low freedom) vs. open fi
 | Sonnet | Clear and efficient? (balanced) |
 | Opus | Avoid over-explaining? (may need less) |
 
-*Source: skills/skill-authoring-best-practices.md lines 11-145*
 
 ---
 
@@ -82,7 +80,6 @@ my-skill/
 | `hooks` | No | Hooks scoped to this skill's lifecycle |
 | `argument-hint` | No | Autocomplete hint, e.g. `[issue-number]` |
 
-*Source: skills/extend-claude-with-skills.md lines 169-199*
 
 ---
 
@@ -98,7 +95,6 @@ my-skill/
 
 Include: (1) what it does, (2) when to use it, (3) specific trigger terms for matching.
 
-*Source: skills/skill-authoring-best-practices.md lines 168-250*
 
 ---
 
@@ -118,7 +114,6 @@ Load only the references needed for each phase, not all at once.
 
 Keep SKILL.md under 500 lines. Move detailed reference material to separate files. Reference supporting files explicitly so Claude knows what they contain.
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300; skills/extend-claude-with-skills.md lines 223-246*
 
 ---
 
@@ -132,7 +127,6 @@ Keep SKILL.md under 500 lines. Move detailed reference material to separate file
 
 Use `disable-model-invocation: true` for workflows with side effects (commit, deploy, send-message). Use `user-invocable: false` for background knowledge Claude should apply but users shouldn't invoke directly.
 
-*Source: skills/extend-claude-with-skills.md lines 248-283*
 
 ---
 
@@ -147,4 +141,3 @@ Use `disable-model-invocation: true` for workflows with side effects (commit, de
 | Over-explaining for Opus | Patronizing + token waste | Trust the model; provide minimal scaffolding |
 | Contradictions between phases | Claude picks one arbitrarily | Review all phases for consistency |
 
-*Source: skills/skill-authoring-best-practices.md lines 800-1100*

--- a/skills/improve-skill/references/skill-evaluation-criteria.md
+++ b/skills/improve-skill/references/skill-evaluation-criteria.md
@@ -1,7 +1,6 @@
 # Skill Evaluation Criteria
 
 Scoring rubric for assessing existing SKILL.md files before improvement.
-Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
 
 ---
 
@@ -18,18 +17,17 @@ Source: skills/skill-authoring-best-practices.md, Evaluating-AGENTS-paper.md
 
 ## Hard Limits Table
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | Reference files hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present, non-empty, ≤ 1024 chars | Required for skill discovery and Agent Skills spec |
-| `name` field | Present, non-empty, 1-64 chars, kebab-case | Agent Skills specification |
-| Phase structure | At least one clear phase defined | Anthropic skill authoring patterns |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present, non-empty, ≤ 1024 chars |
+| `name` field | Present, non-empty, 1-64 chars, kebab-case |
+| Phase structure | At least one clear phase defined |
 
 A skill violating any hard limit is flagged **OVER LIMIT** regardless of content quality.
 
-*Source: skills/skill-authoring-best-practices.md line 259*
 
 ---
 
@@ -44,7 +42,6 @@ A skill violating any hard limit is flagged **OVER LIMIT** regardless of content
 | Explaining standard practices Claude already knows | "Claude is already very smart — add only novel context" |
 | Hardcoded absolute paths (not using relative `references/` paths) | Will go stale; breaks skill portability |
 
-*Source: skills/skill-authoring-best-practices.md lines 11-60*
 
 ---
 
@@ -58,7 +55,6 @@ A skill violating any hard limit is flagged **OVER LIMIT** regardless of content
 | Hardcoded file paths in SKILL.md body | Check if referenced paths actually exist |
 | `user-invocable: true` (was the default, now explicit) | Remove redundant explicit defaults |
 
-*Source: skills/skill-authoring-best-practices.md lines 146-167*
 
 ---
 
@@ -71,7 +67,6 @@ A skill violating any hard limit is flagged **OVER LIMIT** regardless of content
 | Are supporting files referenced explicitly? | "Read references/X.md" | Files exist but never referenced |
 | Is SKILL.md body under 500 lines? | Clean entry point with external depth | Monolithic, all content inline |
 
-*Source: skills/skill-authoring-best-practices.md lines 251-300*
 
 ---
 
@@ -88,7 +83,6 @@ Score each dimension 1–10 based on observed issues:
 | Evidence Grounding | References cited per phase | Some references | No references |
 | **Overall** | | | |
 
-*Source: Evaluating-AGENTS-paper.md lines 1-100*
 
 ---
 

--- a/skills/improve-skill/references/skill-evaluator.md
+++ b/skills/improve-skill/references/skill-evaluator.md
@@ -1,7 +1,6 @@
 # Skill Evaluation Instructions
 Structured process for evaluating SKILL.md files against evidence-based quality criteria.
 Used by IMPROVE-SKILL skill for current state analysis.
-Source: agents/skill-evaluator.md
 ---
 
 ## Contents
@@ -30,13 +29,13 @@ Follow these evaluation instructions. Analyze the target SKILL.md file and evalu
 
 ### Hard Limits (Auto-fail if violated)
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | reference-files.md rule constraint |
-| `description` field | Present and non-empty | Required for skill discovery |
-| `name` field format | Lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Claude picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| `description` field | Present and non-empty |
+| `name` field format | Lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
 ### Structural Checks
 

--- a/skills/improve-skill/references/skill-format-reference.md
+++ b/skills/improve-skill/references/skill-format-reference.md
@@ -1,7 +1,6 @@
 # Skill Format Reference
 
 Technical specification for SKILL.md format, directory structure, variables, and discovery.
-Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-skills.md
 
 ---
 
@@ -43,7 +42,6 @@ Source: skills/research-claude-code-skills-format.md, skills/extend-claude-with-
 - Must NOT contain reserved words: `anthropic`, `claude`
 - Must match the parent directory name
 
-*Source: skills/research-claude-code-skills-format.md lines 103-108*
 
 ---
 
@@ -69,7 +67,6 @@ Dynamic context injection with `!` prefix runs shell commands before skill loads
 - Current branch: !`git branch --show-current`
 ```
 
-*Source: skills/extend-claude-with-skills.md lines 201-210; skills/research-claude-code-skills-format.md lines 126-149*
 
 ---
 
@@ -94,7 +91,6 @@ my-skill/
 - `references/` files load only when skill phases explicitly read them
 - `scripts/` files are executed, not loaded into context
 
-*Source: skills/research-claude-code-skills-format.md lines 153-186; skills/extend-claude-with-skills.md lines 100-115*
 
 ---
 
@@ -108,7 +104,6 @@ my-skill/
 
 Keep SKILL.md under **500 lines**. Move detailed reference material to `references/` subdirectory. Explicitly reference supporting files from SKILL.md so Claude knows what to load and when.
 
-*Source: skills/research-claude-code-skills-format.md lines 172-186*
 
 ---
 
@@ -123,4 +118,3 @@ Keep SKILL.md under **500 lines**. Move detailed reference material to `referenc
 
 Priority: enterprise > personal > project. Plugin skills use `plugin-name:skill-name` namespace — no conflicts.
 
-*Source: skills/extend-claude-with-skills.md lines 85-97; skills/research-claude-code-skills-format.md lines 189-200*

--- a/skills/improve-skill/references/skill-validation-criteria.md
+++ b/skills/improve-skill/references/skill-validation-criteria.md
@@ -1,8 +1,6 @@
 # Skill Validation Criteria
 
 Quality checklist for generated and improved SKILL.md files.
-Source: skills/skill-authoring-best-practices.md, skills/extend-claude-with-skills.md,
-karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical tag vocabulary)
 
 ---
 
@@ -21,16 +19,15 @@ karpathy-guidelines, persuasion-principles.md, skill-body-convention (canonical 
 
 Any skill violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| SKILL.md body length | ≤ 500 lines | Anthropic: "Keep SKILL.md under 500 lines" |
-| Reference files | ≤ 200 lines each | Reference files hard limit |
-| Reference files >100 lines | Must include a `## Contents` TOC | skill-authoring-best-practices.md line 403 |
-| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags | Agent Skills specification |
-| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars | Agent Skills specification |
-| Contradictions between phases | 0 | Agent picks arbitrarily when contradictions exist |
+| Criterion | Threshold |
+|-----------|-----------|
+| SKILL.md body length | ≤ 500 lines |
+| Reference files | ≤ 200 lines each |
+| Reference files >100 lines | Must include a `## Contents` TOC |
+| `description` field | Present; non-empty; ≤ 1024 chars; no XML tags |
+| `name` field format | Present; non-empty; lowercase letters, numbers, hyphens only; max 64 chars |
+| Contradictions between phases | 0 |
 
-*Source: skills/skill-authoring-best-practices.md lines 259; skills/extend-claude-with-skills.md lines 183-199*
 
 ---
 

--- a/skills/init-agents/references/codebase-analyzer.md
+++ b/skills/init-agents/references/codebase-analyzer.md
@@ -1,7 +1,6 @@
 # Codebase Analysis Instructions
 Structured process for detecting project tech stack, tooling, and non-standard patterns.
 Used by INIT and IMPROVE skills for codebase analysis.
-Source: agents/codebase-analyzer.md
 ---
 
 Follow these codebase analysis instructions. Analyze the project at the current working directory and return a structured summary of its technical characteristics. Focus on facts that would cause mistakes if an AI coding agent didn't know them.
@@ -89,7 +88,6 @@ Look for anything unusual that would trip up an agent:
 - Migration workflows that live in app-specific directories rather than a root config file
 - Repository-specific tools mentioned in existing documentation
 
-*Source: agents/codebase-analyzer.md lines 22-82*
 
 ---
 
@@ -127,7 +125,6 @@ Return your analysis in exactly this format:
 
 If a section has nothing non-standard to report, omit it entirely. Shorter is better.
 
-*Source: agents/codebase-analyzer.md lines 83-113*
 
 ---
 
@@ -140,4 +137,3 @@ Before returning results, verify:
 3. Output follows the exact format specified above
 4. Sections with no findings are omitted, not left empty
 
-*Source: agents/codebase-analyzer.md lines 115-122*

--- a/skills/init-agents/references/context-optimization.md
+++ b/skills/init-agents/references/context-optimization.md
@@ -1,7 +1,6 @@
 # Context Optimization
 
 Evidence-based instructions for managing token budgets and attention in agent configuration files.
-Source: research-context-engineering-comprehensive.md
 
 ---
 
@@ -13,17 +12,16 @@ Source: research-context-engineering-comprehensive.md
 - Quality over quantity checklist (include/exclude decision table)
 - Context poisoning vectors (detection and removal)
 - JIT documentation patterns (on-demand loading strategies)
-- Key citations
 
 ---
 
 ## Hard Limits
 
-| Limit | Value | Source |
-|-------|-------|--------|
-| Lines per configuration file | ≤ 200 | Anthropic Docs: "Target under 200 lines per CLAUDE.md file." |
-| Instructions per file | ≤ 150-200 | HumanLayer: "Frontier LLMs can follow ~150-200 instructions with reasonable consistency." |
-| Contradictions between files | 0 | Anthropic: "Claude may pick one arbitrarily." |
+| Limit | Value |
+|-------|-------|
+| Lines per configuration file | ≤ 200 |
+| Instructions per file | ≤ 150-200 |
+| Contradictions between files | 0 |
 
 > "Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"
 > — Anthropic Best Practices
@@ -79,7 +77,6 @@ For each instruction line, ask: **"Would removing this cause the agent to make m
 - ✅ "Run `npm test` before committing" vs. ❌ "Test your changes"
 - ✅ "API handlers live in `src/api/handlers/`" vs. ❌ "Keep files organized"
 
-*Source: research-context-engineering-comprehensive.md lines 113-134*
 
 ---
 
@@ -97,7 +94,6 @@ Detect and remove these before generating or improving configuration files:
 
 > "Treat CLAUDE.md like code: review it when things go wrong, prune it regularly." — Anthropic Best Practices
 
-*Source: research-context-engineering-comprehensive.md lines 213-253*
 
 ---
 
@@ -114,17 +110,4 @@ Use these patterns to move content from always-consumed to on-demand locations:
 > "Rather than pre-processing all relevant data up front, agents maintain lightweight identifiers and use these references to dynamically load data into context at runtime."
 > — Anthropic Engineering: Effective Context Engineering
 
-*Source: research-context-engineering-comprehensive.md lines 138-208, 451-461*
 
----
-
-## Key Citations
-
-| Claim | Source |
-|-------|--------|
-| ≤200 lines per file | Agent Skills Standard |
-| ~150-200 instruction limit | HumanLayer (Kyle) via a-guide-to-agents.md |
-| n² attention constraint / context rot | Anthropic Engineering Blog |
-| Lost-in-the-middle effect | Liu et al., arXiv:2307.03172 |
-| Quality over quantity heuristic | Anthropic Best Practices |
-| JIT documentation strategy | Anthropic Engineering: Effective Context Engineering |

--- a/skills/init-agents/references/progressive-disclosure-guide.md
+++ b/skills/init-agents/references/progressive-disclosure-guide.md
@@ -1,7 +1,6 @@
 # Progressive Disclosure Guide
 
 Evidence-based instructions for structuring AGENTS.md hierarchies.
-Sources: a-guide-to-agents.md, research-context-engineering-comprehensive.md
 
 ---
 
@@ -28,7 +27,6 @@ When deciding where to place content, use this table:
 | Subdirectory AGENTS.md | Specific to one package or area | On-demand when working there |
 | Skill | A workflow the agent should invoke explicitly | On-demand when invoked |
 
-*Source: a-guide-to-agents.md lines 228-233; research-context-engineering-comprehensive.md lines 257-305*
 
 ---
 
@@ -93,7 +91,6 @@ docs/
 
 **Use skills for workflows** — agents invoke skills only when needed, keeping base context minimal.
 
-*Source: a-guide-to-agents.md lines 110-163*
 
 ---
 

--- a/skills/init-agents/references/scope-detector.md
+++ b/skills/init-agents/references/scope-detector.md
@@ -1,7 +1,6 @@
 # Scope Detection Instructions
 Structured process for identifying distinct project contexts that need separate configuration files.
 Used by INIT skills for scope detection.
-Source: agents/scope-detector.md
 ---
 
 Follow these scope detection instructions. Identify distinct contexts within the project at the current working directory that would benefit from their own configuration file (AGENTS.md or CLAUDE.md). Each scope represents an area where an agent needs different guidance than the root-level instructions.
@@ -91,7 +90,6 @@ For each identified scope, determine what makes it different:
 - What conventions apply here but not elsewhere?
 - What tech-specific knowledge would an agent need?
 
-*Source: agents/scope-detector.md lines 41-76*
 
 ---
 
@@ -131,7 +129,6 @@ Return your analysis in exactly this format:
 
 If the project is a simple single-package project, report zero additional scopes — the root file is sufficient.
 
-*Source: agents/scope-detector.md lines 77-112*
 
 ---
 
@@ -144,4 +141,3 @@ Before returning results, verify:
 3. The recommended file count is the minimum necessary
 4. Simple projects correctly return zero additional scopes
 
-*Source: agents/scope-detector.md lines 113-121*

--- a/skills/init-agents/references/validation-criteria.md
+++ b/skills/init-agents/references/validation-criteria.md
@@ -1,7 +1,6 @@
 # Validation Criteria
 
 Quality checklist for generated and improved AGENTS.md files.
-Source: improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
 
 ---
 
@@ -9,13 +8,13 @@ Source: improve-agents/SKILL.md:108-122, file-evaluator.md:23-59
 
 Any file violating these criteria must be fixed before proceeding:
 
-| Criterion | Threshold | Source |
-|-----------|-----------|--------|
-| File length | ≤ 200 lines | Anthropic Docs: "Target under 200 lines per CLAUDE.md file" |
-| Instruction count | ≤ 150-200 | HumanLayer: "~150-200 instructions with reasonable consistency" |
-| Contradictions (within or between files) | 0 | Anthropic: "Claude may pick one arbitrarily" |
-| Language-specific rules in root | 0 | Domain rules belong in separate files |
-| Stale file path references | 0 | "File paths change constantly... actively poisons context" |
+| Criterion | Threshold |
+|-----------|-----------|
+| File length | ≤ 200 lines |
+| Instruction count | ≤ 150-200 |
+| Contradictions (within or between files) | 0 |
+| Language-specific rules in root | 0 |
+| Stale file path references | 0 |
 
 ## Recommended Targets (Advisory)
 

--- a/skills/init-agents/references/what-not-to-include.md
+++ b/skills/init-agents/references/what-not-to-include.md
@@ -1,28 +1,26 @@
 # What NOT to Include
 
 Evidence-based exclusion table for AGENTS.md content.
-Sources: ETH Zurich paper (Evaluating AGENTS.md), Anthropic Best Practices, a-guide-to-agents.md
 
 ---
 
 ## Exclusion Evidence Table
 
-| Content Type | Why to Exclude | Evidence Quote | Source |
-|-------------|----------------|---------------|--------|
-| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" | ETH Zurich: Evaluating AGENTS.md |
-| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" | Anthropic Best Practices |
-| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" | ETH Zurich: Evaluating AGENTS.md |
-| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" | a-guide-to-agents.md |
-| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" | a-guide-to-agents.md |
-| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" | a-guide-to-agents.md |
-| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" | Anthropic Best Practices |
-| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" | research-context-engineering-comprehensive.md |
-| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) | Anthropic Best Practices |
-| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column | Anthropic Best Practices |
-| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" | Anthropic Best Practices |
+| Content Type | Why to Exclude | Evidence Quote |
+|-------------|----------------|---------------|
+| Directory/file structure listings | Agents use grep/glob to navigate; static lists become stale instantly | "Not effective at providing repository overview" |
+| Standard language conventions | Agent training data already includes these | Agent "already knows these from training data" |
+| Codebase overview paragraphs | Increases exploration steps without improving navigation success | "Increases steps without improving navigation" |
+| Vague guidance ("write clean code") | Cannot be acted on; wastes attention budget without guiding behavior | "Not actionable, wastes attention budget" |
+| File path references | Paths change constantly; stale paths actively mislead the agent | "File paths change constantly... actively poisons context" |
+| Everything in one file (all topics) | Exceeds ~150-200 instruction attention budget; creates ball-of-mud | "Ball of mud problem, exceeds attention budget" |
+| Obvious tooling ("use git for version control") | Agent already knows standard tooling from training | "If Claude already does it correctly, delete it" |
+| Duplicated information across files | Consumes tokens on every request; creates contradiction risk | "Wastes tokens on every request" |
+| Version numbers and release names | High-churn content; stale immediately after updates | "Information that changes frequently" (explicit ❌ Exclude) |
+| Long explanations and tutorials | Context is for instructions, not education | Listed in explicit ❌ Exclude column |
+| Detailed API documentation | Link to external docs instead of inlining | Listed in explicit ❌ Exclude column |
+| Anything the agent can infer from code | Agent reads code directly; redundant instructions waste tokens | "Anything Claude can figure out by reading code" |
 
-*Source: init-agents/SKILL.md:106-116 expanded; research-context-engineering-comprehensive.md:113-121; Evaluating-AGENTS-paper.md abstract*
 
 ### Exclusion Actions
 


### PR DESCRIPTION
Extra slice on the PRD #143 umbrella — removes every external-document reference from skill and agent artifacts so each artifact is fully self-contained.

## What changed

- **~150 artifact files** across all five distributions (agent-customizer, agents-initializer, cursor-customizer, cursor-initializer, standalone `skills/`) had dangling external citations removed: top-of-file `Source:` lines, inline `*Source: ...*` trailers, and `Source` columns inside tables. Pure-citation sections (`## Key Citations`, `## Evidence Citations`) were deleted whole. Distilled content was preserved — deletion-only.
- **`.claude/rules/reference-files.md`** — replaced the old "must have a clear source attribution" mandate with a self-containment requirement; extended the path glob to also cover `cursor-customizer` and `orchestrate`.

Research, implementation (7 parallel subagents, one per distribution batch), and review were all done by subagents. The reviewer found and fixed 2 defects inline (a stale TOC entry, a `docs/cursor/` prose pointer).

## Verification

- Zero remaining `^Source:` / `^Sources:` / `^*Source:*` lines outside the `docs-drift-checker.md` agents (which describe the convention) and same-skill internal pointers (deliberately kept).
- All `Source`-column table removals keep tables structurally valid (column counts consistent).
- `<REFERENCES>` blocks in SKILL.md bodies untouched. No SKILL.md changed.
- Net diff: +435 / -1130 lines (removal-dominant, as expected).

## Follow-ups (NOT in this slice — flagged for later)

- `docs-drift-checker.md` agents (agent-customizer + cursor-customizer) and any phase invoking them: their job was extracting `Source:` attributions — now partially inert.
- `skills/docs-drift-manifest.md`: maps reference files to source docs — now stale.
- `skill-validation-criteria.md` (create-skill / improve-skill): a checklist item still expects "evidence citations" — contradicts the new self-containment contract.
- 3 `artifact-format-routing.md` files are >100 lines without a `## Contents` TOC — pre-existing, unrelated to this cleanup.