### PR TITLE
fix(orchestrate): SSH fetch + namespacing + wave-base freshness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-engineering-toolkit",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Multi-plugin marketplace for evidence-based Claude Code artifact engineering. Provides plugins for configuration initialization (AGENTS.md, CLAUDE.md), artifact creation/optimization (skills, hooks, rules, subagents), and autonomous backlog orchestration.",
   "owner": {
     "name": "rodrigorjsf",
@@ -33,7 +33,7 @@
     {
       "name": "orchestrate",
       "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"

--- a/plugins/orchestrate/.claude-plugin/plugin.json
+++ b/plugins/orchestrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestrate",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
   "author": {
     "name": "rodrigorjsf"

--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -31,7 +31,7 @@ Given a repository with open issues labelled `ready-for-agent`, one `/orchestrat
 
 The orchestrate skill is the **orchestrator**. It is the single actor that touches git, GitHub, and the shell — branches, worktrees, commits, pushes, pull requests, merges, label transitions, and the `run-state.json` checkpoint. It also assesses each issue's complexity tier and routes each role accordingly.
 
-Every other role is a **subagent**, spawned with the standard Agent tool:
+Every other role is a **subagent**, spawned with the standard Agent tool by its namespaced type — `orchestrate:<role>-<effort>`, where `<effort>` is `standard` or `deep` (for example `orchestrate:implementer-deep`). The `orchestrate:` prefix is required; a bare name does not resolve.
 
 | Role | Effort variants | Access |
 |------|-----------------|--------|

--- a/plugins/orchestrate/orchestrate-mcp/src/git.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/git.ts
@@ -21,10 +21,11 @@ const GIT_CONFIG_OVERRIDES: string[] = [
   "core.fsmonitor=",
   // `core.sshCommand=ssh`, not a blank value. A command-line `-c` overrides
   // whatever an untrusted repo's `.git/config` sets, so a malicious
-  // `core.sshCommand` still cannot run — the code-execution surface stays
-  // closed. A blank value would also close it, but it makes an SSH `fetch`
-  // spawn an empty command and fail (F-005); `ssh` is the real, working
-  // invocation, resolved from PATH.
+  // `core.sshCommand` from the repo config cannot run. A blank value would
+  // also close that vector, but it makes an SSH `fetch` spawn an empty
+  // command and fail (F-005); `ssh` is the real, working invocation,
+  // resolved from PATH. Note: an inherited `GIT_SSH_COMMAND` env var takes
+  // precedence over `core.sshCommand` and is not neutralized here — see #200.
   "-c",
   "core.sshCommand=ssh",
   "-c",

--- a/plugins/orchestrate/orchestrate-mcp/src/git.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/git.ts
@@ -19,8 +19,14 @@ const GIT_CONFIG_OVERRIDES: string[] = [
   "core.hooksPath=/dev/null",
   "-c",
   "core.fsmonitor=",
+  // `core.sshCommand=ssh`, not a blank value. A command-line `-c` overrides
+  // whatever an untrusted repo's `.git/config` sets, so a malicious
+  // `core.sshCommand` still cannot run — the code-execution surface stays
+  // closed. A blank value would also close it, but it makes an SSH `fetch`
+  // spawn an empty command and fail (F-005); `ssh` is the real, working
+  // invocation, resolved from PATH.
   "-c",
-  "core.sshCommand=",
+  "core.sshCommand=ssh",
   "-c",
   "core.pager=cat",
 ];

--- a/plugins/orchestrate/orchestrate-mcp/test/worktree.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/worktree.test.ts
@@ -223,6 +223,57 @@ describe("create_worktree", () => {
     expect(retry.branch).toBe("orphan-candidate-branch");
     expect(fs.existsSync(goodPath)).toBe(true);
   });
+
+  it("fetches over an ssh:// remote and reports fetchStatus='ok' (F-005 regression)", async () => {
+    // F-005: the git wrapper must not blank `core.sshCommand` in a way that
+    // breaks SSH transport. A bare repo reached over an `ssh://` URL stands in
+    // for a real SSH remote; a stub `ssh` keeps the test offline.
+    const remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-remote-"));
+    const remoteBare = path.join(remoteDir, "remote.git");
+    git(["clone", "--bare", repoPath, remoteBare], remoteDir);
+    git(["remote", "add", "origin", `ssh://fake${remoteBare}`], repoPath);
+
+    // Stub `ssh`: ignore the options and host, run the remote command (git
+    // passes it as the last argument) locally. Prepended to PATH so the
+    // wrapper's `core.sshCommand=ssh` override resolves to this stub.
+    const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-ssh-"));
+    const stubSsh = path.join(stubDir, "ssh");
+    fs.writeFileSync(
+      stubSsh,
+      '#!/bin/sh\nfor arg in "$@"; do cmd="$arg"; done\nexec sh -c "$cmd"\n'
+    );
+    fs.chmodSync(stubSsh, 0o755);
+
+    // GIT_SSH_COMMAND would override `-c core.sshCommand` and mask the bug —
+    // strip it for the test, restore it after.
+    const savedPath = process.env.PATH;
+    const savedSshCommand = process.env.GIT_SSH_COMMAND;
+    delete process.env.GIT_SSH_COMMAND;
+    process.env.PATH = `${stubDir}${path.delimiter}${savedPath ?? ""}`;
+
+    try {
+      const wtPath = path.join(worktreesDir, "ssh-fetch-wt");
+      const result = await createWorktree({
+        baseRef: "HEAD",
+        branch: "ssh-fetch-branch",
+        worktreePath: wtPath,
+        repoPath,
+      });
+
+      expect(result.status).toBe("ok");
+      expect(result.fetchStatus).toBe("ok");
+      expect(result.fetchError).toBeUndefined();
+    } finally {
+      process.env.PATH = savedPath;
+      if (savedSshCommand === undefined) {
+        delete process.env.GIT_SSH_COMMAND;
+      } else {
+        process.env.GIT_SSH_COMMAND = savedSshCommand;
+      }
+      rmrf(remoteDir);
+      rmrf(stubDir);
+    }
+  });
 });
 
 // ─── remove_worktree ──────────────────────────────────────────────────────────

--- a/plugins/orchestrate/orchestrate-mcp/test/worktree.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/worktree.test.ts
@@ -228,30 +228,37 @@ describe("create_worktree", () => {
     // F-005: the git wrapper must not blank `core.sshCommand` in a way that
     // breaks SSH transport. A bare repo reached over an `ssh://` URL stands in
     // for a real SSH remote; a stub `ssh` keeps the test offline.
+    //
+    // The temp dirs are created before the try so the finally can always clean
+    // them; everything that can fail runs inside the try.
     const remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-remote-"));
-    const remoteBare = path.join(remoteDir, "remote.git");
-    git(["clone", "--bare", repoPath, remoteBare], remoteDir);
-    git(["remote", "add", "origin", `ssh://fake${remoteBare}`], repoPath);
-
-    // Stub `ssh`: ignore the options and host, run the remote command (git
-    // passes it as the last argument) locally. Prepended to PATH so the
-    // wrapper's `core.sshCommand=ssh` override resolves to this stub.
     const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-ssh-"));
-    const stubSsh = path.join(stubDir, "ssh");
-    fs.writeFileSync(
-      stubSsh,
-      '#!/bin/sh\nfor arg in "$@"; do cmd="$arg"; done\nexec sh -c "$cmd"\n'
-    );
-    fs.chmodSync(stubSsh, 0o755);
 
     // GIT_SSH_COMMAND would override `-c core.sshCommand` and mask the bug —
-    // strip it for the test, restore it after.
+    // strip it for the test, restore it after. PATH is restored the same way:
+    // assigning `undefined` back would coerce to the string "undefined".
     const savedPath = process.env.PATH;
     const savedSshCommand = process.env.GIT_SSH_COMMAND;
-    delete process.env.GIT_SSH_COMMAND;
-    process.env.PATH = `${stubDir}${path.delimiter}${savedPath ?? ""}`;
 
     try {
+      const remoteBare = path.join(remoteDir, "remote.git");
+      git(["clone", "--bare", repoPath, remoteBare], remoteDir);
+      git(["remote", "add", "origin", `ssh://fake${remoteBare}`], repoPath);
+
+      // Stub `ssh`: ignore the options and host, run the remote command
+      // locally. Git passes the remote command (`git-upload-pack '<path>'`) as
+      // the last argument, so the stub runs the last arg via `sh -c`.
+      // Prepended to PATH so the wrapper's `core.sshCommand=ssh` resolves here.
+      const stubSsh = path.join(stubDir, "ssh");
+      fs.writeFileSync(
+        stubSsh,
+        '#!/bin/sh\nfor arg in "$@"; do cmd="$arg"; done\nexec sh -c "$cmd"\n'
+      );
+      fs.chmodSync(stubSsh, 0o755);
+
+      delete process.env.GIT_SSH_COMMAND;
+      process.env.PATH = `${stubDir}${path.delimiter}${savedPath ?? ""}`;
+
       const wtPath = path.join(worktreesDir, "ssh-fetch-wt");
       const result = await createWorktree({
         baseRef: "HEAD",
@@ -264,7 +271,11 @@ describe("create_worktree", () => {
       expect(result.fetchStatus).toBe("ok");
       expect(result.fetchError).toBeUndefined();
     } finally {
-      process.env.PATH = savedPath;
+      if (savedPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = savedPath;
+      }
       if (savedSshCommand === undefined) {
         delete process.env.GIT_SSH_COMMAND;
       } else {

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -243,10 +243,9 @@ These are the per-slice steps the wave loop invokes. Update the slice's entry in
    slice has **FAILED**.
 5. **Run the reviewer.** Spawn the `orchestrate:reviewer-<effort>` subagent —
    `<effort>` and the `model` override from `routing.reviewer` — in the same
-   worktree. Its
-   prompt must carry the issue, the worktree path, the implementer's
-   `filesChanged` list and `notes`, and the investigator's brief if one was
-   produced. If it returns `failed`, the slice has **FAILED**.
+   worktree. Its prompt must carry the issue, the worktree path, the
+   implementer's `filesChanged` list and `notes`, and the investigator's brief
+   if one was produced. If it returns `failed`, the slice has **FAILED**.
 6. **Commit and push.** Stage only the files the subagents reported changing —
    the union of the implementer's and reviewer's `filesChanged` lists. Never
    `git add -A`: the capability tools leave untracked build artifacts in the

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -30,10 +30,15 @@ of restarting.
 
 Every role except the orchestrator exists in two effort variants — `-standard`
 and `-deep`. The `resolve_routing` tool picks the variant and model per role
-from the issue's complexity tier (section 3, step 2). All four subagents have
-**no Bash and no git access** — they are sandboxed to one worktree (the
-investigator is read-only). Only the orchestrator touches branches, remotes,
-and the tracker.
+from the issue's complexity tier (section 3, step 2). Each role is spawned by
+its **namespaced** subagent type — `orchestrate:investigator-<effort>`,
+`orchestrate:implementer-<effort>`, `orchestrate:reviewer-<effort>`, and
+`orchestrate:conflict-resolver-<effort>`, where `<effort>` is `standard` or
+`deep`. The `orchestrate:` prefix is required: the plugin registers its bundled
+subagents under that namespace, so a bare, un-namespaced name fails to resolve.
+All four subagents have **no Bash and no git access** — they are sandboxed to
+one worktree (the investigator is read-only). Only the orchestrator touches
+branches, remotes, and the tracker.
 
 ## Prerequisites
 
@@ -207,19 +212,20 @@ These are the per-slice steps the wave loop invokes. Update the slice's entry in
    - `errorCode: "CONFIG_INVALID"` — the routing config is broken; the slice
      has **FAILED**.
 3. **Run the investigator (higher tiers only).** If `routing.investigator` is
-   non-null, spawn the `investigator-<effort>` subagent — `<effort>` and the
-   Agent `model` override both come from `routing.investigator`. Its prompt
+   non-null, spawn the `orchestrate:investigator-<effort>` subagent — `<effort>`
+   and the Agent `model` override both come from `routing.investigator`. Its prompt
    carries the issue and the repository root; keep its returned brief for the
    implementer. If `routing.investigator` is null, skip this step.
-4. **Run the implementer.** Spawn the `implementer-<effort>` subagent —
-   `<effort>` and the `model` override from `routing.implementer`. Its prompt
+4. **Run the implementer.** Spawn the `orchestrate:implementer-<effort>`
+   subagent — `<effort>` and the `model` override from `routing.implementer`. Its prompt
    must carry the issue number/title/body, the worktree path (every change goes
    there), the investigator's brief if one was produced, an instruction to
    verify with the capability tools using the worktree path as `repoPath`, and
    a reminder not to commit, push, or run git. If it returns `blocked`, the
    slice has **FAILED**.
-5. **Run the reviewer.** Spawn the `reviewer-<effort>` subagent — `<effort>`
-   and the `model` override from `routing.reviewer` — in the same worktree. Its
+5. **Run the reviewer.** Spawn the `orchestrate:reviewer-<effort>` subagent —
+   `<effort>` and the `model` override from `routing.reviewer` — in the same
+   worktree. Its
    prompt must carry the issue, the worktree path, the implementer's
    `filesChanged` list and `notes`, and the investigator's brief if one was
    produced. If it returns `failed`, the slice has **FAILED**.
@@ -286,9 +292,10 @@ These are the per-slice steps the wave loop invokes. Update the slice's entry in
       slice has **FAILED**. If all pass, the merge commit already exists —
       push and merge the slice PR: `git -C <worktree-path> push` then
       `gh pr merge <pr-number> --squash`.
-   4. Spawn the `conflict-resolver-<effort>` subagent — `<effort>` and the
-      `model` override from `routing.conflict-resolver`. Its prompt must carry
-      the issue, the worktree path, and the list of conflicted files.
+   4. Spawn the `orchestrate:conflict-resolver-<effort>` subagent — `<effort>`
+      and the `model` override from `routing.conflict-resolver`. Its prompt
+      must carry the issue, the worktree path, and the list of conflicted
+      files.
    5. If it returns `failed`, abort and the slice has **FAILED**:
       `git -C <worktree-path> merge --abort`.
    6. If it returns `resolved`, stage the resolved files and **confirm no

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -73,7 +73,7 @@ autonomous run must not stop mid-wave.
 Also clear any stale handoff flag: if `.orchestrate/context-flag.json` exists,
 delete it. On a resumed run it is the predecessor's handoff trigger, now
 consumed; on a fresh run it is leftover from an earlier run. Either way,
-leaving it would make this session hand off immediately (section 2, step 3).
+leaving it would make this session hand off immediately (section 2, step 4).
 
 Then check for `.orchestrate/run-state.json` (its schema is in
 `references/run-state.md`).
@@ -147,26 +147,44 @@ Then check for `.orchestrate/run-state.json` (its schema is in
 
 Process waves in order, starting at index `completedWaves`. For each wave:
 
-1. **Select the processable slices.** A slice in this wave is processable when
+1. **Refresh the umbrella base.** Before creating this wave's worktrees,
+   fast-forward the local umbrella ref to its remote counterpart — every prior
+   wave's slices were squash-merged into `orchestrate/umbrella-<runId>` on the
+   remote, and this wave's worktrees must branch from that integrated state:
+
+   ```
+   git fetch origin orchestrate/umbrella-<runId>:orchestrate/umbrella-<runId>
+   ```
+
+   The `<src>:<dst>` refspec updates the local branch ref directly without a
+   checkout, and **fails loudly** (non-zero exit) when the update is not a
+   fast-forward — a non-fast-forward means the umbrella history diverged, and
+   the run must stop rather than branch a wave from a wrong base. This step is
+   what guarantees a dependent slice is built on the slices it is blocked by;
+   it does **not** rely on `create_worktree`'s internal fetch, which may be
+   skipped or may fail. It runs on every wave — the first wave's fetch is a
+   no-op fast-forward — and on a resumed run, since the wave loop is re-entered
+   from this step.
+2. **Select the processable slices.** A slice in this wave is processable when
    its state is `pending` and every id in its `blockedBy` that belongs to the
    backlog reached `passed`. If any such blocker is `failed` or `skipped`, mark
    this slice `skipped` with a `failureReason` naming the blocker, checkpoint,
    and do not process it.
-2. **Process the slices.** Run section 3 for every processable slice. Slices in
+3. **Process the slices.** Run section 3 for every processable slice. Slices in
    a wave are independent, so parallelize: when several slices are at the same
    subagent stage (investigation, implementation, review), spawn those
    subagents by issuing all the Agent tool calls **in a single message**. Each
    slice has its own worktree, so they never collide.
-3. **Integrate sequentially.** The commit, pull-request, and merge steps
+4. **Integrate sequentially.** The commit, pull-request, and merge steps
    (section 3, steps 6–9) run **one slice at a time** — merges into the
    umbrella branch must not race each other. After each slice finishes
    integrating, check for `.orchestrate/context-flag.json`: if it exists, the
    context-watchdog has signalled that this session's context is filling. Do
    not start the next slice — finish writing `run-state.json` for the slice
    just integrated, then go to section 4 (Context handoff).
-4. **Checkpoint the wave.** Set `completedWaves` to this wave's index + 1 and
+5. **Checkpoint the wave.** Set `completedWaves` to this wave's index + 1 and
    write `run-state.json`.
-5. **Report wave progress to the PRD.** If `parentIssue` is set, post a comment
+6. **Report wave progress to the PRD.** If `parentIssue` is set, post a comment
    on it summarizing this wave's outcomes — which child issues passed, failed,
    or were skipped: `gh issue comment <parentIssue> --body "..."`.
 
@@ -324,7 +342,7 @@ These are the per-slice steps the wave loop invokes. Update the slice's entry in
 A long run can fill this session's context before every wave is done. The
 `context-watchdog` hook bundled with this plugin watches token usage and writes
 `.orchestrate/context-flag.json` past a configurable threshold. When the wave
-loop (section 2, step 3) sees that flag, hand the run off to a fresh Claude
+loop (section 2, step 4) sees that flag, hand the run off to a fresh Claude
 Code session instead of continuing — the successor resumes from the
 `run-state.json` checkpoint exactly as section 1 describes. See
 `references/context-handoff.md` for the full mechanism.
@@ -375,7 +393,7 @@ The orchestrator is the **single writer** of GitHub tracker state — the
 subagents never touch issues, labels, or pull requests. Tracker writes happen
 only at a slice's terminal state (see section 3 step 9 for the pass label
 command and *Failure handling* for the failure label command) and as PRD
-progress/summary comments (see section 2 steps 5 and the final-PR paragraph).
+progress/summary comments (see section 2 steps 6 and the final-PR paragraph).
 The parent PRD issue receives a progress comment after each wave and a final
 summary when the run completes.
 


### PR DESCRIPTION
## Summary

Carved out of a `/orchestrate 181` run that was deliberately **stopped before it started**. PRD #181 hardens the `orchestrate` plugin against eleven defects from a real run; feeding its own fix-backlog through the still-buggy plugin is a dogfooding catch-22 the PRD itself flags. Rather than babysit a buggy autonomous run, the foundational fixes that make a future run clean are landed here as a normal, reviewed PR.

Three foundational issues, each an atomic commit:

- **#184 — SSH-safe git fetch.** The MCP git wrapper hardened every call with `-c core.sshCommand=` (blank); on an SSH `origin` that makes `git fetch` spawn an empty command and fail (`cannot run :`), so `create_worktree`'s internal fetch reported `fetchStatus: "failed"` on every SSH remote. Changed to `core.sshCommand=ssh` — a working invocation a command-line `-c` still forces over any untrusted repo `.git/config`. Added a vitest regression test that fetches over an `ssh://` remote via a PATH-injected stub ssh.
- **#185 — namespace subagent types.** The skill spawned subagents by bare names; an installed plugin registers them under the `orchestrate:` namespace, so the first spawn of every role failed with "agent type not found". Every subagent type now carries the `orchestrate:` prefix in `SKILL.md` and `README.md`.
- **#188 — wave-base umbrella-ref freshness.** Added an explicit wave-loop step that fast-forwards the local umbrella ref before each wave's worktrees are cut, so a dependent slice is always built on the slices it is blocked by — independently of `create_worktree`'s internal fetch.

A `chore(release)` commit bumps the orchestrate plugin to **1.0.2** (`plugin.json` + the marketplace per-plugin entry) and the marketplace registry to **1.4.1**, per the versioning cascade rule. A fifth commit applies code-review fixes (test cleanup, a skill-text reflow, a narrowed `git.ts` comment).

## Reinstall note — required before re-running /orchestrate

The installed plugin cache is keyed on version. After this merges, run `/plugin marketplace update` so the cache picks up orchestrate **1.0.2** — without the version bump that update is a no-op, and a re-run of `/orchestrate 181` would still hit the buggy plugin.

## Pre-existing security finding (out of scope) — #200

The code review surfaced a **pre-existing** P1: `gitEnv()` spreads `...process.env` and does not neutralize `GIT_SSH_COMMAND`, which git treats as higher-precedence than `core.sshCommand`. An inherited `GIT_SSH_COMMAND` (parent shell, launching agent, CI runner) therefore overrides the `-c core.sshCommand=ssh` hardening — empirically confirmed (`git fetch` executed an attacker-controlled script). The blank-value form had the identical gap, so #184 neither introduced nor closed it, and the env vector is outside #184's `.git/config`-scoped acceptance criteria. Filed as **#200** for a follow-up fix. The `git.ts` comment is scoped accordingly.

## Test plan

- [x] `npm test` in `plugins/orchestrate/orchestrate-mcp/` — 161/161 pass (includes the new F-005 regression test)
- [x] `npm run typecheck` — clean
- [x] F-005 regression test verified red on the bug, green on the fix
- [x] `SKILL.md` wave-loop step renumbering + cross-references verified consistent
- [ ] Re-run `/orchestrate 181` against the reinstalled 1.0.2 plugin (post-merge)

Closes #184
Closes #185
Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)