### PR TITLE
orchestrate: neutralize inherited GIT_SSH_COMMAND in the MCP git wrapper

### DIFF
--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -21120,8 +21120,8 @@ var GIT_CONFIG_OVERRIDES = [
   // `core.sshCommand` from the repo config cannot run. A blank value would
   // also close that vector, but it makes an SSH `fetch` spawn an empty
   // command and fail (F-005); `ssh` is the real, working invocation,
-  // resolved from PATH. Note: an inherited `GIT_SSH_COMMAND` env var takes
-  // precedence over `core.sshCommand` and is not neutralized here — see #200.
+  // resolved from PATH. The corresponding `GIT_SSH_COMMAND` env-var override
+  // is neutralized in gitEnv() — see the GIT_SSH_COMMAND key there.
   "-c",
   "core.sshCommand=ssh",
   "-c",
@@ -21132,7 +21132,9 @@ function gitEnv() {
     ...process.env,
     GIT_TERMINAL_PROMPT: "0",
     GIT_CONFIG_NOSYSTEM: "1",
-    GIT_CONFIG_GLOBAL: "/dev/null"
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_SSH_COMMAND: "ssh",
+    GIT_SSH: "ssh"
   };
 }
 var GitExecError = class extends Error {

--- a/plugins/orchestrate/orchestrate-mcp/src/git.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/git.ts
@@ -24,8 +24,8 @@ const GIT_CONFIG_OVERRIDES: string[] = [
   // `core.sshCommand` from the repo config cannot run. A blank value would
   // also close that vector, but it makes an SSH `fetch` spawn an empty
   // command and fail (F-005); `ssh` is the real, working invocation,
-  // resolved from PATH. Note: an inherited `GIT_SSH_COMMAND` env var takes
-  // precedence over `core.sshCommand` and is not neutralized here — see #200.
+  // resolved from PATH. The corresponding `GIT_SSH_COMMAND` env-var override
+  // is neutralized in gitEnv() — see the GIT_SSH_COMMAND key there.
   "-c",
   "core.sshCommand=ssh",
   "-c",
@@ -38,6 +38,12 @@ const GIT_CONFIG_OVERRIDES: string[] = [
  * - `GIT_TERMINAL_PROMPT=0`: an auth prompt fails fast instead of hanging.
  * - `GIT_CONFIG_NOSYSTEM=1`: ignore the system-wide git config.
  * - `GIT_CONFIG_GLOBAL=/dev/null`: ignore the user-global git config.
+ * - `GIT_SSH_COMMAND=ssh`: neutralize any inherited value — git's SSH-command
+ *   precedence is GIT_SSH_COMMAND > core.sshCommand config, so an inherited
+ *   env var would bypass the `-c core.sshCommand=ssh` hardening applied by
+ *   GIT_CONFIG_OVERRIDES. Resetting to "ssh" closes that vector (#200).
+ * - `GIT_SSH=ssh`: defense-in-depth for the legacy variable; on git 2.43 it
+ *   does not override `-c core.sshCommand`, but clearing it is cheap.
  */
 function gitEnv(): NodeJS.ProcessEnv {
   return {
@@ -45,6 +51,8 @@ function gitEnv(): NodeJS.ProcessEnv {
     GIT_TERMINAL_PROMPT: "0",
     GIT_CONFIG_NOSYSTEM: "1",
     GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_SSH_COMMAND: "ssh",
+    GIT_SSH: "ssh",
   };
 }
 

--- a/plugins/orchestrate/orchestrate-mcp/test/worktree.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/worktree.test.ts
@@ -300,6 +300,139 @@ describe("create_worktree", () => {
     }
   });
 
+  it("does not execute a malicious GIT_SSH_COMMAND inherited from the environment", async () => {
+    // Security: GIT_SSH_COMMAND overrides `-c core.sshCommand` in git's
+    // precedence, so an inherited value can bypass the hardening. gitEnv() must
+    // neutralize it by setting GIT_SSH_COMMAND="ssh" after ...process.env.
+    //
+    // Setup mirrors the F-005 test: ssh:// remote + stub `ssh` on PATH.
+    // Additionally, a sentinel-writing command is injected via GIT_SSH_COMMAND.
+    // After createWorktree, the sentinel must NOT exist.
+    const remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-remote-"));
+    const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-ssh-"));
+    const sentinelDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-sentinel-"));
+    const sentinelPath = path.join(sentinelDir, "SSH_COMMAND_EXECUTED");
+
+    const savedPath = process.env.PATH;
+    const savedSshCommand = process.env.GIT_SSH_COMMAND;
+
+    try {
+      const remoteBare = path.join(remoteDir, "remote.git");
+      git(["clone", "--bare", repoPath, remoteBare], remoteDir);
+      git(["remote", "add", "origin", `ssh://fake${remoteBare}`], repoPath);
+
+      // Stub `ssh` on PATH so the neutralized GIT_SSH_COMMAND="ssh" resolves
+      // to something that actually runs the git-upload-pack command (keeping
+      // the fetch functional).
+      const stubSsh = path.join(stubDir, "ssh");
+      fs.writeFileSync(
+        stubSsh,
+        '#!/bin/sh\nfor arg in "$@"; do cmd="$arg"; done\nexec sh -c "$cmd"\n'
+      );
+      fs.chmodSync(stubSsh, 0o755);
+
+      // Inject the malicious GIT_SSH_COMMAND that would write the sentinel.
+      process.env.GIT_SSH_COMMAND = `sh -c 'touch ${sentinelPath}; for arg in "$@"; do cmd="$arg"; done; sh -c "$cmd"' --`;
+      process.env.PATH = `${stubDir}${path.delimiter}${savedPath ?? ""}`;
+
+      const wtPath = path.join(worktreesDir, "malicious-ssh-cmd-wt");
+      await createWorktree({
+        baseRef: "HEAD",
+        branch: "malicious-ssh-cmd-branch",
+        worktreePath: wtPath,
+        repoPath,
+      });
+
+      // The sentinel must NOT have been written — the injected GIT_SSH_COMMAND
+      // must have been neutralized by gitEnv() before git was invoked.
+      expect(fs.existsSync(sentinelPath)).toBe(false);
+    } finally {
+      if (savedPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = savedPath;
+      }
+      if (savedSshCommand === undefined) {
+        delete process.env.GIT_SSH_COMMAND;
+      } else {
+        process.env.GIT_SSH_COMMAND = savedSshCommand;
+      }
+      rmrf(remoteDir);
+      rmrf(stubDir);
+      rmrf(sentinelDir);
+    }
+  });
+
+  it("core.sshCommand in repo .git/config is overridden by -c and does not execute", async () => {
+    // Security invariant pinned by #184: a malicious `core.sshCommand` in an
+    // untrusted repo's `.git/config` must NOT run because gitExecFile prepends
+    // `-c core.sshCommand=ssh` which takes precedence over repo config.
+    //
+    // This test locks that invariant in place so future refactors cannot
+    // accidentally remove the `-c core.sshCommand=ssh` override.
+    const remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-remote-"));
+    const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-ssh-"));
+    const sentinelDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-sentinel-"));
+    const sentinelPath = path.join(sentinelDir, "CORE_SSH_COMMAND_EXECUTED");
+
+    const savedPath = process.env.PATH;
+    const savedSshCommand = process.env.GIT_SSH_COMMAND;
+
+    try {
+      const remoteBare = path.join(remoteDir, "remote.git");
+      git(["clone", "--bare", repoPath, remoteBare], remoteDir);
+      git(["remote", "add", "origin", `ssh://fake${remoteBare}`], repoPath);
+
+      // Stub `ssh` on PATH so the legitimate `-c core.sshCommand=ssh` resolves
+      // to something functional.
+      const stubSsh = path.join(stubDir, "ssh");
+      fs.writeFileSync(
+        stubSsh,
+        '#!/bin/sh\nfor arg in "$@"; do cmd="$arg"; done\nexec sh -c "$cmd"\n'
+      );
+      fs.chmodSync(stubSsh, 0o755);
+
+      // Write a malicious core.sshCommand into the repo's .git/config.
+      git(
+        ["config", "core.sshCommand", `sh -c 'touch ${sentinelPath}; for arg in "$@"; do cmd="$arg"; done; sh -c "$cmd"' --`],
+        repoPath
+      );
+
+      // Ensure GIT_SSH_COMMAND is not set so env-var path is not the actor.
+      delete process.env.GIT_SSH_COMMAND;
+      process.env.PATH = `${stubDir}${path.delimiter}${savedPath ?? ""}`;
+
+      const wtPath = path.join(worktreesDir, "malicious-core-ssh-wt");
+      const result = await createWorktree({
+        baseRef: "HEAD",
+        branch: "malicious-core-ssh-branch",
+        worktreePath: wtPath,
+        repoPath,
+      });
+
+      // Fetch should succeed via the stub ssh (not the malicious command).
+      expect(result.status).toBe("ok");
+      expect(result.fetchStatus).toBe("ok");
+      // The sentinel must NOT have been written — the `-c core.sshCommand=ssh`
+      // override must have taken precedence over repo config.
+      expect(fs.existsSync(sentinelPath)).toBe(false);
+    } finally {
+      if (savedPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = savedPath;
+      }
+      if (savedSshCommand === undefined) {
+        delete process.env.GIT_SSH_COMMAND;
+      } else {
+        process.env.GIT_SSH_COMMAND = savedSshCommand;
+      }
+      rmrf(remoteDir);
+      rmrf(stubDir);
+      rmrf(sentinelDir);
+    }
+  });
+
   it("runs the configured install command and reports installStatus='installed'", async () => {
     commitCommandsJson(repoPath, {
       install: [


### PR DESCRIPTION
Implements #200.

Closes a code-execution hole: `GIT_SSH_COMMAND` in the environment overrides the `-c core.sshCommand` hardening. `gitEnv()` now sets `GIT_SSH_COMMAND` (and `GIT_SSH`) after the `...process.env` spread so the explicit value wins. A regression test proves the vector is closed; a companion test pins the #184 `-c`-override invariant. Built red-green-refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)