### PR TITLE
fix(orchestrate): correct capability-tool MCP namespace in subagent definitions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-engineering-toolkit",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Multi-plugin marketplace for evidence-based Claude Code artifact engineering. Provides plugins for configuration initialization (AGENTS.md, CLAUDE.md), artifact creation/optimization (skills, hooks, rules, subagents), and autonomous backlog orchestration.",
   "owner": {
     "name": "rodrigorjsf",
@@ -33,7 +33,7 @@
     {
       "name": "orchestrate",
       "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"

--- a/plugins/orchestrate/.claude-plugin/plugin.json
+++ b/plugins/orchestrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestrate",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
   "author": {
     "name": "rodrigorjsf"

--- a/plugins/orchestrate/agents/conflict-resolver-deep.md
+++ b/plugins/orchestrate/agents/conflict-resolver-deep.md
@@ -1,7 +1,7 @@
 ---
 name: conflict-resolver-deep
 description: Resolves a merge conflict between a slice branch and the umbrella branch — edits the conflicted files to a correct merged state and re-verifies. Deep-effort variant for complex, high-risk issues. Spawned by the orchestrate skill; not invoked directly.
-tools: Read, Edit, Write, Grep, Glob, mcp__orchestrate__run_tests, mcp__orchestrate__run_typecheck, mcp__orchestrate__run_build, mcp__orchestrate__run_lint
+tools: Read, Edit, Write, Grep, Glob, mcp__plugin_orchestrate_orchestrate__run_tests, mcp__plugin_orchestrate_orchestrate__run_typecheck, mcp__plugin_orchestrate_orchestrate__run_build, mcp__plugin_orchestrate_orchestrate__run_lint
 model: opus
 effort: xhigh
 maxTurns: 40

--- a/plugins/orchestrate/agents/conflict-resolver-standard.md
+++ b/plugins/orchestrate/agents/conflict-resolver-standard.md
@@ -1,7 +1,7 @@
 ---
 name: conflict-resolver-standard
 description: Resolves a merge conflict between a slice branch and the umbrella branch — edits the conflicted files to a correct merged state and re-verifies. Standard-effort variant for trivial- and standard-tier issues. Spawned by the orchestrate skill; not invoked directly.
-tools: Read, Edit, Write, Grep, Glob, mcp__orchestrate__run_tests, mcp__orchestrate__run_typecheck, mcp__orchestrate__run_build, mcp__orchestrate__run_lint
+tools: Read, Edit, Write, Grep, Glob, mcp__plugin_orchestrate_orchestrate__run_tests, mcp__plugin_orchestrate_orchestrate__run_typecheck, mcp__plugin_orchestrate_orchestrate__run_build, mcp__plugin_orchestrate_orchestrate__run_lint
 model: sonnet
 maxTurns: 30
 ---

--- a/plugins/orchestrate/agents/implementer-deep.md
+++ b/plugins/orchestrate/agents/implementer-deep.md
@@ -1,7 +1,7 @@
 ---
 name: implementer-deep
 description: Implements a single tracked issue inside an isolated git worktree — edits files and verifies the work through the orchestrate capability tools. Deep-effort variant for complex, high-risk issues. Spawned by the orchestrate skill; not invoked directly.
-tools: Read, Edit, Write, Grep, Glob, mcp__orchestrate__run_tests, mcp__orchestrate__run_typecheck, mcp__orchestrate__run_build, mcp__orchestrate__run_lint
+tools: Read, Edit, Write, Grep, Glob, mcp__plugin_orchestrate_orchestrate__run_tests, mcp__plugin_orchestrate_orchestrate__run_typecheck, mcp__plugin_orchestrate_orchestrate__run_build, mcp__plugin_orchestrate_orchestrate__run_lint
 model: opus
 effort: xhigh
 maxTurns: 70

--- a/plugins/orchestrate/agents/implementer-standard.md
+++ b/plugins/orchestrate/agents/implementer-standard.md
@@ -1,7 +1,7 @@
 ---
 name: implementer-standard
 description: Implements a single tracked issue inside an isolated git worktree — edits files and verifies the work through the orchestrate capability tools. Standard-effort variant for trivial- and standard-tier issues. Spawned by the orchestrate skill; not invoked directly.
-tools: Read, Edit, Write, Grep, Glob, mcp__orchestrate__run_tests, mcp__orchestrate__run_typecheck, mcp__orchestrate__run_build, mcp__orchestrate__run_lint
+tools: Read, Edit, Write, Grep, Glob, mcp__plugin_orchestrate_orchestrate__run_tests, mcp__plugin_orchestrate_orchestrate__run_typecheck, mcp__plugin_orchestrate_orchestrate__run_build, mcp__plugin_orchestrate_orchestrate__run_lint
 model: sonnet
 maxTurns: 50
 ---

--- a/plugins/orchestrate/agents/investigator-deep.md
+++ b/plugins/orchestrate/agents/investigator-deep.md
@@ -1,7 +1,7 @@
 ---
 name: investigator-deep
 description: Investigates the codebase and issue before implementation — explores relevant files, patterns, and risks, then returns a research brief for the implementer. Deep-effort variant for complex-tier issues requiring wider exploration. Spawned by the orchestrate skill before the implementer; not invoked directly.
-tools: Read, Grep, Glob, mcp__orchestrate__search_structural
+tools: Read, Grep, Glob, mcp__plugin_orchestrate_orchestrate__search_structural
 model: opus
 effort: xhigh
 maxTurns: 30

--- a/plugins/orchestrate/agents/investigator-standard.md
+++ b/plugins/orchestrate/agents/investigator-standard.md
@@ -1,7 +1,7 @@
 ---
 name: investigator-standard
 description: Investigates the codebase and issue before implementation — explores relevant files, patterns, and risks, then returns a research brief for the implementer. Standard-effort variant for complex-tier issues. Spawned by the orchestrate skill before the implementer; not invoked directly.
-tools: Read, Grep, Glob, mcp__orchestrate__search_structural
+tools: Read, Grep, Glob, mcp__plugin_orchestrate_orchestrate__search_structural
 model: sonnet
 maxTurns: 20
 ---

--- a/plugins/orchestrate/agents/reviewer-deep.md
+++ b/plugins/orchestrate/agents/reviewer-deep.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer-deep
 description: Reviews an implemented slice inside its git worktree — fixes clarity and consistency issues inline, re-runs the orchestrate capability tools, and gates the auto-merge. Deep-effort variant for complex, high-risk issues. Spawned by the orchestrate skill; not invoked directly.
-tools: Read, Edit, Write, Grep, Glob, mcp__orchestrate__run_tests, mcp__orchestrate__run_typecheck, mcp__orchestrate__run_build, mcp__orchestrate__run_lint, mcp__orchestrate__search_structural
+tools: Read, Edit, Write, Grep, Glob, mcp__plugin_orchestrate_orchestrate__run_tests, mcp__plugin_orchestrate_orchestrate__run_typecheck, mcp__plugin_orchestrate_orchestrate__run_build, mcp__plugin_orchestrate_orchestrate__run_lint, mcp__plugin_orchestrate_orchestrate__search_structural
 model: opus
 effort: xhigh
 maxTurns: 55

--- a/plugins/orchestrate/agents/reviewer-standard.md
+++ b/plugins/orchestrate/agents/reviewer-standard.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer-standard
 description: Reviews an implemented slice inside its git worktree — fixes clarity and consistency issues inline, re-runs the orchestrate capability tools, and gates the auto-merge. Standard-effort variant for trivial- and standard-tier issues. Spawned by the orchestrate skill; not invoked directly.
-tools: Read, Edit, Write, Grep, Glob, mcp__orchestrate__run_tests, mcp__orchestrate__run_typecheck, mcp__orchestrate__run_build, mcp__orchestrate__run_lint, mcp__orchestrate__search_structural
+tools: Read, Edit, Write, Grep, Glob, mcp__plugin_orchestrate_orchestrate__run_tests, mcp__plugin_orchestrate_orchestrate__run_typecheck, mcp__plugin_orchestrate_orchestrate__run_build, mcp__plugin_orchestrate_orchestrate__run_lint, mcp__plugin_orchestrate_orchestrate__search_structural
 model: sonnet
 maxTurns: 40
 ---


### PR DESCRIPTION
## Summary

- The eight bundled orchestrate subagent definitions (`investigator`/`implementer`/`reviewer`/`conflict-resolver`, each `-standard` and `-deep`) granted the capability MCP tools as `mcp__orchestrate__*` in their `tools:` frontmatter. The Claude Code harness exposes the plugin's MCP server tools as `mcp__plugin_orchestrate_orchestrate__*`, so the names matched no registered tool — every spawned subagent received only `Read/Edit/Write/Grep/Glob` and **no capability tools at all**.
- Consequence: subagents could not run `run_tests` / `run_typecheck` / `run_build` / `run_lint` or `search_structural`. The `/tdd` red-green contract could not execute in the sandbox, `dist/` could not be rebuilt by a subagent, and the orchestrate run could not self-verify any slice — a silent-failure class exactly like the F-001..F-011 defects PRD #181 targets.
- Fix: corrected the `tools:` namespace in all 8 definitions; bumped the orchestrate plugin to 1.0.4 and the marketplace manifest to 1.4.3.

## Context

Discovered during a `/orchestrate 181` run when every Wave 0 implementer independently reported the capability tools unavailable. Filed as #204. Fixed manually via this PR rather than as an orchestrate slice because of the dogfooding catch-22 — a plugin whose self-verification is broken cannot safely self-fix it — the same pattern used for #184 / #185 / #188.

## Test plan

- [ ] Merge, then `/plugin marketplace update` + `/reload-plugins` to install orchestrate 1.0.4.
- [ ] Empirically probe: spawn an `orchestrate:implementer-standard` subagent and confirm it can invoke `mcp__plugin_orchestrate_orchestrate__run_tests` against a worktree.
- [ ] Restart `/orchestrate 181` and confirm subagents verify their slices through the capability tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)