### PR TITLE
fix(orchestrate): install worktree dependencies after create_worktree (#207)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-engineering-toolkit",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Multi-plugin marketplace for evidence-based Claude Code artifact engineering. Provides plugins for configuration initialization (AGENTS.md, CLAUDE.md), artifact creation/optimization (skills, hooks, rules, subagents), and autonomous backlog orchestration.",
   "owner": {
     "name": "rodrigorjsf",
@@ -33,7 +33,7 @@
     {
       "name": "orchestrate",
       "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"

--- a/.orchestrate/commands.json
+++ b/.orchestrate/commands.json
@@ -1,5 +1,6 @@
 {
   "tests": ["npm", "--prefix", "plugins/orchestrate/orchestrate-mcp", "run", "test"],
   "typecheck": ["npm", "--prefix", "plugins/orchestrate/orchestrate-mcp", "run", "typecheck"],
-  "build": ["npm", "--prefix", "plugins/orchestrate/orchestrate-mcp", "run", "build"]
+  "build": ["npm", "--prefix", "plugins/orchestrate/orchestrate-mcp", "run", "build"],
+  "install": ["npm", "--prefix", "plugins/orchestrate/orchestrate-mcp", "ci"]
 }

--- a/plugins/orchestrate/.claude-plugin/plugin.json
+++ b/plugins/orchestrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestrate",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
   "author": {
     "name": "rodrigorjsf"

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -21636,11 +21636,14 @@ async function createWorktree(input) {
   }
   const install = await runInstall({ repoPath: absWorktreePath });
   if (install.status === "failed" || install.status === "error") {
-    const detail = install.status === "failed" ? `the install command exited ${install.exitCode}` : install.errorMessage;
+    const detail = install.status === "failed" ? `the install command exited ${install.exitCode ?? "(unknown)"}` : install.errorMessage ?? "unknown error";
+    const stderrTail = install.stderr?.trim() ? `
+Install stderr (tail):
+${install.stderr.trim().slice(-1e3)}` : "";
     return {
       status: "error",
       errorCode: "INSTALL_FAILED",
-      errorMessage: `The worktree was created at ${absWorktreePath} but the dependency install step failed (${detail}). The worktree is left on disk for inspection.`
+      errorMessage: `The worktree was created at ${absWorktreePath} but the dependency install step failed (${detail}). The worktree is left on disk for inspection.${stderrTail}`
     };
   }
   return {

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -21102,8 +21102,8 @@ var StdioServerTransport = class {
 };
 
 // src/tools/worktree.ts
-var path = __toESM(require("path"));
-var fs = __toESM(require("fs"));
+var path2 = __toESM(require("path"));
+var fs2 = __toESM(require("fs"));
 
 // src/git.ts
 var import_child_process = require("child_process");
@@ -21184,292 +21184,9 @@ function cleanGitError(err) {
   return firstLine7 ?? "Unknown git error";
 }
 
-// src/tools/worktree.ts
-var createWorktreeInputSchema = external_exports.object({
-  baseRef: external_exports.string().describe(
-    "The git ref (branch, tag, or SHA) to branch the new worktree from. A 'git fetch' is attempted before branching; see the `fetchStatus` output field for whether it ran."
-  ),
-  branch: external_exports.string().describe(
-    "Name of the new local branch to create for the worktree. Must not already exist (see the BRANCH_EXISTS error code)."
-  ),
-  worktreePath: external_exports.string().describe(
-    "Absolute or relative (to `repoPath`) filesystem path where the worktree will be created. Must not already exist."
-  ),
-  repoPath: external_exports.string().optional().describe(
-    "Path to the git repository. Defaults to the current working directory."
-  )
-});
-var removeWorktreeInputSchema = external_exports.object({
-  worktreePath: external_exports.string().describe(
-    "Absolute or relative (to `repoPath`) path to the worktree ROOT to remove. Must be a registered worktree root, not a subdirectory of one."
-  ),
-  repoPath: external_exports.string().optional().describe(
-    "Path to the git repository that owns the worktree. Defaults to the current working directory."
-  ),
-  force: external_exports.boolean().optional().describe(
-    "When true, remove the worktree even if it has uncommitted or untracked changes ('git worktree remove --force'), and the dirty check is skipped. Default false \u2014 a dirty worktree is refused. The registered-worktree-root guard is always enforced, force or not."
-  )
-});
-var createWorktreeOutputSchema = external_exports.object({
-  status: external_exports.enum(["ok", "error"]).describe(
-    "Outcome discriminant. 'ok' = worktree created; 'error' = creation failed. create_worktree never refuses."
-  ),
-  path: external_exports.string().optional().describe(
-    "Absolute filesystem path of the created worktree. Present when status='ok'."
-  ),
-  branch: external_exports.string().optional().describe("Name of the branch in the worktree. Present when status='ok'."),
-  fetchStatus: external_exports.enum(["ok", "skipped-no-remote", "failed"]).optional().describe(
-    "Outcome of the pre-branch 'git fetch'. Present when status='ok'. 'ok' = fetch succeeded; 'skipped-no-remote' = no remote configured; 'failed' = a remote exists but fetch threw (the worktree was still created from a possibly-stale ref \u2014 see `fetchError`)."
-  ),
-  fetchError: external_exports.string().optional().describe(
-    "Cleaned, human-readable reason the fetch failed. Present only when fetchStatus='failed'."
-  ),
-  errorCode: external_exports.enum([
-    "INVALID_INPUT",
-    "BRANCH_EXISTS",
-    "PATH_EXISTS",
-    "BASE_REF_NOT_FOUND",
-    "GIT_ERROR"
-  ]).optional().describe("Machine-readable failure category. Present when status='error'."),
-  errorMessage: external_exports.string().optional().describe(
-    "Cleaned, human-readable failure description. Present when status='error'."
-  )
-});
-var removeWorktreeOutputSchema = external_exports.object({
-  status: external_exports.enum(["ok", "refused", "error"]).describe(
-    "Outcome discriminant. 'ok' = worktree removed; 'refused' = worktree had uncommitted/untracked changes and was left intact; 'error' = the request could not be processed."
-  ),
-  removedPath: external_exports.string().optional().describe(
-    "Absolute path of the worktree that was removed. Present when status='ok'."
-  ),
-  dirtyFiles: external_exports.array(external_exports.string()).optional().describe(
-    "Real path strings of the uncommitted/untracked files that triggered the refusal. Present when status='refused'. Each entry is a single path \u2014 rename/copy entries are never rendered as 'old -> new'."
-  ),
-  refusalReason: external_exports.string().optional().describe(
-    "Human-readable explanation of why removal was refused. Present when status='refused'."
-  ),
-  errorCode: external_exports.enum(["INVALID_INPUT", "PATH_NOT_FOUND", "NOT_A_WORKTREE", "GIT_ERROR"]).optional().describe("Machine-readable failure category. Present when status='error'."),
-  errorMessage: external_exports.string().optional().describe(
-    "Cleaned, human-readable failure description. Present when status='error'."
-  )
-});
-function classifyCreateError(err) {
-  const stderr = (err instanceof GitExecError ? err.stderr : "").toLowerCase();
-  if (stderr.includes("already exists")) {
-    return "PATH_EXISTS";
-  }
-  if (stderr.includes("not a valid") || stderr.includes("invalid reference") || stderr.includes("unknown revision")) {
-    return "BASE_REF_NOT_FOUND";
-  }
-  return "GIT_ERROR";
-}
-function resolveWorktreePath(worktreePath, cwd) {
-  return path.isAbsolute(worktreePath) ? worktreePath : path.resolve(cwd, worktreePath);
-}
-function canonicalize(p) {
-  try {
-    return fs.realpathSync(p);
-  } catch {
-    return path.resolve(p);
-  }
-}
-async function branchExists(branch, cwd) {
-  try {
-    await gitExecFile(
-      ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`],
-      cwd
-    );
-    return true;
-  } catch {
-    return false;
-  }
-}
-async function listWorktreeRoots(cwd) {
-  const { stdout } = await gitExecFile(
-    ["worktree", "list", "--porcelain"],
-    cwd
-  );
-  const roots = [];
-  for (const line of stdout.split("\n")) {
-    if (line.startsWith("worktree ")) {
-      roots.push(line.slice("worktree ".length).trim());
-    }
-  }
-  return roots;
-}
-async function createWorktree(input) {
-  const { baseRef, branch, worktreePath } = input;
-  const cwd = input.repoPath ?? process.cwd();
-  for (const [field, value] of [
-    ["branch", branch],
-    ["baseRef", baseRef],
-    ["worktreePath", worktreePath]
-  ]) {
-    const guardErr = optionInjectionError(field, value);
-    if (guardErr) {
-      return {
-        status: "error",
-        errorCode: "INVALID_INPUT",
-        errorMessage: guardErr
-      };
-    }
-  }
-  if (await branchExists(branch, cwd)) {
-    return {
-      status: "error",
-      errorCode: "BRANCH_EXISTS",
-      errorMessage: `A branch named "${branch}" already exists.`
-    };
-  }
-  let fetchStatus;
-  let fetchError;
-  try {
-    const { stdout: remotes } = await gitExecFile(["remote"], cwd);
-    if (remotes.trim().length === 0) {
-      fetchStatus = "skipped-no-remote";
-    } else {
-      try {
-        await gitExecFile(["fetch", "--all", "--prune"], cwd);
-        fetchStatus = "ok";
-      } catch (err) {
-        fetchStatus = "failed";
-        fetchError = cleanGitError(err);
-      }
-    }
-  } catch (err) {
-    fetchStatus = "failed";
-    fetchError = cleanGitError(err);
-  }
-  const absWorktreePath = resolveWorktreePath(worktreePath, cwd);
-  try {
-    await gitExecFile(
-      ["worktree", "add", "-b", branch, "--", absWorktreePath, baseRef],
-      cwd
-    );
-  } catch (err) {
-    try {
-      await gitExecFile(["branch", "-D", branch], cwd);
-    } catch {
-    }
-    return {
-      status: "error",
-      errorCode: classifyCreateError(err),
-      errorMessage: cleanGitError(err)
-    };
-  }
-  return {
-    status: "ok",
-    path: absWorktreePath,
-    branch,
-    fetchStatus,
-    ...fetchError ? { fetchError } : {}
-  };
-}
-async function removeWorktree(input) {
-  const { worktreePath } = input;
-  const cwd = input.repoPath ?? process.cwd();
-  const guardErr = optionInjectionError("worktreePath", worktreePath);
-  if (guardErr) {
-    return {
-      status: "error",
-      errorCode: "INVALID_INPUT",
-      errorMessage: guardErr
-    };
-  }
-  const absWorktreePath = resolveWorktreePath(worktreePath, cwd);
-  if (!fs.existsSync(absWorktreePath)) {
-    return {
-      status: "error",
-      errorCode: "PATH_NOT_FOUND",
-      errorMessage: `Worktree path does not exist: ${absWorktreePath}`
-    };
-  }
-  let worktreeRoots;
-  try {
-    worktreeRoots = await listWorktreeRoots(cwd);
-  } catch (err) {
-    return {
-      status: "error",
-      errorCode: "GIT_ERROR",
-      errorMessage: cleanGitError(err)
-    };
-  }
-  const canonicalTarget = canonicalize(absWorktreePath);
-  const isRegisteredRoot = worktreeRoots.some(
-    (root) => canonicalize(root) === canonicalTarget
-  );
-  if (!isRegisteredRoot) {
-    return {
-      status: "error",
-      errorCode: "NOT_A_WORKTREE",
-      errorMessage: `Path is not a registered git worktree root: ${absWorktreePath}`
-    };
-  }
-  const force = input.force ?? false;
-  if (!force) {
-    let porcelain;
-    try {
-      const { stdout } = await gitExecFile(
-        ["status", "--porcelain", "-z"],
-        absWorktreePath
-      );
-      porcelain = stdout;
-    } catch (err) {
-      return {
-        status: "error",
-        errorCode: "GIT_ERROR",
-        errorMessage: cleanGitError(err)
-      };
-    }
-    const dirtyFiles = parsePorcelainZ(porcelain);
-    if (dirtyFiles.length > 0) {
-      return {
-        status: "refused",
-        dirtyFiles,
-        refusalReason: "Worktree has uncommitted or untracked changes; removal refused. The worktree and its branch have been left intact. Pass force=true to remove it anyway."
-      };
-    }
-  }
-  const removeArgs = force ? ["worktree", "remove", "--force", "--", absWorktreePath] : ["worktree", "remove", "--", absWorktreePath];
-  try {
-    await gitExecFile(removeArgs, cwd);
-  } catch (err) {
-    return {
-      status: "error",
-      errorCode: "GIT_ERROR",
-      errorMessage: cleanGitError(err)
-    };
-  }
-  return {
-    status: "ok",
-    removedPath: absWorktreePath
-  };
-}
-function parsePorcelainZ(porcelain) {
-  const tokens = porcelain.split("\0").filter((t) => t.length > 0);
-  const paths = [];
-  for (let i = 0; i < tokens.length; i++) {
-    const token = tokens[i];
-    const statusPrefix = token.slice(0, 2);
-    const renameOrCopy = statusPrefix.includes("R") || statusPrefix.includes("C");
-    const filePath = token.slice(3);
-    if (filePath.length > 0) {
-      paths.push(filePath);
-    }
-    if (renameOrCopy) {
-      const source = tokens[i + 1];
-      if (source !== void 0 && source.length > 0) {
-        paths.push(source);
-        i++;
-      }
-    }
-  }
-  return paths;
-}
-
 // src/tools/run-command.ts
-var path2 = __toESM(require("path"));
-var fs2 = __toESM(require("fs"));
+var path = __toESM(require("path"));
+var fs = __toESM(require("fs"));
 var import_child_process2 = require("child_process");
 var import_util7 = require("util");
 var execFileAsync2 = (0, import_util7.promisify)(import_child_process2.execFile);
@@ -21480,7 +21197,8 @@ var commandsConfigSchema = external_exports.object({
   tests: external_exports.array(external_exports.string().min(1)).optional(),
   typecheck: external_exports.array(external_exports.string().min(1)).optional(),
   build: external_exports.array(external_exports.string().min(1)).optional(),
-  lint: external_exports.array(external_exports.string().min(1)).optional()
+  lint: external_exports.array(external_exports.string().min(1)).optional(),
+  install: external_exports.array(external_exports.string().min(1)).optional()
 });
 var runCommandInputSchema = external_exports.object({
   repoPath: external_exports.string().optional().describe(
@@ -21587,18 +21305,15 @@ async function execCommand(argv, cwd, timeoutMs) {
     };
   }
 }
-async function runConfiguredCommand(verb, input, opts = {}) {
-  const cwd = input.repoPath ?? process.cwd();
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const configPath = path2.join(cwd, ".orchestrate", "commands.json");
+function loadCommandsConfig(cwd) {
+  const configPath = path.join(cwd, ".orchestrate", "commands.json");
   let raw;
   try {
-    raw = fs2.readFileSync(configPath, "utf8");
+    raw = fs.readFileSync(configPath, "utf8");
   } catch {
     return {
-      status: "not-configured",
-      capability: verb,
-      reason: `No .orchestrate/commands.json found in ${cwd}. Copy the orchestrate plugin's templates/commands.json to .orchestrate/commands.json and set the "${verb}" command.`
+      kind: "not-configured",
+      reason: `No .orchestrate/commands.json found in ${cwd}. Copy the orchestrate plugin's templates/commands.json to .orchestrate/commands.json.`
     };
   }
   let parsed;
@@ -21606,9 +21321,7 @@ async function runConfiguredCommand(verb, input, opts = {}) {
     parsed = JSON.parse(raw);
   } catch (err) {
     return {
-      status: "error",
-      capability: verb,
-      errorCode: "CONFIG_INVALID",
+      kind: "invalid",
       errorMessage: `.orchestrate/commands.json is not valid JSON: ${firstLine(
         err instanceof Error ? err.message : String(err)
       )}`
@@ -21618,13 +21331,28 @@ async function runConfiguredCommand(verb, input, opts = {}) {
   if (!config2.success) {
     const detail = config2.error.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`).join("; ");
     return {
-      status: "error",
-      capability: verb,
-      errorCode: "CONFIG_INVALID",
+      kind: "invalid",
       errorMessage: `.orchestrate/commands.json does not match the expected shape: ${detail}`
     };
   }
-  const argv = config2.data[verb];
+  return { kind: "loaded", config: config2.data };
+}
+async function runConfiguredCommand(verb, input, opts = {}) {
+  const cwd = input.repoPath ?? process.cwd();
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const loaded = loadCommandsConfig(cwd);
+  if (loaded.kind === "not-configured") {
+    return { status: "not-configured", capability: verb, reason: loaded.reason };
+  }
+  if (loaded.kind === "invalid") {
+    return {
+      status: "error",
+      capability: verb,
+      errorCode: "CONFIG_INVALID",
+      errorMessage: loaded.errorMessage
+    };
+  }
+  const argv = loaded.config[verb];
   if (!argv || argv.length === 0) {
     return {
       status: "not-configured",
@@ -21673,6 +21401,358 @@ var runTests = (input, opts) => runConfiguredCommand("tests", input, opts);
 var runTypecheck = (input, opts) => runConfiguredCommand("typecheck", input, opts);
 var runBuild = (input, opts) => runConfiguredCommand("build", input, opts);
 var runLint = (input, opts) => runConfiguredCommand("lint", input, opts);
+async function runInstall(input, opts = {}) {
+  const cwd = input.repoPath ?? process.cwd();
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const loaded = loadCommandsConfig(cwd);
+  if (loaded.kind === "not-configured") {
+    return { status: "not-configured", reason: loaded.reason };
+  }
+  if (loaded.kind === "invalid") {
+    return {
+      status: "error",
+      errorCode: "CONFIG_INVALID",
+      errorMessage: loaded.errorMessage
+    };
+  }
+  const argv = loaded.config.install;
+  if (!argv || argv.length === 0) {
+    return {
+      status: "not-configured",
+      reason: `No "install" command is configured in .orchestrate/commands.json.`
+    };
+  }
+  const exec = await execCommand(argv, cwd, timeoutMs);
+  if (exec.kind === "timeout") {
+    const out2 = capOutput(exec.stdout);
+    const errOut2 = capOutput(exec.stderr);
+    return {
+      status: "error",
+      errorCode: "TIMEOUT",
+      errorMessage: `The "install" command exceeded the ${timeoutMs} ms time limit and was killed.`,
+      stdout: out2.text,
+      stderr: errOut2.text,
+      truncated: out2.truncated || errOut2.truncated,
+      durationMs: exec.durationMs
+    };
+  }
+  if (exec.kind === "exec-error") {
+    return {
+      status: "error",
+      errorCode: "EXEC_ERROR",
+      errorMessage: `The "install" command could not be executed: ${exec.message}`,
+      durationMs: exec.durationMs
+    };
+  }
+  const out = capOutput(exec.stdout);
+  const errOut = capOutput(exec.stderr);
+  return {
+    status: exec.exitCode === 0 ? "installed" : "failed",
+    command: argv,
+    exitCode: exec.exitCode,
+    stdout: out.text,
+    stderr: errOut.text,
+    truncated: out.truncated || errOut.truncated,
+    durationMs: exec.durationMs
+  };
+}
+
+// src/tools/worktree.ts
+var createWorktreeInputSchema = external_exports.object({
+  baseRef: external_exports.string().describe(
+    "The git ref (branch, tag, or SHA) to branch the new worktree from. A 'git fetch' is attempted before branching; see the `fetchStatus` output field for whether it ran."
+  ),
+  branch: external_exports.string().describe(
+    "Name of the new local branch to create for the worktree. Must not already exist (see the BRANCH_EXISTS error code)."
+  ),
+  worktreePath: external_exports.string().describe(
+    "Absolute or relative (to `repoPath`) filesystem path where the worktree will be created. Must not already exist."
+  ),
+  repoPath: external_exports.string().optional().describe(
+    "Path to the git repository. Defaults to the current working directory."
+  )
+});
+var removeWorktreeInputSchema = external_exports.object({
+  worktreePath: external_exports.string().describe(
+    "Absolute or relative (to `repoPath`) path to the worktree ROOT to remove. Must be a registered worktree root, not a subdirectory of one."
+  ),
+  repoPath: external_exports.string().optional().describe(
+    "Path to the git repository that owns the worktree. Defaults to the current working directory."
+  ),
+  force: external_exports.boolean().optional().describe(
+    "When true, remove the worktree even if it has uncommitted or untracked changes ('git worktree remove --force'), and the dirty check is skipped. Default false \u2014 a dirty worktree is refused. The registered-worktree-root guard is always enforced, force or not."
+  )
+});
+var createWorktreeOutputSchema = external_exports.object({
+  status: external_exports.enum(["ok", "error"]).describe(
+    "Outcome discriminant. 'ok' = worktree created; 'error' = creation failed. create_worktree never refuses."
+  ),
+  path: external_exports.string().optional().describe(
+    "Absolute filesystem path of the created worktree. Present when status='ok'."
+  ),
+  branch: external_exports.string().optional().describe("Name of the branch in the worktree. Present when status='ok'."),
+  fetchStatus: external_exports.enum(["ok", "skipped-no-remote", "failed"]).optional().describe(
+    "Outcome of the pre-branch 'git fetch'. Present when status='ok'. 'ok' = fetch succeeded; 'skipped-no-remote' = no remote configured; 'failed' = a remote exists but fetch threw (the worktree was still created from a possibly-stale ref \u2014 see `fetchError`)."
+  ),
+  fetchError: external_exports.string().optional().describe(
+    "Cleaned, human-readable reason the fetch failed. Present only when fetchStatus='failed'."
+  ),
+  installStatus: external_exports.enum(["installed", "not-configured"]).optional().describe(
+    "Outcome of the post-creation dependency install. Present when status='ok'. 'installed' = the configured install command ran and exited 0; 'not-configured' = no install command is set, so the step was a no-op. An install that fails makes the whole call status='error' with errorCode='INSTALL_FAILED' \u2014 it is never reported here."
+  ),
+  errorCode: external_exports.enum([
+    "INVALID_INPUT",
+    "BRANCH_EXISTS",
+    "PATH_EXISTS",
+    "BASE_REF_NOT_FOUND",
+    "GIT_ERROR",
+    "INSTALL_FAILED"
+  ]).optional().describe("Machine-readable failure category. Present when status='error'."),
+  errorMessage: external_exports.string().optional().describe(
+    "Cleaned, human-readable failure description. Present when status='error'."
+  )
+});
+var removeWorktreeOutputSchema = external_exports.object({
+  status: external_exports.enum(["ok", "refused", "error"]).describe(
+    "Outcome discriminant. 'ok' = worktree removed; 'refused' = worktree had uncommitted/untracked changes and was left intact; 'error' = the request could not be processed."
+  ),
+  removedPath: external_exports.string().optional().describe(
+    "Absolute path of the worktree that was removed. Present when status='ok'."
+  ),
+  dirtyFiles: external_exports.array(external_exports.string()).optional().describe(
+    "Real path strings of the uncommitted/untracked files that triggered the refusal. Present when status='refused'. Each entry is a single path \u2014 rename/copy entries are never rendered as 'old -> new'."
+  ),
+  refusalReason: external_exports.string().optional().describe(
+    "Human-readable explanation of why removal was refused. Present when status='refused'."
+  ),
+  errorCode: external_exports.enum(["INVALID_INPUT", "PATH_NOT_FOUND", "NOT_A_WORKTREE", "GIT_ERROR"]).optional().describe("Machine-readable failure category. Present when status='error'."),
+  errorMessage: external_exports.string().optional().describe(
+    "Cleaned, human-readable failure description. Present when status='error'."
+  )
+});
+function classifyCreateError(err) {
+  const stderr = (err instanceof GitExecError ? err.stderr : "").toLowerCase();
+  if (stderr.includes("already exists")) {
+    return "PATH_EXISTS";
+  }
+  if (stderr.includes("not a valid") || stderr.includes("invalid reference") || stderr.includes("unknown revision")) {
+    return "BASE_REF_NOT_FOUND";
+  }
+  return "GIT_ERROR";
+}
+function resolveWorktreePath(worktreePath, cwd) {
+  return path2.isAbsolute(worktreePath) ? worktreePath : path2.resolve(cwd, worktreePath);
+}
+function canonicalize(p) {
+  try {
+    return fs2.realpathSync(p);
+  } catch {
+    return path2.resolve(p);
+  }
+}
+async function branchExists(branch, cwd) {
+  try {
+    await gitExecFile(
+      ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`],
+      cwd
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+async function listWorktreeRoots(cwd) {
+  const { stdout } = await gitExecFile(
+    ["worktree", "list", "--porcelain"],
+    cwd
+  );
+  const roots = [];
+  for (const line of stdout.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      roots.push(line.slice("worktree ".length).trim());
+    }
+  }
+  return roots;
+}
+async function createWorktree(input) {
+  const { baseRef, branch, worktreePath } = input;
+  const cwd = input.repoPath ?? process.cwd();
+  for (const [field, value] of [
+    ["branch", branch],
+    ["baseRef", baseRef],
+    ["worktreePath", worktreePath]
+  ]) {
+    const guardErr = optionInjectionError(field, value);
+    if (guardErr) {
+      return {
+        status: "error",
+        errorCode: "INVALID_INPUT",
+        errorMessage: guardErr
+      };
+    }
+  }
+  if (await branchExists(branch, cwd)) {
+    return {
+      status: "error",
+      errorCode: "BRANCH_EXISTS",
+      errorMessage: `A branch named "${branch}" already exists.`
+    };
+  }
+  let fetchStatus;
+  let fetchError;
+  try {
+    const { stdout: remotes } = await gitExecFile(["remote"], cwd);
+    if (remotes.trim().length === 0) {
+      fetchStatus = "skipped-no-remote";
+    } else {
+      try {
+        await gitExecFile(["fetch", "--all", "--prune"], cwd);
+        fetchStatus = "ok";
+      } catch (err) {
+        fetchStatus = "failed";
+        fetchError = cleanGitError(err);
+      }
+    }
+  } catch (err) {
+    fetchStatus = "failed";
+    fetchError = cleanGitError(err);
+  }
+  const absWorktreePath = resolveWorktreePath(worktreePath, cwd);
+  try {
+    await gitExecFile(
+      ["worktree", "add", "-b", branch, "--", absWorktreePath, baseRef],
+      cwd
+    );
+  } catch (err) {
+    try {
+      await gitExecFile(["branch", "-D", branch], cwd);
+    } catch {
+    }
+    return {
+      status: "error",
+      errorCode: classifyCreateError(err),
+      errorMessage: cleanGitError(err)
+    };
+  }
+  const install = await runInstall({ repoPath: absWorktreePath });
+  if (install.status === "failed" || install.status === "error") {
+    const detail = install.status === "failed" ? `the install command exited ${install.exitCode}` : install.errorMessage;
+    return {
+      status: "error",
+      errorCode: "INSTALL_FAILED",
+      errorMessage: `The worktree was created at ${absWorktreePath} but the dependency install step failed (${detail}). The worktree is left on disk for inspection.`
+    };
+  }
+  return {
+    status: "ok",
+    path: absWorktreePath,
+    branch,
+    fetchStatus,
+    ...fetchError ? { fetchError } : {},
+    installStatus: install.status
+  };
+}
+async function removeWorktree(input) {
+  const { worktreePath } = input;
+  const cwd = input.repoPath ?? process.cwd();
+  const guardErr = optionInjectionError("worktreePath", worktreePath);
+  if (guardErr) {
+    return {
+      status: "error",
+      errorCode: "INVALID_INPUT",
+      errorMessage: guardErr
+    };
+  }
+  const absWorktreePath = resolveWorktreePath(worktreePath, cwd);
+  if (!fs2.existsSync(absWorktreePath)) {
+    return {
+      status: "error",
+      errorCode: "PATH_NOT_FOUND",
+      errorMessage: `Worktree path does not exist: ${absWorktreePath}`
+    };
+  }
+  let worktreeRoots;
+  try {
+    worktreeRoots = await listWorktreeRoots(cwd);
+  } catch (err) {
+    return {
+      status: "error",
+      errorCode: "GIT_ERROR",
+      errorMessage: cleanGitError(err)
+    };
+  }
+  const canonicalTarget = canonicalize(absWorktreePath);
+  const isRegisteredRoot = worktreeRoots.some(
+    (root) => canonicalize(root) === canonicalTarget
+  );
+  if (!isRegisteredRoot) {
+    return {
+      status: "error",
+      errorCode: "NOT_A_WORKTREE",
+      errorMessage: `Path is not a registered git worktree root: ${absWorktreePath}`
+    };
+  }
+  const force = input.force ?? false;
+  if (!force) {
+    let porcelain;
+    try {
+      const { stdout } = await gitExecFile(
+        ["status", "--porcelain", "-z"],
+        absWorktreePath
+      );
+      porcelain = stdout;
+    } catch (err) {
+      return {
+        status: "error",
+        errorCode: "GIT_ERROR",
+        errorMessage: cleanGitError(err)
+      };
+    }
+    const dirtyFiles = parsePorcelainZ(porcelain);
+    if (dirtyFiles.length > 0) {
+      return {
+        status: "refused",
+        dirtyFiles,
+        refusalReason: "Worktree has uncommitted or untracked changes; removal refused. The worktree and its branch have been left intact. Pass force=true to remove it anyway."
+      };
+    }
+  }
+  const removeArgs = force ? ["worktree", "remove", "--force", "--", absWorktreePath] : ["worktree", "remove", "--", absWorktreePath];
+  try {
+    await gitExecFile(removeArgs, cwd);
+  } catch (err) {
+    return {
+      status: "error",
+      errorCode: "GIT_ERROR",
+      errorMessage: cleanGitError(err)
+    };
+  }
+  return {
+    status: "ok",
+    removedPath: absWorktreePath
+  };
+}
+function parsePorcelainZ(porcelain) {
+  const tokens = porcelain.split("\0").filter((t) => t.length > 0);
+  const paths = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const statusPrefix = token.slice(0, 2);
+    const renameOrCopy = statusPrefix.includes("R") || statusPrefix.includes("C");
+    const filePath = token.slice(3);
+    if (filePath.length > 0) {
+      paths.push(filePath);
+    }
+    if (renameOrCopy) {
+      const source = tokens[i + 1];
+      if (source !== void 0 && source.length > 0) {
+        paths.push(source);
+        i++;
+      }
+    }
+  }
+  return paths;
+}
 
 // src/tools/plan-waves.ts
 var planWavesInputSchema = external_exports.object({

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/run-command.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/run-command.ts
@@ -37,12 +37,18 @@ export type CapabilityVerb = (typeof CAPABILITY_VERBS)[number];
  * never be word-split, glob-expanded, or interpreted. Unknown keys are
  * stripped, so a `$schema` pointer or future additive keys do not break an
  * existing config.
+ *
+ * `install` is a setup verb, not a capability verb — it runs once after a
+ * worktree is created (a fresh worktree has no installed dependencies) so the
+ * four capability commands above have what they need. It is optional: a
+ * project whose capability commands need no install simply omits it.
  */
 export const commandsConfigSchema = z.object({
   tests: z.array(z.string().min(1)).optional(),
   typecheck: z.array(z.string().min(1)).optional(),
   build: z.array(z.string().min(1)).optional(),
   lint: z.array(z.string().min(1)).optional(),
+  install: z.array(z.string().min(1)).optional(),
 });
 
 export const runCommandInputSchema = z.object({
@@ -269,6 +275,63 @@ async function execCommand(
   }
 }
 
+/**
+ * Outcome of loading and validating `.orchestrate/commands.json`. `runInstall`
+ * and `runConfiguredCommand` share this loader so the file is read, parsed, and
+ * shape-checked in exactly one place.
+ */
+type LoadCommandsConfigResult =
+  | { kind: "loaded"; config: CommandsConfig }
+  | { kind: "not-configured"; reason: string }
+  | { kind: "invalid"; errorMessage: string };
+
+/**
+ * Reads `<cwd>/.orchestrate/commands.json` and validates it against
+ * {@link commandsConfigSchema}. A missing file is not an error — it means the
+ * project has not configured orchestrate commands yet. Malformed JSON or a
+ * wrong shape is a real misconfiguration. Never throws.
+ */
+function loadCommandsConfig(cwd: string): LoadCommandsConfigResult {
+  const configPath = path.join(cwd, ".orchestrate", "commands.json");
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, "utf8");
+  } catch {
+    return {
+      kind: "not-configured",
+      reason:
+        `No .orchestrate/commands.json found in ${cwd}. Copy the orchestrate ` +
+        `plugin's templates/commands.json to .orchestrate/commands.json.`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      kind: "invalid",
+      errorMessage: `.orchestrate/commands.json is not valid JSON: ${firstLine(
+        err instanceof Error ? err.message : String(err)
+      )}`,
+    };
+  }
+
+  const config = commandsConfigSchema.safeParse(parsed);
+  if (!config.success) {
+    const detail = config.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
+    return {
+      kind: "invalid",
+      errorMessage: `.orchestrate/commands.json does not match the expected shape: ${detail}`,
+    };
+  }
+
+  return { kind: "loaded", config: config.data };
+}
+
 // ─── Core ─────────────────────────────────────────────────────────────────────
 
 /**
@@ -286,54 +349,22 @@ export async function runConfiguredCommand(
 ): Promise<RunCommandOutput> {
   const cwd = input.repoPath ?? process.cwd();
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const configPath = path.join(cwd, ".orchestrate", "commands.json");
 
-  // Load the config file. A missing file is not an error — it means the
-  // project has not configured orchestrate commands yet.
-  let raw: string;
-  try {
-    raw = fs.readFileSync(configPath, "utf8");
-  } catch {
-    return {
-      status: "not-configured",
-      capability: verb,
-      reason:
-        `No .orchestrate/commands.json found in ${cwd}. Copy the orchestrate ` +
-        `plugin's templates/commands.json to .orchestrate/commands.json and ` +
-        `set the "${verb}" command.`,
-    };
+  const loaded = loadCommandsConfig(cwd);
+  if (loaded.kind === "not-configured") {
+    return { status: "not-configured", capability: verb, reason: loaded.reason };
   }
-
-  // Malformed JSON is a real misconfiguration the caller must fix.
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (err) {
+  if (loaded.kind === "invalid") {
     return {
       status: "error",
       capability: verb,
       errorCode: "CONFIG_INVALID",
-      errorMessage: `.orchestrate/commands.json is not valid JSON: ${firstLine(
-        err instanceof Error ? err.message : String(err)
-      )}`,
-    };
-  }
-
-  const config = commandsConfigSchema.safeParse(parsed);
-  if (!config.success) {
-    const detail = config.error.issues
-      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
-      .join("; ");
-    return {
-      status: "error",
-      capability: verb,
-      errorCode: "CONFIG_INVALID",
-      errorMessage: `.orchestrate/commands.json does not match the expected shape: ${detail}`,
+      errorMessage: loaded.errorMessage,
     };
   }
 
   // An absent key or an empty argv array both mean "this verb is unconfigured".
-  const argv = config.data[verb];
+  const argv = loaded.config[verb];
   if (!argv || argv.length === 0) {
     return {
       status: "not-configured",
@@ -399,3 +430,107 @@ export const runBuild = (input: RunCommandInput, opts?: RunCommandOptions) =>
 
 export const runLint = (input: RunCommandInput, opts?: RunCommandOptions) =>
   runConfiguredCommand("lint", input, opts);
+
+// ─── Install (setup verb) ─────────────────────────────────────────────────────
+
+/**
+ * Result of running the configured `install` command.
+ *
+ * Not an MCP tool output — `runInstall` is internal, called by `create_worktree`
+ * after a worktree is created. Mirrors the shape of {@link RunCommandOutput}
+ * minus `capability`: `install` is a setup verb, not one of the four capability
+ * verbs.
+ *
+ * - `installed` — the install command exited 0.
+ * - `not-configured` — no `install` command is set (a clean, expected state —
+ *   a project that needs no install simply omits it).
+ * - `failed` — the install command exited non-zero.
+ * - `error` — the command could not be run (invalid config, timeout, spawn
+ *   failure).
+ */
+export interface InstallResult {
+  status: "installed" | "not-configured" | "failed" | "error";
+  command?: string[];
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+  truncated?: boolean;
+  durationMs?: number;
+  reason?: string;
+  errorCode?: "CONFIG_INVALID" | "EXEC_ERROR" | "TIMEOUT";
+  errorMessage?: string;
+}
+
+/**
+ * Runs the project's configured `install` command — the dependency-install step
+ * a freshly created worktree needs before any capability command can run.
+ *
+ * Reads `<repoPath>/.orchestrate/commands.json` and executes the `install` argv
+ * with no shell. A missing file or absent `install` key is `not-configured`,
+ * never an error. Every failure mode is a structured result; this function does
+ * not throw.
+ */
+export async function runInstall(
+  input: RunCommandInput,
+  opts: RunCommandOptions = {}
+): Promise<InstallResult> {
+  const cwd = input.repoPath ?? process.cwd();
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const loaded = loadCommandsConfig(cwd);
+  if (loaded.kind === "not-configured") {
+    return { status: "not-configured", reason: loaded.reason };
+  }
+  if (loaded.kind === "invalid") {
+    return {
+      status: "error",
+      errorCode: "CONFIG_INVALID",
+      errorMessage: loaded.errorMessage,
+    };
+  }
+
+  // An absent key or an empty argv array both mean "no install step needed".
+  const argv = loaded.config.install;
+  if (!argv || argv.length === 0) {
+    return {
+      status: "not-configured",
+      reason: `No "install" command is configured in .orchestrate/commands.json.`,
+    };
+  }
+
+  const exec = await execCommand(argv, cwd, timeoutMs);
+
+  if (exec.kind === "timeout") {
+    const out = capOutput(exec.stdout);
+    const errOut = capOutput(exec.stderr);
+    return {
+      status: "error",
+      errorCode: "TIMEOUT",
+      errorMessage: `The "install" command exceeded the ${timeoutMs} ms time limit and was killed.`,
+      stdout: out.text,
+      stderr: errOut.text,
+      truncated: out.truncated || errOut.truncated,
+      durationMs: exec.durationMs,
+    };
+  }
+  if (exec.kind === "exec-error") {
+    return {
+      status: "error",
+      errorCode: "EXEC_ERROR",
+      errorMessage: `The "install" command could not be executed: ${exec.message}`,
+      durationMs: exec.durationMs,
+    };
+  }
+
+  const out = capOutput(exec.stdout);
+  const errOut = capOutput(exec.stderr);
+  return {
+    status: exec.exitCode === 0 ? "installed" : "failed",
+    command: argv,
+    exitCode: exec.exitCode,
+    stdout: out.text,
+    stderr: errOut.text,
+    truncated: out.truncated || errOut.truncated,
+    durationMs: exec.durationMs,
+  };
+}

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/worktree.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/worktree.ts
@@ -7,6 +7,7 @@ import {
   cleanGitError,
   GitExecError,
 } from "../git.js";
+import { runInstall } from "./run-command.js";
 
 // ─── Schemas — z.object is the single source of truth; TS types via z.infer ───
 
@@ -96,6 +97,16 @@ export const createWorktreeOutputSchema = z.object({
       "Cleaned, human-readable reason the fetch failed. Present only when " +
         "fetchStatus='failed'."
     ),
+  installStatus: z
+    .enum(["installed", "not-configured"])
+    .optional()
+    .describe(
+      "Outcome of the post-creation dependency install. Present when " +
+        "status='ok'. 'installed' = the configured install command ran and " +
+        "exited 0; 'not-configured' = no install command is set, so the step " +
+        "was a no-op. An install that fails makes the whole call status='error' " +
+        "with errorCode='INSTALL_FAILED' — it is never reported here."
+    ),
   errorCode: z
     .enum([
       "INVALID_INPUT",
@@ -103,6 +114,7 @@ export const createWorktreeOutputSchema = z.object({
       "PATH_EXISTS",
       "BASE_REF_NOT_FOUND",
       "GIT_ERROR",
+      "INSTALL_FAILED",
     ])
     .optional()
     .describe("Machine-readable failure category. Present when status='error'."),
@@ -325,12 +337,33 @@ export async function createWorktree(
     };
   }
 
+  // The worktree exists, but `git worktree add` checks out only tracked
+  // files — a gitignored dependency directory (node_modules and the like) is
+  // absent. Run the configured install command so the capability tools have
+  // what they need. A missing install command is a clean no-op.
+  const install = await runInstall({ repoPath: absWorktreePath });
+  if (install.status === "failed" || install.status === "error") {
+    const detail =
+      install.status === "failed"
+        ? `the install command exited ${install.exitCode}`
+        : install.errorMessage;
+    return {
+      status: "error",
+      errorCode: "INSTALL_FAILED",
+      errorMessage:
+        `The worktree was created at ${absWorktreePath} but the dependency ` +
+        `install step failed (${detail}). The worktree is left on disk for ` +
+        `inspection.`,
+    };
+  }
+
   return {
     status: "ok",
     path: absWorktreePath,
     branch,
     fetchStatus,
     ...(fetchError ? { fetchError } : {}),
+    installStatus: install.status,
   };
 }
 

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/worktree.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/worktree.ts
@@ -343,17 +343,25 @@ export async function createWorktree(
   // what they need. A missing install command is a clean no-op.
   const install = await runInstall({ repoPath: absWorktreePath });
   if (install.status === "failed" || install.status === "error") {
+    // The `??` fallbacks are defensive: runInstall always sets exitCode on
+    // "failed" and errorMessage on "error", but the InstallResult type does
+    // not prove it — guard against a future return path that forgets.
     const detail =
       install.status === "failed"
-        ? `the install command exited ${install.exitCode}`
-        : install.errorMessage;
+        ? `the install command exited ${install.exitCode ?? "(unknown)"}`
+        : install.errorMessage ?? "unknown error";
+    // Surface the install's own stderr tail — without it, diagnosing a failed
+    // `npm ci` (or similar) means opening the worktree on disk by hand.
+    const stderrTail = install.stderr?.trim()
+      ? `\nInstall stderr (tail):\n${install.stderr.trim().slice(-1000)}`
+      : "";
     return {
       status: "error",
       errorCode: "INSTALL_FAILED",
       errorMessage:
         `The worktree was created at ${absWorktreePath} but the dependency ` +
         `install step failed (${detail}). The worktree is left on disk for ` +
-        `inspection.`,
+        `inspection.${stderrTail}`,
     };
   }
 

--- a/plugins/orchestrate/orchestrate-mcp/test/run-command.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/run-command.test.ts
@@ -268,4 +268,37 @@ describe("runInstall", () => {
     expect(r.status).toBe("installed");
     expect(r.stdout).toContain("deps installed");
   });
+
+  it("treats an empty install argv array as not-configured", async () => {
+    const dir = project({ install: [] });
+    const r = await runInstall({ repoPath: dir });
+
+    expect(r.status).toBe("not-configured");
+  });
+
+  it("returns errorCode='EXEC_ERROR' when the install binary does not exist", async () => {
+    const dir = project({
+      install: ["orchestrate-nonexistent-binary-xyz", "--ci"],
+    });
+    const r = await runInstall({ repoPath: dir });
+
+    expect(r.status).toBe("error");
+    expect(r.errorCode).toBe("EXEC_ERROR");
+    expect(r.errorMessage).toBeDefined();
+  });
+
+  it(
+    "returns errorCode='TIMEOUT' when the install command exceeds the limit",
+    async () => {
+      const dir = project({
+        install: ["node", "-e", "setTimeout(() => {}, 30000)"],
+      });
+      const r = await runInstall({ repoPath: dir }, { timeoutMs: 1500 });
+
+      expect(r.status).toBe("error");
+      expect(r.errorCode).toBe("TIMEOUT");
+      expect(typeof r.durationMs).toBe("number");
+    },
+    10_000
+  );
 });

--- a/plugins/orchestrate/orchestrate-mcp/test/run-command.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/run-command.test.ts
@@ -7,6 +7,7 @@ import {
   runTypecheck,
   runBuild,
   runLint,
+  runInstall,
   runCommandInputSchema,
 } from "../src/tools/run-command.js";
 
@@ -210,5 +211,61 @@ describe("run-command capability tools", () => {
 
   it("exposes only repoPath as input — never a free-form command string", () => {
     expect(Object.keys(runCommandInputSchema.shape)).toEqual(["repoPath"]);
+  });
+});
+
+describe("runInstall", () => {
+  it("returns status='installed' when the configured install command exits 0", async () => {
+    const dir = project({ install: ["node", "-e", "process.exit(0)"] });
+    const r = await runInstall({ repoPath: dir });
+
+    expect(r.status).toBe("installed");
+    expect(r.exitCode).toBe(0);
+    expect(r.command).toEqual(["node", "-e", "process.exit(0)"]);
+    expect(typeof r.durationMs).toBe("number");
+  });
+
+  it("returns status='failed' with the non-zero exitCode when the install command fails", async () => {
+    const dir = project({ install: ["node", "-e", "process.exit(5)"] });
+    const r = await runInstall({ repoPath: dir });
+
+    expect(r.status).toBe("failed");
+    expect(r.exitCode).toBe(5);
+  });
+
+  it("returns status='not-configured' when no install command is set", async () => {
+    const dir = project({ tests: ["node", "-e", "process.exit(0)"] });
+    const r = await runInstall({ repoPath: dir });
+
+    expect(r.status).toBe("not-configured");
+    expect(r.reason).toBeDefined();
+    expect(r.errorCode).toBeUndefined();
+  });
+
+  it("returns status='not-configured' when no commands.json file exists", async () => {
+    const dir = project(null);
+    const r = await runInstall({ repoPath: dir });
+
+    expect(r.status).toBe("not-configured");
+    expect(r.reason).toBeDefined();
+  });
+
+  it("returns errorCode='CONFIG_INVALID' for malformed commands.json", async () => {
+    const dir = project("{ not valid json");
+    const r = await runInstall({ repoPath: dir });
+
+    expect(r.status).toBe("error");
+    expect(r.errorCode).toBe("CONFIG_INVALID");
+    expect(r.errorMessage).toBeDefined();
+  });
+
+  it("captures stdout from the install command", async () => {
+    const dir = project({
+      install: ["node", "-e", "process.stdout.write('deps installed')"],
+    });
+    const r = await runInstall({ repoPath: dir });
+
+    expect(r.status).toBe("installed");
+    expect(r.stdout).toContain("deps installed");
   });
 });

--- a/plugins/orchestrate/orchestrate-mcp/test/worktree.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/worktree.test.ts
@@ -359,6 +359,29 @@ describe("create_worktree", () => {
     // disk for inspection, consistent with the skill's failed-slice handling.
     expect(fs.existsSync(wtPath)).toBe(true);
   });
+
+  it("returns errorCode=INSTALL_FAILED when the install command cannot be spawned", async () => {
+    // A nonexistent binary makes runInstall return status='error' (EXEC_ERROR),
+    // exercising the create_worktree failure branch distinct from a non-zero exit.
+    commitCommandsJson(repoPath, {
+      install: ["orchestrate-nonexistent-binary-xyz", "--ci"],
+    });
+
+    const wtPath = path.join(worktreesDir, "install-exec-error-wt");
+    const result = await createWorktree({
+      baseRef: "HEAD",
+      branch: "install-exec-error-branch",
+      worktreePath: wtPath,
+      repoPath,
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.errorCode).toBe("INSTALL_FAILED");
+    expect(result.errorMessage).toBeDefined();
+    // The failure detail must carry a real reason, never the literal "undefined".
+    expect(result.errorMessage).not.toContain("undefined");
+    expect(fs.existsSync(wtPath)).toBe(true);
+  });
 });
 
 // ─── remove_worktree ──────────────────────────────────────────────────────────

--- a/plugins/orchestrate/orchestrate-mcp/test/worktree.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/worktree.test.ts
@@ -36,6 +36,20 @@ function rmrf(dirPath: string) {
   }
 }
 
+/**
+ * Writes `.orchestrate/commands.json` into `repo` and commits it, so a worktree
+ * branched from HEAD carries the config.
+ */
+function commitCommandsJson(repo: string, commands: unknown): void {
+  fs.mkdirSync(path.join(repo, ".orchestrate"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repo, ".orchestrate", "commands.json"),
+    JSON.stringify(commands, null, 2)
+  );
+  git(["add", "."], repo);
+  git(["commit", "-m", "Add orchestrate commands.json"], repo);
+}
+
 // ─── Test state ───────────────────────────────────────────────────────────────
 
 let repoPath: string;
@@ -284,6 +298,66 @@ describe("create_worktree", () => {
       rmrf(remoteDir);
       rmrf(stubDir);
     }
+  });
+
+  it("runs the configured install command and reports installStatus='installed'", async () => {
+    commitCommandsJson(repoPath, {
+      install: [
+        "node",
+        "-e",
+        "require('fs').writeFileSync('INSTALLED.marker', 'ok')",
+      ],
+    });
+
+    const wtPath = path.join(worktreesDir, "install-wt");
+    const result = await createWorktree({
+      baseRef: "HEAD",
+      branch: "install-branch",
+      worktreePath: wtPath,
+      repoPath,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.installStatus).toBe("installed");
+    // The install command runs with the worktree as cwd — its side-effect
+    // must land inside the worktree.
+    expect(fs.existsSync(path.join(wtPath, "INSTALLED.marker"))).toBe(true);
+  });
+
+  it("reports installStatus='not-configured' when no install command is set", async () => {
+    // createTempRepo writes no commands.json — install is simply absent.
+    const wtPath = path.join(worktreesDir, "no-install-wt");
+    const result = await createWorktree({
+      baseRef: "HEAD",
+      branch: "no-install-branch",
+      worktreePath: wtPath,
+      repoPath,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.installStatus).toBe("not-configured");
+    expect(fs.existsSync(wtPath)).toBe(true);
+  });
+
+  it("returns errorCode=INSTALL_FAILED when the install command exits non-zero", async () => {
+    commitCommandsJson(repoPath, {
+      install: ["node", "-e", "process.exit(1)"],
+    });
+
+    const wtPath = path.join(worktreesDir, "install-fail-wt");
+    const result = await createWorktree({
+      baseRef: "HEAD",
+      branch: "install-fail-branch",
+      worktreePath: wtPath,
+      repoPath,
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.errorCode).toBe("INSTALL_FAILED");
+    expect(result.errorMessage).toBeDefined();
+    // The worktree was created before the install failed — it is left on
+    // disk for inspection, consistent with the skill's failed-slice handling.
+    expect(fs.existsSync(wtPath)).toBe(true);
   });
 });
 

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -54,8 +54,12 @@ Check these before starting. If one is missing, report it and stop.
 The target project should also have committed `.orchestrate/commands.json` and
 `.orchestrate/routing.json` (see the plugin's `templates/`). Without
 `commands.json` the capability tools return `not-configured`, which is
-tolerated. Without `routing.json` the `resolve_routing` tool errors and the run
-falls back to the `-standard` variant of every role with no model override.
+tolerated. If the project's capability commands need installed dependencies,
+`commands.json` must also set an `install` command — `create_worktree` runs it
+in every fresh worktree, which checks out only tracked files and so has no
+dependency directory of its own. Without `routing.json` the `resolve_routing`
+tool errors and the run falls back to the `-standard` variant of every role
+with no model override.
 An optional `.orchestrate/handoff.json` tunes the context-watchdog threshold
 and the successor launcher; without it, built-in defaults apply (see
 `references/context-handoff.md`). Installing the `ast-grep` CLI is optional —
@@ -218,8 +222,10 @@ These are the per-slice steps the wave loop invokes. Update the slice's entry in
    Use the `create_worktree` MCP tool: `baseRef` = `orchestrate/umbrella-<runId>`,
    `branch` = `orchestrate/slice-<N>`, `worktreePath` = an absolute path outside
    the repo (e.g. `<repo-parent>/.orchestrate-worktrees/<runId>/slice-<N>`),
-   `repoPath` = the repository root. On `status: "error"`, the slice has
-   **FAILED** (see *Failure handling*).
+   `repoPath` = the repository root. `create_worktree` also runs the configured
+   `install` command in the new worktree before returning, so the capability
+   tools have the dependencies they need. On `status: "error"` — including an
+   `install` that failed — the slice has **FAILED** (see *Failure handling*).
 2. **Resolve routing.** Call the `resolve_routing` MCP tool with the slice's
    `tier` and the repository root as `repoPath`. It returns, per role, the
    `model` and effort variant to spawn:

--- a/plugins/orchestrate/templates/commands.json
+++ b/plugins/orchestrate/templates/commands.json
@@ -2,5 +2,6 @@
   "tests": ["npm", "test"],
   "typecheck": ["npm", "run", "typecheck"],
   "build": ["npm", "run", "build"],
-  "lint": ["npm", "run", "lint"]
+  "lint": ["npm", "run", "lint"],
+  "install": ["npm", "ci"]
 }


### PR DESCRIPTION
## Problem

`/orchestrate` runs were blocked by a pre-flight gap discovered before any slice branch was created (issue #207).

`create_worktree` built each slice worktree with `git worktree add` and nothing else. A git worktree checks out only tracked files, so a gitignored dependency directory (`node_modules`, etc.) is absent. The capability tools (`run_tests` / `run_typecheck` / `run_build` / `run_lint`) then fail in every fresh worktree — `vitest: not found`, exit 127 — so the reviewer fails every slice and no slice of a run can pass.

Empirically confirmed: a hand-created worktree at `origin/development` returned `{"status":"failed","exitCode":127,"stderr":"sh: 1: vitest: not found"}` from the `run_tests` capability tool.

## Fix

Add an `install` setup verb to `.orchestrate/commands.json`:

- `run-command.ts` — new `runInstall()` runs the configured install command; a shared `loadCommandsConfig()` helper is extracted so `runInstall` and `runConfiguredCommand` read and validate the config in one place.
- `worktree.ts` — `create_worktree` runs the install in the new worktree after `git worktree add`. A missing install command is a clean no-op (`installStatus: "not-configured"`); an install that fails returns `errorCode: "INSTALL_FAILED"` with the install's stderr tail, so the slice fails loudly rather than silently producing an unusable worktree.
- `templates/commands.json` and this repo's `.orchestrate/commands.json` gain the `install` verb.
- `dist/` rebuilt; orchestrate plugin bumped `1.0.4 → 1.1.0` (MINOR — additive `install` surface), Claude marketplace cascaded `1.4.3 → 1.5.0`.

## Verification

- **174 unit tests** pass (9 new, built test-first via `/tdd`), typecheck clean, committed `dist/` confirmed byte-current with `npm run build` output.
- **ce-code-review** — 7 reviewer personas; all actionable findings resolved (defensive null-coalescing on the failure detail, install stderr surfaced for triage, failure-path test coverage).
- **Shipped-artifact E2E** — the built `dist/index.js`, spawned as a real MCP server, created a worktree via `create_worktree` → `installStatus: "installed"`, then `run_tests` against that worktree returned `Tests 174 passed (174)`. The orchestrate restart path is proven end to end.

## Considered and deferred (not in scope for #207)

Raised by the multi-agent review and consciously deferred — none are regressions, and the change does not make them worse than the pre-existing capability-tool trust model:

- `create_worktree` runs the checked-out ref's `install` command — the same exec-from-config trust model the capability tools already use.
- `runInstall` uses the 600s default timeout with no per-verb override — a slow `npm ci` on a cold cache could hit it.
- A worktree left on disk after `INSTALL_FAILED` keeps its branch, so a same-name retry needs a `remove_worktree` first.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
