### PR TITLE
orchestrate-mcp: CI verifies committed dist matches build output

### DIFF
--- a/.github/workflows/orchestrate-mcp-bundle-check.yml
+++ b/.github/workflows/orchestrate-mcp-bundle-check.yml
@@ -1,0 +1,69 @@
+name: orchestrate-mcp bundle check
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Why this workflow exists
+# ──────────────────────────────────────────────────────────────────────────────
+# The orchestrate MCP server ships as a committed build artifact:
+# `.mcp.json` runs `node .../dist/index.js` directly. Because the vitest suite
+# imports from `src/`, tests pass green even when `dist/` is stale — the bug
+# that surfaced in PR #201 (source fix) and PR #202 (bundle rebuild follow-up).
+#
+# This check re-runs `npm run build` inside the CI job and then asserts that
+# the working tree is clean. If `dist/index.js` (or any other file under
+# `dist/`) differs from the committed artifact, the job fails with a clear
+# message — making a stale committed bundle a hard CI failure.
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/orchestrate/orchestrate-mcp/**'
+
+# One run per PR head SHA; cancel any in-progress run for the same PR when a
+# new commit arrives.
+concurrency:
+  group: orchestrate-mcp-bundle-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bundle-check:
+    name: Verify committed dist/ matches npm run build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: plugins/orchestrate/orchestrate-mcp
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Keep in sync with the `engines.node` field in package.json.
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: plugins/orchestrate/orchestrate-mcp/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild bundle
+        run: npm run build
+
+      # `git diff --exit-code` exits 0 when the tree is clean and 1 when
+      # there are unstaged changes. Scoping it to the dist/ path makes the
+      # error message precise: only a stale bundle triggers it, not unrelated
+      # working-tree noise from other steps.
+      - name: Assert committed dist/ is up to date
+        run: |
+          if ! git diff --exit-code -- dist/; then
+            echo ""
+            echo "::error::dist/ is out of sync with src/. Run 'npm run build' inside plugins/orchestrate/orchestrate-mcp/ and commit the result."
+            exit 1
+          fi

--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -228,6 +228,21 @@ plugins/orchestrate/
     └── dist/                    # Bundled server + context-watchdog hook
 ```
 
+## Contributing to orchestrate-mcp
+
+The `orchestrate-mcp/` directory contains a TypeScript MCP server whose compiled output (`dist/`) is committed so the plugin works without a build step at install time. When you change any source file under `src/`, you **must** rebuild before committing:
+
+```bash
+cd plugins/orchestrate/orchestrate-mcp
+npm ci          # if node_modules is stale
+npm run build   # regenerates dist/index.js and dist/context-watchdog.js
+git add dist/
+```
+
+A CI job (`orchestrate-mcp bundle check`) runs on every PR that touches any file under `plugins/orchestrate/orchestrate-mcp/`. It rebuilds the bundle from scratch and fails if `git diff -- dist/` is non-empty. This means a PR that modifies source without rebuilding — or that edits `dist/` directly — will fail CI, not slip through silently.
+
+The vitest suite (`npm test`) imports from `src/`, so tests pass whether or not `dist/` is current. Do not rely on green tests as evidence that the committed bundle is fresh — the CI bundle check is the authoritative gate.
+
 ## License
 
 MIT


### PR DESCRIPTION
Implements #203.

New GitHub Actions workflow `orchestrate-mcp-bundle-check.yml`: on PRs touching `plugins/orchestrate/orchestrate-mcp/**`, runs `npm ci` + `npm run build` and fails the job if `git diff --exit-code -- dist/` is non-empty — making a stale committed bundle a hard CI failure. Documented in the orchestrate README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)