### PR TITLE
orchestrate: per-run directory layout

### DIFF
--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -21,7 +21,7 @@ Given a repository with open issues labelled `ready-for-agent`, one `/orchestrat
 3. **Cuts an umbrella branch** from `development` — every slice's pull request merges into it, never directly into `development`.
 4. **Processes each slice** in its own isolated worktree — routed investigator (complex tier only), implementer, then reviewer; then commit, push, open a slice pull request, and squash-merge it into the umbrella branch.
 5. **Resolves merge conflicts** once per conflicting slice via a dedicated conflict-resolver subagent.
-6. **Checkpoints** `.orchestrate/run-state.json` after every step — an interrupted run re-invoked with `/orchestrate` skips every completed slice and continues.
+6. **Checkpoints** the run's `run-state.json` (under the per-run directory `.orchestrate/runs/<runId>/`) after every step — an interrupted run re-invoked with `/orchestrate` skips every completed slice and continues.
 7. **Hands off** to a fresh Claude Code session when the orchestrator's context window fills, so a long run survives without degrading.
 8. **Opens a final pull request** from the umbrella branch into `development`, left unmerged for a developer to review — and renders HTML dashboard, dependency-graph, and report artifacts from the run state.
 
@@ -60,7 +60,7 @@ Every tool returns a discriminated `status` and never throws — failures are st
 
 ### Context handoff
 
-A long backlog can fill the orchestrator session's context window before every wave is done. The bundled `context-watchdog` hook (a `PostToolUse` hook) estimates context usage from the session transcript and, past a configurable threshold (default 40%), writes `.orchestrate/context-flag.json`. The orchestrator finishes the current slice, checkpoints, and calls `spawn_successor` to launch a new interactive Claude Code session that resumes from `run-state.json` — then the predecessor exits. The successor clears the stale flag on startup, so there is no handoff loop.
+A long backlog can fill the orchestrator session's context window before every wave is done. The bundled `context-watchdog` hook (a `PostToolUse` hook) estimates context usage from the session transcript and, past a configurable threshold (default 40%), writes the active run's `.orchestrate/runs/<runId>/context-flag.json`. The orchestrator finishes the current slice, checkpoints, and calls `spawn_successor` to launch a new interactive Claude Code session that resumes from `run-state.json` — then the predecessor exits. The successor clears the stale flag on startup, so there is no handoff loop.
 
 ## Installation
 
@@ -92,7 +92,7 @@ If the plugin is installed at user scope (the default), the namespace prefix is 
 /orchestrate
 ```
 
-The run is autonomous — it processes the whole backlog, resolves conflicts, checkpoints, hands off if its context fills, and ends by opening the final umbrella pull request. To resume an interrupted run, invoke `/orchestrate` again in the same repository: it detects `.orchestrate/run-state.json` and continues from the last checkpoint.
+The run is autonomous — it processes the whole backlog, resolves conflicts, checkpoints, hands off if its context fills, and ends by opening the final umbrella pull request. To resume an interrupted run, invoke `/orchestrate` again in the same repository: it scans `.orchestrate/runs/*/run-state.json` for an in-progress run and continues from the last checkpoint.
 
 ## Importing Into Another Project
 
@@ -106,15 +106,13 @@ To run orchestrate against another repository, that repository needs:
 
 Optionally, install the **`ast-grep` CLI** to enable the investigator and reviewer subagents' structural code search; without it, they fall back to text search.
 
-Add the run's generated, ephemeral files to the target repository's `.gitignore`:
+Add the run's generated, ephemeral files to the target repository's `.gitignore`. Every run keeps its `run-state.json`, `context-flag.json`, and rendered HTML artifacts under a per-run directory, `.orchestrate/runs/<runId>/`, so one gitignore line covers them all:
 
 ```gitignore
-.orchestrate/run-state.json
-.orchestrate/context-flag.json
-.orchestrate/*.html
+.orchestrate/runs/
 ```
 
-The committed `.orchestrate/commands.json`, `.orchestrate/routing.json`, and `.orchestrate/handoff.json` are configuration and stay tracked.
+The committed `.orchestrate/commands.json`, `.orchestrate/routing.json`, and `.orchestrate/handoff.json` stay flat at the `.orchestrate/` top level — they are configuration and stay tracked.
 
 ## Configuration Reference
 
@@ -197,9 +195,31 @@ Optional. Tunes the context-watchdog threshold and the successor-session launche
 
 The default terminal chain targets a WSL2 environment. On another host, replace the `terminals` entries with your terminal's new-window invocation. See `skills/orchestrate/references/context-handoff.md` for the full mechanism.
 
-### `.orchestrate/run-state.json`
+### `.orchestrate/runs/<runId>/` — per-run directory
 
-Generated, not authored — the durable run checkpoint. The orchestrator writes it after every slice state change and every wave, and reads it on startup to resume an interrupted run. Gitignore it. Its schema is documented in `skills/orchestrate/references/run-state.md`.
+Generated, not authored. Every run keeps its ephemeral state in its own per-run directory, `.orchestrate/runs/<runId>/`, where `<runId>` is the run's timestamp id. The directory holds:
+
+- `run-state.json` — the durable run checkpoint. The orchestrator writes it after every slice state change and every wave, and reads it on startup to resume an interrupted run.
+- `context-flag.json` — the context-handoff signal, written by the watchdog when the threshold is reached.
+- `dashboard.html`, `graph.html`, `report.html` — the rendered HTML artifacts.
+
+Two distinct runs never share a directory, so their ephemeral state never collides — the per-run layout is the structural foundation for concurrent runs. The committed config files (`commands.json`, `routing.json`, `handoff.json`) stay flat at the `.orchestrate/` top level.
+
+```text
+.orchestrate/
+├── commands.json                 # committed config (flat)
+├── routing.json                  # committed config (flat)
+├── handoff.json                  # committed config (flat)
+└── runs/
+    └── 20260521-015143/          # one per-run directory per run
+        ├── run-state.json
+        ├── context-flag.json     # present only after a handoff is signalled
+        ├── dashboard.html
+        ├── graph.html
+        └── report.html
+```
+
+Gitignore the `.orchestrate/runs/` directory. The `run-state.json` schema is documented in `skills/orchestrate/references/run-state.md`.
 
 ## Optional: Agent Teams
 

--- a/plugins/orchestrate/orchestrate-mcp/dist/context-watchdog.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/context-watchdog.js
@@ -28,7 +28,7 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
 ));
 
 // src/hooks/context-watchdog.ts
-var path2 = __toESM(require("path"));
+var path3 = __toESM(require("path"));
 var fs2 = __toESM(require("fs"));
 
 // src/handoff-config.ts
@@ -513,8 +513,8 @@ function getErrorMap() {
 
 // node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
-  const { data, path: path3, errorMaps, issueData } = params;
-  const fullPath = [...path3, ...issueData.path || []];
+  const { data, path: path4, errorMaps, issueData } = params;
+  const fullPath = [...path4, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -630,11 +630,11 @@ var errorUtil;
 
 // node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path3, key) {
+  constructor(parent, value, path4, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path3;
+    this._path = path4;
     this._key = key;
   }
   get path() {
@@ -4160,6 +4160,34 @@ function loadHandoffConfig(repoPath) {
   return { config: result.data, warning: null };
 }
 
+// src/run-dir.ts
+var path2 = __toESM(require("path"));
+var RUN_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+function isValidRunId(runId) {
+  return RUN_ID_PATTERN.test(runId);
+}
+function resolveRunDir(repoPath, runId) {
+  if (!isValidRunId(runId)) {
+    return {
+      ok: false,
+      errorCode: "RUN_ID_INVALID",
+      errorMessage: `Invalid runId '${runId}': a runId must be a non-empty string of letters, digits, underscores, and hyphens (e.g. '20260521-015143').`
+    };
+  }
+  const runDir = path2.join(repoPath, ".orchestrate", "runs", runId);
+  return {
+    ok: true,
+    paths: {
+      runDir,
+      runStatePath: path2.join(runDir, "run-state.json"),
+      contextFlagPath: path2.join(runDir, "context-flag.json"),
+      dashboardPath: path2.join(runDir, "dashboard.html"),
+      graphPath: path2.join(runDir, "graph.html"),
+      reportPath: path2.join(runDir, "report.html")
+    }
+  };
+}
+
 // src/hooks/context-watchdog.ts
 function parseLatestUsage(transcriptText) {
   const lines = transcriptText.split("\n");
@@ -4223,8 +4251,35 @@ function readTranscriptText(transcriptPath) {
     fs2.closeSync(fd);
   }
 }
+function discoverActiveRunId(cwd) {
+  const runsDir = path3.join(cwd, ".orchestrate", "runs");
+  let entries;
+  try {
+    entries = fs2.readdirSync(runsDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const statePath = path3.join(runsDir, entry.name, "run-state.json");
+    let runState;
+    try {
+      runState = JSON.parse(fs2.readFileSync(statePath, "utf8"));
+    } catch {
+      continue;
+    }
+    if (typeof runState === "object" && runState !== null && runState.status === "in-progress") {
+      return entry.name;
+    }
+  }
+  return null;
+}
 function runWatchdog(input) {
-  const runStatePath = path2.join(input.cwd, ".orchestrate", "run-state.json");
+  const resolved = resolveRunDir(input.cwd, input.runId);
+  if (!resolved.ok) {
+    return { acted: false, flagRaised: false };
+  }
+  const { runStatePath, contextFlagPath: flagPath } = resolved.paths;
   let runState;
   try {
     runState = JSON.parse(fs2.readFileSync(runStatePath, "utf8"));
@@ -4234,7 +4289,6 @@ function runWatchdog(input) {
   if (typeof runState !== "object" || runState === null || runState.status !== "in-progress") {
     return { acted: false, flagRaised: false };
   }
-  const flagPath = path2.join(input.cwd, ".orchestrate", "context-flag.json");
   if (!input.transcriptPath) return { acted: true, flagRaised: false, flagPath };
   let transcriptText;
   try {
@@ -4261,7 +4315,7 @@ function runWatchdog(input) {
     usagePercent: evaluation.usagePercent
   };
   try {
-    fs2.mkdirSync(path2.dirname(flagPath), { recursive: true });
+    fs2.mkdirSync(path3.dirname(flagPath), { recursive: true });
     fs2.writeFileSync(flagPath, JSON.stringify(flag, null, 2));
   } catch {
     return { acted: true, flagRaised: false, flagPath, evaluation };
@@ -4290,9 +4344,15 @@ async function main() {
   }
   try {
     const event = raw ? JSON.parse(raw) : {};
+    const cwd = typeof event.cwd === "string" ? event.cwd : process.cwd();
+    const runId = discoverActiveRunId(cwd);
+    if (runId === null) {
+      process.exit(0);
+    }
     const result = runWatchdog({
       transcriptPath: typeof event.transcript_path === "string" ? event.transcript_path : void 0,
-      cwd: typeof event.cwd === "string" ? event.cwd : process.cwd()
+      cwd,
+      runId
     });
     if (result.flagRaised && result.evaluation) {
       const e = result.evaluation;

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -3226,8 +3226,8 @@ var require_utils = __commonJS({
       }
       return ind;
     }
-    function removeDotSegments(path6) {
-      let input = path6;
+    function removeDotSegments(path7) {
+      let input = path7;
       const output = [];
       let nextSlash = -1;
       let len = 0;
@@ -3479,8 +3479,8 @@ var require_schemes = __commonJS({
         wsComponent.secure = void 0;
       }
       if (wsComponent.resourceName) {
-        const [path6, query] = wsComponent.resourceName.split("?");
-        wsComponent.path = path6 && path6 !== "/" ? path6 : void 0;
+        const [path7, query] = wsComponent.resourceName.split("?");
+        wsComponent.path = path7 && path7 !== "/" ? path7 : void 0;
         wsComponent.query = query;
         wsComponent.resourceName = void 0;
       }
@@ -7364,8 +7364,8 @@ function getErrorMap() {
 
 // node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
-  const { data, path: path6, errorMaps, issueData } = params;
-  const fullPath = [...path6, ...issueData.path || []];
+  const { data, path: path7, errorMaps, issueData } = params;
+  const fullPath = [...path7, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -7481,11 +7481,11 @@ var errorUtil;
 
 // node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path6, key) {
+  constructor(parent, value, path7, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path6;
+    this._path = path7;
     this._key = key;
   }
   get path() {
@@ -11123,10 +11123,10 @@ function assignProp(target, prop, value) {
     configurable: true
   });
 }
-function getElementAtPath(obj, path6) {
-  if (!path6)
+function getElementAtPath(obj, path7) {
+  if (!path7)
     return obj;
-  return path6.reduce((acc, key) => acc?.[key], obj);
+  return path7.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -11446,11 +11446,11 @@ function aborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path6, issues) {
+function prefixIssues(path7, issues) {
   return issues.map((iss) => {
     var _a;
     (_a = iss).path ?? (_a.path = []);
-    iss.path.unshift(path6);
+    iss.path.unshift(path7);
     return iss;
   });
 }
@@ -21959,8 +21959,38 @@ function resolveRoutingFromConfig(input) {
 }
 
 // src/tools/render.ts
-var path4 = __toESM(require("path"));
+var path5 = __toESM(require("path"));
 var fs4 = __toESM(require("fs"));
+
+// src/run-dir.ts
+var path4 = __toESM(require("path"));
+var RUN_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+function isValidRunId(runId) {
+  return RUN_ID_PATTERN.test(runId);
+}
+function resolveRunDir(repoPath, runId) {
+  if (!isValidRunId(runId)) {
+    return {
+      ok: false,
+      errorCode: "RUN_ID_INVALID",
+      errorMessage: `Invalid runId '${runId}': a runId must be a non-empty string of letters, digits, underscores, and hyphens (e.g. '20260521-015143').`
+    };
+  }
+  const runDir = path4.join(repoPath, ".orchestrate", "runs", runId);
+  return {
+    ok: true,
+    paths: {
+      runDir,
+      runStatePath: path4.join(runDir, "run-state.json"),
+      contextFlagPath: path4.join(runDir, "context-flag.json"),
+      dashboardPath: path4.join(runDir, "dashboard.html"),
+      graphPath: path4.join(runDir, "graph.html"),
+      reportPath: path4.join(runDir, "report.html")
+    }
+  };
+}
+
+// src/tools/render.ts
 var sliceStateEnum = external_exports.enum(["pending", "in-progress", "passed", "failed", "skipped"]);
 var tierEnum = external_exports.enum(["trivial", "standard", "complex"]);
 var sliceSchema = external_exports.object({
@@ -21990,26 +22020,29 @@ var runStateSchema = external_exports.object({
   slices: external_exports.record(external_exports.string(), sliceSchema)
 });
 var renderInputSchema = external_exports.object({
+  runId: external_exports.string().describe(
+    "The orchestration run's id (its YYYYMMDD-HHMMSS timestamp). It selects the per-run directory .orchestrate/runs/<runId>/, which holds that run's run-state.json and is where the HTML artifact is written. Required \u2014 every render call happens after the run has a runId."
+  ),
   repoPath: external_exports.string().optional().describe(
-    "Path to the project root that holds the .orchestrate/run-state.json file. Defaults to the MCP server process's current working directory \u2014 callers should pass this explicitly rather than rely on the default."
+    "Path to the project root that holds the .orchestrate/ directory. Defaults to the MCP server process's current working directory \u2014 callers should pass this explicitly rather than rely on the default."
   ),
   outputPath: external_exports.string().optional().describe(
-    "Override the default output path for the HTML artifact. When omitted the artifact is written under <repoPath>/.orchestrate/ with a fixed filename per tool (dashboard.html, graph.html, report.html)."
+    "Override the default output path for the HTML artifact. When omitted the artifact is written under <repoPath>/.orchestrate/runs/<runId>/ with a fixed filename per tool (dashboard.html, graph.html, report.html)."
   )
 });
 var renderOutputSchema = external_exports.object({
   status: external_exports.enum(["ok", "error"]).describe("Outcome discriminant. 'ok' = artifact written; 'error' = could not complete."),
   artifactPath: external_exports.string().optional().describe("Absolute path to the written HTML artifact. Present when status='ok'."),
-  errorCode: external_exports.enum(["RUN_STATE_NOT_FOUND", "RUN_STATE_INVALID", "WRITE_FAILED"]).optional().describe(
-    "Machine-readable failure category. Present when status='error'. 'RUN_STATE_NOT_FOUND' = no .orchestrate/run-state.json; 'RUN_STATE_INVALID' = malformed JSON or schema mismatch; 'WRITE_FAILED' = could not write the HTML artifact."
+  errorCode: external_exports.enum([
+    "RUN_ID_INVALID",
+    "RUN_STATE_NOT_FOUND",
+    "RUN_STATE_INVALID",
+    "WRITE_FAILED"
+  ]).optional().describe(
+    "Machine-readable failure category. Present when status='error'. 'RUN_ID_INVALID' = the runId is malformed and cannot resolve a run directory; 'RUN_STATE_NOT_FOUND' = no run-state.json under .orchestrate/runs/<runId>/; 'RUN_STATE_INVALID' = malformed JSON or schema mismatch; 'WRITE_FAILED' = could not write the HTML artifact."
   ),
   errorMessage: external_exports.string().optional().describe("Human-readable failure description. Present when status='error'.")
 });
-var ARTIFACT_DEFAULTS = {
-  dashboard: ".orchestrate/dashboard.html",
-  graph: ".orchestrate/graph.html",
-  report: ".orchestrate/report.html"
-};
 function firstLine3(message) {
   const line = message.split("\n").map((l) => l.trim()).find((l) => l.length > 0);
   return line ?? message.trim();
@@ -22032,8 +22065,22 @@ function formatDuration(startedAt, updatedAt) {
   if (mins > 0) return `${mins}m ${secs % 60}s`;
   return `${secs}s`;
 }
-function readAndValidateRunState(repoPath) {
-  const statePath = path4.join(repoPath, ".orchestrate", "run-state.json");
+function resolveRenderPaths(input) {
+  const repoPath = input.repoPath ?? process.cwd();
+  const resolved = resolveRunDir(repoPath, input.runId);
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      response: {
+        status: "error",
+        errorCode: resolved.errorCode,
+        errorMessage: resolved.errorMessage
+      }
+    };
+  }
+  return { ok: true, paths: resolved.paths };
+}
+function readAndValidateRunState(statePath) {
   let raw;
   try {
     raw = fs4.readFileSync(statePath, "utf8");
@@ -22043,7 +22090,7 @@ function readAndValidateRunState(repoPath) {
       response: {
         status: "error",
         errorCode: "RUN_STATE_NOT_FOUND",
-        errorMessage: `No .orchestrate/run-state.json found in ${repoPath}.`
+        errorMessage: `No run-state.json found at ${statePath}.`
       }
     };
   }
@@ -22056,7 +22103,7 @@ function readAndValidateRunState(repoPath) {
       response: {
         status: "error",
         errorCode: "RUN_STATE_INVALID",
-        errorMessage: `.orchestrate/run-state.json is not valid JSON: ${firstLine3(
+        errorMessage: `run-state.json is not valid JSON: ${firstLine3(
           err instanceof Error ? err.message : String(err)
         )}`
       }
@@ -22070,7 +22117,7 @@ function readAndValidateRunState(repoPath) {
       response: {
         status: "error",
         errorCode: "RUN_STATE_INVALID",
-        errorMessage: `.orchestrate/run-state.json does not match the expected shape: ${detail}`
+        errorMessage: `run-state.json does not match the expected shape: ${detail}`
       }
     };
   }
@@ -22078,7 +22125,7 @@ function readAndValidateRunState(repoPath) {
 }
 function writeArtifact(html, outputPath) {
   try {
-    fs4.mkdirSync(path4.dirname(outputPath), { recursive: true });
+    fs4.mkdirSync(path5.dirname(outputPath), { recursive: true });
     fs4.writeFileSync(outputPath, html, "utf8");
     return void 0;
   } catch (err) {
@@ -22548,31 +22595,34 @@ function renderReport(state) {
 </html>`;
 }
 async function renderDashboardArtifact(input) {
-  const repoPath = input.repoPath ?? process.cwd();
-  const read = readAndValidateRunState(repoPath);
+  const resolved = resolveRenderPaths(input);
+  if (!resolved.ok) return resolved.response;
+  const read = readAndValidateRunState(resolved.paths.runStatePath);
   if (!read.ok) return read.response;
   const html = renderDashboard(read.state);
-  const artifactPath = input.outputPath ?? path4.join(repoPath, ARTIFACT_DEFAULTS.dashboard);
+  const artifactPath = input.outputPath ?? resolved.paths.dashboardPath;
   const writeErr = writeArtifact(html, artifactPath);
   if (writeErr) return writeErr;
   return { status: "ok", artifactPath };
 }
 async function renderGraphArtifact(input) {
-  const repoPath = input.repoPath ?? process.cwd();
-  const read = readAndValidateRunState(repoPath);
+  const resolved = resolveRenderPaths(input);
+  if (!resolved.ok) return resolved.response;
+  const read = readAndValidateRunState(resolved.paths.runStatePath);
   if (!read.ok) return read.response;
   const html = renderGraph(read.state);
-  const artifactPath = input.outputPath ?? path4.join(repoPath, ARTIFACT_DEFAULTS.graph);
+  const artifactPath = input.outputPath ?? resolved.paths.graphPath;
   const writeErr = writeArtifact(html, artifactPath);
   if (writeErr) return writeErr;
   return { status: "ok", artifactPath };
 }
 async function renderReportArtifact(input) {
-  const repoPath = input.repoPath ?? process.cwd();
-  const read = readAndValidateRunState(repoPath);
+  const resolved = resolveRenderPaths(input);
+  if (!resolved.ok) return resolved.response;
+  const read = readAndValidateRunState(resolved.paths.runStatePath);
   if (!read.ok) return read.response;
   const html = renderReport(read.state);
-  const artifactPath = input.outputPath ?? path4.join(repoPath, ARTIFACT_DEFAULTS.report);
+  const artifactPath = input.outputPath ?? resolved.paths.reportPath;
   const writeErr = writeArtifact(html, artifactPath);
   if (writeErr) return writeErr;
   return { status: "ok", artifactPath };
@@ -22582,7 +22632,7 @@ async function renderReportArtifact(input) {
 var import_child_process3 = require("child_process");
 
 // src/handoff-config.ts
-var path5 = __toESM(require("path"));
+var path6 = __toESM(require("path"));
 var fs5 = __toESM(require("fs"));
 var watchdogConfigSchema = external_exports.object({
   thresholdPercent: external_exports.number().min(1).max(100).default(40).describe(
@@ -22637,7 +22687,7 @@ function firstLine4(message) {
   return line ?? message.trim();
 }
 function loadHandoffConfig(repoPath) {
-  const configPath = path5.join(repoPath, ".orchestrate", "handoff.json");
+  const configPath = path6.join(repoPath, ".orchestrate", "handoff.json");
   const defaults = handoffConfigSchema.parse({});
   let raw;
   try {
@@ -22670,7 +22720,7 @@ function loadHandoffConfig(repoPath) {
 // src/tools/spawn-successor.ts
 var spawnSuccessorInputSchema = external_exports.object({
   repoPath: external_exports.string().optional().describe(
-    "Path to the repository root \u2014 the directory holding .orchestrate/. The successor session opens here and reads run-state.json to resume. Defaults to the MCP server process's current working directory; callers should pass it explicitly."
+    "Path to the repository root \u2014 the directory holding .orchestrate/. The successor session opens here and re-discovers the active run from .orchestrate/runs/*/run-state.json to resume. Defaults to the MCP server process's current working directory; callers should pass it explicitly."
   )
 });
 var launchAttemptSchema = external_exports.object({
@@ -23110,19 +23160,19 @@ var RENDER_TOOLS = [
   {
     name: "render_dashboard",
     title: "Render Run Dashboard",
-    description: "Reads .orchestrate/run-state.json and writes a standalone HTML dashboard showing the live run state: run id, status, wave progress, and a color-coded slice table. Returns only the artifact path \u2014 the HTML is written to disk, never returned in the response.",
+    description: "Reads run-state.json from the per-run directory .orchestrate/runs/<runId>/ and writes a standalone HTML dashboard into it showing the live run state: run id, status, wave progress, and a color-coded slice table. Requires a `runId`. Returns only the artifact path \u2014 the HTML is written to disk, never returned in the response.",
     run: renderDashboardArtifact
   },
   {
     name: "render_graph",
     title: "Render Dependency Graph",
-    description: "Reads .orchestrate/run-state.json and writes a standalone HTML dependency graph: waves as columns, slices as nodes, blockedBy edges as SVG lines. Layout is deterministic (x = wave index, y = slice index in wave). Returns only the artifact path.",
+    description: "Reads run-state.json from the per-run directory .orchestrate/runs/<runId>/ and writes a standalone HTML dependency graph into it: waves as columns, slices as nodes, blockedBy edges as SVG lines. Layout is deterministic (x = wave index, y = slice index in wave). Requires a `runId`. Returns only the artifact path.",
     run: renderGraphArtifact
   },
   {
     name: "render_report",
     title: "Render Run Report",
-    description: "Reads .orchestrate/run-state.json and writes a standalone HTML final report: run duration, outcome counts (passed/failed/skipped), the final pull request link, and a per-slice outcome table. Returns only the artifact path.",
+    description: "Reads run-state.json from the per-run directory .orchestrate/runs/<runId>/ and writes a standalone HTML final report into it: run duration, outcome counts (passed/failed/skipped), the final pull request link, and a per-slice outcome table. Requires a `runId`. Returns only the artifact path.",
     run: renderReportArtifact
   }
 ];
@@ -23168,7 +23218,7 @@ registerTool(
   "spawn_successor",
   {
     title: "Spawn Successor Session",
-    description: "Launches a fresh interactive Claude Code session that resumes an interrupted orchestration run from the .orchestrate/run-state.json checkpoint, then the predecessor exits. The successor opens in a new terminal window with Remote Control active and re-invokes /orchestrate \u2014 never print mode. The terminal fallback chain and claude flags are configured in .orchestrate/handoff.json; built-in defaults target a WSL2 environment. Returns a discriminated `status` of 'ok' or 'error'.",
+    description: "Launches a fresh interactive Claude Code session that resumes an interrupted orchestration run from its run-state.json checkpoint (under the per-run directory .orchestrate/runs/<runId>/), then the predecessor exits. The successor opens in a new terminal window with Remote Control active and re-invokes /orchestrate \u2014 never print mode \u2014 which re-discovers the active run. The terminal fallback chain and claude flags are configured in .orchestrate/handoff.json; built-in defaults target a WSL2 environment. Returns a discriminated `status` of 'ok' or 'error'.",
     inputSchema: spawnSuccessorInputSchema.shape,
     outputSchema: spawnSuccessorOutputSchema.shape
   },

--- a/plugins/orchestrate/orchestrate-mcp/src/hooks/context-watchdog-cli.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/hooks/context-watchdog-cli.ts
@@ -1,11 +1,17 @@
 #!/usr/bin/env node
-import { runWatchdog } from "./context-watchdog.js";
+import { runWatchdog, discoverActiveRunId } from "./context-watchdog.js";
 
 // Entry point for the `context-watchdog` PostToolUse hook. Claude Code pipes
 // the hook event JSON on stdin; this script estimates the session's context
 // usage and raises the orchestrate handoff flag past the threshold. It always
 // exits 0 — a hook must never fail a tool call — and only emits output on the
 // turn the flag is first raised, so it stays silent in unrelated sessions.
+//
+// The hook event carries only `cwd` and `transcript_path` — never a runId.
+// Run state now lives in per-run directories (.orchestrate/runs/<runId>/), so
+// the hook first discovers the active run by scanning for the single
+// in-progress run-state.json, then runs the watchdog against it. With no
+// active run, it is a silent no-op.
 
 /** Reads all of stdin as a string. Resolves with whatever arrived on error. */
 function readStdin(): Promise<string> {
@@ -30,12 +36,21 @@ async function main(): Promise<void> {
 
   try {
     const event = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+    const cwd = typeof event.cwd === "string" ? event.cwd : process.cwd();
+
+    // Discover the active run; with none, the watchdog has nothing to do.
+    const runId = discoverActiveRunId(cwd);
+    if (runId === null) {
+      process.exit(0);
+    }
+
     const result = runWatchdog({
       transcriptPath:
         typeof event.transcript_path === "string"
           ? event.transcript_path
           : undefined,
-      cwd: typeof event.cwd === "string" ? event.cwd : process.cwd(),
+      cwd,
+      runId,
     });
 
     if (result.flagRaised && result.evaluation) {

--- a/plugins/orchestrate/orchestrate-mcp/src/hooks/context-watchdog.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/hooks/context-watchdog.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as fs from "fs";
 import { loadHandoffConfig } from "../handoff-config.js";
+import { resolveRunDir } from "../run-dir.js";
 
 // The context-watchdog estimates how full the orchestrator session's context
 // window is by reading the session transcript, and raises a handoff flag once
@@ -155,7 +156,10 @@ export interface WatchdogResult {
   evaluation?: WatchdogEvaluation;
 }
 
-/** Shape written to `.orchestrate/context-flag.json` when the flag is raised. */
+/**
+ * Shape written to the per-run `context-flag.json` (under
+ * `.orchestrate/runs/<runId>/`) when the flag is raised.
+ */
 interface ContextFlag {
   raisedAt: string;
   usedTokens: number;
@@ -165,21 +169,68 @@ interface ContextFlag {
 }
 
 /**
+ * Scans `.orchestrate/runs/*` for the single run whose `run-state.json` has
+ * `status: "in-progress"` and returns its `runId`, or null when none is found.
+ * Pure-ish — reads the filesystem but never throws.
+ *
+ * The `PostToolUse` hook receives only the session `cwd`, not a `runId`, so the
+ * watchdog must discover the active run before it can resolve the per-run
+ * paths. This deliberately handles only the single-active-run case: a session
+ * drives exactly one orchestration run. Disambiguating concurrent runs is a
+ * separate concern and out of scope here.
+ */
+export function discoverActiveRunId(cwd: string): string | null {
+  const runsDir = path.join(cwd, ".orchestrate", "runs");
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(runsDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const statePath = path.join(runsDir, entry.name, "run-state.json");
+    let runState: unknown;
+    try {
+      runState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    } catch {
+      continue;
+    }
+    if (
+      typeof runState === "object" &&
+      runState !== null &&
+      (runState as Record<string, unknown>).status === "in-progress"
+    ) {
+      return entry.name;
+    }
+  }
+  return null;
+}
+
+/**
  * Reads the session transcript, estimates context usage, and raises the
  * handoff flag when usage passes the configured threshold.
  *
- * The watchdog only acts while an orchestration run is in progress — it checks
- * `.orchestrate/run-state.json` first and is a silent no-op otherwise, so the
- * bundled hook is harmless in unrelated sessions. The flag is written at most
- * once per run: if `.orchestrate/context-flag.json` already exists this is a
- * no-op. Never throws.
+ * The watchdog only acts while the named run is in progress — it checks the
+ * per-run `run-state.json` under `.orchestrate/runs/<runId>/` first and is a
+ * silent no-op otherwise, so the bundled hook is harmless in unrelated
+ * sessions. The flag is written at most once per run: if the per-run
+ * `context-flag.json` already exists this is a no-op. Never throws.
  */
 export function runWatchdog(input: {
   transcriptPath?: string;
   cwd: string;
+  runId: string;
 }): WatchdogResult {
-  // 1. Act only while an orchestration run is in progress.
-  const runStatePath = path.join(input.cwd, ".orchestrate", "run-state.json");
+  // 1. Resolve the per-run paths; a malformed runId is a silent no-op.
+  const resolved = resolveRunDir(input.cwd, input.runId);
+  if (!resolved.ok) {
+    return { acted: false, flagRaised: false };
+  }
+  const { runStatePath, contextFlagPath: flagPath } = resolved.paths;
+
+  // 2. Act only while this orchestration run is in progress.
   let runState: unknown;
   try {
     runState = JSON.parse(fs.readFileSync(runStatePath, "utf8"));
@@ -194,9 +245,7 @@ export function runWatchdog(input: {
     return { acted: false, flagRaised: false };
   }
 
-  const flagPath = path.join(input.cwd, ".orchestrate", "context-flag.json");
-
-  // 2. A transcript is required to estimate usage.
+  // 3. A transcript is required to estimate usage.
   if (!input.transcriptPath) return { acted: true, flagRaised: false, flagPath };
   let transcriptText: string;
   try {
@@ -205,11 +254,11 @@ export function runWatchdog(input: {
     return { acted: true, flagRaised: false, flagPath };
   }
 
-  // 3. Estimate usage from the latest assistant turn.
+  // 4. Estimate usage from the latest assistant turn.
   const usage = parseLatestUsage(transcriptText);
   if (!usage) return { acted: true, flagRaised: false, flagPath };
 
-  // 4. Evaluate against the (possibly defaulted) config.
+  // 5. Evaluate against the (possibly defaulted) config.
   const { config } = loadHandoffConfig(input.cwd);
   const evaluation = evaluateWatchdog({
     usedTokens: contextTokens(usage),
@@ -217,12 +266,12 @@ export function runWatchdog(input: {
     thresholdPercent: config.watchdog.thresholdPercent,
   });
 
-  // 5. Below threshold, or the flag is already raised — nothing to do.
+  // 6. Below threshold, or the flag is already raised — nothing to do.
   if (!evaluation.overThreshold || fs.existsSync(flagPath)) {
     return { acted: true, flagRaised: false, flagPath, evaluation };
   }
 
-  // 6. Raise the flag.
+  // 7. Raise the flag.
   const flag: ContextFlag = {
     raisedAt: new Date().toISOString(),
     usedTokens: evaluation.usedTokens,

--- a/plugins/orchestrate/orchestrate-mcp/src/index.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/index.ts
@@ -349,9 +349,10 @@ registerTool(
 );
 
 // ─── render_dashboard / render_graph / render_report ─────────────────────────
-// Three HTML-rendering tools. Each reads .orchestrate/run-state.json,
-// generates a deterministic HTML artifact, writes it to disk, and returns
-// only the artifact path — no HTML is returned in the tool response.
+// Three HTML-rendering tools. Each reads the run-state.json under the per-run
+// directory .orchestrate/runs/<runId>/, generates a deterministic HTML
+// artifact, writes it back into that same run directory, and returns only the
+// artifact path — no HTML is returned in the tool response.
 
 const RENDER_TOOLS: {
   name: string;
@@ -363,9 +364,10 @@ const RENDER_TOOLS: {
     name: "render_dashboard",
     title: "Render Run Dashboard",
     description:
-      "Reads .orchestrate/run-state.json and writes a standalone HTML dashboard " +
-      "showing the live run state: run id, status, wave progress, and a " +
-      "color-coded slice table. Returns only the artifact path — the HTML is " +
+      "Reads run-state.json from the per-run directory .orchestrate/runs/<runId>/ " +
+      "and writes a standalone HTML dashboard into it showing the live run " +
+      "state: run id, status, wave progress, and a color-coded slice table. " +
+      "Requires a `runId`. Returns only the artifact path — the HTML is " +
       "written to disk, never returned in the response.",
     run: renderDashboardArtifact,
   },
@@ -373,9 +375,10 @@ const RENDER_TOOLS: {
     name: "render_graph",
     title: "Render Dependency Graph",
     description:
-      "Reads .orchestrate/run-state.json and writes a standalone HTML dependency " +
-      "graph: waves as columns, slices as nodes, blockedBy edges as SVG lines. " +
-      "Layout is deterministic (x = wave index, y = slice index in wave). Returns " +
+      "Reads run-state.json from the per-run directory .orchestrate/runs/<runId>/ " +
+      "and writes a standalone HTML dependency graph into it: waves as columns, " +
+      "slices as nodes, blockedBy edges as SVG lines. Layout is deterministic " +
+      "(x = wave index, y = slice index in wave). Requires a `runId`. Returns " +
       "only the artifact path.",
     run: renderGraphArtifact,
   },
@@ -383,10 +386,11 @@ const RENDER_TOOLS: {
     name: "render_report",
     title: "Render Run Report",
     description:
-      "Reads .orchestrate/run-state.json and writes a standalone HTML final " +
-      "report: run duration, outcome counts (passed/failed/skipped), the final " +
-      "pull request link, and a per-slice outcome table. Returns only the " +
-      "artifact path.",
+      "Reads run-state.json from the per-run directory .orchestrate/runs/<runId>/ " +
+      "and writes a standalone HTML final report into it: run duration, outcome " +
+      "counts (passed/failed/skipped), the final pull request link, and a " +
+      "per-slice outcome table. Requires a `runId`. Returns only the artifact " +
+      "path.",
     run: renderReportArtifact,
   },
 ];
@@ -446,12 +450,14 @@ registerTool(
     title: "Spawn Successor Session",
     description:
       "Launches a fresh interactive Claude Code session that resumes an " +
-      "interrupted orchestration run from the .orchestrate/run-state.json " +
-      "checkpoint, then the predecessor exits. The successor opens in a new " +
-      "terminal window with Remote Control active and re-invokes /orchestrate " +
-      "— never print mode. The terminal fallback chain and claude flags are " +
-      "configured in .orchestrate/handoff.json; built-in defaults target a " +
-      "WSL2 environment. Returns a discriminated `status` of 'ok' or 'error'.",
+      "interrupted orchestration run from its run-state.json checkpoint " +
+      "(under the per-run directory .orchestrate/runs/<runId>/), then the " +
+      "predecessor exits. The successor opens in a new terminal window with " +
+      "Remote Control active and re-invokes /orchestrate — never print mode — " +
+      "which re-discovers the active run. The terminal fallback chain and " +
+      "claude flags are configured in .orchestrate/handoff.json; built-in " +
+      "defaults target a WSL2 environment. Returns a discriminated `status` " +
+      "of 'ok' or 'error'.",
     inputSchema: spawnSuccessorInputSchema.shape,
     outputSchema: spawnSuccessorOutputSchema.shape,
   },

--- a/plugins/orchestrate/orchestrate-mcp/src/run-dir.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/run-dir.ts
@@ -1,0 +1,90 @@
+import * as path from "path";
+
+// ─── Per-run directory resolver ───────────────────────────────────────────────
+//
+// Every orchestration run keeps its ephemeral state — the run-state checkpoint,
+// the context-flag, and the rendered HTML artifacts — under a per-run directory,
+// `.orchestrate/runs/<runId>/`. The committed config files (`commands.json`,
+// `routing.json`, `handoff.json`) stay flat at the `.orchestrate/` top level and
+// are NOT resolved here.
+//
+// This module is a pure function of `(repoPath, runId)` — no filesystem I/O —
+// so it is directly unit-testable and callers can resolve paths without side
+// effects. It is the structural foundation for concurrent runs: two distinct
+// run ids can never resolve to a shared path.
+
+/**
+ * Allowed `runId` shape. The skill mints run ids as `YYYYMMDD-HHMMSS`
+ * timestamps, which this pattern admits. The pattern is also the path-traversal
+ * guard: a `runId` flows into `path.join`, so an id like `../../etc` or one
+ * carrying a separator must be rejected before it can escape the run directory.
+ */
+const RUN_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/** The ephemeral paths owned by one orchestration run. */
+export interface RunPaths {
+  /** The per-run directory: `<repoPath>/.orchestrate/runs/<runId>/`. */
+  runDir: string;
+  /** The run-state checkpoint inside the run directory. */
+  runStatePath: string;
+  /** The context-handoff flag file inside the run directory. */
+  contextFlagPath: string;
+  /** The rendered dashboard HTML artifact inside the run directory. */
+  dashboardPath: string;
+  /** The rendered dependency-graph HTML artifact inside the run directory. */
+  graphPath: string;
+  /** The rendered report HTML artifact inside the run directory. */
+  reportPath: string;
+}
+
+/** Discriminated result of {@link resolveRunDir}. */
+export type ResolveRunDirResult =
+  | { ok: true; paths: RunPaths }
+  | { ok: false; errorCode: "RUN_ID_INVALID"; errorMessage: string };
+
+/**
+ * Returns true when `runId` is a safe run-directory name: a non-empty string of
+ * letters, digits, underscores, and hyphens only. Anything that could traverse
+ * out of the run directory (`..`, a path separator, a dot) is rejected. Pure.
+ */
+export function isValidRunId(runId: string): boolean {
+  return RUN_ID_PATTERN.test(runId);
+}
+
+/**
+ * Resolves a `runId` to its ephemeral paths under
+ * `<repoPath>/.orchestrate/runs/<runId>/`. Pure — performs no filesystem I/O;
+ * the caller is responsible for `mkdirSync` before any write.
+ *
+ * A malformed `runId` (one that fails {@link isValidRunId}) is returned as a
+ * structured `RUN_ID_INVALID` error rather than throwing — the resolver never
+ * throws, in keeping with the discriminated-result contract of the tools that
+ * consume it. Two distinct valid run ids always resolve to disjoint paths.
+ */
+export function resolveRunDir(
+  repoPath: string,
+  runId: string
+): ResolveRunDirResult {
+  if (!isValidRunId(runId)) {
+    return {
+      ok: false,
+      errorCode: "RUN_ID_INVALID",
+      errorMessage:
+        `Invalid runId '${runId}': a runId must be a non-empty string of ` +
+        `letters, digits, underscores, and hyphens (e.g. '20260521-015143').`,
+    };
+  }
+
+  const runDir = path.join(repoPath, ".orchestrate", "runs", runId);
+  return {
+    ok: true,
+    paths: {
+      runDir,
+      runStatePath: path.join(runDir, "run-state.json"),
+      contextFlagPath: path.join(runDir, "context-flag.json"),
+      dashboardPath: path.join(runDir, "dashboard.html"),
+      graphPath: path.join(runDir, "graph.html"),
+      reportPath: path.join(runDir, "report.html"),
+    },
+  };
+}

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/render.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/render.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as fs from "fs";
 import { z } from "zod";
+import { resolveRunDir, type RunPaths } from "../run-dir.js";
 
 // ─── Schemas — z.object is the single source of truth; TS types via z.infer ───
 
@@ -36,11 +37,19 @@ export const runStateSchema = z.object({
 });
 
 export const renderInputSchema = z.object({
+  runId: z
+    .string()
+    .describe(
+      "The orchestration run's id (its YYYYMMDD-HHMMSS timestamp). It selects " +
+        "the per-run directory .orchestrate/runs/<runId>/, which holds that " +
+        "run's run-state.json and is where the HTML artifact is written. " +
+        "Required — every render call happens after the run has a runId."
+    ),
   repoPath: z
     .string()
     .optional()
     .describe(
-      "Path to the project root that holds the .orchestrate/run-state.json file. " +
+      "Path to the project root that holds the .orchestrate/ directory. " +
         "Defaults to the MCP server process's current working directory — callers " +
         "should pass this explicitly rather than rely on the default."
     ),
@@ -49,8 +58,8 @@ export const renderInputSchema = z.object({
     .optional()
     .describe(
       "Override the default output path for the HTML artifact. When omitted the " +
-        "artifact is written under <repoPath>/.orchestrate/ with a fixed filename " +
-        "per tool (dashboard.html, graph.html, report.html)."
+        "artifact is written under <repoPath>/.orchestrate/runs/<runId>/ with a " +
+        "fixed filename per tool (dashboard.html, graph.html, report.html)."
     ),
 });
 
@@ -63,13 +72,19 @@ export const renderOutputSchema = z.object({
     .optional()
     .describe("Absolute path to the written HTML artifact. Present when status='ok'."),
   errorCode: z
-    .enum(["RUN_STATE_NOT_FOUND", "RUN_STATE_INVALID", "WRITE_FAILED"])
+    .enum([
+      "RUN_ID_INVALID",
+      "RUN_STATE_NOT_FOUND",
+      "RUN_STATE_INVALID",
+      "WRITE_FAILED",
+    ])
     .optional()
     .describe(
       "Machine-readable failure category. Present when status='error'. " +
-        "'RUN_STATE_NOT_FOUND' = no .orchestrate/run-state.json; " +
-        "'RUN_STATE_INVALID' = malformed JSON or schema mismatch; " +
-        "'WRITE_FAILED' = could not write the HTML artifact."
+        "'RUN_ID_INVALID' = the runId is malformed and cannot resolve a run " +
+        "directory; 'RUN_STATE_NOT_FOUND' = no run-state.json under " +
+        ".orchestrate/runs/<runId>/; 'RUN_STATE_INVALID' = malformed JSON or " +
+        "schema mismatch; 'WRITE_FAILED' = could not write the HTML artifact."
     ),
   errorMessage: z
     .string()
@@ -83,14 +98,6 @@ export type RunState = z.infer<typeof runStateSchema>;
 export type SliceState = z.infer<typeof sliceStateEnum>;
 export type RenderInput = z.infer<typeof renderInputSchema>;
 export type RenderOutput = z.infer<typeof renderOutputSchema>;
-
-// ─── Default artifact paths ───────────────────────────────────────────────────
-
-const ARTIFACT_DEFAULTS = {
-  dashboard: ".orchestrate/dashboard.html",
-  graph: ".orchestrate/graph.html",
-  report: ".orchestrate/report.html",
-} as const;
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
@@ -137,14 +144,35 @@ function formatDuration(startedAt: string, updatedAt: string): string {
 }
 
 /**
- * Reads and validates `.orchestrate/run-state.json` from the given repoPath.
- * Returns either the validated state or a structured error response.
+ * Resolves the per-run paths for `input`, mapping a malformed runId onto a
+ * structured `RUN_ID_INVALID` response so the caller never has to throw.
+ */
+function resolveRenderPaths(
+  input: RenderInput
+): { ok: true; paths: RunPaths } | { ok: false; response: RenderOutput } {
+  const repoPath = input.repoPath ?? process.cwd();
+  const resolved = resolveRunDir(repoPath, input.runId);
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      response: {
+        status: "error",
+        errorCode: resolved.errorCode,
+        errorMessage: resolved.errorMessage,
+      },
+    };
+  }
+  return { ok: true, paths: resolved.paths };
+}
+
+/**
+ * Reads and validates the run-state.json at `statePath` (the per-run path from
+ * the run-directory resolver). Returns either the validated state or a
+ * structured error response.
  */
 function readAndValidateRunState(
-  repoPath: string
+  statePath: string
 ): { ok: true; state: RunState } | { ok: false; response: RenderOutput } {
-  const statePath = path.join(repoPath, ".orchestrate", "run-state.json");
-
   let raw: string;
   try {
     raw = fs.readFileSync(statePath, "utf8");
@@ -154,7 +182,7 @@ function readAndValidateRunState(
       response: {
         status: "error",
         errorCode: "RUN_STATE_NOT_FOUND",
-        errorMessage: `No .orchestrate/run-state.json found in ${repoPath}.`,
+        errorMessage: `No run-state.json found at ${statePath}.`,
       },
     };
   }
@@ -168,7 +196,7 @@ function readAndValidateRunState(
       response: {
         status: "error",
         errorCode: "RUN_STATE_INVALID",
-        errorMessage: `.orchestrate/run-state.json is not valid JSON: ${firstLine(
+        errorMessage: `run-state.json is not valid JSON: ${firstLine(
           err instanceof Error ? err.message : String(err)
         )}`,
       },
@@ -185,7 +213,7 @@ function readAndValidateRunState(
       response: {
         status: "error",
         errorCode: "RUN_STATE_INVALID",
-        errorMessage: `.orchestrate/run-state.json does not match the expected shape: ${detail}`,
+        errorMessage: `run-state.json does not match the expected shape: ${detail}`,
       },
     };
   }
@@ -754,12 +782,13 @@ export function renderReport(state: RunState): string {
 export async function renderDashboardArtifact(
   input: RenderInput
 ): Promise<RenderOutput> {
-  const repoPath = input.repoPath ?? process.cwd();
-  const read = readAndValidateRunState(repoPath);
+  const resolved = resolveRenderPaths(input);
+  if (!resolved.ok) return resolved.response;
+  const read = readAndValidateRunState(resolved.paths.runStatePath);
   if (!read.ok) return read.response;
 
   const html = renderDashboard(read.state);
-  const artifactPath = input.outputPath ?? path.join(repoPath, ARTIFACT_DEFAULTS.dashboard);
+  const artifactPath = input.outputPath ?? resolved.paths.dashboardPath;
   const writeErr = writeArtifact(html, artifactPath);
   if (writeErr) return writeErr;
 
@@ -773,12 +802,13 @@ export async function renderDashboardArtifact(
 export async function renderGraphArtifact(
   input: RenderInput
 ): Promise<RenderOutput> {
-  const repoPath = input.repoPath ?? process.cwd();
-  const read = readAndValidateRunState(repoPath);
+  const resolved = resolveRenderPaths(input);
+  if (!resolved.ok) return resolved.response;
+  const read = readAndValidateRunState(resolved.paths.runStatePath);
   if (!read.ok) return read.response;
 
   const html = renderGraph(read.state);
-  const artifactPath = input.outputPath ?? path.join(repoPath, ARTIFACT_DEFAULTS.graph);
+  const artifactPath = input.outputPath ?? resolved.paths.graphPath;
   const writeErr = writeArtifact(html, artifactPath);
   if (writeErr) return writeErr;
 
@@ -792,12 +822,13 @@ export async function renderGraphArtifact(
 export async function renderReportArtifact(
   input: RenderInput
 ): Promise<RenderOutput> {
-  const repoPath = input.repoPath ?? process.cwd();
-  const read = readAndValidateRunState(repoPath);
+  const resolved = resolveRenderPaths(input);
+  if (!resolved.ok) return resolved.response;
+  const read = readAndValidateRunState(resolved.paths.runStatePath);
   if (!read.ok) return read.response;
 
   const html = renderReport(read.state);
-  const artifactPath = input.outputPath ?? path.join(repoPath, ARTIFACT_DEFAULTS.report);
+  const artifactPath = input.outputPath ?? resolved.paths.reportPath;
   const writeErr = writeArtifact(html, artifactPath);
   if (writeErr) return writeErr;
 

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/spawn-successor.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/spawn-successor.ts
@@ -8,9 +8,17 @@ import {
 
 // `spawn_successor` launches a fresh interactive Claude Code session that
 // resumes an interrupted orchestration run, then the predecessor exits. The
-// run is resumable from `.orchestrate/run-state.json`, so the successor only
-// needs to re-invoke `/orchestrate`. Command construction is pure and tested;
-// the detached spawn itself is verified end-to-end, not by unit tests.
+// run is resumable from its per-run `run-state.json` (under
+// `.orchestrate/runs/<runId>/`), so the successor only needs to re-invoke
+// `/orchestrate`. Command construction is pure and tested; the detached spawn
+// itself is verified end-to-end, not by unit tests.
+//
+// `spawn_successor` deliberately takes NO `runId` parameter. It resolves no
+// per-run path itself: it reads only the flat `.orchestrate/handoff.json`
+// config and launches a terminal. The successor's `/orchestrate` invocation
+// re-discovers the active run from `.orchestrate/runs/*/run-state.json` on
+// startup — that re-discovery is what makes the handoff per-run-aware. Adding
+// a `runId` here would be a dead parameter.
 
 // ─── Schemas — z.object is the single source of truth; TS types via z.infer ───
 
@@ -20,9 +28,10 @@ export const spawnSuccessorInputSchema = z.object({
     .optional()
     .describe(
       "Path to the repository root — the directory holding .orchestrate/. " +
-        "The successor session opens here and reads run-state.json to resume. " +
-        "Defaults to the MCP server process's current working directory; " +
-        "callers should pass it explicitly."
+        "The successor session opens here and re-discovers the active run " +
+        "from .orchestrate/runs/*/run-state.json to resume. Defaults to the " +
+        "MCP server process's current working directory; callers should pass " +
+        "it explicitly."
     ),
 });
 

--- a/plugins/orchestrate/orchestrate-mcp/test/context-watchdog.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/context-watchdog.test.ts
@@ -7,6 +7,7 @@ import {
   contextTokens,
   evaluateWatchdog,
   runWatchdog,
+  discoverActiveRunId,
 } from "../src/hooks/context-watchdog.js";
 
 // ─── Transcript fixtures ──────────────────────────────────────────────────────
@@ -41,19 +42,30 @@ function userLine(text: string): string {
 
 const created: string[] = [];
 
+/** The runId every test fixture uses unless a test needs a second run. */
+const RUN_ID = "20260521-015143";
+
+/**
+ * Creates a temp project dir. `runState` and `flag` are written under the
+ * per-run directory `.orchestrate/runs/<runId>/`; `handoff.json` stays flat at
+ * `.orchestrate/` (it is committed config, not ephemeral run state).
+ */
 function project(opts: {
   runState?: unknown;
   handoff?: unknown;
   transcript?: string;
   flag?: unknown;
+  runId?: string;
 }): { dir: string; transcriptPath?: string } {
+  const runId = opts.runId ?? RUN_ID;
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-watchdog-"));
   created.push(dir);
-  fs.mkdirSync(path.join(dir, ".orchestrate"));
+  const runDir = path.join(dir, ".orchestrate", "runs", runId);
+  fs.mkdirSync(runDir, { recursive: true });
 
   if (opts.runState !== undefined) {
     fs.writeFileSync(
-      path.join(dir, ".orchestrate", "run-state.json"),
+      path.join(runDir, "run-state.json"),
       typeof opts.runState === "string"
         ? opts.runState
         : JSON.stringify(opts.runState)
@@ -67,7 +79,7 @@ function project(opts: {
   }
   if (opts.flag !== undefined) {
     fs.writeFileSync(
-      path.join(dir, ".orchestrate", "context-flag.json"),
+      path.join(runDir, "context-flag.json"),
       JSON.stringify(opts.flag)
     );
   }
@@ -87,8 +99,8 @@ afterEach(() => {
   created.length = 0;
 });
 
-function flagPath(dir: string): string {
-  return path.join(dir, ".orchestrate", "context-flag.json");
+function flagPath(dir: string, runId: string = RUN_ID): string {
+  return path.join(dir, ".orchestrate", "runs", runId, "context-flag.json");
 }
 
 // ─── parseLatestUsage ─────────────────────────────────────────────────────────
@@ -190,6 +202,49 @@ describe("evaluateWatchdog", () => {
   });
 });
 
+// ─── discoverActiveRunId ──────────────────────────────────────────────────────
+
+describe("discoverActiveRunId", () => {
+  it("returns null when there is no .orchestrate/runs directory", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-watchdog-"));
+    created.push(dir);
+    expect(discoverActiveRunId(dir)).toBeNull();
+  });
+
+  it("returns null when no run is in-progress", () => {
+    const { dir } = project({ runState: { status: "completed" } });
+    expect(discoverActiveRunId(dir)).toBeNull();
+  });
+
+  it("returns the runId of the single in-progress run", () => {
+    const { dir } = project({ runState: { status: "in-progress" } });
+    expect(discoverActiveRunId(dir)).toBe(RUN_ID);
+  });
+
+  it("returns null when a run-state.json is malformed", () => {
+    const { dir } = project({ runState: "{ not json" });
+    expect(discoverActiveRunId(dir)).toBeNull();
+  });
+
+  it("ignores a completed run and finds the in-progress one", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-watchdog-"));
+    created.push(dir);
+    const done = path.join(dir, ".orchestrate", "runs", "20260101-000000");
+    const active = path.join(dir, ".orchestrate", "runs", "20260202-000000");
+    fs.mkdirSync(done, { recursive: true });
+    fs.mkdirSync(active, { recursive: true });
+    fs.writeFileSync(
+      path.join(done, "run-state.json"),
+      JSON.stringify({ status: "completed" })
+    );
+    fs.writeFileSync(
+      path.join(active, "run-state.json"),
+      JSON.stringify({ status: "in-progress" })
+    );
+    expect(discoverActiveRunId(dir)).toBe("20260202-000000");
+  });
+});
+
 // ─── runWatchdog ──────────────────────────────────────────────────────────────
 
 describe("runWatchdog — no active run", () => {
@@ -197,7 +252,7 @@ describe("runWatchdog — no active run", () => {
     const { dir, transcriptPath } = project({
       transcript: assistantLine(2, 8000, 100000),
     });
-    const result = runWatchdog({ transcriptPath, cwd: dir });
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: RUN_ID });
     expect(result.acted).toBe(false);
     expect(result.flagRaised).toBe(false);
     expect(fs.existsSync(flagPath(dir))).toBe(false);
@@ -208,7 +263,7 @@ describe("runWatchdog — no active run", () => {
       runState: { status: "completed" },
       transcript: assistantLine(2, 8000, 100000),
     });
-    const result = runWatchdog({ transcriptPath, cwd: dir });
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: RUN_ID });
     expect(result.acted).toBe(false);
     expect(fs.existsSync(flagPath(dir))).toBe(false);
   });
@@ -218,8 +273,22 @@ describe("runWatchdog — no active run", () => {
       runState: "{ not json",
       transcript: assistantLine(2, 8000, 100000),
     });
-    const result = runWatchdog({ transcriptPath, cwd: dir });
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: RUN_ID });
     expect(result.acted).toBe(false);
+  });
+
+  it("is a no-op when the runId is malformed", () => {
+    const { dir, transcriptPath } = project({
+      runState: { status: "in-progress" },
+      transcript: assistantLine(2, 8000, 100000),
+    });
+    const result = runWatchdog({
+      transcriptPath,
+      cwd: dir,
+      runId: "../../etc",
+    });
+    expect(result.acted).toBe(false);
+    expect(result.flagRaised).toBe(false);
   });
 });
 
@@ -230,7 +299,7 @@ describe("runWatchdog — active run", () => {
       runState: { status: "in-progress" },
       transcript: assistantLine(2, 8000, 100000),
     });
-    const result = runWatchdog({ transcriptPath, cwd: dir });
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: RUN_ID });
 
     expect(result.acted).toBe(true);
     expect(result.flagRaised).toBe(true);
@@ -243,13 +312,26 @@ describe("runWatchdog — active run", () => {
     expect(typeof flag.raisedAt).toBe("string");
   });
 
+  it("writes the flag under the per-run directory", () => {
+    const { dir, transcriptPath } = project({
+      runState: { status: "in-progress" },
+      transcript: assistantLine(2, 8000, 100000),
+    });
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: RUN_ID });
+
+    expect(result.flagRaised).toBe(true);
+    expect(result.flagPath).toBe(
+      path.join(dir, ".orchestrate", "runs", RUN_ID, "context-flag.json")
+    );
+  });
+
   it("does not raise the flag when usage is below the threshold", () => {
     // 2 + 8000 + 40000 = 48002 tokens = 24% of the default window.
     const { dir, transcriptPath } = project({
       runState: { status: "in-progress" },
       transcript: assistantLine(2, 8000, 40000),
     });
-    const result = runWatchdog({ transcriptPath, cwd: dir });
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: RUN_ID });
 
     expect(result.acted).toBe(true);
     expect(result.flagRaised).toBe(false);
@@ -263,7 +345,7 @@ describe("runWatchdog — active run", () => {
       transcript: assistantLine(2, 8000, 100000),
       flag: { raisedAt: "2026-01-01T00:00:00Z", usedTokens: 1 },
     });
-    const result = runWatchdog({ transcriptPath, cwd: dir });
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: RUN_ID });
 
     expect(result.flagRaised).toBe(false);
     // The pre-existing flag is left untouched.
@@ -278,7 +360,7 @@ describe("runWatchdog — active run", () => {
       handoff: { watchdog: { thresholdPercent: 90 } },
       transcript: assistantLine(2, 8000, 100000),
     });
-    const result = runWatchdog({ transcriptPath, cwd: dir });
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: RUN_ID });
 
     expect(result.flagRaised).toBe(false);
     expect(fs.existsSync(flagPath(dir))).toBe(false);
@@ -291,14 +373,18 @@ describe("runWatchdog — active run", () => {
       handoff: { watchdog: { contextWindowTokens: 1000000 } },
       transcript: assistantLine(2, 8000, 100000),
     });
-    const result = runWatchdog({ transcriptPath, cwd: dir });
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: RUN_ID });
 
     expect(result.flagRaised).toBe(false);
   });
 
   it("does not raise the flag when no transcript is available", () => {
     const { dir } = project({ runState: { status: "in-progress" } });
-    const result = runWatchdog({ transcriptPath: undefined, cwd: dir });
+    const result = runWatchdog({
+      transcriptPath: undefined,
+      cwd: dir,
+      runId: RUN_ID,
+    });
 
     expect(result.acted).toBe(true);
     expect(result.flagRaised).toBe(false);
@@ -309,7 +395,7 @@ describe("runWatchdog — active run", () => {
       runState: { status: "in-progress" },
       transcript: [userLine("one"), userLine("two")].join("\n"),
     });
-    const result = runWatchdog({ transcriptPath, cwd: dir });
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: RUN_ID });
 
     expect(result.flagRaised).toBe(false);
   });
@@ -325,7 +411,7 @@ describe("runWatchdog — active run", () => {
       runState: { status: "in-progress" },
       transcript,
     });
-    const result = runWatchdog({ transcriptPath, cwd: dir });
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: RUN_ID });
 
     expect(result.flagRaised).toBe(true);
     expect(result.evaluation!.usedTokens).toBe(108002);

--- a/plugins/orchestrate/orchestrate-mcp/test/render.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/render.test.ts
@@ -70,25 +70,36 @@ const VALID_STATE: RunState = {
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
 
-/** Writes a project dir; pass null for config to skip creating run-state.json. */
-function makeProject(config: unknown | string | null): string {
+/** The runId every test fixture uses unless it needs a second, distinct run. */
+const RUN_ID = "20260521-010101";
+
+/**
+ * Writes a project dir with a per-run directory at
+ * `.orchestrate/runs/<runId>/`. Pass null for config to skip creating
+ * run-state.json (the run directory is still created).
+ */
+function makeProject(
+  config: unknown | string | null,
+  runId: string = RUN_ID
+): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-render-"));
+  const runDir = path.join(dir, ".orchestrate", "runs", runId);
+  fs.mkdirSync(runDir, { recursive: true });
   if (config !== null) {
-    fs.mkdirSync(path.join(dir, ".orchestrate"));
     const content =
       typeof config === "string" ? config : JSON.stringify(config, null, 2);
-    fs.writeFileSync(
-      path.join(dir, ".orchestrate", "run-state.json"),
-      content
-    );
+    fs.writeFileSync(path.join(runDir, "run-state.json"), content);
   }
   return dir;
 }
 
 const created: string[] = [];
 
-function project(config: unknown | string | null): string {
-  const dir = makeProject(config);
+function project(
+  config: unknown | string | null,
+  runId: string = RUN_ID
+): string {
+  const dir = makeProject(config, runId);
   created.push(dir);
   return dir;
 }
@@ -203,7 +214,7 @@ describe("renderReport (pure)", () => {
 describe("renderDashboardArtifact", () => {
   it("writes the file and returns status ok with the artifact path", async () => {
     const dir = project(VALID_STATE);
-    const result = await renderDashboardArtifact({ repoPath: dir });
+    const result = await renderDashboardArtifact({ repoPath: dir, runId: RUN_ID });
 
     expect(result.status).toBe("ok");
     expect(result.artifactPath).toBeDefined();
@@ -212,10 +223,24 @@ describe("renderDashboardArtifact", () => {
     expect(content).toContain("20260521-010101");
   });
 
+  it("writes the artifact under .orchestrate/runs/<runId>/", async () => {
+    const dir = project(VALID_STATE);
+    const result = await renderDashboardArtifact({ repoPath: dir, runId: RUN_ID });
+
+    expect(result.status).toBe("ok");
+    expect(result.artifactPath).toBe(
+      path.join(dir, ".orchestrate", "runs", RUN_ID, "dashboard.html")
+    );
+  });
+
   it("respects an explicit outputPath override", async () => {
     const dir = project(VALID_STATE);
     const outputPath = path.join(dir, "custom-dashboard.html");
-    const result = await renderDashboardArtifact({ repoPath: dir, outputPath });
+    const result = await renderDashboardArtifact({
+      repoPath: dir,
+      runId: RUN_ID,
+      outputPath,
+    });
 
     expect(result.status).toBe("ok");
     expect(result.artifactPath).toBe(outputPath);
@@ -226,7 +251,7 @@ describe("renderDashboardArtifact", () => {
 describe("renderGraphArtifact", () => {
   it("writes the file and returns status ok with the artifact path", async () => {
     const dir = project(VALID_STATE);
-    const result = await renderGraphArtifact({ repoPath: dir });
+    const result = await renderGraphArtifact({ repoPath: dir, runId: RUN_ID });
 
     expect(result.status).toBe("ok");
     expect(result.artifactPath).toBeDefined();
@@ -239,7 +264,7 @@ describe("renderGraphArtifact", () => {
 describe("renderReportArtifact", () => {
   it("writes the file and returns status ok with the artifact path", async () => {
     const dir = project(VALID_STATE);
-    const result = await renderReportArtifact({ repoPath: dir });
+    const result = await renderReportArtifact({ repoPath: dir, runId: RUN_ID });
 
     expect(result.status).toBe("ok");
     expect(result.artifactPath).toBeDefined();
@@ -249,12 +274,78 @@ describe("renderReportArtifact", () => {
   });
 });
 
+// ─── Per-run path isolation ──────────────────────────────────────────────────
+
+describe("artifact tools — per-run path isolation", () => {
+  it("two render calls with distinct run ids write to distinct paths", async () => {
+    const runA = "20260521-010101";
+    const runB = "20260521-020202";
+    // One repo dir holding two distinct run directories.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-render-"));
+    created.push(dir);
+    for (const runId of [runA, runB]) {
+      const runDir = path.join(dir, ".orchestrate", "runs", runId);
+      fs.mkdirSync(runDir, { recursive: true });
+      const state = JSON.parse(JSON.stringify(VALID_STATE)) as RunState;
+      state.runId = runId;
+      fs.writeFileSync(
+        path.join(runDir, "run-state.json"),
+        JSON.stringify(state, null, 2)
+      );
+    }
+
+    const resultA = await renderDashboardArtifact({ repoPath: dir, runId: runA });
+    const resultB = await renderDashboardArtifact({ repoPath: dir, runId: runB });
+
+    expect(resultA.status).toBe("ok");
+    expect(resultB.status).toBe("ok");
+    expect(resultA.artifactPath).not.toBe(resultB.artifactPath);
+    expect(resultA.artifactPath).toContain(runA);
+    expect(resultB.artifactPath).toContain(runB);
+    // Each artifact embeds its own run's id — no cross-contamination.
+    expect(fs.readFileSync(resultA.artifactPath!, "utf8")).toContain(runA);
+    expect(fs.readFileSync(resultB.artifactPath!, "utf8")).toContain(runB);
+  });
+});
+
+// ─── Invalid runId ───────────────────────────────────────────────────────────
+
+describe("artifact tools — invalid runId", () => {
+  it("renderDashboardArtifact → RUN_ID_INVALID for a path-traversal runId", async () => {
+    const dir = project(VALID_STATE);
+    const result = await renderDashboardArtifact({
+      repoPath: dir,
+      runId: "../../etc",
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.errorCode).toBe("RUN_ID_INVALID");
+    expect(result.artifactPath).toBeUndefined();
+  });
+
+  it("renderGraphArtifact → RUN_ID_INVALID for an empty runId", async () => {
+    const dir = project(VALID_STATE);
+    const result = await renderGraphArtifact({ repoPath: dir, runId: "" });
+
+    expect(result.status).toBe("error");
+    expect(result.errorCode).toBe("RUN_ID_INVALID");
+  });
+
+  it("renderReportArtifact → RUN_ID_INVALID for a runId with a separator", async () => {
+    const dir = project(VALID_STATE);
+    const result = await renderReportArtifact({ repoPath: dir, runId: "a/b" });
+
+    expect(result.status).toBe("error");
+    expect(result.errorCode).toBe("RUN_ID_INVALID");
+  });
+});
+
 // ─── Error path tests ─────────────────────────────────────────────────────────
 
 describe("artifact tools — missing run-state.json", () => {
   it("renderDashboardArtifact → RUN_STATE_NOT_FOUND", async () => {
     const dir = project(null);
-    const result = await renderDashboardArtifact({ repoPath: dir });
+    const result = await renderDashboardArtifact({ repoPath: dir, runId: RUN_ID });
 
     expect(result.status).toBe("error");
     expect(result.errorCode).toBe("RUN_STATE_NOT_FOUND");
@@ -263,7 +354,7 @@ describe("artifact tools — missing run-state.json", () => {
 
   it("renderGraphArtifact → RUN_STATE_NOT_FOUND", async () => {
     const dir = project(null);
-    const result = await renderGraphArtifact({ repoPath: dir });
+    const result = await renderGraphArtifact({ repoPath: dir, runId: RUN_ID });
 
     expect(result.status).toBe("error");
     expect(result.errorCode).toBe("RUN_STATE_NOT_FOUND");
@@ -271,7 +362,7 @@ describe("artifact tools — missing run-state.json", () => {
 
   it("renderReportArtifact → RUN_STATE_NOT_FOUND", async () => {
     const dir = project(null);
-    const result = await renderReportArtifact({ repoPath: dir });
+    const result = await renderReportArtifact({ repoPath: dir, runId: RUN_ID });
 
     expect(result.status).toBe("error");
     expect(result.errorCode).toBe("RUN_STATE_NOT_FOUND");
@@ -281,7 +372,7 @@ describe("artifact tools — missing run-state.json", () => {
 describe("artifact tools — malformed JSON", () => {
   it("renderDashboardArtifact → RUN_STATE_INVALID", async () => {
     const dir = project("{ not valid json");
-    const result = await renderDashboardArtifact({ repoPath: dir });
+    const result = await renderDashboardArtifact({ repoPath: dir, runId: RUN_ID });
 
     expect(result.status).toBe("error");
     expect(result.errorCode).toBe("RUN_STATE_INVALID");
@@ -289,7 +380,7 @@ describe("artifact tools — malformed JSON", () => {
 
   it("renderGraphArtifact → RUN_STATE_INVALID", async () => {
     const dir = project("{ not valid json");
-    const result = await renderGraphArtifact({ repoPath: dir });
+    const result = await renderGraphArtifact({ repoPath: dir, runId: RUN_ID });
 
     expect(result.status).toBe("error");
     expect(result.errorCode).toBe("RUN_STATE_INVALID");
@@ -297,7 +388,7 @@ describe("artifact tools — malformed JSON", () => {
 
   it("renderReportArtifact → RUN_STATE_INVALID", async () => {
     const dir = project("{ not valid json");
-    const result = await renderReportArtifact({ repoPath: dir });
+    const result = await renderReportArtifact({ repoPath: dir, runId: RUN_ID });
 
     expect(result.status).toBe("error");
     expect(result.errorCode).toBe("RUN_STATE_INVALID");
@@ -308,7 +399,7 @@ describe("artifact tools — schema mismatch", () => {
   it("renderDashboardArtifact → RUN_STATE_INVALID when required fields are missing", async () => {
     const invalid = { runId: "x", status: "in-progress" }; // missing most required fields
     const dir = project(invalid);
-    const result = await renderDashboardArtifact({ repoPath: dir });
+    const result = await renderDashboardArtifact({ repoPath: dir, runId: RUN_ID });
 
     expect(result.status).toBe("error");
     expect(result.errorCode).toBe("RUN_STATE_INVALID");
@@ -317,7 +408,7 @@ describe("artifact tools — schema mismatch", () => {
   it("renderReportArtifact → RUN_STATE_INVALID when required fields are missing", async () => {
     const invalid = { runId: "x" };
     const dir = project(invalid);
-    const result = await renderReportArtifact({ repoPath: dir });
+    const result = await renderReportArtifact({ repoPath: dir, runId: RUN_ID });
 
     expect(result.status).toBe("error");
     expect(result.errorCode).toBe("RUN_STATE_INVALID");
@@ -363,6 +454,7 @@ describe("artifact tools — write failure", () => {
     // no-op and writeFileSync onto the directory path fails (EISDIR).
     const result = await renderDashboardArtifact({
       repoPath: dir,
+      runId: RUN_ID,
       outputPath: dir,
     });
 
@@ -379,6 +471,7 @@ describe("artifact tools — write failure", () => {
     fs.writeFileSync(blocker, "i am a file, not a directory");
     const result = await renderReportArtifact({
       repoPath: dir,
+      runId: RUN_ID,
       outputPath: path.join(blocker, "nested", "report.html"),
     });
 

--- a/plugins/orchestrate/orchestrate-mcp/test/run-dir.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/run-dir.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import * as path from "path";
+import { resolveRunDir, isValidRunId } from "../src/run-dir.js";
+
+// `run-dir` is a pure module — every test exercises path computation only, with
+// no filesystem I/O. The resolver maps a (repoPath, runId) pair to the run's
+// ephemeral directory and the files inside it.
+
+// ─── isValidRunId ─────────────────────────────────────────────────────────────
+
+describe("isValidRunId", () => {
+  it("accepts the skill's YYYYMMDD-HHMMSS timestamp ids", () => {
+    expect(isValidRunId("20260521-015143")).toBe(true);
+  });
+
+  it("accepts ids made of letters, digits, underscores, and hyphens", () => {
+    expect(isValidRunId("run_42-abc")).toBe(true);
+    expect(isValidRunId("A")).toBe(true);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isValidRunId("")).toBe(false);
+  });
+
+  it("rejects a path-traversal id", () => {
+    expect(isValidRunId("../../etc")).toBe(false);
+    expect(isValidRunId("..")).toBe(false);
+  });
+
+  it("rejects an id containing a path separator", () => {
+    expect(isValidRunId("a/b")).toBe(false);
+    expect(isValidRunId("a\\b")).toBe(false);
+  });
+
+  it("rejects an id containing a dot", () => {
+    expect(isValidRunId("run.1")).toBe(false);
+  });
+
+  it("rejects an id containing whitespace", () => {
+    expect(isValidRunId("run 1")).toBe(false);
+  });
+});
+
+// ─── resolveRunDir — invalid ids ─────────────────────────────────────────────
+
+describe("resolveRunDir — invalid runId", () => {
+  it("returns ok:false with RUN_ID_INVALID for a path-traversal id", () => {
+    const result = resolveRunDir("/repo", "../../etc");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errorCode).toBe("RUN_ID_INVALID");
+      expect(result.errorMessage).toContain("../../etc");
+    }
+  });
+
+  it("returns ok:false with RUN_ID_INVALID for an empty id", () => {
+    const result = resolveRunDir("/repo", "");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errorCode).toBe("RUN_ID_INVALID");
+    }
+  });
+
+  it("returns ok:false with RUN_ID_INVALID for an id with a separator", () => {
+    const result = resolveRunDir("/repo", "a/b");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errorCode).toBe("RUN_ID_INVALID");
+    }
+  });
+});
+
+// ─── resolveRunDir — valid ids ───────────────────────────────────────────────
+
+describe("resolveRunDir — valid runId", () => {
+  it("returns ok:true with every ephemeral path present", () => {
+    const result = resolveRunDir("/repo", "20260521-015143");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.paths.runDir).toBeDefined();
+      expect(result.paths.runStatePath).toBeDefined();
+      expect(result.paths.contextFlagPath).toBeDefined();
+      expect(result.paths.dashboardPath).toBeDefined();
+      expect(result.paths.graphPath).toBeDefined();
+      expect(result.paths.reportPath).toBeDefined();
+    }
+  });
+
+  it("nests the run directory under .orchestrate/runs/<runId>/", () => {
+    const result = resolveRunDir("/repo", "20260521-015143");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.paths.runDir).toBe(
+        path.join("/repo", ".orchestrate", "runs", "20260521-015143")
+      );
+    }
+  });
+
+  it("places run-state.json and context-flag.json inside the run directory", () => {
+    const result = resolveRunDir("/repo", "20260521-015143");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.paths.runStatePath).toBe(
+        path.join(result.paths.runDir, "run-state.json")
+      );
+      expect(result.paths.contextFlagPath).toBe(
+        path.join(result.paths.runDir, "context-flag.json")
+      );
+    }
+  });
+
+  it("places the three HTML artifacts inside the run directory", () => {
+    const result = resolveRunDir("/repo", "20260521-015143");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.paths.dashboardPath).toBe(
+        path.join(result.paths.runDir, "dashboard.html")
+      );
+      expect(result.paths.graphPath).toBe(
+        path.join(result.paths.runDir, "graph.html")
+      );
+      expect(result.paths.reportPath).toBe(
+        path.join(result.paths.runDir, "report.html")
+      );
+    }
+  });
+});
+
+// ─── Per-run isolation invariant ─────────────────────────────────────────────
+
+describe("resolveRunDir — per-run path isolation", () => {
+  it("two distinct run ids never resolve to a shared path", () => {
+    const a = resolveRunDir("/repo", "20260521-010101");
+    const b = resolveRunDir("/repo", "20260521-020202");
+    expect(a.ok && b.ok).toBe(true);
+    if (a.ok && b.ok) {
+      // No path in run A equals any path in run B.
+      const aPaths = Object.values(a.paths);
+      const bPaths = Object.values(b.paths);
+      for (const ap of aPaths) {
+        for (const bp of bPaths) {
+          expect(ap).not.toBe(bp);
+        }
+      }
+    }
+  });
+
+  it("the same run id resolves deterministically to the same paths", () => {
+    const first = resolveRunDir("/repo", "20260521-015143");
+    const second = resolveRunDir("/repo", "20260521-015143");
+    expect(first.ok && second.ok).toBe(true);
+    if (first.ok && second.ok) {
+      expect(first.paths).toEqual(second.paths);
+    }
+  });
+
+  it("keeps the run directory inside the repo's .orchestrate tree", () => {
+    const result = resolveRunDir("/repo", "20260521-015143");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const expectedPrefix = path.join("/repo", ".orchestrate", "runs");
+      expect(result.paths.runDir.startsWith(expectedPrefix)).toBe(true);
+    }
+  });
+});

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -74,27 +74,33 @@ as a checkable end-state, e.g. `/goal the orchestrate run has opened its final
 integration pull request, or a successor session has been launched`. An
 autonomous run must not stop mid-wave.
 
-Also clear any stale handoff flag: if `.orchestrate/context-flag.json` exists,
-delete it. On a resumed run it is the predecessor's handoff trigger, now
-consumed; on a fresh run it is leftover from an earlier run. Either way,
-leaving it would make this session hand off immediately (section 2, step 4).
+Every run keeps its ephemeral state in a **per-run directory**,
+`.orchestrate/runs/<runId>/`, holding that run's `run-state.json`,
+`context-flag.json`, and rendered HTML artifacts. The committed config files
+(`commands.json`, `routing.json`, `handoff.json`) stay flat at the
+`.orchestrate/` top level. The run directory's schema and rationale are in
+`references/run-state.md`.
 
-Then check for `.orchestrate/run-state.json` (its schema is in
-`references/run-state.md`).
+**Discover the active run.** Scan `.orchestrate/runs/*/run-state.json` for a run
+whose `status` is `in-progress`.
 
-- **It exists and `status` is `in-progress`** — resume. Load the whole file,
-  preserving every top-level field — `runId`, `umbrellaBranch`, `parentIssue`,
-  `waves`, `completedWaves`, `finalPullRequest`, and `slices`. Every slice in a
-  terminal state (`passed`, `failed`, `skipped`) is left untouched — completed
-  work is never redone. Every slice still `in-progress` was interrupted before
-  finishing: discard its partial artifacts so it re-processes cleanly — if it
-  has a `worktreePath`, call `remove_worktree` (`force: true`); delete its
-  `sliceBranch` if it exists (locally, and on the remote if it was pushed) —
-  deleting the remote branch also auto-closes any orphaned slice pull request
-  GitHub opened for it, so re-processing produces a clean branch and PR with no
-  manual PR cleanup needed — then coerce that slice back to `pending`. Skip to
-  section 2.
-- **It is absent, or `status` is `completed`** — start a fresh run below.
+- **A run directory with an `in-progress` `run-state.json` exists** — resume it.
+  Its `runId` is the directory name. First clear that run's stale handoff flag:
+  if `.orchestrate/runs/<runId>/context-flag.json` exists, delete it — it is the
+  predecessor's handoff trigger, now consumed, and leaving it would make this
+  session hand off immediately (section 2, step 4). Then load the whole
+  `run-state.json`, preserving every top-level field — `runId`,
+  `umbrellaBranch`, `parentIssue`, `waves`, `completedWaves`,
+  `finalPullRequest`, and `slices`. Every slice in a terminal state (`passed`,
+  `failed`, `skipped`) is left untouched — completed work is never redone. Every
+  slice still `in-progress` was interrupted before finishing: discard its
+  partial artifacts so it re-processes cleanly — if it has a `worktreePath`,
+  call `remove_worktree` (`force: true`); delete its `sliceBranch` if it exists
+  (locally, and on the remote if it was pushed) — deleting the remote branch
+  also auto-closes any orphaned slice pull request GitHub opened for it, so
+  re-processing produces a clean branch and PR with no manual PR cleanup needed
+  — then coerce that slice back to `pending`. Skip to section 2.
+- **No run directory holds an `in-progress` run** — start a fresh run below.
 
 ### Fresh run
 
@@ -136,8 +142,9 @@ Then check for `.orchestrate/run-state.json` (its schema is in
    git push -u origin orchestrate/umbrella-<runId>
    ```
 
-6. Write the initial `.orchestrate/run-state.json` with **every field the
-   schema declares** (see `references/run-state.md`):
+6. Create the run directory `.orchestrate/runs/<runId>/`, then write the initial
+   `run-state.json` into it as `.orchestrate/runs/<runId>/run-state.json` with
+   **every field the schema declares** (see `references/run-state.md`):
    - Top level: `runId`, `status: "in-progress"`, `umbrellaBranch`,
      `integrationBase: "development"`, `parentIssue` (the parent PRD number, or
      null), `startedAt` and `updatedAt` (current UTC time), the `waves` from
@@ -182,10 +189,10 @@ Process waves in order, starting at index `completedWaves`. For each wave:
 4. **Integrate sequentially.** The commit, pull-request, and merge steps
    (section 3, steps 6–9) run **one slice at a time** — merges into the
    umbrella branch must not race each other. After each slice finishes
-   integrating, check for `.orchestrate/context-flag.json`: if it exists, the
-   context-watchdog has signalled that this session's context is filling. Do
-   not start the next slice — finish writing `run-state.json` for the slice
-   just integrated, then go to section 4 (Context handoff).
+   integrating, check for `.orchestrate/runs/<runId>/context-flag.json`: if it
+   exists, the context-watchdog has signalled that this session's context is
+   filling. Do not start the next slice — finish writing `run-state.json` for
+   the slice just integrated, then go to section 4 (Context handoff).
 5. **Checkpoint the wave.** Set `completedWaves` to this wave's index + 1 and
    write `run-state.json`.
 6. **Report wave progress to the PRD.** If `parentIssue` is set, post a comment
@@ -205,11 +212,13 @@ gh pr create --base development --head orchestrate/umbrella-<runId> \
 Record its URL as `finalPullRequest` in `run-state.json`, set
 `status: "completed"`, and checkpoint. Then render the run's HTML artifacts
 from the final checkpoint — call the `render_dashboard`, `render_graph`, and
-`render_report` MCP tools, each with the repository root as `repoPath` — so a
-developer has a visual summary of the run. If `parentIssue` is set, post a
-final summary comment on it. Report to the user: the umbrella branch, the
-final pull request URL, the paths of the three rendered artifacts, and — per
-slice — its final state and pull request.
+`render_report` MCP tools, each with the repository root as `repoPath` and the
+run's `runId`; each tool reads `.orchestrate/runs/<runId>/run-state.json` and
+writes its artifact into that same run directory — so a developer has a visual
+summary of the run. If `parentIssue` is set, post a final summary comment on
+it. Report to the user: the umbrella branch, the final pull request URL, the
+paths of the three rendered artifacts, and — per slice — its final state and
+pull request.
 
 ## 3. Processing one slice
 
@@ -346,18 +355,18 @@ These are the per-slice steps the wave loop invokes. Update the slice's entry in
 
 A long run can fill this session's context before every wave is done. The
 `context-watchdog` hook bundled with this plugin watches token usage and writes
-`.orchestrate/context-flag.json` past a configurable threshold. When the wave
-loop (section 2, step 4) sees that flag, hand the run off to a fresh Claude
-Code session instead of continuing — the successor resumes from the
-`run-state.json` checkpoint exactly as section 1 describes. See
+`.orchestrate/runs/<runId>/context-flag.json` past a configurable threshold.
+When the wave loop (section 2, step 4) sees that flag, hand the run off to a
+fresh Claude Code session instead of continuing — the successor resumes from
+the `run-state.json` checkpoint exactly as section 1 describes. See
 `references/context-handoff.md` for the full mechanism.
 
 To hand off:
 
 1. Make sure `run-state.json` is checkpointed and its `status` is still
    `in-progress` — the successor resumes from it. Do **not** delete
-   `.orchestrate/context-flag.json`; the successor deletes it on startup once
-   it has consumed it.
+   `.orchestrate/runs/<runId>/context-flag.json`; the successor deletes it on
+   startup once it has consumed it.
 2. Call the `spawn_successor` MCP tool with the repository root as `repoPath`.
    It launches a new interactive Claude Code session — terminal and `claude`
    flags come from `.orchestrate/handoff.json`, defaults otherwise — that
@@ -408,8 +417,9 @@ commits close them when a developer merges the final umbrella pull request into
 
 ## Checkpointing
 
-Write `.orchestrate/run-state.json` after every slice state change and after
-every wave. Every write refreshes the top-level `updatedAt`, and a slice's own
-`updatedAt` whenever its entry changes, so an artifact rendered from the file
-has accurate timestamps. The checkpoint is what makes a run resumable: an
-interrupted run, re-invoked, skips every terminal-state slice and continues.
+Write the run's `run-state.json` — at `.orchestrate/runs/<runId>/run-state.json`
+— after every slice state change and after every wave. Every write refreshes
+the top-level `updatedAt`, and a slice's own `updatedAt` whenever its entry
+changes, so an artifact rendered from the file has accurate timestamps. The
+checkpoint is what makes a run resumable: an interrupted run, re-invoked, skips
+every terminal-state slice and continues.

--- a/plugins/orchestrate/skills/orchestrate/references/context-handoff.md
+++ b/plugins/orchestrate/skills/orchestrate/references/context-handoff.md
@@ -9,9 +9,13 @@ checkpoint, and the predecessor exits. This file documents the three pieces.
 
 `context-watchdog` is a `PostToolUse` hook bundled with the orchestrate plugin
 (`hooks/hooks.json`). It runs after every tool call, asynchronously, and is a
-**silent no-op unless an orchestration run is in progress** — it checks
-`.orchestrate/run-state.json` for `status: "in-progress"` first, so it is
-harmless in unrelated sessions even though the plugin is always enabled.
+**silent no-op unless an orchestration run is in progress**.
+
+The hook event carries only the session `cwd` and `transcript_path` — never a
+runId. The watchdog therefore first **discovers the active run**: it scans
+`.orchestrate/runs/*/run-state.json` for the single run whose `status` is
+`in-progress`. With no active run it does nothing, so it is harmless in
+unrelated sessions even though the plugin is always enabled.
 
 When a run is active it:
 
@@ -20,16 +24,18 @@ When a run is active it:
    `cache_read_input_tokens`).
 2. Compares that against the context window and threshold from
    `.orchestrate/handoff.json` (defaults: 40% of a 200000-token window).
-3. On the first sample that reaches the threshold, writes
-   `.orchestrate/context-flag.json` and surfaces a `systemMessage`. The flag is
-   written **at most once per run** — once it exists, later samples are no-ops.
+3. On the first sample that reaches the threshold, writes the discovered run's
+   `.orchestrate/runs/<runId>/context-flag.json` and surfaces a `systemMessage`.
+   The flag is written **at most once per run** — once it exists, later samples
+   are no-ops.
 
 The hook never throws and never blocks a tool call; a watchdog that disrupts
 the session would be worse than one that misses.
 
-## 2. `.orchestrate/context-flag.json` — the handoff signal
+## 2. `context-flag.json` — the handoff signal
 
-A small JSON file the watchdog writes when the threshold is reached:
+A small JSON file the watchdog writes when the threshold is reached. It lives in
+the run's per-run directory, at `.orchestrate/runs/<runId>/context-flag.json`:
 
 ```json
 {
@@ -46,8 +52,8 @@ integrates (SKILL.md section 2); the successor **deletes it on startup**
 (SKILL.md section 1) once consumed — a stale flag would make the successor hand
 off again immediately, an infinite spawn loop.
 
-It is ephemeral run state, not config — the target project should gitignore it
-alongside `run-state.json`.
+It is ephemeral run state, not config — it lives in `.orchestrate/runs/<runId>/`
+alongside `run-state.json`, which the target project should gitignore.
 
 ## 3. `.orchestrate/handoff.json` — configuration (optional)
 

--- a/plugins/orchestrate/skills/orchestrate/references/run-state.md
+++ b/plugins/orchestrate/skills/orchestrate/references/run-state.md
@@ -1,11 +1,40 @@
 # run-state.json — the orchestration checkpoint
 
-`.orchestrate/run-state.json` is the durable checkpoint of an orchestration run.
-The orchestrator writes it after every slice state change and after every wave,
-and reads it on startup to resume an interrupted run instead of restarting.
+`run-state.json` is the durable checkpoint of an orchestration run. The
+orchestrator writes it after every slice state change and after every wave, and
+reads it on startup to resume an interrupted run instead of restarting.
 
-It lives at `.orchestrate/run-state.json` in the repository root. It is run
-metadata, not source — the target project should gitignore it.
+## The per-run directory
+
+Every run keeps its ephemeral state in a **per-run directory**,
+`.orchestrate/runs/<runId>/`, where `<runId>` is the run's timestamp id. That
+directory holds the run's `run-state.json`, its `context-flag.json` (the
+context-handoff signal), and the rendered HTML artifacts (`dashboard.html`,
+`graph.html`, `report.html`). Two distinct runs never share a directory, so
+their ephemeral state never collides — the per-run layout is the structural
+foundation for concurrent runs.
+
+The committed config files — `commands.json`, `routing.json`, and
+`handoff.json` — stay flat at the `.orchestrate/` top level; they are
+configuration, not run state, and are shared across runs.
+
+The run's `run-state.json` therefore lives at
+`.orchestrate/runs/<runId>/run-state.json`. It is run metadata, not source —
+the target project should gitignore the `.orchestrate/runs/` directory.
+
+```text
+.orchestrate/
+├── commands.json                 # committed config (flat, shared)
+├── routing.json                  # committed config (flat, shared)
+├── handoff.json                  # committed config (flat, shared)
+└── runs/
+    └── 20260521-015143/          # one per-run directory per run
+        ├── run-state.json        # the run checkpoint
+        ├── context-flag.json     # the context-handoff signal (when raised)
+        ├── dashboard.html        # rendered artifact
+        ├── graph.html            # rendered artifact
+        └── report.html           # rendered artifact
+```
 
 ## Schema
 
@@ -87,9 +116,10 @@ re-processed on resume.
 
 ## Resume
 
-On startup the orchestrator reads `.orchestrate/run-state.json`. If it exists
-and `status` is `in-progress`, the run resumes: every slice already in a
-terminal state is left untouched; every `in-progress` slice has its partial
-artifacts discarded (worktree removed, slice branch deleted) and is coerced back
-to `pending` before re-processing — it is not merely continued. A run with no
-state file, or one whose `status` is `completed`, starts fresh.
+On startup the orchestrator scans `.orchestrate/runs/*/run-state.json` for a run
+whose `status` is `in-progress`. If one is found, the run resumes: every slice
+already in a terminal state is left untouched; every `in-progress` slice has its
+partial artifacts discarded (worktree removed, slice branch deleted) and is
+coerced back to `pending` before re-processing — it is not merely continued.
+When no run directory holds an `in-progress` run — none exist, or every run's
+`status` is `completed` — a fresh run starts.


### PR DESCRIPTION
Implements #191.

Moves every run's ephemeral state into `.orchestrate/runs/<runId>/` (run-state.json, context-flag.json, HTML artifacts) while committed config files stay flat. New pure `resolveRunDir` resolver with a path-traversal guard; `render_*` and the context-watchdog hook resolve through the runId; the watchdog CLI discovers the active run by scanning in-progress run-state files. SKILL.md + references updated. 17 new resolver tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)