### PR TITLE
orchestrate: project capability detector module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,6 +149,14 @@ _Avoid_: main, master, trunk (the integration base is `development`, distinct fr
 Removal of a concluded run's run directory, worktrees, and umbrella/slice branches — gated on that run's final integration pull request having been merged into the **Integration base**.
 _Avoid_: purge, garbage collection, prune
 
+**Capability detector** (`detect-project` module):
+A pure module in `orchestrate-mcp/src/tools/detect-project.ts` that inspects a repository root's top-level manifest files and returns the **Capability command map** for the detected project type. Input: a repository root path. Output: a command map or empty object. No side effects. Detection precedence: npm (`package.json`) > Cargo (`Cargo.toml`) > Python (`pyproject.toml`) > Make (`Makefile`) > none. A repository with no recognized manifest yields an empty map — never a fallback npm map.
+_Avoid_: project sniffer, auto-configurator, manifest scanner
+
+**Capability command map**:
+A plain object with the four fixed capability verb keys (`tests`, `typecheck`, `build`, `lint`), each mapping to an argv array consumed directly by the orchestrate run tools. Produced by the **Capability detector**. The `install` verb is never included — that is a setup verb, not a capability verb. For unrecognized project types the map is empty (`{}`).
+_Avoid_: command config, verb table, command dictionary
+
 ## Relationships
 
 - A **Distribution** owns at most one **Initializer** and at most one **Customizer**.

--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -58,6 +58,39 @@ The plugin bundles `orchestrate-mcp`, a Model Context Protocol server providing 
 
 Every tool returns a discriminated `status` and never throws — failures are structured results, not exceptions.
 
+### Project capability detection
+
+The `detect-project` module (`orchestrate-mcp/src/tools/detect-project.ts`) auto-detects a repository's project type from its top-level manifest files and emits the matching capability command map. It is pure — repository root in, command map out, no side effects.
+
+**Detection precedence** (first match wins):
+
+| Manifest file | Project type | Command set |
+|---------------|-------------|-------------|
+| `package.json` | npm | `npm test`, `npm run typecheck`, `npm run build`, `npm run lint` |
+| `Cargo.toml` | Cargo | `cargo test`, `cargo check`, `cargo build`, `cargo clippy` |
+| `pyproject.toml` | Python | `pytest`, `mypy .`, `python -m build`, `ruff check .` |
+| `Makefile` | Make | `make test`, `make typecheck`, `make build`, `make lint` |
+| _(none found)_ | none | empty map — no capability tool is wired to a failing command |
+
+**Usage example** (TypeScript):
+
+```typescript
+import { detectCommandMap } from "./tools/detect-project.js";
+
+// Detect from a repository root — returns the command map or {} if unrecognized.
+const map = detectCommandMap("/path/to/repo");
+// For a repo with package.json:
+// { tests: ["npm", "test"], typecheck: ["npm", "run", "typecheck"],
+//   build: ["npm", "run", "build"], lint: ["npm", "run", "lint"] }
+
+// Or use the pure functions directly (no I/O):
+import { detectProjectType, buildCommandMap } from "./tools/detect-project.js";
+const type = detectProjectType(["Cargo.toml", "Makefile"]); // "cargo"
+const commands = buildCommandMap(type); // cargo argv arrays
+```
+
+A manifest-less repository yields `{}` — never an npm fallback — so no capability tool is ever wired to a command guaranteed to fail.
+
 ### Context handoff
 
 A long backlog can fill the orchestrator session's context window before every wave is done. The bundled `context-watchdog` hook (a `PostToolUse` hook) estimates context usage from the session transcript and, past a configurable threshold (default 40%), writes `.orchestrate/context-flag.json`. The orchestrator finishes the current slice, checkpoints, and calls `spawn_successor` to launch a new interactive Claude Code session that resumes from `run-state.json` — then the predecessor exits. The successor clears the stale flag on startup, so there is no handoff loop.

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/detect-project.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/detect-project.ts
@@ -1,0 +1,156 @@
+import * as fs from "fs";
+
+// ─── Project type ─────────────────────────────────────────────────────────────
+
+/**
+ * A recognized project type, or 'none' when no manifest is detected.
+ *
+ * Detection precedence (manifest-first, then Make):
+ *   npm (package.json) > cargo (Cargo.toml) > python (pyproject.toml) > make (Makefile) > none
+ *
+ * Python detection uses `pyproject.toml` only (the modern standard as of PEP 517/518).
+ * `setup.py` is legacy and intentionally excluded.
+ */
+export type ProjectType = "npm" | "cargo" | "python" | "make" | "none";
+
+/**
+ * A capability command map — the four fixed verbs the orchestrate run tools
+ * consume. Each verb maps to an argv array (no shell). For 'none', the map is
+ * empty (`{}`). The `install` verb is never included — it is a setup verb, not
+ * a capability verb.
+ */
+export type CapabilityCommandMap = {
+  tests?: string[];
+  typecheck?: string[];
+  build?: string[];
+  lint?: string[];
+};
+
+// ─── Detection manifest list ──────────────────────────────────────────────────
+
+/**
+ * Ordered detection rules. The first match wins — earlier entries have higher
+ * priority. `Makefile` is last because it often wraps another toolchain;
+ * language-specific manifests take precedence over a thin Make wrapper.
+ */
+const DETECTION_RULES: ReadonlyArray<{ manifest: string; type: ProjectType }> =
+  [
+    { manifest: "package.json", type: "npm" },
+    { manifest: "Cargo.toml", type: "cargo" },
+    { manifest: "pyproject.toml", type: "python" },
+    { manifest: "Makefile", type: "make" },
+  ];
+
+// ─── Command maps ─────────────────────────────────────────────────────────────
+
+/**
+ * Canonical argv arrays for each project type. Every array is the no-shell
+ * form executed by `execFile` — `argv[0]` is the binary, the rest are literal
+ * arguments.
+ *
+ * Python commands assume the standard modern toolchain:
+ *   - `pytest`   for tests (de-facto standard)
+ *   - `mypy .`   for type checking
+ *   - `python -m build` for building
+ *   - `ruff check .` for linting (modern replacement for flake8)
+ */
+const COMMAND_MAPS: Record<
+  Exclude<ProjectType, "none">,
+  Required<CapabilityCommandMap>
+> = {
+  npm: {
+    tests: ["npm", "test"],
+    typecheck: ["npm", "run", "typecheck"],
+    build: ["npm", "run", "build"],
+    lint: ["npm", "run", "lint"],
+  },
+  cargo: {
+    tests: ["cargo", "test"],
+    typecheck: ["cargo", "check"],
+    build: ["cargo", "build"],
+    lint: ["cargo", "clippy"],
+  },
+  python: {
+    tests: ["pytest"],
+    typecheck: ["mypy", "."],
+    build: ["python", "-m", "build"],
+    lint: ["ruff", "check", "."],
+  },
+  make: {
+    tests: ["make", "test"],
+    typecheck: ["make", "typecheck"],
+    build: ["make", "build"],
+    lint: ["make", "lint"],
+  },
+};
+
+// ─── Pure functions ───────────────────────────────────────────────────────────
+
+/**
+ * Determines the project type from the list of filenames present in a
+ * repository root. Pure — no I/O; the caller supplies the manifest list.
+ *
+ * Returns the first match from {@link DETECTION_RULES}, applying
+ * manifest-first priority (npm > cargo > python > make). Returns 'none' when
+ * no recognized manifest is present.
+ */
+export function detectProjectType(manifestsPresent: string[]): ProjectType {
+  const present = new Set(manifestsPresent);
+  for (const rule of DETECTION_RULES) {
+    if (present.has(rule.manifest)) {
+      return rule.type;
+    }
+  }
+  return "none";
+}
+
+/**
+ * Returns the capability command map for a given project type. Pure — no I/O.
+ *
+ * For 'none', returns an empty object (`{}`). For any recognized type, returns
+ * an object with exactly the four capability verb keys (`tests`, `typecheck`,
+ * `build`, `lint`). The `install` verb is never included.
+ */
+export function buildCommandMap(type: ProjectType): CapabilityCommandMap {
+  if (type === "none") {
+    return {};
+  }
+  return { ...COMMAND_MAPS[type] };
+}
+
+// ─── I/O function ─────────────────────────────────────────────────────────────
+
+/**
+ * Detects the project type from the repository root and returns the
+ * corresponding capability command map.
+ *
+ * Reads only the top-level directory entries of `repoRoot` — no subdirectory
+ * traversal, no config parsing. Checks for the presence of the manifest files
+ * defined in {@link DETECTION_RULES} and delegates to the pure functions.
+ *
+ * Returns an empty map (`{}`) when:
+ * - The repository has no recognized manifest.
+ * - `repoRoot` does not exist or cannot be read.
+ *
+ * Never throws — every failure mode yields an empty map.
+ */
+export function detectCommandMap(repoRoot: string): CapabilityCommandMap {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(repoRoot);
+  } catch {
+    // Unreadable or non-existent directory — treat as "no manifest found".
+    return {};
+  }
+
+  // Build the set of manifest filenames we care about (no subdirectory walk).
+  const manifests = DETECTION_RULES.map((r) => r.manifest);
+  const presentManifests = entries.filter((e) => manifests.includes(e));
+
+  const projectType = detectProjectType(presentManifests);
+  return buildCommandMap(projectType);
+}
+
+// ─── Re-exports for consumers ─────────────────────────────────────────────────
+
+export { DETECTION_RULES, COMMAND_MAPS };

--- a/plugins/orchestrate/orchestrate-mcp/test/detect-project.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/detect-project.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  detectProjectType,
+  buildCommandMap,
+  detectCommandMap,
+  type ProjectType,
+  type CapabilityCommandMap,
+} from "../src/tools/detect-project.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Creates a temporary directory and optionally writes marker files into it.
+ * The `files` record maps relative paths to content (empty string = touch).
+ */
+function makeRepo(files: Record<string, string> = {}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-detect-"));
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, "utf8");
+  }
+  return dir;
+}
+
+const created: string[] = [];
+
+function repo(files: Record<string, string> = {}): string {
+  const dir = makeRepo(files);
+  created.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of created) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  created.length = 0;
+});
+
+// ─── detectProjectType (pure function) ────────────────────────────────────────
+
+describe("detectProjectType (pure)", () => {
+  it("returns 'npm' when package.json is present in the manifest list", () => {
+    expect(detectProjectType(["package.json"])).toBe("npm");
+  });
+
+  it("returns 'cargo' when Cargo.toml is present", () => {
+    expect(detectProjectType(["Cargo.toml"])).toBe("cargo");
+  });
+
+  it("returns 'python' when pyproject.toml is present", () => {
+    expect(detectProjectType(["pyproject.toml"])).toBe("python");
+  });
+
+  it("returns 'make' when Makefile is present", () => {
+    expect(detectProjectType(["Makefile"])).toBe("make");
+  });
+
+  it("returns 'none' when no recognized manifest is present", () => {
+    expect(detectProjectType([])).toBe("none");
+    expect(detectProjectType(["README.md", "src/index.ts"])).toBe("none");
+  });
+
+  it("prefers npm over Makefile when both are present (manifest-first priority)", () => {
+    expect(detectProjectType(["Makefile", "package.json"])).toBe("npm");
+  });
+
+  it("prefers cargo over Makefile when both are present", () => {
+    expect(detectProjectType(["Makefile", "Cargo.toml"])).toBe("cargo");
+  });
+
+  it("prefers python over Makefile when both are present", () => {
+    expect(detectProjectType(["Makefile", "pyproject.toml"])).toBe("python");
+  });
+
+  it("prefers npm over python when both are present", () => {
+    expect(detectProjectType(["pyproject.toml", "package.json"])).toBe("npm");
+  });
+});
+
+// ─── buildCommandMap (pure function) ──────────────────────────────────────────
+
+describe("buildCommandMap (pure)", () => {
+  it("returns the npm command map for 'npm'", () => {
+    const map = buildCommandMap("npm");
+    expect(map.tests).toEqual(["npm", "test"]);
+    expect(map.typecheck).toEqual(["npm", "run", "typecheck"]);
+    expect(map.build).toEqual(["npm", "run", "build"]);
+    expect(map.lint).toEqual(["npm", "run", "lint"]);
+    // install is not a capability verb — must not appear in the capability map
+    expect("install" in map).toBe(false);
+  });
+
+  it("returns the cargo command map for 'cargo'", () => {
+    const map = buildCommandMap("cargo");
+    expect(map.tests).toEqual(["cargo", "test"]);
+    expect(map.typecheck).toEqual(["cargo", "check"]);
+    expect(map.build).toEqual(["cargo", "build"]);
+    expect(map.lint).toEqual(["cargo", "clippy"]);
+    expect("install" in map).toBe(false);
+  });
+
+  it("returns the python command map for 'python'", () => {
+    const map = buildCommandMap("python");
+    expect(map.tests).toEqual(["pytest"]);
+    expect(map.typecheck).toEqual(["mypy", "."]);
+    expect(map.build).toEqual(["python", "-m", "build"]);
+    expect(map.lint).toEqual(["ruff", "check", "."]);
+    expect("install" in map).toBe(false);
+  });
+
+  it("returns the make command map for 'make'", () => {
+    const map = buildCommandMap("make");
+    expect(map.tests).toEqual(["make", "test"]);
+    expect(map.typecheck).toEqual(["make", "typecheck"]);
+    expect(map.build).toEqual(["make", "build"]);
+    expect(map.lint).toEqual(["make", "lint"]);
+    expect("install" in map).toBe(false);
+  });
+
+  it("returns an empty map for 'none'", () => {
+    const map = buildCommandMap("none");
+    expect(map).toEqual({});
+    expect(Object.keys(map)).toHaveLength(0);
+  });
+
+  it("the command map has exactly the four capability verb keys for recognized types", () => {
+    for (const type of ["npm", "cargo", "python", "make"] as ProjectType[]) {
+      const map = buildCommandMap(type);
+      const keys = Object.keys(map).sort();
+      expect(keys).toEqual(["build", "lint", "tests", "typecheck"]);
+    }
+  });
+});
+
+// ─── detectCommandMap (I/O function) ──────────────────────────────────────────
+
+describe("detectCommandMap", () => {
+  it("returns an empty map for a repository with no recognized manifest", () => {
+    const dir = repo({ "README.md": "hello" });
+    const map = detectCommandMap(dir);
+    expect(map).toEqual({});
+  });
+
+  it("returns an empty map for a completely empty directory", () => {
+    const dir = repo();
+    const map = detectCommandMap(dir);
+    expect(map).toEqual({});
+  });
+
+  it("detects npm from package.json", () => {
+    const dir = repo({ "package.json": '{"name":"test"}' });
+    const map = detectCommandMap(dir);
+    expect(map.tests).toEqual(["npm", "test"]);
+    expect(map.build).toEqual(["npm", "run", "build"]);
+  });
+
+  it("detects cargo from Cargo.toml", () => {
+    const dir = repo({ "Cargo.toml": '[package]\nname = "test"' });
+    const map = detectCommandMap(dir);
+    expect(map.tests).toEqual(["cargo", "test"]);
+    expect(map.build).toEqual(["cargo", "build"]);
+  });
+
+  it("detects python from pyproject.toml", () => {
+    const dir = repo({ "pyproject.toml": "[tool.pytest]" });
+    const map = detectCommandMap(dir);
+    expect(map.tests).toEqual(["pytest"]);
+    expect(map.typecheck).toEqual(["mypy", "."]);
+  });
+
+  it("detects make from Makefile", () => {
+    const dir = repo({ "Makefile": "test:\n\techo test" });
+    const map = detectCommandMap(dir);
+    expect(map.tests).toEqual(["make", "test"]);
+    expect(map.build).toEqual(["make", "build"]);
+  });
+
+  it("prefers npm over Makefile when both are present", () => {
+    const dir = repo({
+      "package.json": '{"name":"test"}',
+      "Makefile": "test:\n\techo test",
+    });
+    const map = detectCommandMap(dir);
+    expect(map.tests).toEqual(["npm", "test"]);
+  });
+
+  it("does not include an 'install' key in the result", () => {
+    const dir = repo({ "package.json": '{"name":"test"}' });
+    const map = detectCommandMap(dir);
+    expect("install" in map).toBe(false);
+  });
+
+  it("returns the full four-key map for npm", () => {
+    const dir = repo({ "package.json": '{"name":"test"}' });
+    const map = detectCommandMap(dir);
+    const keys = Object.keys(map).sort();
+    expect(keys).toEqual(["build", "lint", "tests", "typecheck"]);
+  });
+
+  it("none case yields empty map — never a fallback to npm commands", () => {
+    const dir = repo({ "go.mod": "module example.com/test" });
+    const map = detectCommandMap(dir);
+    // go.mod is not a recognized manifest; must not fall back to npm
+    expect(map).toEqual({});
+  });
+});


### PR DESCRIPTION
Implements #186.

Pure project-type detector that emits the capability command map for npm, Cargo, Python, and Make projects; a manifest-less repo yields an empty map (never an npm fallback). Three-function split: `detectProjectType` and `buildCommandMap` pure, `detectCommandMap` the I/O wrapper. 25 new vitest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)