### PR TITLE
orchestrate: subagent result envelope with git-status fallback

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,6 +149,18 @@ _Avoid_: main, master, trunk (the integration base is `development`, distinct fr
 Removal of a concluded run's run directory, worktrees, and umbrella/slice branches — gated on that run's final integration pull request having been merged into the **Integration base**.
 _Avoid_: purge, garbage collection, prune
 
+**Result envelope**:
+The machine-checkable structured result every orchestrate subagent emits as the last of its turn — a fenced ` ```orchestrate-envelope ` JSON block conforming to a per-role schema (a `discriminatedUnion` on `role`). Worker roles (implementer, reviewer, conflict-resolver) carry `status`, `filesChanged`, `verification`, and `notes`; the read-only investigator carries a research brief and no `status`/`filesChanged`. It is the orchestrator's only source of a subagent's status and changed-file set — the orchestrator never parses subagent prose.
+_Avoid_: result blob, subagent summary, return payload
+
+**Envelope validator**:
+The deterministic `validate_envelope` MCP tool that classifies a subagent's returned text into exactly one of `valid` (a schema-conforming envelope for the expected role), `invalid` (an envelope was attempted but is truncated, malformed, or off-schema), or `missing` (no envelope block found). A truncated envelope is always reported `invalid`, never silently accepted.
+_Avoid_: envelope parser, schema checker (validator is the contract name; it classifies, it does not merely parse)
+
+**Worktree fallback**:
+The orchestrator's recovery path, the `recover_changed_files` MCP tool, for when a subagent's **Result envelope** is missing or invalid: it inspects the slice worktree directly with `git status` and returns the full changed-file set (build artifacts included), treating the worktree as the source of truth. Applies to the implementer, reviewer, and conflict-resolver only — the read-only investigator leaves no worktree changes to recover.
+_Avoid_: git-status recovery, changed-file scan (worktree fallback is the precise term — it is the fallback, not the primary path)
+
 ## Relationships
 
 - A **Distribution** owns at most one **Initializer** and at most one **Customizer**.
@@ -166,6 +178,8 @@ _Avoid_: purge, garbage collection, prune
 - Sibling **Orchestration runs** in the same repository must own disjoint **Run partitions** — one parent PRD's children each.
 - A **Driver session** executes exactly one **Orchestration run**; the context-watchdog binds a run by matching the **Driver session** identity recorded in run-state.
 - **Run cleanup** acts on an **Orchestration run** only after its final pull request has merged into the **Integration base**.
+- Every orchestrate subagent returns exactly one **Result envelope**; the **Envelope validator** classifies it, and the orchestrator acts only on that classification — never on subagent prose.
+- The **Worktree fallback** runs only when the **Envelope validator** reports a worker subagent's **Result envelope** `invalid` or `missing` — it never substitutes for a `valid` envelope.
 
 ## Example dialogue
 

--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -42,6 +42,8 @@ Every other role is a **subagent**, spawned with the standard Agent tool by its 
 
 This is the **no-Bash safety model**: the subagents have no shell and no git access. They are sandboxed to a single worktree, and the investigator cannot write at all. Only the orchestrator runs commands, touches branches and remotes, and writes to the issue tracker. A subagent cannot push, cannot merge, cannot edit an issue, and cannot reach outside its worktree — so the blast radius of any one subagent is one directory.
 
+Every subagent ends its turn with a machine-checkable **result envelope** — a fenced ` ```orchestrate-envelope ` JSON block conforming to a per-role schema. The orchestrator reads a subagent's status and changed-file set only from this validated envelope (via the `validate_envelope` tool), never from its prose — so a turn that was truncated or cut short is detected, never silently accepted. When an envelope is missing or invalid, the orchestrator recovers the worktree's changed-file set by inspecting it directly with `recover_changed_files`, treating the worktree as the source of truth.
+
 ### The orchestrate MCP server
 
 The plugin bundles `orchestrate-mcp`, a Model Context Protocol server providing the deterministic tools the orchestrator and subagents call:
@@ -52,6 +54,8 @@ The plugin bundles `orchestrate-mcp`, a Model Context Protocol server providing 
 | `run_tests` / `run_typecheck` / `run_build` / `run_lint` | Run the project's configured capability commands |
 | `plan_waves` | Topologically sort issues into dependency waves; detects cycles |
 | `resolve_routing` | Resolve the model and effort variant for each role from a complexity tier |
+| `validate_envelope` | Validate a subagent's result envelope against its role schema — distinguishes a valid, a truncated/invalid, and a missing envelope |
+| `recover_changed_files` | Recover a worktree's changed-file set by inspecting it directly — the orchestrator's fallback when an envelope is missing or invalid |
 | `render_dashboard` / `render_graph` / `render_report` | Render standalone HTML artifacts from the run state |
 | `spawn_successor` | Launch a fresh Claude Code session that resumes the run |
 | `search_structural` | Syntax-aware (ast-grep) code search, with a text-search fallback |

--- a/plugins/orchestrate/agents/conflict-resolver-deep.md
+++ b/plugins/orchestrate/agents/conflict-resolver-deep.md
@@ -75,12 +75,36 @@ before declaring `resolved`.
 
 ## What you return
 
-Return a structured summary with these fields:
+End your turn with a **result envelope** — a single fenced
+` ```orchestrate-envelope ` block holding one JSON object. The orchestrator
+validates this envelope; it never parses your prose. Emit the envelope as the
+**last thing** in your final message, complete and unabbreviated — a truncated
+or missing envelope is treated as a FAILED slice.
 
-- **status** — `resolved` (every marker gone, every configured capability tool
-  passes) or `failed` (a conflict you could not resolve correctly).
-- **filesChanged** — the conflicted files you edited, relative to the worktree
-  root.
-- **verification** — each capability tool you ran and its result.
-- **notes** — how you reconciled each conflict; or, if `failed`, the exact
-  conflict that defeated you and why it could not be resolved safely.
+The envelope object has exactly these fields:
+
+- **role** — the string `"conflict-resolver"`.
+- **status** — `"resolved"` (every marker gone, every configured capability tool
+  passes) or `"failed"` (a conflict you could not resolve correctly).
+- **filesChanged** — an array of the conflicted files you edited, relative to the
+  worktree root.
+- **verification** — an array of objects, one per capability tool you ran, each
+  `{ "capability": "tests" | "typecheck" | "build" | "lint", "result":
+  "passed" | "failed" | "not-configured" }`.
+- **notes** — a string: how you reconciled each conflict; or, if `failed`, the
+  exact conflict that defeated you and why it could not be resolved safely.
+
+Example:
+
+```orchestrate-envelope
+{
+  "role": "conflict-resolver",
+  "status": "resolved",
+  "filesChanged": ["src/index.ts"],
+  "verification": [
+    { "capability": "typecheck", "result": "passed" },
+    { "capability": "tests", "result": "passed" }
+  ],
+  "notes": "Reconciled both intents in the import block; no markers remain."
+}
+```

--- a/plugins/orchestrate/agents/conflict-resolver-standard.md
+++ b/plugins/orchestrate/agents/conflict-resolver-standard.md
@@ -52,12 +52,36 @@ smaller surface than a full implementation.
 
 ## What you return
 
-Return a structured summary with these fields:
+End your turn with a **result envelope** — a single fenced
+` ```orchestrate-envelope ` block holding one JSON object. The orchestrator
+validates this envelope; it never parses your prose. Emit the envelope as the
+**last thing** in your final message, complete and unabbreviated — a truncated
+or missing envelope is treated as a FAILED slice.
 
-- **status** — `resolved` (every marker gone, every configured capability tool
-  passes) or `failed` (a conflict you could not resolve correctly).
-- **filesChanged** — the conflicted files you edited, relative to the worktree
-  root.
-- **verification** — each capability tool you ran and its result.
-- **notes** — how you reconciled each conflict; or, if `failed`, the exact
-  conflict that defeated you and why it could not be resolved safely.
+The envelope object has exactly these fields:
+
+- **role** — the string `"conflict-resolver"`.
+- **status** — `"resolved"` (every marker gone, every configured capability tool
+  passes) or `"failed"` (a conflict you could not resolve correctly).
+- **filesChanged** — an array of the conflicted files you edited, relative to the
+  worktree root.
+- **verification** — an array of objects, one per capability tool you ran, each
+  `{ "capability": "tests" | "typecheck" | "build" | "lint", "result":
+  "passed" | "failed" | "not-configured" }`.
+- **notes** — a string: how you reconciled each conflict; or, if `failed`, the
+  exact conflict that defeated you and why it could not be resolved safely.
+
+Example:
+
+```orchestrate-envelope
+{
+  "role": "conflict-resolver",
+  "status": "resolved",
+  "filesChanged": ["src/index.ts"],
+  "verification": [
+    { "capability": "typecheck", "result": "passed" },
+    { "capability": "tests", "result": "passed" }
+  ],
+  "notes": "Reconciled both intents in the import block; no markers remain."
+}
+```

--- a/plugins/orchestrate/agents/implementer-deep.md
+++ b/plugins/orchestrate/agents/implementer-deep.md
@@ -75,14 +75,39 @@ exist specifically to support this wider, deeper pass — use them.
 
 ## What you return
 
-Return a structured summary with these fields:
+End your turn with a **result envelope** — a single fenced
+` ```orchestrate-envelope ` block holding one JSON object. The orchestrator
+validates this envelope; it never parses your prose. Emit the envelope as the
+**last thing** in your final message, complete and unabbreviated — a truncated
+or missing envelope is treated as a FAILED slice.
 
-- **status** — `completed` (acceptance criteria met and all configured
-  capability tools pass) or `blocked` (you could not finish).
-- **filesChanged** — the files you created or edited, as paths relative to the
-  worktree root.
-- **verification** — each capability tool you ran and its result (`passed`,
-  `failed`, or `not-configured`).
-- **notes** — anything the orchestrator or a later reviewer must know:
-  assumptions you made, partial work, or — if `blocked` — exactly what stopped
+The envelope object has exactly these fields:
+
+- **role** — the string `"implementer"`.
+- **status** — `"completed"` (acceptance criteria met and all configured
+  capability tools pass) or `"blocked"` (you could not finish).
+- **filesChanged** — an array of the files you created or edited, as paths
+  relative to the worktree root (`[]` if you changed nothing).
+- **verification** — an array of objects, one per capability tool you ran, each
+  `{ "capability": "tests" | "typecheck" | "build" | "lint", "result":
+  "passed" | "failed" | "not-configured" }`.
+- **notes** — a string: anything the orchestrator or a later reviewer must know
+  — assumptions you made, partial work, or, if `blocked`, exactly what stopped
   you and what was tried.
+
+Example:
+
+```orchestrate-envelope
+{
+  "role": "implementer",
+  "status": "completed",
+  "filesChanged": ["src/foo.ts", "test/foo.test.ts"],
+  "verification": [
+    { "capability": "typecheck", "result": "passed" },
+    { "capability": "build", "result": "passed" },
+    { "capability": "tests", "result": "passed" },
+    { "capability": "lint", "result": "not-configured" }
+  ],
+  "notes": "Implemented per the acceptance criteria."
+}
+```

--- a/plugins/orchestrate/agents/implementer-standard.md
+++ b/plugins/orchestrate/agents/implementer-standard.md
@@ -53,14 +53,39 @@ The orchestrator gives you:
 
 ## What you return
 
-Return a structured summary with these fields:
+End your turn with a **result envelope** — a single fenced
+` ```orchestrate-envelope ` block holding one JSON object. The orchestrator
+validates this envelope; it never parses your prose. Emit the envelope as the
+**last thing** in your final message, complete and unabbreviated — a truncated
+or missing envelope is treated as a FAILED slice.
 
-- **status** — `completed` (acceptance criteria met and all configured
-  capability tools pass) or `blocked` (you could not finish).
-- **filesChanged** — the files you created or edited, as paths relative to the
-  worktree root.
-- **verification** — each capability tool you ran and its result (`passed`,
-  `failed`, or `not-configured`).
-- **notes** — anything the orchestrator or a later reviewer must know:
-  assumptions you made, partial work, or — if `blocked` — exactly what stopped
+The envelope object has exactly these fields:
+
+- **role** — the string `"implementer"`.
+- **status** — `"completed"` (acceptance criteria met and all configured
+  capability tools pass) or `"blocked"` (you could not finish).
+- **filesChanged** — an array of the files you created or edited, as paths
+  relative to the worktree root (`[]` if you changed nothing).
+- **verification** — an array of objects, one per capability tool you ran, each
+  `{ "capability": "tests" | "typecheck" | "build" | "lint", "result":
+  "passed" | "failed" | "not-configured" }`.
+- **notes** — a string: anything the orchestrator or a later reviewer must know
+  — assumptions you made, partial work, or, if `blocked`, exactly what stopped
   you and what was tried.
+
+Example:
+
+```orchestrate-envelope
+{
+  "role": "implementer",
+  "status": "completed",
+  "filesChanged": ["src/foo.ts", "test/foo.test.ts"],
+  "verification": [
+    { "capability": "typecheck", "result": "passed" },
+    { "capability": "build", "result": "passed" },
+    { "capability": "tests", "result": "passed" },
+    { "capability": "lint", "result": "not-configured" }
+  ],
+  "notes": "Implemented per the acceptance criteria."
+}
+```

--- a/plugins/orchestrate/agents/investigator-deep.md
+++ b/plugins/orchestrate/agents/investigator-deep.md
@@ -81,15 +81,39 @@ brief that genuinely de-risks the implementation.
 
 ## What you return
 
-Return a structured brief with these fields:
+End your turn with a **result envelope** — a single fenced
+` ```orchestrate-envelope ` block holding one JSON object. The orchestrator
+validates this envelope; it never parses your prose. Emit the envelope as the
+**last thing** in your final message, complete and unabbreviated — a truncated
+or missing envelope is treated as a failed investigation pass.
 
-- **relevantFiles** — paths (relative to the repository root) the implementer
-  will likely need to read or change.
-- **patterns** — existing conventions in the affected areas that the implementer
-  must follow (naming, structure, error handling, test style, etc.).
-- **risks** — edge cases and failure modes the implementer must handle; callers
-  or consumers whose behavior could break; invariants that must be preserved.
-- **approach** — a suggested implementation approach: what to change, in what
-  order, and why.
-- **notes** — anything else the implementer should know that does not fit the
-  fields above.
+The envelope object has exactly these fields:
+
+- **role** — the string `"investigator"`.
+- **relevantFiles** — an array of paths (relative to the repository root) the
+  implementer will likely need to read or change.
+- **patterns** — a string: existing conventions in the affected areas the
+  implementer must follow (naming, structure, error handling, test style, etc.).
+- **risks** — a string: edge cases and failure modes the implementer must
+  handle; callers or consumers whose behavior could break; invariants that must
+  be preserved.
+- **approach** — a string: a suggested implementation approach — what to change,
+  in what order, and why.
+- **notes** — a string: anything else the implementer should know that does not
+  fit the fields above.
+
+The investigator is read-only, so the envelope carries no `status` and no
+`filesChanged`.
+
+Example:
+
+```orchestrate-envelope
+{
+  "role": "investigator",
+  "relevantFiles": ["src/tools/foo.ts", "test/foo.test.ts"],
+  "patterns": "Zod schemas are the single source of truth; types via z.infer.",
+  "risks": "Callers of parseFoo() assume a non-null return — preserve that.",
+  "approach": "Add the schema, then the validator, then the tests.",
+  "notes": "ast-grep was unavailable; text search was used instead."
+}
+```

--- a/plugins/orchestrate/agents/investigator-standard.md
+++ b/plugins/orchestrate/agents/investigator-standard.md
@@ -57,15 +57,39 @@ always acceptable.
 
 ## What you return
 
-Return a structured brief with these fields:
+End your turn with a **result envelope** — a single fenced
+` ```orchestrate-envelope ` block holding one JSON object. The orchestrator
+validates this envelope; it never parses your prose. Emit the envelope as the
+**last thing** in your final message, complete and unabbreviated — a truncated
+or missing envelope is treated as a failed investigation pass.
 
-- **relevantFiles** — paths (relative to the repository root) the implementer
-  will likely need to read or change.
-- **patterns** — existing conventions in the affected areas that the implementer
-  must follow (naming, structure, error handling, test style, etc.).
-- **risks** — edge cases and failure modes the implementer must handle; callers
-  or consumers whose behavior could break; invariants that must be preserved.
-- **approach** — a suggested implementation approach: what to change, in what
-  order, and why.
-- **notes** — anything else the implementer should know that does not fit the
-  fields above.
+The envelope object has exactly these fields:
+
+- **role** — the string `"investigator"`.
+- **relevantFiles** — an array of paths (relative to the repository root) the
+  implementer will likely need to read or change.
+- **patterns** — a string: existing conventions in the affected areas the
+  implementer must follow (naming, structure, error handling, test style, etc.).
+- **risks** — a string: edge cases and failure modes the implementer must
+  handle; callers or consumers whose behavior could break; invariants that must
+  be preserved.
+- **approach** — a string: a suggested implementation approach — what to change,
+  in what order, and why.
+- **notes** — a string: anything else the implementer should know that does not
+  fit the fields above.
+
+The investigator is read-only, so the envelope carries no `status` and no
+`filesChanged`.
+
+Example:
+
+```orchestrate-envelope
+{
+  "role": "investigator",
+  "relevantFiles": ["src/tools/foo.ts", "test/foo.test.ts"],
+  "patterns": "Zod schemas are the single source of truth; types via z.infer.",
+  "risks": "Callers of parseFoo() assume a non-null return — preserve that.",
+  "approach": "Add the schema, then the validator, then the tests.",
+  "notes": "ast-grep was unavailable; text search was used instead."
+}
+```

--- a/plugins/orchestrate/agents/reviewer-deep.md
+++ b/plugins/orchestrate/agents/reviewer-deep.md
@@ -88,12 +88,36 @@ or failing.
 
 ## What you return
 
-Return a structured summary with these fields:
+End your turn with a **result envelope** — a single fenced
+` ```orchestrate-envelope ` block holding one JSON object. The orchestrator
+validates this envelope; it never parses your prose. Emit the envelope as the
+**last thing** in your final message, complete and unabbreviated — a truncated
+or missing envelope is treated as a FAILED slice.
 
-- **status** — `passed` (acceptance criteria met, code sound, all configured
-  capability tools pass) or `failed` (an unrecoverable blocker — explain it).
-- **filesChanged** — the files you edited during review, relative to the
-  worktree root (empty if you changed nothing).
-- **verification** — each capability tool you ran and its result.
-- **notes** — what you fixed and why; or, if `failed`, the exact blocker, why it
-  is unsafe to fix inline, and what you tried.
+The envelope object has exactly these fields:
+
+- **role** — the string `"reviewer"`.
+- **status** — `"passed"` (acceptance criteria met, code sound, all configured
+  capability tools pass) or `"failed"` (an unrecoverable blocker — explain it).
+- **filesChanged** — an array of the files you edited during review, relative to
+  the worktree root (`[]` if you changed nothing).
+- **verification** — an array of objects, one per capability tool you ran, each
+  `{ "capability": "tests" | "typecheck" | "build" | "lint", "result":
+  "passed" | "failed" | "not-configured" }`.
+- **notes** — a string: what you fixed and why; or, if `failed`, the exact
+  blocker, why it is unsafe to fix inline, and what you tried.
+
+Example:
+
+```orchestrate-envelope
+{
+  "role": "reviewer",
+  "status": "passed",
+  "filesChanged": ["src/foo.ts"],
+  "verification": [
+    { "capability": "typecheck", "result": "passed" },
+    { "capability": "tests", "result": "passed" }
+  ],
+  "notes": "Fixed a naming inconsistency inline; acceptance criteria met."
+}
+```

--- a/plugins/orchestrate/agents/reviewer-standard.md
+++ b/plugins/orchestrate/agents/reviewer-standard.md
@@ -64,12 +64,36 @@ always acceptable.
 
 ## What you return
 
-Return a structured summary with these fields:
+End your turn with a **result envelope** — a single fenced
+` ```orchestrate-envelope ` block holding one JSON object. The orchestrator
+validates this envelope; it never parses your prose. Emit the envelope as the
+**last thing** in your final message, complete and unabbreviated — a truncated
+or missing envelope is treated as a FAILED slice.
 
-- **status** — `passed` (acceptance criteria met, code sound, all configured
-  capability tools pass) or `failed` (an unrecoverable blocker — explain it).
-- **filesChanged** — the files you edited during review, relative to the
-  worktree root (empty if you changed nothing).
-- **verification** — each capability tool you ran and its result.
-- **notes** — what you fixed and why; or, if `failed`, the exact blocker, why it
-  is unsafe to fix inline, and what you tried.
+The envelope object has exactly these fields:
+
+- **role** — the string `"reviewer"`.
+- **status** — `"passed"` (acceptance criteria met, code sound, all configured
+  capability tools pass) or `"failed"` (an unrecoverable blocker — explain it).
+- **filesChanged** — an array of the files you edited during review, relative to
+  the worktree root (`[]` if you changed nothing).
+- **verification** — an array of objects, one per capability tool you ran, each
+  `{ "capability": "tests" | "typecheck" | "build" | "lint", "result":
+  "passed" | "failed" | "not-configured" }`.
+- **notes** — a string: what you fixed and why; or, if `failed`, the exact
+  blocker, why it is unsafe to fix inline, and what you tried.
+
+Example:
+
+```orchestrate-envelope
+{
+  "role": "reviewer",
+  "status": "passed",
+  "filesChanged": ["src/foo.ts"],
+  "verification": [
+    { "capability": "typecheck", "result": "passed" },
+    { "capability": "tests", "result": "passed" }
+  ],
+  "notes": "Fixed a naming inconsistency inline; acceptance criteria met."
+}
+```

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -6873,12 +6873,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs6, exportName) {
+    function addFormats(ajv, list, fs7, exportName) {
       var _a;
       var _b;
       (_a = (_b = ajv.opts.code).formats) !== null && _a !== void 0 ? _a : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs6[f]);
+        ajv.addFormat(f, fs7[f]);
     }
     module2.exports = exports2 = formatsPlugin;
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -22948,6 +22948,256 @@ async function searchStructural(input, opts = {}) {
   }
 }
 
+// src/tools/validate-envelope.ts
+var verificationEntrySchema = external_exports.object({
+  capability: external_exports.enum(["tests", "typecheck", "build", "lint"]).describe("Which capability tool was run."),
+  result: external_exports.enum(["passed", "failed", "not-configured"]).describe(
+    "Outcome of that run. 'not-configured' means the verb has no command set."
+  )
+});
+var implementerEnvelopeSchema = external_exports.object({
+  role: external_exports.literal("implementer").describe("Discriminant \u2014 the implementer role."),
+  status: external_exports.enum(["completed", "blocked"]).describe(
+    "Outcome. 'completed' = acceptance criteria met and every configured capability tool passed; 'blocked' = the implementer could not finish."
+  ),
+  filesChanged: external_exports.array(external_exports.string()).describe(
+    "Files the implementer created or edited, as paths relative to the worktree root. An empty array means no file was changed."
+  ),
+  verification: external_exports.array(verificationEntrySchema).describe("Each capability tool the implementer ran and its result."),
+  notes: external_exports.string().describe(
+    "Free-form notes for the orchestrator or a later reviewer \u2014 assumptions, partial work, or, when blocked, exactly what stopped the implementer."
+  )
+});
+var reviewerEnvelopeSchema = external_exports.object({
+  role: external_exports.literal("reviewer").describe("Discriminant \u2014 the reviewer role."),
+  status: external_exports.enum(["passed", "failed"]).describe(
+    "Outcome. 'passed' = acceptance criteria met, code sound, every configured capability tool passed; 'failed' = an unrecoverable blocker."
+  ),
+  filesChanged: external_exports.array(external_exports.string()).describe(
+    "Files the reviewer edited during review, relative to the worktree root. An empty array means the reviewer changed nothing."
+  ),
+  verification: external_exports.array(verificationEntrySchema).describe("Each capability tool the reviewer ran and its result."),
+  notes: external_exports.string().describe(
+    "Free-form notes \u2014 what was fixed and why, or, when failed, the exact blocker and why it is unsafe to fix inline."
+  )
+});
+var conflictResolverEnvelopeSchema = external_exports.object({
+  role: external_exports.literal("conflict-resolver").describe("Discriminant \u2014 the conflict-resolver role."),
+  status: external_exports.enum(["resolved", "failed"]).describe(
+    "Outcome. 'resolved' = every conflict marker gone and every configured capability tool passed; 'failed' = a conflict that could not be resolved correctly."
+  ),
+  filesChanged: external_exports.array(external_exports.string()).describe(
+    "The conflicted files the resolver edited, relative to the worktree root."
+  ),
+  verification: external_exports.array(verificationEntrySchema).describe("Each capability tool the conflict-resolver ran and its result."),
+  notes: external_exports.string().describe(
+    "Free-form notes \u2014 how each conflict was reconciled, or, when failed, the exact conflict that could not be resolved safely."
+  )
+});
+var investigatorEnvelopeSchema = external_exports.object({
+  role: external_exports.literal("investigator").describe("Discriminant \u2014 the investigator role."),
+  relevantFiles: external_exports.array(external_exports.string()).describe(
+    "Paths, relative to the repository root, the implementer will likely need to read or change."
+  ),
+  patterns: external_exports.string().describe(
+    "Existing conventions in the affected areas the implementer must follow."
+  ),
+  risks: external_exports.string().describe(
+    "Edge cases, failure modes, affected callers, and invariants to preserve."
+  ),
+  approach: external_exports.string().describe("A suggested implementation approach \u2014 what to change and why."),
+  notes: external_exports.string().describe("Anything else that does not fit the fields above.")
+});
+var envelopeSchema = external_exports.discriminatedUnion("role", [
+  implementerEnvelopeSchema,
+  reviewerEnvelopeSchema,
+  conflictResolverEnvelopeSchema,
+  investigatorEnvelopeSchema
+]);
+var ENVELOPE_ROLES = [
+  "implementer",
+  "reviewer",
+  "conflict-resolver",
+  "investigator"
+];
+var validateEnvelopeInputSchema = external_exports.object({
+  text: external_exports.string().describe(
+    "The raw, verbatim text a subagent returned as its final message. The validator locates the ```orchestrate-envelope fenced block within it."
+  ),
+  role: external_exports.enum(ENVELOPE_ROLES).describe(
+    "The role the subagent was spawned as. The located envelope must declare this same role \u2014 a role mismatch is reported as an invalid envelope."
+  )
+});
+var validateEnvelopeOutputSchema = external_exports.object({
+  status: external_exports.enum(["valid", "invalid", "missing"]).describe(
+    "Outcome discriminant. 'valid' = a well-formed envelope matching the expected role was found; 'invalid' = an envelope was attempted but is truncated, malformed, or does not match the schema (a truncated envelope is ALWAYS reported invalid, never silently accepted); 'missing' = no orchestrate-envelope block was found at all."
+  ),
+  role: external_exports.enum(ENVELOPE_ROLES).describe("The role the envelope was validated against \u2014 echoes the input."),
+  envelope: envelopeSchema.optional().describe(
+    "The parsed, schema-conforming envelope. Present only when status='valid'."
+  ),
+  errorCode: external_exports.enum(["TRUNCATED_OR_MALFORMED", "SCHEMA_MISMATCH"]).optional().describe(
+    "Machine-readable reason an attempted envelope was rejected. Present when status='invalid'. 'TRUNCATED_OR_MALFORMED' = the fenced block could not be parsed as JSON (truncated mid-turn, or not JSON); 'SCHEMA_MISMATCH' = it parsed as JSON but does not match the role's envelope schema (a missing field, wrong role, or bad value)."
+  ),
+  errorMessage: external_exports.string().optional().describe(
+    "Human-readable description of why the envelope is invalid or missing. Present when status='invalid' or status='missing'."
+  )
+});
+var FENCE_TAG = "orchestrate-envelope";
+function extractEnvelopeBlocks(text) {
+  const lines = text.split("\n");
+  const blocks = [];
+  let inBlock = false;
+  let buffer = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!inBlock) {
+      if (trimmed === "```" + FENCE_TAG) {
+        inBlock = true;
+        buffer = [];
+      }
+    } else {
+      if (trimmed === "```") {
+        blocks.push(buffer.join("\n"));
+        inBlock = false;
+      } else {
+        buffer.push(line);
+      }
+    }
+  }
+  return blocks;
+}
+function hasUnclosedEnvelopeFence(text) {
+  const lines = text.split("\n");
+  let openCount = 0;
+  let inBlock = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!inBlock) {
+      if (trimmed === "```" + FENCE_TAG) {
+        inBlock = true;
+        openCount++;
+      }
+    } else if (trimmed === "```") {
+      inBlock = false;
+    }
+  }
+  return inBlock && openCount > 0;
+}
+function validateEnvelope(input) {
+  const { text, role } = input;
+  const blocks = extractEnvelopeBlocks(text);
+  const truncated = hasUnclosedEnvelopeFence(text);
+  if (blocks.length === 0 && !truncated) {
+    return {
+      status: "missing",
+      role,
+      errorMessage: `No \`\`\`${FENCE_TAG} block was found in the subagent's output. The subagent did not emit a result envelope.`
+    };
+  }
+  if (truncated) {
+    return {
+      status: "invalid",
+      role,
+      errorCode: "TRUNCATED_OR_MALFORMED",
+      errorMessage: `An opening \`\`\`${FENCE_TAG} fence was found with no closing fence \u2014 the subagent's turn was truncated mid-envelope. A truncated envelope is never accepted.`
+    };
+  }
+  const lastBlock = blocks[blocks.length - 1];
+  let parsed;
+  try {
+    parsed = JSON.parse(lastBlock);
+  } catch (err) {
+    return {
+      status: "invalid",
+      role,
+      errorCode: "TRUNCATED_OR_MALFORMED",
+      errorMessage: `The \`\`\`${FENCE_TAG} block does not contain valid JSON: ${err instanceof Error ? err.message : String(err)}. The envelope is truncated or malformed.`
+    };
+  }
+  const result = envelopeSchema.safeParse(parsed);
+  if (!result.success) {
+    const detail = result.error.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`).join("; ");
+    return {
+      status: "invalid",
+      role,
+      errorCode: "SCHEMA_MISMATCH",
+      errorMessage: `The envelope does not match the expected schema: ${detail}.`
+    };
+  }
+  if (result.data.role !== role) {
+    return {
+      status: "invalid",
+      role,
+      errorCode: "SCHEMA_MISMATCH",
+      errorMessage: `The envelope declares role "${result.data.role}" but the subagent was spawned as "${role}".`
+    };
+  }
+  return {
+    status: "valid",
+    role,
+    envelope: result.data
+  };
+}
+
+// src/tools/recover-changed-files.ts
+var fs6 = __toESM(require("fs"));
+var recoverChangedFilesInputSchema = external_exports.object({
+  worktreePath: external_exports.string().describe(
+    "Absolute path to the slice worktree to inspect. The recovery treats this worktree as the source of truth for the changed-file set."
+  )
+});
+var recoverChangedFilesOutputSchema = external_exports.object({
+  status: external_exports.enum(["ok", "error"]).describe(
+    "Outcome discriminant. 'ok' = the changed-file set was recovered; 'error' = the worktree could not be inspected."
+  ),
+  changedFiles: external_exports.array(external_exports.string()).optional().describe(
+    "Every changed path in the worktree \u2014 tracked modifications, staged changes, AND untracked files (build artifacts included; no filter is applied). Each entry is a single real path relative to the worktree root; a rename emits both its source and destination path, never an 'old -> new' composite. Present when status='ok' (an empty array means a clean worktree)."
+  ),
+  errorCode: external_exports.enum(["INVALID_INPUT", "PATH_NOT_FOUND", "GIT_ERROR"]).optional().describe(
+    "Machine-readable failure category. Present when status='error'. 'INVALID_INPUT' = the path would be parsed by git as an option flag; 'PATH_NOT_FOUND' = the worktree path does not exist on disk; 'GIT_ERROR' = git could not report status (e.g. not a git worktree)."
+  ),
+  errorMessage: external_exports.string().optional().describe(
+    "Cleaned, human-readable failure description. Present when status='error'."
+  )
+});
+async function recoverChangedFiles(input) {
+  const { worktreePath } = input;
+  const guardErr = optionInjectionError("worktreePath", worktreePath);
+  if (guardErr) {
+    return {
+      status: "error",
+      errorCode: "INVALID_INPUT",
+      errorMessage: guardErr
+    };
+  }
+  if (!fs6.existsSync(worktreePath)) {
+    return {
+      status: "error",
+      errorCode: "PATH_NOT_FOUND",
+      errorMessage: `Worktree path does not exist: ${worktreePath}`
+    };
+  }
+  let porcelain;
+  try {
+    const { stdout } = await gitExecFile(
+      ["status", "--porcelain", "-z"],
+      worktreePath
+    );
+    porcelain = stdout;
+  } catch (err) {
+    return {
+      status: "error",
+      errorCode: "GIT_ERROR",
+      errorMessage: cleanGitError(err)
+    };
+  }
+  return {
+    status: "ok",
+    changedFiles: parsePorcelainZ(porcelain)
+  };
+}
+
 // src/index.ts
 var server = new McpServer({
   name: "orchestrate",
@@ -23202,6 +23452,58 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleSearchStructural
+);
+var handleValidateEnvelope = async (input) => {
+  const result = validateEnvelope(input);
+  let text;
+  if (result.status === "valid") {
+    text = `Valid ${result.role} envelope.`;
+  } else if (result.status === "invalid") {
+    text = `Invalid ${result.role} envelope [${result.errorCode}]: ${result.errorMessage}`;
+  } else {
+    text = `Missing ${result.role} envelope: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text", text }]
+  };
+};
+registerTool(
+  "validate_envelope",
+  {
+    title: "Validate Subagent Result Envelope",
+    description: "Validates a subagent's result envelope \u2014 the ```orchestrate-envelope fenced JSON block a subagent emits as its final message \u2014 against the defined schema for its role. Returns a discriminated `status`: 'valid' (a well-formed envelope matching the role, with the parsed `envelope`), 'invalid' (an envelope was attempted but is truncated, malformed, or off-schema \u2014 a truncated envelope is ALWAYS invalid, never silently accepted), or 'missing' (no envelope block was found). The orchestrator uses this instead of parsing subagent prose for status or changed files.",
+    inputSchema: validateEnvelopeInputSchema.shape,
+    outputSchema: validateEnvelopeOutputSchema.shape
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleValidateEnvelope
+);
+var handleRecoverChangedFiles = async (input) => {
+  const result = await recoverChangedFiles(input);
+  let text;
+  if (result.status === "ok") {
+    text = `Recovered ${result.changedFiles.length} changed file(s) from the worktree.`;
+  } else {
+    text = `Changed-file recovery failed [${result.errorCode}]: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text", text }]
+  };
+};
+registerTool(
+  "recover_changed_files",
+  {
+    title: "Recover Changed Files From a Worktree",
+    description: "Recovers the changed-file set of a slice worktree by inspecting it directly with 'git status --porcelain -z' \u2014 the orchestrator's fallback for when a subagent's result envelope is missing or invalid and its `filesChanged` list cannot be trusted. Returns ALL changes (tracked, staged, and untracked alike \u2014 build artifacts NOT filtered); a rename emits both real paths, never an 'old -> new' composite. Discriminated `status` of 'ok' or 'error'.",
+    inputSchema: recoverChangedFilesInputSchema.shape,
+    outputSchema: recoverChangedFilesOutputSchema.shape
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleRecoverChangedFiles
 );
 async function main() {
   const transport = new StdioServerTransport();

--- a/plugins/orchestrate/orchestrate-mcp/src/index.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/index.ts
@@ -59,6 +59,20 @@ import {
   type SearchStructuralInput,
   type SearchStructuralOutput,
 } from "./tools/search-structural.js";
+import {
+  validateEnvelope,
+  validateEnvelopeInputSchema,
+  validateEnvelopeOutputSchema,
+  type ValidateEnvelopeInput,
+  type ValidateEnvelopeOutput,
+} from "./tools/validate-envelope.js";
+import {
+  recoverChangedFiles,
+  recoverChangedFilesInputSchema,
+  recoverChangedFilesOutputSchema,
+  type RecoverChangedFilesInput,
+  type RecoverChangedFilesOutput,
+} from "./tools/recover-changed-files.js";
 
 const server = new McpServer({
   name: "orchestrate",
@@ -502,6 +516,87 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleSearchStructural as unknown as AnyToolHandler
+);
+
+// ─── validate_envelope ────────────────────────────────────────────────────────
+
+const handleValidateEnvelope: ToolHandler<
+  ValidateEnvelopeInput,
+  ValidateEnvelopeOutput
+> = async (input) => {
+  const result = validateEnvelope(input);
+  let text: string;
+  if (result.status === "valid") {
+    text = `Valid ${result.role} envelope.`;
+  } else if (result.status === "invalid") {
+    text = `Invalid ${result.role} envelope [${result.errorCode}]: ${result.errorMessage}`;
+  } else {
+    text = `Missing ${result.role} envelope: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text" as const, text }],
+  };
+};
+
+registerTool(
+  "validate_envelope",
+  {
+    title: "Validate Subagent Result Envelope",
+    description:
+      "Validates a subagent's result envelope — the ```orchestrate-envelope " +
+      "fenced JSON block a subagent emits as its final message — against the " +
+      "defined schema for its role. Returns a discriminated `status`: 'valid' " +
+      "(a well-formed envelope matching the role, with the parsed `envelope`), " +
+      "'invalid' (an envelope was attempted but is truncated, malformed, or " +
+      "off-schema — a truncated envelope is ALWAYS invalid, never silently " +
+      "accepted), or 'missing' (no envelope block was found). The orchestrator " +
+      "uses this instead of parsing subagent prose for status or changed files.",
+    inputSchema: validateEnvelopeInputSchema.shape,
+    outputSchema: validateEnvelopeOutputSchema.shape,
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleValidateEnvelope as unknown as AnyToolHandler
+);
+
+// ─── recover_changed_files ────────────────────────────────────────────────────
+
+const handleRecoverChangedFiles: ToolHandler<
+  RecoverChangedFilesInput,
+  RecoverChangedFilesOutput
+> = async (input) => {
+  const result = await recoverChangedFiles(input);
+  let text: string;
+  if (result.status === "ok") {
+    text = `Recovered ${result.changedFiles!.length} changed file(s) from the worktree.`;
+  } else {
+    text = `Changed-file recovery failed [${result.errorCode}]: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text" as const, text }],
+  };
+};
+
+registerTool(
+  "recover_changed_files",
+  {
+    title: "Recover Changed Files From a Worktree",
+    description:
+      "Recovers the changed-file set of a slice worktree by inspecting it " +
+      "directly with 'git status --porcelain -z' — the orchestrator's fallback " +
+      "for when a subagent's result envelope is missing or invalid and its " +
+      "`filesChanged` list cannot be trusted. Returns ALL changes (tracked, " +
+      "staged, and untracked alike — build artifacts NOT filtered); a rename " +
+      "emits both real paths, never an 'old -> new' composite. Discriminated " +
+      "`status` of 'ok' or 'error'.",
+    inputSchema: recoverChangedFilesInputSchema.shape,
+    outputSchema: recoverChangedFilesOutputSchema.shape,
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleRecoverChangedFiles as unknown as AnyToolHandler
 );
 
 // ─── Start server ─────────────────────────────────────────────────────────────

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/recover-changed-files.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/recover-changed-files.ts
@@ -1,0 +1,122 @@
+import * as fs from "fs";
+import { z } from "zod";
+import { gitExecFile, optionInjectionError, cleanGitError } from "../git.js";
+import { parsePorcelainZ } from "./worktree.js";
+
+// ─── Schemas — z.object is the single source of truth; TS types via z.infer ───
+
+export const recoverChangedFilesInputSchema = z.object({
+  worktreePath: z
+    .string()
+    .describe(
+      "Absolute path to the slice worktree to inspect. The recovery treats " +
+        "this worktree as the source of truth for the changed-file set."
+    ),
+});
+
+export const recoverChangedFilesOutputSchema = z.object({
+  status: z
+    .enum(["ok", "error"])
+    .describe(
+      "Outcome discriminant. 'ok' = the changed-file set was recovered; " +
+        "'error' = the worktree could not be inspected."
+    ),
+  changedFiles: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Every changed path in the worktree — tracked modifications, staged " +
+        "changes, AND untracked files (build artifacts included; no filter is " +
+        "applied). Each entry is a single real path relative to the worktree " +
+        "root; a rename emits both its source and destination path, never an " +
+        "'old -> new' composite. Present when status='ok' (an empty array " +
+        "means a clean worktree)."
+    ),
+  errorCode: z
+    .enum(["INVALID_INPUT", "PATH_NOT_FOUND", "GIT_ERROR"])
+    .optional()
+    .describe(
+      "Machine-readable failure category. Present when status='error'. " +
+        "'INVALID_INPUT' = the path would be parsed by git as an option flag; " +
+        "'PATH_NOT_FOUND' = the worktree path does not exist on disk; " +
+        "'GIT_ERROR' = git could not report status (e.g. not a git worktree)."
+    ),
+  errorMessage: z
+    .string()
+    .optional()
+    .describe(
+      "Cleaned, human-readable failure description. Present when status='error'."
+    ),
+});
+
+// ─── TS types — derived from the schemas (single source of truth) ─────────────
+
+export type RecoverChangedFilesInput = z.infer<
+  typeof recoverChangedFilesInputSchema
+>;
+export type RecoverChangedFilesOutput = z.infer<
+  typeof recoverChangedFilesOutputSchema
+>;
+
+// ─── recover_changed_files ────────────────────────────────────────────────────
+
+/**
+ * Recovers the changed-file set of a slice worktree by inspecting it directly
+ * with `git status --porcelain -z` — the orchestrator's fallback for when a
+ * subagent's result envelope is missing or invalid and its `filesChanged` list
+ * therefore cannot be trusted. The worktree is the source of truth.
+ *
+ * The recovery returns ALL changes — tracked modifications, staged changes, and
+ * untracked files alike, build artifacts NOT filtered out. The orchestrator
+ * already owns build-artifact handling on its commit path (it stages an
+ * explicit file list, never `git add -A`); this tool is the diagnostic for an
+ * inspect-and-preserve flow, where the complete picture is what is useful.
+ *
+ * Never throws — every failure mode is a structured result.
+ */
+export async function recoverChangedFiles(
+  input: RecoverChangedFilesInput
+): Promise<RecoverChangedFilesOutput> {
+  const { worktreePath } = input;
+
+  // Option-injection guard: reject a path git would treat as a flag.
+  const guardErr = optionInjectionError("worktreePath", worktreePath);
+  if (guardErr) {
+    return {
+      status: "error",
+      errorCode: "INVALID_INPUT",
+      errorMessage: guardErr,
+    };
+  }
+
+  // The path must exist on disk before git can be run against it.
+  if (!fs.existsSync(worktreePath)) {
+    return {
+      status: "error",
+      errorCode: "PATH_NOT_FOUND",
+      errorMessage: `Worktree path does not exist: ${worktreePath}`,
+    };
+  }
+
+  // `-z` emits NUL-terminated records with no C-style quoting; rename/copy
+  // entries split cleanly into both real paths via parsePorcelainZ.
+  let porcelain: string;
+  try {
+    const { stdout } = await gitExecFile(
+      ["status", "--porcelain", "-z"],
+      worktreePath
+    );
+    porcelain = stdout;
+  } catch (err) {
+    return {
+      status: "error",
+      errorCode: "GIT_ERROR",
+      errorMessage: cleanGitError(err),
+    };
+  }
+
+  return {
+    status: "ok",
+    changedFiles: parsePorcelainZ(porcelain),
+  };
+}

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/validate-envelope.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/validate-envelope.ts
@@ -1,0 +1,403 @@
+import { z } from "zod";
+
+// ─── Envelope schemas — z.object is the single source of truth ────────────────
+//
+// Each orchestrate subagent ends its turn by emitting a result *envelope*: a
+// JSON object inside an ```orchestrate-envelope fenced block. The envelope is
+// the orchestrator's ONLY machine-checkable source of a subagent's status and
+// changed-file set — the orchestrator never parses the subagent's prose. The
+// worker roles (implementer, reviewer, conflict-resolver) carry a work summary;
+// the investigator carries a research brief. A discriminated union on `role`
+// keeps each role's existing status vocabulary intact.
+
+/**
+ * One capability-tool run and its outcome. An array (not a map) so a re-run of
+ * the same capability is representable and the order is preserved.
+ */
+const verificationEntrySchema = z.object({
+  capability: z
+    .enum(["tests", "typecheck", "build", "lint"])
+    .describe("Which capability tool was run."),
+  result: z
+    .enum(["passed", "failed", "not-configured"])
+    .describe(
+      "Outcome of that run. 'not-configured' means the verb has no command set."
+    ),
+});
+
+/**
+ * Result envelope for the implementer role. `status` keeps the implementer's
+ * existing vocabulary: 'completed' or 'blocked'.
+ */
+export const implementerEnvelopeSchema = z.object({
+  role: z.literal("implementer").describe("Discriminant — the implementer role."),
+  status: z
+    .enum(["completed", "blocked"])
+    .describe(
+      "Outcome. 'completed' = acceptance criteria met and every configured " +
+        "capability tool passed; 'blocked' = the implementer could not finish."
+    ),
+  filesChanged: z
+    .array(z.string())
+    .describe(
+      "Files the implementer created or edited, as paths relative to the " +
+        "worktree root. An empty array means no file was changed."
+    ),
+  verification: z
+    .array(verificationEntrySchema)
+    .describe("Each capability tool the implementer ran and its result."),
+  notes: z
+    .string()
+    .describe(
+      "Free-form notes for the orchestrator or a later reviewer — assumptions, " +
+        "partial work, or, when blocked, exactly what stopped the implementer."
+    ),
+});
+
+/**
+ * Result envelope for the reviewer role. `status` keeps the reviewer's existing
+ * vocabulary: 'passed' or 'failed'.
+ */
+export const reviewerEnvelopeSchema = z.object({
+  role: z.literal("reviewer").describe("Discriminant — the reviewer role."),
+  status: z
+    .enum(["passed", "failed"])
+    .describe(
+      "Outcome. 'passed' = acceptance criteria met, code sound, every " +
+        "configured capability tool passed; 'failed' = an unrecoverable blocker."
+    ),
+  filesChanged: z
+    .array(z.string())
+    .describe(
+      "Files the reviewer edited during review, relative to the worktree root. " +
+        "An empty array means the reviewer changed nothing."
+    ),
+  verification: z
+    .array(verificationEntrySchema)
+    .describe("Each capability tool the reviewer ran and its result."),
+  notes: z
+    .string()
+    .describe(
+      "Free-form notes — what was fixed and why, or, when failed, the exact " +
+        "blocker and why it is unsafe to fix inline."
+    ),
+});
+
+/**
+ * Result envelope for the conflict-resolver role. `status` keeps the
+ * conflict-resolver's existing vocabulary: 'resolved' or 'failed'.
+ */
+export const conflictResolverEnvelopeSchema = z.object({
+  role: z
+    .literal("conflict-resolver")
+    .describe("Discriminant — the conflict-resolver role."),
+  status: z
+    .enum(["resolved", "failed"])
+    .describe(
+      "Outcome. 'resolved' = every conflict marker gone and every configured " +
+        "capability tool passed; 'failed' = a conflict that could not be " +
+        "resolved correctly."
+    ),
+  filesChanged: z
+    .array(z.string())
+    .describe(
+      "The conflicted files the resolver edited, relative to the worktree root."
+    ),
+  verification: z
+    .array(verificationEntrySchema)
+    .describe("Each capability tool the conflict-resolver ran and its result."),
+  notes: z
+    .string()
+    .describe(
+      "Free-form notes — how each conflict was reconciled, or, when failed, the " +
+        "exact conflict that could not be resolved safely."
+    ),
+});
+
+/**
+ * Result envelope for the investigator role. The investigator is read-only — it
+ * produces a research brief, not a work summary, so it carries no `status` and
+ * no `filesChanged`; no worktree fallback applies to it.
+ */
+export const investigatorEnvelopeSchema = z.object({
+  role: z
+    .literal("investigator")
+    .describe("Discriminant — the investigator role."),
+  relevantFiles: z
+    .array(z.string())
+    .describe(
+      "Paths, relative to the repository root, the implementer will likely " +
+        "need to read or change."
+    ),
+  patterns: z
+    .string()
+    .describe(
+      "Existing conventions in the affected areas the implementer must follow."
+    ),
+  risks: z
+    .string()
+    .describe(
+      "Edge cases, failure modes, affected callers, and invariants to preserve."
+    ),
+  approach: z
+    .string()
+    .describe("A suggested implementation approach — what to change and why."),
+  notes: z
+    .string()
+    .describe("Anything else that does not fit the fields above."),
+});
+
+/**
+ * The full set of envelope shapes, discriminated on `role`. Each subagent role
+ * maps to exactly one member.
+ */
+export const envelopeSchema = z.discriminatedUnion("role", [
+  implementerEnvelopeSchema,
+  reviewerEnvelopeSchema,
+  conflictResolverEnvelopeSchema,
+  investigatorEnvelopeSchema,
+]);
+
+// ─── validate_envelope tool I/O schemas ───────────────────────────────────────
+
+/** The subagent roles an envelope can belong to. */
+export const ENVELOPE_ROLES = [
+  "implementer",
+  "reviewer",
+  "conflict-resolver",
+  "investigator",
+] as const;
+
+export const validateEnvelopeInputSchema = z.object({
+  text: z
+    .string()
+    .describe(
+      "The raw, verbatim text a subagent returned as its final message. The " +
+        "validator locates the ```orchestrate-envelope fenced block within it."
+    ),
+  role: z
+    .enum(ENVELOPE_ROLES)
+    .describe(
+      "The role the subagent was spawned as. The located envelope must declare " +
+        "this same role — a role mismatch is reported as an invalid envelope."
+    ),
+});
+
+export const validateEnvelopeOutputSchema = z.object({
+  status: z
+    .enum(["valid", "invalid", "missing"])
+    .describe(
+      "Outcome discriminant. 'valid' = a well-formed envelope matching the " +
+        "expected role was found; 'invalid' = an envelope was attempted but is " +
+        "truncated, malformed, or does not match the schema (a truncated " +
+        "envelope is ALWAYS reported invalid, never silently accepted); " +
+        "'missing' = no orchestrate-envelope block was found at all."
+    ),
+  role: z
+    .enum(ENVELOPE_ROLES)
+    .describe("The role the envelope was validated against — echoes the input."),
+  envelope: envelopeSchema
+    .optional()
+    .describe(
+      "The parsed, schema-conforming envelope. Present only when status='valid'."
+    ),
+  errorCode: z
+    .enum(["TRUNCATED_OR_MALFORMED", "SCHEMA_MISMATCH"])
+    .optional()
+    .describe(
+      "Machine-readable reason an attempted envelope was rejected. Present when " +
+        "status='invalid'. 'TRUNCATED_OR_MALFORMED' = the fenced block could " +
+        "not be parsed as JSON (truncated mid-turn, or not JSON); " +
+        "'SCHEMA_MISMATCH' = it parsed as JSON but does not match the role's " +
+        "envelope schema (a missing field, wrong role, or bad value)."
+    ),
+  errorMessage: z
+    .string()
+    .optional()
+    .describe(
+      "Human-readable description of why the envelope is invalid or missing. " +
+        "Present when status='invalid' or status='missing'."
+    ),
+});
+
+// ─── TS types — derived from the schemas (single source of truth) ─────────────
+
+export type VerificationEntry = z.infer<typeof verificationEntrySchema>;
+export type Envelope = z.infer<typeof envelopeSchema>;
+export type ImplementerEnvelope = z.infer<typeof implementerEnvelopeSchema>;
+export type ReviewerEnvelope = z.infer<typeof reviewerEnvelopeSchema>;
+export type ConflictResolverEnvelope = z.infer<
+  typeof conflictResolverEnvelopeSchema
+>;
+export type InvestigatorEnvelope = z.infer<typeof investigatorEnvelopeSchema>;
+export type ValidateEnvelopeInput = z.infer<typeof validateEnvelopeInputSchema>;
+export type ValidateEnvelopeOutput = z.infer<
+  typeof validateEnvelopeOutputSchema
+>;
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/** The fence identifier that marks a result envelope. */
+const FENCE_TAG = "orchestrate-envelope";
+
+/**
+ * Extracts the body of every complete ```orchestrate-envelope fenced block in
+ * `text`, in document order. A "complete" block has both an opening and a
+ * matching closing fence; an opening fence with no closing fence is handled
+ * separately by {@link hasUnclosedEnvelopeFence}.
+ *
+ * The opening fence is `\`\`\`orchestrate-envelope` on its own line (leading
+ * whitespace tolerated); the closing fence is `\`\`\`` on its own line.
+ */
+function extractEnvelopeBlocks(text: string): string[] {
+  const lines = text.split("\n");
+  const blocks: string[] = [];
+  let inBlock = false;
+  let buffer: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!inBlock) {
+      if (trimmed === "```" + FENCE_TAG) {
+        inBlock = true;
+        buffer = [];
+      }
+    } else {
+      if (trimmed === "```") {
+        blocks.push(buffer.join("\n"));
+        inBlock = false;
+      } else {
+        buffer.push(line);
+      }
+    }
+  }
+  return blocks;
+}
+
+/**
+ * Returns true when `text` contains an opening orchestrate-envelope fence that
+ * is never closed — the signature of a turn cut off mid-emission. The presence
+ * of the opening fence proves an envelope was *attempted*; the missing close
+ * means it was truncated.
+ */
+function hasUnclosedEnvelopeFence(text: string): boolean {
+  const lines = text.split("\n");
+  let openCount = 0;
+  let inBlock = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!inBlock) {
+      if (trimmed === "```" + FENCE_TAG) {
+        inBlock = true;
+        openCount++;
+      }
+    } else if (trimmed === "```") {
+      inBlock = false;
+    }
+  }
+  // `inBlock` still true => the final opening fence was never closed.
+  return inBlock && openCount > 0;
+}
+
+// ─── validate_envelope ────────────────────────────────────────────────────────
+
+/**
+ * Locates and validates a subagent result envelope inside the subagent's raw
+ * returned text. Pure — never throws; every outcome is a structured result.
+ *
+ * Classification:
+ *  - no orchestrate-envelope fence found at all          -> status 'missing'
+ *  - an opening fence with no closing fence (truncated)  -> status 'invalid'
+ *  - a fenced block that is not valid JSON               -> status 'invalid'
+ *  - valid JSON that does not match the role's schema    -> status 'invalid'
+ *  - valid JSON that matches the role's schema           -> status 'valid'
+ *
+ * When several complete envelope blocks are present, the LAST one is used — it
+ * is the block the subagent's turn ended on (e.g. a corrected final envelope
+ * superseding an earlier draft).
+ */
+export function validateEnvelope(
+  input: ValidateEnvelopeInput
+): ValidateEnvelopeOutput {
+  const { text, role } = input;
+
+  const blocks = extractEnvelopeBlocks(text);
+  const truncated = hasUnclosedEnvelopeFence(text);
+
+  // No complete block AND no unclosed opening fence => no envelope was emitted.
+  if (blocks.length === 0 && !truncated) {
+    return {
+      status: "missing",
+      role,
+      errorMessage:
+        `No \`\`\`${FENCE_TAG} block was found in the subagent's output. ` +
+        `The subagent did not emit a result envelope.`,
+    };
+  }
+
+  // An unclosed opening fence is the signature of a truncated turn. It is
+  // reported invalid even when an earlier complete block exists — the truncated
+  // block is what the turn ended on, so the result cannot be trusted.
+  if (truncated) {
+    return {
+      status: "invalid",
+      role,
+      errorCode: "TRUNCATED_OR_MALFORMED",
+      errorMessage:
+        `An opening \`\`\`${FENCE_TAG} fence was found with no closing fence — ` +
+        `the subagent's turn was truncated mid-envelope. A truncated envelope ` +
+        `is never accepted.`,
+    };
+  }
+
+  // Use the LAST complete block — the one the turn ended on.
+  const lastBlock = blocks[blocks.length - 1];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(lastBlock);
+  } catch (err) {
+    return {
+      status: "invalid",
+      role,
+      errorCode: "TRUNCATED_OR_MALFORMED",
+      errorMessage:
+        `The \`\`\`${FENCE_TAG} block does not contain valid JSON: ` +
+        `${err instanceof Error ? err.message : String(err)}. The envelope is ` +
+        `truncated or malformed.`,
+    };
+  }
+
+  // Validate against the discriminated union, then confirm the role matches the
+  // role the subagent was spawned as.
+  const result = envelopeSchema.safeParse(parsed);
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
+    return {
+      status: "invalid",
+      role,
+      errorCode: "SCHEMA_MISMATCH",
+      errorMessage:
+        `The envelope does not match the expected schema: ${detail}.`,
+    };
+  }
+
+  if (result.data.role !== role) {
+    return {
+      status: "invalid",
+      role,
+      errorCode: "SCHEMA_MISMATCH",
+      errorMessage:
+        `The envelope declares role "${result.data.role}" but the subagent was ` +
+        `spawned as "${role}".`,
+    };
+  }
+
+  return {
+    status: "valid",
+    role,
+    envelope: result.data,
+  };
+}

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/worktree.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/worktree.ts
@@ -494,8 +494,11 @@ export async function removeWorktree(
  * destination path (carrying the status prefix) immediately followed by a
  * bare source path. Both are real paths and are returned individually — the
  * output never contains an `old -> new` composite.
+ *
+ * Exported so the changed-file recovery tool (`recover_changed_files`) reuses
+ * the identical rename/copy NUL handling rather than re-deriving it.
  */
-function parsePorcelainZ(porcelain: string): string[] {
+export function parsePorcelainZ(porcelain: string): string[] {
   // Records are NUL-terminated; the final record has a trailing NUL.
   const tokens = porcelain.split("\0").filter((t) => t.length > 0);
   const paths: string[] = [];

--- a/plugins/orchestrate/orchestrate-mcp/test/recover-changed-files.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/recover-changed-files.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import { recoverChangedFiles } from "../src/tools/recover-changed-files.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { encoding: "utf8", cwd }).trim();
+}
+
+/** Creates a temporary git repository with one commit and returns its path. */
+function createTempRepo(): string {
+  const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-test-"));
+
+  git(["init"], repoPath);
+  git(["config", "user.email", "test@test.local"], repoPath);
+  git(["config", "user.name", "Test User"], repoPath);
+
+  fs.writeFileSync(path.join(repoPath, "README.md"), "# Test repo\n");
+  git(["add", "README.md"], repoPath);
+  git(["commit", "-m", "Initial commit"], repoPath);
+
+  return repoPath;
+}
+
+/** Recursively remove a directory. */
+function rmrf(dirPath: string) {
+  if (fs.existsSync(dirPath)) {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  }
+}
+
+// ─── Test state ───────────────────────────────────────────────────────────────
+
+let repoPath: string;
+
+beforeEach(() => {
+  repoPath = createTempRepo();
+});
+
+afterEach(() => {
+  rmrf(repoPath);
+});
+
+// ─── recover_changed_files ────────────────────────────────────────────────────
+
+describe("recover_changed_files", () => {
+  it("returns status='ok' with an empty list for a clean worktree", async () => {
+    const r = await recoverChangedFiles({ worktreePath: repoPath });
+
+    expect(r.status).toBe("ok");
+    expect(r.changedFiles).toEqual([]);
+  });
+
+  it("recovers a modified tracked file", async () => {
+    fs.appendFileSync(path.join(repoPath, "README.md"), "\nmodified line\n");
+
+    const r = await recoverChangedFiles({ worktreePath: repoPath });
+
+    expect(r.status).toBe("ok");
+    expect(r.changedFiles).toContain("README.md");
+  });
+
+  it("recovers a staged tracked-file change", async () => {
+    fs.appendFileSync(path.join(repoPath, "README.md"), "\nstaged line\n");
+    git(["add", "README.md"], repoPath);
+
+    const r = await recoverChangedFiles({ worktreePath: repoPath });
+
+    expect(r.status).toBe("ok");
+    expect(r.changedFiles).toContain("README.md");
+  });
+
+  it("recovers an untracked file", async () => {
+    fs.writeFileSync(path.join(repoPath, "new-file.ts"), "export const x = 1;\n");
+
+    const r = await recoverChangedFiles({ worktreePath: repoPath });
+
+    expect(r.status).toBe("ok");
+    expect(r.changedFiles).toContain("new-file.ts");
+  });
+
+  it("recovers both real paths of a staged rename, never as 'old -> new'", async () => {
+    git(["mv", "README.md", "RENAMED.md"], repoPath);
+
+    const r = await recoverChangedFiles({ worktreePath: repoPath });
+
+    expect(r.status).toBe("ok");
+    for (const entry of r.changedFiles!) {
+      expect(entry).not.toContain(" -> ");
+    }
+    expect(r.changedFiles).toContain("RENAMED.md");
+    expect(r.changedFiles).toContain("README.md");
+  });
+
+  it("recovers multiple changed files together", async () => {
+    fs.appendFileSync(path.join(repoPath, "README.md"), "\nmod\n");
+    fs.writeFileSync(path.join(repoPath, "a.ts"), "a\n");
+    fs.writeFileSync(path.join(repoPath, "b.ts"), "b\n");
+
+    const r = await recoverChangedFiles({ worktreePath: repoPath });
+
+    expect(r.status).toBe("ok");
+    expect(r.changedFiles).toEqual(
+      expect.arrayContaining(["README.md", "a.ts", "b.ts"])
+    );
+  });
+
+  it("returns errorCode=PATH_NOT_FOUND when the worktree path does not exist", async () => {
+    const r = await recoverChangedFiles({
+      worktreePath: path.join(repoPath, "does-not-exist"),
+    });
+
+    expect(r.status).toBe("error");
+    expect(r.errorCode).toBe("PATH_NOT_FOUND");
+    expect(r.errorMessage).toMatch(/does not exist/i);
+  });
+
+  it("returns errorCode=GIT_ERROR for a non-git directory", async () => {
+    const plainDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-plain-"));
+    try {
+      const r = await recoverChangedFiles({ worktreePath: plainDir });
+
+      expect(r.status).toBe("error");
+      expect(r.errorCode).toBe("GIT_ERROR");
+      expect(r.errorMessage).toBeDefined();
+    } finally {
+      rmrf(plainDir);
+    }
+  });
+
+  it("refuses a worktreePath starting with '-' with errorCode=INVALID_INPUT", async () => {
+    const r = await recoverChangedFiles({ worktreePath: "--git-dir" });
+
+    expect(r.status).toBe("error");
+    expect(r.errorCode).toBe("INVALID_INPUT");
+    expect(r.errorMessage).toMatch(/worktreePath/);
+  });
+});

--- a/plugins/orchestrate/orchestrate-mcp/test/validate-envelope.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/validate-envelope.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from "vitest";
+import { validateEnvelope } from "../src/tools/validate-envelope.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+/** Wraps an object as a complete, properly-fenced orchestrate-envelope block. */
+function fenced(obj: unknown): string {
+  return [
+    "Some prose the orchestrator must never parse.",
+    "",
+    "```orchestrate-envelope",
+    JSON.stringify(obj, null, 2),
+    "```",
+    "",
+    "Trailing prose.",
+  ].join("\n");
+}
+
+/** A complete, valid implementer envelope. */
+function implementerEnvelope() {
+  return {
+    role: "implementer" as const,
+    status: "completed" as const,
+    filesChanged: ["src/tools/foo.ts", "test/foo.test.ts"],
+    verification: [
+      { capability: "typecheck", result: "passed" },
+      { capability: "build", result: "passed" },
+      { capability: "tests", result: "passed" },
+      { capability: "lint", result: "not-configured" },
+    ],
+    notes: "Implemented per the acceptance criteria.",
+  };
+}
+
+/** A complete, valid reviewer envelope. */
+function reviewerEnvelope() {
+  return {
+    role: "reviewer" as const,
+    status: "passed" as const,
+    filesChanged: ["src/tools/foo.ts"],
+    verification: [{ capability: "tests", result: "passed" }],
+    notes: "Fixed a naming inconsistency inline.",
+  };
+}
+
+/** A complete, valid conflict-resolver envelope. */
+function conflictResolverEnvelope() {
+  return {
+    role: "conflict-resolver" as const,
+    status: "resolved" as const,
+    filesChanged: ["src/index.ts"],
+    verification: [{ capability: "tests", result: "passed" }],
+    notes: "Reconciled both intents in the import block.",
+  };
+}
+
+/** A complete, valid investigator envelope. */
+function investigatorEnvelope() {
+  return {
+    role: "investigator" as const,
+    relevantFiles: ["src/tools/foo.ts"],
+    patterns: "Zod schemas as the single source of truth.",
+    risks: "Truncated envelopes must never be accepted.",
+    approach: "Add the schema, then the validator, then tests.",
+    notes: "Investigator is read-only.",
+  };
+}
+
+// ─── valid envelopes, one per role ────────────────────────────────────────────
+
+describe("validateEnvelope — valid envelopes", () => {
+  it("accepts a valid implementer envelope and returns the parsed value", () => {
+    const r = validateEnvelope({
+      text: fenced(implementerEnvelope()),
+      role: "implementer",
+    });
+
+    expect(r.status).toBe("valid");
+    expect(r.envelope).toEqual(implementerEnvelope());
+    expect(r.errorCode).toBeUndefined();
+  });
+
+  it("accepts a valid reviewer envelope", () => {
+    const r = validateEnvelope({
+      text: fenced(reviewerEnvelope()),
+      role: "reviewer",
+    });
+
+    expect(r.status).toBe("valid");
+    expect(r.envelope).toEqual(reviewerEnvelope());
+  });
+
+  it("accepts a valid conflict-resolver envelope", () => {
+    const r = validateEnvelope({
+      text: fenced(conflictResolverEnvelope()),
+      role: "conflict-resolver",
+    });
+
+    expect(r.status).toBe("valid");
+    expect(r.envelope).toEqual(conflictResolverEnvelope());
+  });
+
+  it("accepts a valid investigator envelope with no filesChanged field", () => {
+    const r = validateEnvelope({
+      text: fenced(investigatorEnvelope()),
+      role: "investigator",
+    });
+
+    expect(r.status).toBe("valid");
+    expect(r.envelope).toEqual(investigatorEnvelope());
+  });
+
+  it("accepts an implementer envelope with an empty filesChanged list", () => {
+    const env = { ...implementerEnvelope(), filesChanged: [] };
+    const r = validateEnvelope({ text: fenced(env), role: "implementer" });
+
+    expect(r.status).toBe("valid");
+    expect(r.envelope!.role).toBe("implementer");
+  });
+});
+
+// ─── truncated envelopes ──────────────────────────────────────────────────────
+
+describe("validateEnvelope — truncated envelopes", () => {
+  it("reports a fence opened but never closed as invalid, never missing", () => {
+    // A turn cut off mid-emission: the opening fence is present, the JSON is
+    // partial, and there is no closing fence.
+    const text = [
+      "Some prose.",
+      "",
+      "```orchestrate-envelope",
+      '{\n  "role": "implementer",\n  "status": "comple',
+    ].join("\n");
+
+    const r = validateEnvelope({ text, role: "implementer" });
+
+    expect(r.status).toBe("invalid");
+    expect(r.errorCode).toBeDefined();
+    expect(r.envelope).toBeUndefined();
+  });
+
+  it("reports a closed fence with mid-string-truncated JSON as invalid", () => {
+    // The fence closed but the JSON itself was cut mid-string — JSON.parse fails.
+    const text = [
+      "```orchestrate-envelope",
+      '{\n  "role": "implementer",\n  "status": "comp',
+      "```",
+    ].join("\n");
+
+    const r = validateEnvelope({ text, role: "implementer" });
+
+    expect(r.status).toBe("invalid");
+    expect(r.envelope).toBeUndefined();
+  });
+});
+
+// ─── malformed and schema-invalid envelopes ───────────────────────────────────
+
+describe("validateEnvelope — malformed and schema-invalid envelopes", () => {
+  it("reports a properly-fenced block of non-JSON as invalid", () => {
+    const text = [
+      "```orchestrate-envelope",
+      "this is not json at all",
+      "```",
+    ].join("\n");
+
+    const r = validateEnvelope({ text, role: "implementer" });
+
+    expect(r.status).toBe("invalid");
+    expect(r.envelope).toBeUndefined();
+  });
+
+  it("reports a parseable envelope missing a required field as invalid", () => {
+    // Valid JSON, properly fenced, but `verification` is absent.
+    const partial = {
+      role: "implementer",
+      status: "completed",
+      filesChanged: ["src/foo.ts"],
+      notes: "missing verification",
+    };
+    const r = validateEnvelope({
+      text: fenced(partial),
+      role: "implementer",
+    });
+
+    expect(r.status).toBe("invalid");
+    expect(r.envelope).toBeUndefined();
+  });
+
+  it("reports an envelope whose role mismatches the expected role as invalid", () => {
+    // A reviewer envelope validated against the implementer role.
+    const r = validateEnvelope({
+      text: fenced(reviewerEnvelope()),
+      role: "implementer",
+    });
+
+    expect(r.status).toBe("invalid");
+    expect(r.envelope).toBeUndefined();
+  });
+
+  it("reports an implementer envelope with an unknown status value as invalid", () => {
+    const env = { ...implementerEnvelope(), status: "done" };
+    const r = validateEnvelope({ text: fenced(env), role: "implementer" });
+
+    expect(r.status).toBe("invalid");
+    expect(r.envelope).toBeUndefined();
+  });
+});
+
+// ─── missing envelopes ────────────────────────────────────────────────────────
+
+describe("validateEnvelope — missing envelopes", () => {
+  it("reports text with no envelope fence at all as missing", () => {
+    const text =
+      "The implementer wrote a prose summary and forgot the envelope entirely.";
+    const r = validateEnvelope({ text, role: "implementer" });
+
+    expect(r.status).toBe("missing");
+    expect(r.envelope).toBeUndefined();
+  });
+
+  it("does not treat an unrelated json fenced block as an envelope", () => {
+    const text = [
+      "Here is a config snippet:",
+      "```json",
+      '{ "role": "implementer", "status": "completed" }',
+      "```",
+    ].join("\n");
+
+    const r = validateEnvelope({ text, role: "implementer" });
+
+    expect(r.status).toBe("missing");
+  });
+
+  it("reports empty text as missing", () => {
+    const r = validateEnvelope({ text: "", role: "implementer" });
+    expect(r.status).toBe("missing");
+  });
+});
+
+// ─── multiple envelopes ───────────────────────────────────────────────────────
+
+describe("validateEnvelope — multiple envelopes", () => {
+  it("uses the last envelope when more than one fenced block is present", () => {
+    // A subagent that emitted a draft envelope, then a corrected final one.
+    const draft = { ...implementerEnvelope(), notes: "draft" };
+    const final = { ...implementerEnvelope(), notes: "final" };
+    const text = [fenced(draft), fenced(final)].join("\n\n");
+
+    const r = validateEnvelope({ text, role: "implementer" });
+
+    expect(r.status).toBe("valid");
+    expect(r.envelope!.notes).toBe("final");
+  });
+
+  it("reports invalid when the last of several blocks is truncated", () => {
+    // An earlier valid block must not rescue a truncated final block — the
+    // last block is what the turn ended on.
+    const valid = fenced(implementerEnvelope());
+    const truncated = [
+      "```orchestrate-envelope",
+      '{\n  "role": "implementer",\n  "status": "comple',
+    ].join("\n");
+    const text = [valid, truncated].join("\n\n");
+
+    const r = validateEnvelope({ text, role: "implementer" });
+
+    expect(r.status).toBe("invalid");
+  });
+});

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -216,6 +216,21 @@ slice — its final state and pull request.
 These are the per-slice steps the wave loop invokes. Update the slice's entry in
 `run-state.json` and write the file at every state change.
 
+**The result-envelope contract.** Every subagent ends its turn with a **result
+envelope** — a fenced ` ```orchestrate-envelope ` JSON block conforming to a
+defined schema. The orchestrator determines a subagent's status and
+changed-file set **only** from this validated envelope; it never reads the
+subagent's prose. After each subagent (investigator, implementer, reviewer,
+conflict-resolver) returns, call the `validate_envelope` MCP tool with the
+subagent's verbatim returned text and its `role`:
+
+- `status: "valid"` — use the parsed `envelope` as the single source of the
+  subagent's outcome and `filesChanged`.
+- `status: "invalid"` (truncated, malformed, or off-schema) or
+  `status: "missing"` (no envelope emitted) — the subagent's result cannot be
+  trusted. The slice has **FAILED** (see *Failure handling*). A truncated
+  envelope is never silently accepted.
+
 1. **Create the worktree.** Set the slice `state` to `in-progress`, write its
    `sliceBranch` (`orchestrate/slice-<N>`) and the `worktreePath` you will use
    into the slice entry, and checkpoint — so an interruption here is resumable.
@@ -237,25 +252,35 @@ These are the per-slice steps the wave loop invokes. Update the slice's entry in
      has **FAILED**.
 3. **Run the investigator (higher tiers only).** If `routing.investigator` is
    non-null, spawn the `orchestrate:investigator-<effort>` subagent — `<effort>`
-   and the Agent `model` override both come from `routing.investigator`. Its prompt
-   carries the issue and the repository root; keep its returned brief for the
-   implementer. If `routing.investigator` is null, skip this step.
+   and the Agent `model` override both come from `routing.investigator`. Its
+   prompt carries the issue and the repository root. Validate its returned text
+   with `validate_envelope` (role `investigator`); a `valid` envelope is the
+   research brief to keep for the implementer. An `invalid` or `missing`
+   envelope is a failed investigation pass — the slice has **FAILED** (the
+   investigator is read-only, so no worktree fallback applies). If
+   `routing.investigator` is null, skip this step.
 4. **Run the implementer.** Spawn the `orchestrate:implementer-<effort>`
-   subagent — `<effort>` and the `model` override from `routing.implementer`. Its prompt
-   must carry the issue number/title/body, the worktree path (every change goes
-   there), the investigator's brief if one was produced, an instruction to
-   verify with the capability tools using the worktree path as `repoPath`, and
-   a reminder not to commit, push, or run git. If it returns `blocked`, the
-   slice has **FAILED**.
+   subagent — `<effort>` and the `model` override from `routing.implementer`. Its
+   prompt must carry the issue number/title/body, the worktree path (every
+   change goes there), the investigator's brief if one was produced, an
+   instruction to verify with the capability tools using the worktree path as
+   `repoPath`, and a reminder not to commit, push, or run git. Validate its
+   returned text with `validate_envelope` (role `implementer`). On a `valid`
+   envelope, an envelope `status` of `blocked` means the slice has **FAILED**;
+   `completed` proceeds. An `invalid` or `missing` envelope also means the slice
+   has **FAILED**.
 5. **Run the reviewer.** Spawn the `orchestrate:reviewer-<effort>` subagent —
    `<effort>` and the `model` override from `routing.reviewer` — in the same
-   worktree. Its prompt must carry the issue, the worktree path, the
-   implementer's `filesChanged` list and `notes`, and the investigator's brief
-   if one was produced. If it returns `failed`, the slice has **FAILED**.
+   worktree. Its prompt must carry the issue, the worktree path, the implementer
+   envelope's `filesChanged` and `notes`, and the investigator's brief if one
+   was produced. Validate its returned text with `validate_envelope` (role
+   `reviewer`). On a `valid` envelope, an envelope `status` of `failed` means
+   the slice has **FAILED**; `passed` proceeds. An `invalid` or `missing`
+   envelope also means the slice has **FAILED**.
 6. **Commit and push.** Stage only the files the subagents reported changing —
-   the union of the implementer's and reviewer's `filesChanged` lists. Never
-   `git add -A`: the capability tools leave untracked build artifacts in the
-   worktree.
+   the union of the `filesChanged` arrays from the validated implementer and
+   reviewer envelopes. Never `git add -A`: the capability tools leave untracked
+   build artifacts in the worktree.
 
    ```
    git -C <worktree-path> add -- <file> <file> ...
@@ -319,15 +344,18 @@ These are the per-slice steps the wave loop invokes. Update the slice's entry in
       and the `model` override from `routing.conflict-resolver`. Its prompt
       must carry the issue, the worktree path, and the list of conflicted
       files.
-   5. If it returns `failed`, abort and the slice has **FAILED**:
-      `git -C <worktree-path> merge --abort`.
-   6. If it returns `resolved`, stage the resolved files and **confirm no
-      conflict markers remain** — inspect `git -C <worktree-path> diff --cached`
-      for leftover `<<<<<<<`, `=======`, or `>>>>>>>` lines. If any remain, the
-      resolution is incomplete: `git -C <worktree-path> merge --abort` and the
-      slice has **FAILED**. Otherwise complete the merge, push, and merge the pull
-      request — if `gh pr merge` fails (the resolution did not make the pull
-      request mergeable), the slice has **FAILED**; the one attempt is spent.
+   5. Validate its returned text with `validate_envelope` (role
+      `conflict-resolver`). An `invalid` or `missing` envelope, or a `valid`
+      envelope with `status: "failed"`, means resolution failed: abort and the
+      slice has **FAILED** — `git -C <worktree-path> merge --abort`.
+   6. On a `valid` envelope with `status: "resolved"`, stage the resolved files
+      and **confirm no conflict markers remain** — inspect
+      `git -C <worktree-path> diff --cached` for leftover `<<<<<<<`, `=======`,
+      or `>>>>>>>` lines. If any remain, the resolution is incomplete:
+      `git -C <worktree-path> merge --abort` and the slice has **FAILED**.
+      Otherwise complete the merge, push, and merge the pull request — if
+      `gh pr merge` fails (the resolution did not make the pull request
+      mergeable), the slice has **FAILED**; the one attempt is spent.
 
       ```
       git -C <worktree-path> add -- <resolved file> ...
@@ -372,15 +400,32 @@ To hand off:
 
 ## Failure handling
 
-A slice **FAILS** when `create_worktree` errors, the implementer returns
-`blocked`, the reviewer returns `failed`, the staged changeset is empty, or a
-merge conflict the `conflict-resolver` cannot fix. On a FAILED slice:
+A slice **FAILS** when `create_worktree` errors, a subagent's result envelope
+is invalid or missing (`validate_envelope` returns `invalid` or `missing`), a
+validated implementer envelope has `status: "blocked"`, a validated reviewer
+envelope has `status: "failed"`, the staged changeset is empty, or a merge
+conflict the `conflict-resolver` cannot fix. The orchestrator decides FAILURE
+**only** from the validated envelope and tool results — never from a subagent's
+prose. An invalid or missing envelope is always a FAILED slice; it is never
+treated as success.
+
+On a FAILED slice:
 
 - Set its `state` to `failed` with a `failureReason`, checkpoint, and
   transition the issue's tracker label:
   `gh issue edit <N> --remove-label ready-for-agent --add-label needs-triage`.
 - Do **not** merge it. **Preserve its worktree** — leave it on disk for a
   developer to inspect. Do not call `remove_worktree`.
+- **Recover the changed-file set when the envelope was the failure cause.** If
+  the slice failed because a worker subagent's envelope was `invalid` or
+  `missing` — so its `filesChanged` array is unavailable or untrustworthy — call
+  the `recover_changed_files` MCP tool with the slice's `worktreePath`. It
+  inspects the preserved worktree directly with `git status` and returns the
+  full changed-file set (build artifacts included), so the `failureReason` can
+  record what the interrupted subagent had touched for the developer's
+  inspection. This fallback applies to the implementer, reviewer, and
+  conflict-resolver only — the investigator is read-only and leaves no worktree
+  changes to recover.
 - **Continue the wave.** A failed slice never cancels the other slices in its
   wave — they are independent and proceed normally.
 


### PR DESCRIPTION
Implements #189.

Machine-checkable structured result envelope for the orchestrate subagents: a per-role discriminated-union schema, a deterministic `validate_envelope` validator (valid / invalid / missing — a truncated envelope is never accepted), and a `recover_changed_files` worktree fallback. All 8 subagent definitions, SKILL.md, and docs updated so the orchestrator never parses subagent prose. 25 new vitest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)