### PR TITLE
orchestrate: consistent advisor policy across subagents

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,6 +149,10 @@ _Avoid_: main, master, trunk (the integration base is `development`, distinct fr
 Removal of a concluded run's run directory, worktrees, and umbrella/slice branches — gated on that run's final integration pull request having been merged into the **Integration base**.
 _Avoid_: purge, garbage collection, prune
 
+**Subagent advisor policy**:
+The deliberate decision that all eight orchestrate subagents (`investigator`, `implementer`, `reviewer`, `conflict-resolver`, both `-standard` and `-deep` variants) do **not** call an advisor tool. The `advisor` tool is intentionally absent from every subagent's `tools:` frontmatter. Advisor passes, when used, run at the **orchestrator boundary** (the driver session running the `orchestrate` skill), not inside any subagent. The policy is expressed as an explicit `## Advisor policy` section — word-for-word identical between the `-standard` and `-deep` variant of each role — so the decision is self-evident from the definition file. See ADR-0009.
+_Avoid_: no-advisor rule, advisor ban (the policy is positive — advisor responsibility lives at the orchestrator boundary, not absent from the system)
+
 ## Relationships
 
 - A **Distribution** owns at most one **Initializer** and at most one **Customizer**.

--- a/docs/adr/0009-orchestrate-subagent-advisor-policy.md
+++ b/docs/adr/0009-orchestrate-subagent-advisor-policy.md
@@ -1,0 +1,74 @@
+# Orchestrate subagent advisor policy
+
+**Status:** accepted (2026-05-22)
+
+All eight orchestrate subagents (`investigator`, `implementer`, `reviewer`, and
+`conflict-resolver`, in both `-standard` and `-deep` variants) do **not** consult
+an advisor. Advisor passes, when used, happen at the **orchestrator boundary** —
+the driver session running the orchestrate skill — not inside any subagent. This
+decision is expressed positively in every subagent definition, and the same
+statement appears word-for-word in the `-standard` and `-deep` variant of each
+role so the pair is guaranteed consistent.
+
+## Context
+
+Orchestrate subagents are spawned with a restricted `tools:` frontmatter that
+does not grant an `advisor` tool. Their sandboxed environment (no Bash, no git)
+further constrains what they can call. An instruction to "consult the advisor"
+inside a subagent definition is therefore a dead letter — the tool is absent,
+so the call never executes. Leaving the instruction in place creates
+inconsistency: the text says one thing, the tool whitelist enforces another.
+Additionally, policy asymmetry between the `-standard` and `-deep` variants of
+the same role would cause the same work to behave differently depending on how
+the orchestrator routes the issue tier, with no principled reason for the
+divergence.
+
+## Decision
+
+- Subagents do not call an advisor. The `advisor` tool is intentionally absent
+  from every subagent's `tools:` frontmatter.
+- Every subagent definition carries an explicit, positive statement of this
+  policy under its `## Advisor policy` section, so the decision is self-evident
+  from the definition file itself rather than inferred from the absence of a
+  tool.
+- The statement is identical between the `-standard` and `-deep` variant of
+  each role — the only deliberate difference between variants is model, effort,
+  `maxTurns`, and the depth-of-pass instructions; the advisor policy is not a
+  function of tier.
+- Advisor use by the orchestrator (the driver session running the
+  `orchestrate:orchestrate` skill) is unrestricted and outside this decision's
+  scope — it is a different agent with a different tool set.
+
+## Considered options
+
+**Allow advisor calls inside subagents** — rejected: the `advisor` tool is not
+in any subagent's `tools:` frontmatter, so an instruction to call it would be a
+dead letter. Granting the tool would expand each subagent's blast radius and
+increase per-slice cost; the investigator brief and the reviewer's judgment gate
+already provide the quality checks a subagent might reach for the advisor to
+supply.
+
+**Express the policy only via the tool whitelist (no prose statement)** —
+rejected: relying on omission is opaque. A developer reading a subagent
+definition cannot tell whether the absence of an `advisor` tool is an oversight
+or a deliberate decision. An explicit prose statement removes the ambiguity and
+makes the policy verifiable without cross-referencing the frontmatter.
+
+**Different policy between `-standard` and `-deep`** — rejected: the two variants
+of a role exist to vary effort and model, not to change safety or quality-control
+policies. Asymmetric advisor policy would create a class of behaviors that vary
+by tier without a principled reason, and would surface as confusing inconsistency
+when the same issue type routes to different variants.
+
+## Consequences
+
+- Every subagent definition gains an `## Advisor policy` section with a
+  consistent one-sentence statement.
+- The `-standard` and `-deep` variant of each role carry the identical statement
+  for that section — reviewers can diff the two variants and expect zero
+  divergence on advisor policy.
+- `CONTEXT.md` glossary gains a **Subagent advisor policy** entry under
+  `### Orchestrate run vocabulary` recording where the policy lives and what it
+  says.
+- Removing the prose does not change runtime behavior (the tool was already
+  absent); adding it makes the policy explicit and auditable.

--- a/plugins/orchestrate/agents/conflict-resolver-deep.md
+++ b/plugins/orchestrate/agents/conflict-resolver-deep.md
@@ -53,6 +53,12 @@ with higher risk.
   merge is genuinely ambiguous is a `failed` result — never guess and ship a
   silently-wrong merge.
 
+## Advisor policy
+
+This subagent does not call an advisor tool. The `advisor` tool is intentionally
+absent from this subagent's `tools:` frontmatter. Advisor passes, when used, run
+at the orchestrator boundary — not inside any subagent.
+
 ## Deep effort
 
 You are spawned for complex, high-risk conflicts where a shallow pass risks a

--- a/plugins/orchestrate/agents/conflict-resolver-standard.md
+++ b/plugins/orchestrate/agents/conflict-resolver-standard.md
@@ -50,6 +50,12 @@ smaller surface than a full implementation.
   merge is genuinely ambiguous is a `failed` result — never guess and ship a
   silently-wrong merge.
 
+## Advisor policy
+
+This subagent does not call an advisor tool. The `advisor` tool is intentionally
+absent from this subagent's `tools:` frontmatter. Advisor passes, when used, run
+at the orchestrator boundary — not inside any subagent.
+
 ## What you return
 
 Return a structured summary with these fields:

--- a/plugins/orchestrate/agents/implementer-deep.md
+++ b/plugins/orchestrate/agents/implementer-deep.md
@@ -56,6 +56,12 @@ The orchestrator gives you:
   main repository checkout.
 - Do not edit the issue, open pull requests, or change tracker labels.
 
+## Advisor policy
+
+This subagent does not call an advisor tool. The `advisor` tool is intentionally
+absent from this subagent's `tools:` frontmatter. Advisor passes, when used, run
+at the orchestrator boundary — not inside any subagent.
+
 ## Deep effort
 
 You are spawned for complex, high-risk issues where a shallow pass is not

--- a/plugins/orchestrate/agents/implementer-standard.md
+++ b/plugins/orchestrate/agents/implementer-standard.md
@@ -51,6 +51,12 @@ The orchestrator gives you:
   main repository checkout.
 - Do not edit the issue, open pull requests, or change tracker labels.
 
+## Advisor policy
+
+This subagent does not call an advisor tool. The `advisor` tool is intentionally
+absent from this subagent's `tools:` frontmatter. Advisor passes, when used, run
+at the orchestrator boundary — not inside any subagent.
+
 ## What you return
 
 Return a structured summary with these fields:

--- a/plugins/orchestrate/agents/investigator-deep.md
+++ b/plugins/orchestrate/agents/investigator-deep.md
@@ -58,6 +58,12 @@ always acceptable.
 - Do not attempt to implement, fix, or change anything. Investigate only.
 - Do not edit the issue, open pull requests, or change tracker labels.
 
+## Advisor policy
+
+This subagent does not call an advisor tool. The `advisor` tool is intentionally
+absent from this subagent's `tools:` frontmatter. Advisor passes, when used, run
+at the orchestrator boundary — not inside any subagent.
+
 ## Deep effort
 
 You are spawned for complex, high-risk issues where a shallow investigation

--- a/plugins/orchestrate/agents/investigator-standard.md
+++ b/plugins/orchestrate/agents/investigator-standard.md
@@ -55,6 +55,12 @@ always acceptable.
 - Do not attempt to implement, fix, or change anything. Investigate only.
 - Do not edit the issue, open pull requests, or change tracker labels.
 
+## Advisor policy
+
+This subagent does not call an advisor tool. The `advisor` tool is intentionally
+absent from this subagent's `tools:` frontmatter. Advisor passes, when used, run
+at the orchestrator boundary — not inside any subagent.
+
 ## What you return
 
 Return a structured brief with these fields:

--- a/plugins/orchestrate/agents/reviewer-deep.md
+++ b/plugins/orchestrate/agents/reviewer-deep.md
@@ -68,6 +68,12 @@ always acceptable.
 - Fix inline only what you can fix **safely**. A correctness blocker you cannot
   resolve without guessing is a `failed` review — do not merge bad code.
 
+## Advisor policy
+
+This subagent does not call an advisor tool. The `advisor` tool is intentionally
+absent from this subagent's `tools:` frontmatter. Advisor passes, when used, run
+at the orchestrator boundary — not inside any subagent.
+
 ## Deep effort
 
 You are spawned for complex, high-risk issues where a surface review is not

--- a/plugins/orchestrate/agents/reviewer-standard.md
+++ b/plugins/orchestrate/agents/reviewer-standard.md
@@ -62,6 +62,12 @@ always acceptable.
 - Fix inline only what you can fix **safely**. A correctness blocker you cannot
   resolve without guessing is a `failed` review — do not merge bad code.
 
+## Advisor policy
+
+This subagent does not call an advisor tool. The `advisor` tool is intentionally
+absent from this subagent's `tools:` frontmatter. Advisor passes, when used, run
+at the orchestrator boundary — not inside any subagent.
+
 ## What you return
 
 Return a structured summary with these fields:


### PR DESCRIPTION
Implements #190.

Records the deliberate decision (ADR-0009) that orchestrate subagents do not consult an advisor — the `advisor` tool is intentionally absent from their `tools:` frontmatter. Expresses the policy positively via an identical `## Advisor policy` section in all 8 subagent definitions, plus a CONTEXT.md glossary entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)