### PR TITLE
orchestrate: backlog partitioner with parent-PRD exclusion

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,6 +149,22 @@ _Avoid_: main, master, trunk (the integration base is `development`, distinct fr
 Removal of a concluded run's run directory, worktrees, and umbrella/slice branches — gated on that run's final integration pull request having been merged into the **Integration base**.
 _Avoid_: purge, garbage collection, prune
 
+**Backlog partitioner**:
+The pure module (`src/tools/backlog-partitioner.ts`) that splits the fetched `ready-for-agent` backlog into the run's `slices` set and the resolved `parentIssue`. It is the single canonical answer to "which issues are slices, and which is the parent PRD". Two detection signals are applied in order: (1) parent-field reference — any issue named as another backlog issue's `Parent`; (2) the `PRD:` title heuristic — any backlog issue whose title starts with `PRD:` (case-insensitive), catching a parent PRD that child issues have not yet linked via their `Parent` field. The detected parent PRD is excluded from `slices` and surfaced as `parentIssue`; it is only a progress-comment target, never an implementation slice.
+_Avoid_: backlog filter, issue splitter
+
+**Parent PRD**:
+The single parent issue detected by the **Backlog partitioner** for a run — either via parent-field reference or the `PRD:` title heuristic. Recorded as `parentIssue` in `run-state.json`. Its only role during a run is as the target for wave-progress comments (`gh issue comment <parentIssue>`); it is never enrolled as a slice. `null` when no parent is detected.
+_Avoid_: umbrella issue, epic (epic is an unrelated concept)
+
+**PRD: title heuristic**:
+Secondary signal used by the **Backlog partitioner** when no explicit parent-field reference exists: any backlog issue whose title starts with `PRD:` (case-insensitive) is treated as the **Parent PRD**. Catches a decomposed PRD that appears in the backlog before child issues have been created or before children have their `Parent` field set.
+_Avoid_: title matching, title filter
+
+**filterToOneParentPrd**:
+The exported function in `backlog-partitioner.ts` that narrows the full backlog to the child issues of a single parent PRD number (matching `parent === prdNumber`). Used to scope a `/orchestrate <PRD#>` run to one **Run partition**. The parent PRD issue itself is excluded from the result.
+_Avoid_: backlog filter, PRD filter (too generic)
+
 ## Relationships
 
 - A **Distribution** owns at most one **Initializer** and at most one **Customizer**.

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -22948,6 +22948,81 @@ async function searchStructural(input, opts = {}) {
   }
 }
 
+// src/tools/backlog-partitioner.ts
+var backlogIssueSchema = external_exports.object({
+  number: external_exports.number().int().positive().describe("GitHub issue number."),
+  title: external_exports.string().min(1).describe("Issue title, verbatim from GitHub."),
+  blockedBy: external_exports.array(external_exports.number().int().positive()).describe(
+    "Issue numbers this issue is blocked by \u2014 the parsed 'Blocked by' section of the issue body (`- #NNN` lines). Empty array when the section is absent or has no entries."
+  ),
+  parent: external_exports.number().int().positive().nullable().describe(
+    "The issue number named in the 'Parent' section of this issue's body (the `PRD #NNN` line), or null when no parent is declared."
+  )
+});
+var partitionBacklogInputSchema = external_exports.object({
+  issues: external_exports.array(backlogIssueSchema).describe(
+    "The full ready-for-agent backlog. Each issue carries its parsed Blocked by and Parent sections."
+  )
+});
+var partitionBacklogOutputSchema = external_exports.object({
+  slices: external_exports.array(backlogIssueSchema).describe(
+    "Issues to process as implementation slices, in the same order they appeared in the input. The parent PRD (if any) is excluded."
+  ),
+  parentIssue: backlogIssueSchema.nullable().describe(
+    "The detected parent PRD issue, or null when none was detected. This is only the progress-comment target \u2014 it is never implemented as a slice."
+  )
+});
+var filterToOneParentPrdInputSchema = external_exports.object({
+  issues: external_exports.array(backlogIssueSchema).describe("The full backlog to filter."),
+  prdNumber: external_exports.number().int().positive().describe(
+    "The issue number of the parent PRD whose children are requested."
+  )
+});
+var filterToOneParentPrdOutputSchema = external_exports.object({
+  issues: external_exports.array(backlogIssueSchema).describe(
+    "The subset of issues whose parent field equals prdNumber, in input order. The parent PRD issue itself is excluded."
+  )
+});
+function hasPrdTitlePrefix(title) {
+  return /^prd\s*:/i.test(title.trim());
+}
+function partitionBacklog(issues) {
+  if (issues.length === 0) {
+    return { slices: [], parentIssue: null };
+  }
+  const byNumber = /* @__PURE__ */ new Map();
+  for (const issue2 of issues) {
+    byNumber.set(issue2.number, issue2);
+  }
+  const referencedAsParent = /* @__PURE__ */ new Set();
+  for (const issue2 of issues) {
+    if (issue2.parent !== null && byNumber.has(issue2.parent)) {
+      referencedAsParent.add(issue2.parent);
+    }
+  }
+  if (referencedAsParent.size > 0) {
+    const parentIssue = issues.find((i) => referencedAsParent.has(i.number)) ?? null;
+    const parentNumber = parentIssue?.number ?? -1;
+    return {
+      parentIssue,
+      slices: issues.filter((i) => i.number !== parentNumber)
+    };
+  }
+  const prdByTitle = issues.find((i) => hasPrdTitlePrefix(i.title));
+  if (prdByTitle) {
+    return {
+      parentIssue: prdByTitle,
+      slices: issues.filter((i) => i.number !== prdByTitle.number)
+    };
+  }
+  return { slices: issues, parentIssue: null };
+}
+function filterToOneParentPrd(issues, prdNumber) {
+  return issues.filter(
+    (i) => i.parent === prdNumber && i.number !== prdNumber
+  );
+}
+
 // src/index.ts
 var server = new McpServer({
   name: "orchestrate",
@@ -23202,6 +23277,48 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleSearchStructural
+);
+var handlePartitionBacklog = async (input) => {
+  const result = partitionBacklog(input.issues);
+  const sliceCount = result.slices.length;
+  const parentNote = result.parentIssue ? ` Parent PRD is issue #${result.parentIssue.number}.` : " No parent PRD detected.";
+  const text = `Partitioned backlog into ${sliceCount} slice(s).${parentNote}`;
+  return {
+    structuredContent: result,
+    content: [{ type: "text", text }]
+  };
+};
+registerTool(
+  "partition_backlog",
+  {
+    title: "Partition Backlog",
+    description: "Splits the ready-for-agent backlog into implementation slices and an optional parent PRD issue. The parent PRD is detected by two signals in order: (1) parent-field reference \u2014 if any issue names another backlog issue as its parent, that issue is the parent PRD; (2) PRD: title heuristic \u2014 if no explicit parent reference exists, any issue whose title starts with 'PRD:' (case-insensitive) is treated as the parent PRD. The detected parent PRD is excluded from slices and surfaced as parentIssue. If no parent is detected, parentIssue is null and all issues are returned as slices.",
+    inputSchema: partitionBacklogInputSchema.shape,
+    outputSchema: partitionBacklogOutputSchema.shape
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handlePartitionBacklog
+);
+var handleFilterToOneParentPrd = async (input) => {
+  const filtered = filterToOneParentPrd(input.issues, input.prdNumber);
+  const text = `Filtered to ${filtered.length} issue(s) whose parent is #${input.prdNumber}.`;
+  return {
+    structuredContent: { issues: filtered },
+    content: [{ type: "text", text }]
+  };
+};
+registerTool(
+  "filter_to_one_parent_prd",
+  {
+    title: "Filter Backlog to One Parent PRD",
+    description: "Narrows the full backlog to only the issues whose parent field equals prdNumber. The parent PRD issue itself is excluded from the result \u2014 only its child slices are returned, in input order. Use this before calling partition_backlog when the run is scoped to a single PRD (e.g. /orchestrate <PRD#>).",
+    inputSchema: filterToOneParentPrdInputSchema.shape,
+    outputSchema: filterToOneParentPrdOutputSchema.shape
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleFilterToOneParentPrd
 );
 async function main() {
   const transport = new StdioServerTransport();

--- a/plugins/orchestrate/orchestrate-mcp/src/index.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/index.ts
@@ -59,6 +59,18 @@ import {
   type SearchStructuralInput,
   type SearchStructuralOutput,
 } from "./tools/search-structural.js";
+import {
+  partitionBacklog,
+  filterToOneParentPrd,
+  partitionBacklogInputSchema,
+  partitionBacklogOutputSchema,
+  filterToOneParentPrdInputSchema,
+  filterToOneParentPrdOutputSchema,
+  type PartitionBacklogInput,
+  type PartitionBacklogOutput,
+  type FilterToOneParentPrdInput,
+  type FilterToOneParentPrdOutput,
+} from "./tools/backlog-partitioner.js";
 
 const server = new McpServer({
   name: "orchestrate",
@@ -502,6 +514,78 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleSearchStructural as unknown as AnyToolHandler
+);
+
+// ─── partition_backlog ────────────────────────────────────────────────────────
+
+const handlePartitionBacklog: ToolHandler<
+  PartitionBacklogInput,
+  PartitionBacklogOutput
+> = async (input) => {
+  const result = partitionBacklog(input.issues);
+  const sliceCount = result.slices.length;
+  const parentNote = result.parentIssue
+    ? ` Parent PRD is issue #${result.parentIssue.number}.`
+    : " No parent PRD detected.";
+  const text = `Partitioned backlog into ${sliceCount} slice(s).${parentNote}`;
+  return {
+    structuredContent: result,
+    content: [{ type: "text" as const, text }],
+  };
+};
+
+registerTool(
+  "partition_backlog",
+  {
+    title: "Partition Backlog",
+    description:
+      "Splits the ready-for-agent backlog into implementation slices and an " +
+      "optional parent PRD issue. The parent PRD is detected by two signals in " +
+      "order: (1) parent-field reference — if any issue names another backlog " +
+      "issue as its parent, that issue is the parent PRD; (2) PRD: title " +
+      "heuristic — if no explicit parent reference exists, any issue whose " +
+      "title starts with 'PRD:' (case-insensitive) is treated as the parent " +
+      "PRD. The detected parent PRD is excluded from slices and surfaced as " +
+      "parentIssue. If no parent is detected, parentIssue is null and all " +
+      "issues are returned as slices.",
+    inputSchema: partitionBacklogInputSchema.shape,
+    outputSchema: partitionBacklogOutputSchema.shape,
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handlePartitionBacklog as unknown as AnyToolHandler
+);
+
+// ─── filter_to_one_parent_prd ─────────────────────────────────────────────────
+
+const handleFilterToOneParentPrd: ToolHandler<
+  FilterToOneParentPrdInput,
+  FilterToOneParentPrdOutput
+> = async (input) => {
+  const filtered = filterToOneParentPrd(input.issues, input.prdNumber);
+  const text = `Filtered to ${filtered.length} issue(s) whose parent is #${input.prdNumber}.`;
+  return {
+    structuredContent: { issues: filtered },
+    content: [{ type: "text" as const, text }],
+  };
+};
+
+registerTool(
+  "filter_to_one_parent_prd",
+  {
+    title: "Filter Backlog to One Parent PRD",
+    description:
+      "Narrows the full backlog to only the issues whose parent field equals " +
+      "prdNumber. The parent PRD issue itself is excluded from the result — " +
+      "only its child slices are returned, in input order. Use this before " +
+      "calling partition_backlog when the run is scoped to a single PRD " +
+      "(e.g. /orchestrate <PRD#>).",
+    inputSchema: filterToOneParentPrdInputSchema.shape,
+    outputSchema: filterToOneParentPrdOutputSchema.shape,
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleFilterToOneParentPrd as unknown as AnyToolHandler
 );
 
 // ─── Start server ─────────────────────────────────────────────────────────────

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/backlog-partitioner.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/backlog-partitioner.ts
@@ -1,0 +1,216 @@
+import { z } from "zod";
+
+// ─── Schemas — z.object is the single source of truth; TS types via z.infer ───
+
+/**
+ * Zod schema for a single issue in the fetched `ready-for-agent` backlog.
+ * Each issue carries its parsed `Blocked by` and `Parent` sections — numbers
+ * only, already extracted from the GitHub issue body by the caller.
+ */
+export const backlogIssueSchema = z.object({
+  number: z
+    .number()
+    .int()
+    .positive()
+    .describe("GitHub issue number."),
+  title: z
+    .string()
+    .min(1)
+    .describe("Issue title, verbatim from GitHub."),
+  blockedBy: z
+    .array(z.number().int().positive())
+    .describe(
+      "Issue numbers this issue is blocked by — the parsed 'Blocked by' " +
+        "section of the issue body (`- #NNN` lines). Empty array when the " +
+        "section is absent or has no entries."
+    ),
+  parent: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .describe(
+      "The issue number named in the 'Parent' section of this issue's body " +
+        "(the `PRD #NNN` line), or null when no parent is declared."
+    ),
+});
+
+/** TypeScript type inferred from the Zod schema. */
+export type BacklogIssue = z.infer<typeof backlogIssueSchema>;
+
+// ─── partition_backlog MCP tool schemas ───────────────────────────────────────
+
+export const partitionBacklogInputSchema = z.object({
+  issues: z
+    .array(backlogIssueSchema)
+    .describe(
+      "The full ready-for-agent backlog. Each issue carries its parsed " +
+        "Blocked by and Parent sections."
+    ),
+});
+
+export const partitionBacklogOutputSchema = z.object({
+  slices: z
+    .array(backlogIssueSchema)
+    .describe(
+      "Issues to process as implementation slices, in the same order they " +
+        "appeared in the input. The parent PRD (if any) is excluded."
+    ),
+  parentIssue: backlogIssueSchema
+    .nullable()
+    .describe(
+      "The detected parent PRD issue, or null when none was detected. " +
+        "This is only the progress-comment target — it is never implemented " +
+        "as a slice."
+    ),
+});
+
+/** TypeScript input type inferred from the Zod schema. */
+export type PartitionBacklogInput = z.infer<typeof partitionBacklogInputSchema>;
+
+/** TypeScript output type inferred from the Zod schema. */
+export type PartitionBacklogOutput = z.infer<
+  typeof partitionBacklogOutputSchema
+>;
+
+// ─── filter_to_one_parent_prd MCP tool schemas ────────────────────────────────
+
+export const filterToOneParentPrdInputSchema = z.object({
+  issues: z
+    .array(backlogIssueSchema)
+    .describe("The full backlog to filter."),
+  prdNumber: z
+    .number()
+    .int()
+    .positive()
+    .describe(
+      "The issue number of the parent PRD whose children are requested."
+    ),
+});
+
+export const filterToOneParentPrdOutputSchema = z.object({
+  issues: z
+    .array(backlogIssueSchema)
+    .describe(
+      "The subset of issues whose parent field equals prdNumber, in input " +
+        "order. The parent PRD issue itself is excluded."
+    ),
+});
+
+/** TypeScript input type inferred from the Zod schema. */
+export type FilterToOneParentPrdInput = z.infer<
+  typeof filterToOneParentPrdInputSchema
+>;
+
+/** TypeScript output type inferred from the Zod schema. */
+export type FilterToOneParentPrdOutput = z.infer<
+  typeof filterToOneParentPrdOutputSchema
+>;
+
+// ─── BacklogPartition convenience type ───────────────────────────────────────
+
+/**
+ * The result of partitioning the backlog.
+ *
+ * - `slices` — the issues that should be processed as implementation slices,
+ *   in the same order they appeared in the input. The parent PRD (if any) is
+ *   excluded.
+ * - `parentIssue` — the detected parent PRD issue, or `null` when none was
+ *   detected. This is only the progress-comment target — it is never
+ *   implemented as a slice.
+ */
+export type BacklogPartition = PartitionBacklogOutput;
+
+// ─── PRD title heuristic ───────────────────────────────────────────────────────
+
+/**
+ * Returns `true` when the issue title matches the `PRD:` prefix heuristic
+ * (case-insensitive). Used as a secondary signal when no issue explicitly
+ * names another backlog issue as its parent.
+ */
+function hasPrdTitlePrefix(title: string): boolean {
+  return /^prd\s*:/i.test(title.trim());
+}
+
+// ─── partitionBacklog ─────────────────────────────────────────────────────────
+
+/**
+ * Turns the fetched `ready-for-agent` backlog into the run's `slices` set and
+ * resolved `parentIssue`. Pure — no I/O. Never throws.
+ *
+ * Detection order:
+ * 1. **Parent-field reference** — if any issue's `parent` field names another
+ *    backlog issue's number, that issue is the parent PRD.
+ * 2. **PRD title heuristic** — if no parent-field reference exists, any issue
+ *    whose title starts with `PRD:` (case-insensitive) is treated as the
+ *    parent PRD.
+ *
+ * The detected parent PRD is excluded from `slices`. If no parent is detected,
+ * `parentIssue` is `null` and all issues are returned as slices.
+ */
+export function partitionBacklog(issues: BacklogIssue[]): BacklogPartition {
+  if (issues.length === 0) {
+    return { slices: [], parentIssue: null };
+  }
+
+  // Build a lookup by issue number for fast resolution.
+  const byNumber = new Map<number, BacklogIssue>();
+  for (const issue of issues) {
+    byNumber.set(issue.number, issue);
+  }
+
+  // ── Signal 1: parent-field reference ──────────────────────────────────────
+  // Collect every issue number that appears as another issue's `.parent`.
+  // We only consider references to issues that are themselves in the backlog.
+  const referencedAsParent = new Set<number>();
+  for (const issue of issues) {
+    if (issue.parent !== null && byNumber.has(issue.parent)) {
+      referencedAsParent.add(issue.parent);
+    }
+  }
+
+  if (referencedAsParent.size > 0) {
+    // Use the first referenced parent in input order.
+    const parentIssue =
+      issues.find((i) => referencedAsParent.has(i.number)) ?? null;
+    const parentNumber = parentIssue?.number ?? -1;
+    return {
+      parentIssue,
+      slices: issues.filter((i) => i.number !== parentNumber),
+    };
+  }
+
+  // ── Signal 2: PRD title heuristic ─────────────────────────────────────────
+  const prdByTitle = issues.find((i) => hasPrdTitlePrefix(i.title));
+  if (prdByTitle) {
+    return {
+      parentIssue: prdByTitle,
+      slices: issues.filter((i) => i.number !== prdByTitle.number),
+    };
+  }
+
+  // ── No parent detected ────────────────────────────────────────────────────
+  return { slices: issues, parentIssue: null };
+}
+
+// ─── filterToOneParentPrd ─────────────────────────────────────────────────────
+
+/**
+ * Filters a backlog to the subset of issues whose `parent` field equals
+ * `prdNumber`. The parent PRD issue itself is excluded from the result — only
+ * its child slices are returned, in input order.
+ *
+ * This function is the single canonical answer for "/orchestrate <PRD#>" runs:
+ * a later skill slice calls it to narrow the whole backlog to one PRD's
+ * children.
+ *
+ * Pure — no I/O. Never throws.
+ */
+export function filterToOneParentPrd(
+  issues: BacklogIssue[],
+  prdNumber: number
+): BacklogIssue[] {
+  return issues.filter(
+    (i) => i.parent === prdNumber && i.number !== prdNumber
+  );
+}

--- a/plugins/orchestrate/orchestrate-mcp/test/backlog-partitioner.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/backlog-partitioner.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import {
+  partitionBacklog,
+  filterToOneParentPrd,
+  type BacklogIssue,
+} from "../src/tools/backlog-partitioner.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function issue(
+  number: number,
+  title: string,
+  opts: { blockedBy?: number[]; parent?: number | null } = {}
+): BacklogIssue {
+  return {
+    number,
+    title,
+    blockedBy: opts.blockedBy ?? [],
+    parent: opts.parent ?? null,
+  };
+}
+
+// ─── partitionBacklog ─────────────────────────────────────────────────────────
+
+describe("partitionBacklog", () => {
+  it("excludes an issue named as another issue's parent and surfaces it as parentIssue", () => {
+    const issues = [
+      issue(100, "PRD: my feature"),
+      issue(101, "Implement auth", { parent: 100 }),
+      issue(102, "Implement UI", { parent: 100 }),
+    ];
+    const result = partitionBacklog(issues);
+
+    expect(result.parentIssue).not.toBeNull();
+    expect(result.parentIssue!.number).toBe(100);
+    expect(result.slices.map((s) => s.number)).toEqual([101, 102]);
+  });
+
+  it("resolves parentIssue to null when no issue names a parent", () => {
+    const issues = [
+      issue(101, "Implement auth"),
+      issue(102, "Implement UI"),
+    ];
+    const result = partitionBacklog(issues);
+
+    expect(result.parentIssue).toBeNull();
+    expect(result.slices.map((s) => s.number)).toEqual([101, 102]);
+  });
+
+  it("catches a parent PRD not referenced via the Parent field using the PRD: title heuristic", () => {
+    // Issue 100 has title "PRD: ..." but no child issue has parent=100.
+    // The heuristic should still detect it as parentIssue.
+    const issues = [
+      issue(100, "PRD: my feature"),
+      issue(101, "Implement auth"),
+      issue(102, "Implement UI"),
+    ];
+    const result = partitionBacklog(issues);
+
+    expect(result.parentIssue).not.toBeNull();
+    expect(result.parentIssue!.number).toBe(100);
+    expect(result.slices.map((s) => s.number)).toEqual([101, 102]);
+  });
+
+  it("applies the PRD: heuristic case-insensitively", () => {
+    const issues = [
+      issue(100, "prd: my feature"),
+      issue(101, "Implement auth"),
+    ];
+    const result = partitionBacklog(issues);
+
+    expect(result.parentIssue).not.toBeNull();
+    expect(result.parentIssue!.number).toBe(100);
+    expect(result.slices.map((s) => s.number)).toEqual([101]);
+  });
+
+  it("preserves slices order from the input", () => {
+    const issues = [
+      issue(100, "PRD: feature"),
+      issue(103, "C", { parent: 100 }),
+      issue(101, "A", { parent: 100 }),
+      issue(102, "B", { parent: 100 }),
+    ];
+    const result = partitionBacklog(issues);
+
+    expect(result.slices.map((s) => s.number)).toEqual([103, 101, 102]);
+  });
+
+  it("returns all issues as slices when no parent is detected", () => {
+    const issues = [issue(10, "Task A"), issue(11, "Task B")];
+    const result = partitionBacklog(issues);
+
+    expect(result.slices).toHaveLength(2);
+    expect(result.parentIssue).toBeNull();
+  });
+
+  it("prefers the parent field reference over the PRD title heuristic when both are present", () => {
+    // Issue 100 is referenced as parent by issue 101 AND has PRD: title.
+    const issues = [
+      issue(100, "PRD: big feature"),
+      issue(101, "Implement X", { parent: 100 }),
+      issue(102, "Implement Y", { parent: 100 }),
+    ];
+    const result = partitionBacklog(issues);
+
+    // parentIssue is the same issue detected by both signals — the result is the same.
+    expect(result.parentIssue!.number).toBe(100);
+    expect(result.slices.map((s) => s.number)).toEqual([101, 102]);
+  });
+
+  it("handles a single-issue backlog with no parent reference", () => {
+    const issues = [issue(42, "Fix bug")];
+    const result = partitionBacklog(issues);
+
+    expect(result.parentIssue).toBeNull();
+    expect(result.slices).toHaveLength(1);
+    expect(result.slices[0].number).toBe(42);
+  });
+
+  it("handles a single-issue backlog that is itself a PRD", () => {
+    // Only one issue and it matches PRD: heuristic — it becomes parentIssue with zero slices.
+    const issues = [issue(50, "PRD: lone prd")];
+    const result = partitionBacklog(issues);
+
+    expect(result.parentIssue).not.toBeNull();
+    expect(result.parentIssue!.number).toBe(50);
+    expect(result.slices).toHaveLength(0);
+  });
+
+  it("returns an empty slices array for an empty input", () => {
+    const result = partitionBacklog([]);
+
+    expect(result.parentIssue).toBeNull();
+    expect(result.slices).toEqual([]);
+  });
+
+  it("does not enroll a parent issue as a slice even if it has no blockedBy entries", () => {
+    const issues = [
+      issue(100, "PRD: feature"),
+      issue(101, "Implement A", { parent: 100 }),
+    ];
+    const result = partitionBacklog(issues);
+
+    const sliceNumbers = result.slices.map((s) => s.number);
+    expect(sliceNumbers).not.toContain(100);
+    expect(sliceNumbers).toContain(101);
+  });
+});
+
+// ─── filterToOneParentPrd ─────────────────────────────────────────────────────
+
+describe("filterToOneParentPrd", () => {
+  it("returns only issues whose parent matches the given PRD number", () => {
+    const issues = [
+      issue(100, "PRD: feature A"),
+      issue(200, "PRD: feature B"),
+      issue(101, "Impl A1", { parent: 100 }),
+      issue(102, "Impl A2", { parent: 100 }),
+      issue(201, "Impl B1", { parent: 200 }),
+    ];
+    const result = filterToOneParentPrd(issues, 100);
+
+    expect(result.map((i) => i.number)).toEqual([101, 102]);
+  });
+
+  it("returns an empty array when no issues belong to the given PRD", () => {
+    const issues = [issue(101, "Task A"), issue(102, "Task B")];
+    const result = filterToOneParentPrd(issues, 999);
+
+    expect(result).toEqual([]);
+  });
+
+  it("preserves input order of the filtered issues", () => {
+    const issues = [
+      issue(103, "C", { parent: 100 }),
+      issue(101, "A", { parent: 100 }),
+      issue(102, "B", { parent: 100 }),
+    ];
+    const result = filterToOneParentPrd(issues, 100);
+
+    expect(result.map((i) => i.number)).toEqual([103, 101, 102]);
+  });
+
+  it("does not include the parent issue itself in the result", () => {
+    const issues = [
+      issue(100, "PRD: feature"),
+      issue(101, "Task A", { parent: 100 }),
+    ];
+    const result = filterToOneParentPrd(issues, 100);
+
+    expect(result.map((i) => i.number)).not.toContain(100);
+    expect(result.map((i) => i.number)).toContain(101);
+  });
+});

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -116,15 +116,37 @@ Then check for `.orchestrate/run-state.json` (its schema is in
    If the backlog is empty, report "no ready-for-agent issues" and stop — a
    clean no-op.
 3. For each issue, parse the **Blocked by** section of its body into a list of
-   blocker issue numbers (the `- #NNN` lines), and assess its **complexity
-   tier** — `trivial` (a small, localized change), `standard` (an ordinary
-   feature or fix), or `complex` (broad, cross-cutting, or high-risk work).
-   Base the tier on the issue's scope, the number of files it likely touches,
-   and its risk. The tier drives routing in section 3. Also note the parent
-   PRD from each issue's **Parent** section (the `PRD #NNN` line): use the PRD
-   shared by all backlog issues as `parentIssue`, or `null` if they name
-   differing parents or none.
-4. Call the `plan_waves` MCP tool with one entry per issue
+   blocker issue numbers (the `- #NNN` lines), and the **Parent** section into
+   a single parent issue number (`PRD #NNN` line) or `null`. Then assess its
+   **complexity tier** — `trivial` (a small, localized change), `standard` (an
+   ordinary feature or fix), or `complex` (broad, cross-cutting, or high-risk
+   work). Base the tier on the issue's scope, the number of files it likely
+   touches, and its risk. The tier drives routing in section 3.
+
+   Once every issue is parsed, call the **`partition_backlog` MCP tool** to
+   split the backlog into `slices` and `parentIssue`:
+
+   - Pass the full backlog as the `issues` array to `partition_backlog`. It
+     returns `{ slices, parentIssue }`.
+   - `slices` is the subset of issues to process as implementation work — any
+     issue detected as the parent PRD is automatically excluded.
+   - `parentIssue` is the detected parent PRD, or `null`. The parent PRD is
+     only the progress-comment target (section 2 step 6) — it is **never**
+     enrolled as a slice.
+   - Detection uses two signals in order: (1) a `Parent` field reference — if
+     any issue names another backlog issue as its parent, that issue is the
+     parent PRD; (2) the `PRD:` title heuristic — if no explicit parent
+     reference exists, any issue whose title starts with `PRD:` (case-
+     insensitive) is treated as the parent PRD. This ensures a decomposed PRD
+     is never accidentally implemented as a slice.
+
+   To scope a run to one parent PRD's children (e.g. `/orchestrate <PRD#>`),
+   call the **`filter_to_one_parent_prd` MCP tool** first — pass the full
+   backlog and the `prdNumber`; it returns only the issues whose `parent` field
+   equals `prdNumber`, which you then pass to `partition_backlog`.
+
+4. Call the `plan_waves` MCP tool with one entry per **slice** (not the full
+   backlog — the parent PRD is excluded):
    (`{ id: "<number>", blockedBy: ["<number>", ...] }`). If it returns
    `status: "error"` with `errorCode: "CYCLE_DETECTED"`, report the cycle and
    stop — the backlog cannot be ordered.


### PR DESCRIPTION
Implements #187.

Pure backlog partitioner that resolves the run's slice set and parent PRD: excludes any issue named as another's Parent, applies a `PRD:`-title heuristic, and exposes a filter-to-one-parent-PRD function. Registered as the `partition_backlog` and `filter_to_one_parent_prd` MCP tools; SKILL.md backlog-read step wired to them. 15 new vitest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)