### PR TITLE
docs: record orchestrate concurrent run management decision (ADR-0008)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -123,6 +123,32 @@ _Avoid_: all-warn, all-hard (the tiered model balances safety and false-positive
 The four quality-gate skills in `.claude/skills/` (`agent-customizer-quality-gate`, `cursor-customizer-quality-gate`, `cursor-initializer-quality-gate`, `quality-gate`) are out of scope for **Skill body convention** body-format retrofit but in scope for **content** updates that teach them to assert the new convention against plugin/standalone targets. Their own bodies remain markdown without semantic tags until a follow-up PRD.
 _Avoid_: quality-gate refactor, gate-body retrofit (only the *checked-for* clauses change in v1, not the gate's own body)
 
+### Orchestrate run vocabulary
+
+**Orchestration run**:
+One end-to-end execution of the `orchestrate` plugin over a single backlog partition — dependency-ordered waves, slice worktrees, an umbrella branch, and a final integration pull request.
+_Avoid_: job, batch, orchestration session
+
+**Run partition**:
+The subset of the `ready-for-agent` backlog one run owns — the child issues of a single parent PRD, selected by `/orchestrate <PRD#>`. A no-argument run owns the whole backlog as one partition.
+_Avoid_: backlog slice, batch (slice is reserved for a single issue's work)
+
+**Run directory**:
+The per-run `.orchestrate/runs/<runId>/` directory holding that run's ephemeral state — the run-state checkpoint, the context-flag, and rendered HTML artifacts. Gitignored; the committed config files stay at the `.orchestrate/` top level.
+_Avoid_: run folder, state dir
+
+**Driver session**:
+The Claude Code session executing a run's orchestrator. Its identity is recorded in the run's run-state so the global context-watchdog binds the correct run when several runs proceed concurrently.
+_Avoid_: orchestrator window, owner session
+
+**Integration base**:
+The branch every umbrella branch is cut from and every run's final pull request merges back into — `development` in this repository.
+_Avoid_: main, master, trunk (the integration base is `development`, distinct from any release branch)
+
+**Run cleanup**:
+Removal of a concluded run's run directory, worktrees, and umbrella/slice branches — gated on that run's final integration pull request having been merged into the **Integration base**.
+_Avoid_: purge, garbage collection, prune
+
 ## Relationships
 
 - A **Distribution** owns at most one **Initializer** and at most one **Customizer**.
@@ -136,6 +162,10 @@ _Avoid_: quality-gate refactor, gate-body retrofit (only the *checked-for* claus
 - An **HTML artifact** carries one or more **Semantic tags** plus presentation chrome (CSS, layout, navigation) — the tags make it agent-parseable; the chrome makes it human-readable.
 - **Artifact format routing** decides between an **HTML artifact** and a markdown artifact based on whether the consumer is *agent-loaded* / *tooling-locked* (markdown) or *human-rich + agent-executable* (HTML).
 - **Tier-1**, **Tier-2**, and **Tier-3 retrofit** carve up the set of files subject to **Convention scope (v1)** by urgency, not by location.
+- An **Orchestration run** owns exactly one **Run partition** and writes its ephemeral state to exactly one **Run directory**.
+- Sibling **Orchestration runs** in the same repository must own disjoint **Run partitions** — one parent PRD's children each.
+- A **Driver session** executes exactly one **Orchestration run**; the context-watchdog binds a run by matching the **Driver session** identity recorded in run-state.
+- **Run cleanup** acts on an **Orchestration run** only after its final pull request has merged into the **Integration base**.
 
 ## Example dialogue
 
@@ -148,9 +178,14 @@ _Avoid_: quality-gate refactor, gate-body retrofit (only the *checked-for* claus
 > **Dev:** "When `create-skill` generates a new skill whose job is to produce an implementation plan, does the *plan* end up as `.md` or `.html`?"
 > **Domain expert:** "HTML — that's the default per **Artifact format routing** for a human-rich AND agent-executable artifact. The generated HTML carries the same **Canonical tag vocabulary** inside, so the next session parses it the same way it parses a SKILL.md body. The skill itself stays `SKILL.md`."
 
+> **Dev:** "Can I run `/orchestrate` in two windows against the same repository?"
+> **Domain expert:** "Yes — as long as each is an **Orchestration run** over a distinct **Run partition**. Pass `/orchestrate <PRD#>` per window so each owns one parent PRD's children. With no argument a run takes the whole backlog as a single partition, and a second concurrent run would collide on it."
+
 ## Flagged ambiguities
 
 - "Cursor CLI" was used by the user to mean the full Cursor distribution surface (IDE + CLI share the `.cursor/rules/` system). Resolved: in this repo, **Cursor distribution** covers both surfaces — they consume the same artifact files.
 - "knowledge base" was historically used to mean the RAG vector store registered as the `rag-knowledge-base` MCP server. Resolved as of ADR-0004: **Wiki** is the canonical knowledge base; the RAG layer is deleted.
 - "HTML in skill body" was used by the user to mean *both* (a) the semantic-tag-inside-markdown pattern and (b) replacing `SKILL.md` with `.html` files. Resolved during grilling (ADR-0007): only (a) is adopted; **Skill body convention** keeps `SKILL.md` as a `.md` file (Agent Skills spec compliance) and embeds tags inside the markdown body.
 - Legacy `<RULES>` tag (currently used in `plugins/agent-customizer/skills/create-skill/SKILL.md` and elsewhere) is treated as an alias of canonical `<HARD_RULES>`. Tier-3 organic retrofit migrates each occurrence on next touch; no scheduled mass rename.
+- "two orchestrations" was used to mean two concurrent **Orchestration runs** in the *same* repository — resolved: each run must own a disjoint **Run partition** (one parent PRD's children); same-repo runs over an unpartitioned backlog collide on the identical issue set.
+- "merged into main/master" was used for the **Run cleanup** gate — resolved: the gate is the run's final pull request merged into the **Integration base** (`development`), not a release branch. The plugin name and its directory are spelled `orchestrate` / `.orchestrate` (not `orquestrate`).

--- a/docs/adr/0008-orchestrate-concurrent-run-management.md
+++ b/docs/adr/0008-orchestrate-concurrent-run-management.md
@@ -1,0 +1,53 @@
+# Orchestrate concurrent run management
+
+**Status:** accepted (2026-05-21)
+
+The `orchestrate` plugin originally supported one run per repository: a single
+flat `.orchestrate/run-state.json`, a global context-watchdog keyed on it, and
+no cleanup of finished runs. To let an operator run several orchestrations
+concurrently in the same repository, each run now owns a **run partition** —
+the child issues of one parent PRD, selected by `/orchestrate <PRD#>` — and a
+per-run **run directory** at `.orchestrate/runs/<runId>/` holding all ephemeral
+state, while the `commands.json` / `routing.json` / `handoff.json` config stays
+committed at the `.orchestrate/` top level. The global context-watchdog binds a
+run by matching the **driver session** identity recorded in run-state, and
+safely no-ops — the run keeps going, only auto-handoff is lost — when it cannot
+disambiguate. **Run cleanup**, a sweep at every run start plus an
+`/orchestrate-clean` subcommand, removes a run's directory, worktrees, and
+umbrella/slice branches once its final integration pull request has merged into
+the integration base.
+
+## Considered Options
+
+- **Flat per-run filenames** (`run-state-<runId>.json`) instead of a
+  `runs/<runId>/` directory — rejected: scatters ephemeral artifacts among the
+  committed config files and makes both the `.gitignore` rule and the cleanup
+  match fragile.
+- **Concurrency across different repositories only** — rejected: the operator's
+  real need is two runs in one repository; cross-repo concurrency already works
+  because each repository has its own `.orchestrate/` directory.
+- **Keeping `plan_waves`' default** (a blocker outside the input set is assumed
+  satisfied) for cross-partition dependencies — rejected: a partitioned run
+  could then silently build a slice on top of an unbuilt external blocker.
+  Instead the orchestrator verifies the external blocker's real state and skips
+  the dependent slice when that blocker is still open.
+- **A lockfile granting the context-watchdog to one run per repository** —
+  rejected: it degrades the second concurrent run's auto-handoff even after the
+  first run has finished. Matching the driver-session identity scopes the
+  watchdog per run instead.
+
+## Consequences
+
+- The on-disk `.orchestrate/` contract changes: MCP tools and the hook that
+  read `run-state.json` or write HTML artifacts (`render_*`, `spawn_successor`,
+  the `context-watchdog`) take a `runId` and resolve paths under
+  `runs/<runId>/`.
+- `run-state.json` gains a driver-session identity field. Whether the
+  orchestrator can read its own session identity carries a verification spike;
+  if that primitive is absent, the watchdog's safe-no-op fallback means a
+  concurrent run loses auto-handoff but stays correct.
+- The bootstrap step appends `.orchestrate/runs/` to the target repository's
+  `.gitignore` idempotently; the config files stay tracked.
+- This work folds into PRD #181 (orchestrate plugin hardening) — it reuses and
+  extends the same modules: the config bootstrapper, the backlog partitioner,
+  and the context-window / context-watchdog handling.


### PR DESCRIPTION
## What

- Add `docs/adr/0008-orchestrate-concurrent-run-management.md` — an ADR recording the orchestrate plugin's concurrent-run-management design.
- Add the orchestrate run vocabulary to the `CONTEXT.md` glossary — Orchestration run, Run partition, Run directory, Driver session, Integration base, Run cleanup — with relationships, an example dialogue, and the resolved ambiguities.

## Why

These two files document one decision, reached during a `/grill-with-docs` session that re-scoped PRD #181 (orchestrate plugin hardening + concurrent run management). ADR-0008 records the decision and its rejected alternatives; the `CONTEXT.md` additions are the glossary terms that decision introduced. Committed together as one atomic change because the ADR references vocabulary the glossary defines.

## Decision summary

Per-run `.orchestrate/runs/<runId>/` layout, backlog partition by parent PRD, a committed/ephemeral config split, driver-session watchdog binding with a safe no-op, and merge-gated run cleanup. Rejected alternatives — flat per-run filenames, cross-repository-only concurrency, the `plan_waves` default for cross-partition dependencies, and a lockfile watchdog — are recorded in the ADR.

## Related

- PRD #181 — orchestrate plugin hardening + concurrent run management
- Decomposed via `/to-issues` into 15 `ready-for-agent` slices: #184–#198

🤖 Generated with [Claude Code](https://claude.com/claude-code)
