### PR TITLE
fix(orchestrate): rebuild MCP bundle so the SSH fetch fix ships

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-engineering-toolkit",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Multi-plugin marketplace for evidence-based Claude Code artifact engineering. Provides plugins for configuration initialization (AGENTS.md, CLAUDE.md), artifact creation/optimization (skills, hooks, rules, subagents), and autonomous backlog orchestration.",
   "owner": {
     "name": "rodrigorjsf",
@@ -33,7 +33,7 @@
     {
       "name": "orchestrate",
       "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"

--- a/plugins/orchestrate/.claude-plugin/plugin.json
+++ b/plugins/orchestrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestrate",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
   "author": {
     "name": "rodrigorjsf"

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -21115,8 +21115,15 @@ var GIT_CONFIG_OVERRIDES = [
   "core.hooksPath=/dev/null",
   "-c",
   "core.fsmonitor=",
+  // `core.sshCommand=ssh`, not a blank value. A command-line `-c` overrides
+  // whatever an untrusted repo's `.git/config` sets, so a malicious
+  // `core.sshCommand` from the repo config cannot run. A blank value would
+  // also close that vector, but it makes an SSH `fetch` spawn an empty
+  // command and fail (F-005); `ssh` is the real, working invocation,
+  // resolved from PATH. Note: an inherited `GIT_SSH_COMMAND` env var takes
+  // precedence over `core.sshCommand` and is not neutralized here — see #200.
   "-c",
-  "core.sshCommand=",
+  "core.sshCommand=ssh",
   "-c",
   "core.pager=cat"
 ];


### PR DESCRIPTION
## Summary

Follow-up to #201. PR #201 fixed `core.sshCommand` in `src/git.ts` but did not regenerate the committed `dist/index.js` bundle that `.mcp.json` actually executes (`node .../orchestrate-mcp/dist/index.js`). The vitest suite imports from `src/`, so it passed green while the shipped 1.0.2 bundle still carried the F-005 bug (`core.sshCommand=` blank). **The #184 SSH-fetch fix was therefore not live in the running plugin** — caught while validating the 1.0.2 install.

This PR:
- Rebuilds the bundle (`npm run build`) — `dist/index.js` now carries `core.sshCommand=ssh`.
- Bumps orchestrate to **1.0.3** (marketplace registry to 1.4.2) so `/plugin marketplace update` invalidates the stale 1.0.2 cache.

#185 (subagent namespacing) and #188 (wave-base freshness) were `SKILL.md` text changes, read directly with no build step — those shipped correctly in 1.0.2.

## Recurrence

`dist/` is a committed build artifact (per the note in `orchestrate-mcp/.gitignore`). A source change that skips `npm run build` ships a stale bundle silently, because the tests run against `src/`. A CI check that runs `npm run build` and fails on a non-empty `git diff -- dist/` would catch this — recommended as a follow-up.

## Test plan

- [x] `npm run build` clean — only `dist/index.js` changed (`context-watchdog.js` rebuilt byte-identical)
- [x] Verified `dist/index.js` now contains `core.sshCommand=ssh`
- [ ] After merge: `/plugin marketplace update` → orchestrate 1.0.3 → re-run `/orchestrate 181`

Relates to #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)