### PR TITLE
orchestrate: project- and model-aware config bootstrapper

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -173,6 +173,10 @@ _Avoid_: project sniffer, auto-configurator, manifest scanner
 A plain object with the four fixed capability verb keys (`tests`, `typecheck`, `build`, `lint`), each mapping to an argv array consumed directly by the orchestrate run tools. Produced by the **Capability detector**. The `install` verb is never included — that is a setup verb, not a capability verb. For unrecognized project types the map is empty (`{}`).
 _Avoid_: command config, verb table, command dictionary
 
+**Config bootstrapper** (`bootstrap_config` MCP tool):
+The integration module (`orchestrate-mcp/src/tools/bootstrap-config.ts`) that makes a first-ever orchestrate run set up its own `.orchestrate/` configuration. It composes the **Capability detector** to write a project-aware `commands.json`, derives `handoff.json`'s context-window size from the running model (passed as a tool input, since the MCP process cannot see the calling model — unknown or absent falls back to 200000), writes `routing.json` from shipped defaults, creates the **Run directory** parent `.orchestrate/runs/`, and idempotently appends `.orchestrate/runs/` to the target repository's `.gitignore`. Every step is individually idempotent — a committed config file is never overwritten.
+_Avoid_: config generator, init tool, setup wizard
+
 **Result envelope**:
 The machine-checkable structured result every orchestrate subagent emits as the last of its turn — a fenced ` ```orchestrate-envelope ` JSON block conforming to a per-role schema (a `discriminatedUnion` on `role`). Worker roles (implementer, reviewer, conflict-resolver) carry `status`, `filesChanged`, `verification`, and `notes`; the read-only investigator carries a research brief and no `status`/`filesChanged`. It is the orchestrator's only source of a subagent's status and changed-file set — the orchestrator never parses subagent prose.
 _Avoid_: result blob, subagent summary, return payload

--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -50,6 +50,7 @@ The plugin bundles `orchestrate-mcp`, a Model Context Protocol server providing 
 
 | Tool | Purpose |
 |------|---------|
+| `bootstrap_config` | Set up a repository's `.orchestrate/` config on a first-ever run — project-aware `commands.json`, model-derived `handoff.json`, default `routing.json`, the run directory, and the `.gitignore` entry |
 | `create_worktree` / `remove_worktree` | Git worktree lifecycle — isolated per-slice checkouts |
 | `run_tests` / `run_typecheck` / `run_build` / `run_lint` | Run the project's configured capability commands |
 | `plan_waves` | Topologically sort issues into dependency waves; detects cycles |
@@ -95,6 +96,32 @@ const commands = buildCommandMap(type); // cargo argv arrays
 
 A manifest-less repository yields `{}` — never an npm fallback — so no capability tool is ever wired to a command guaranteed to fail.
 
+### Config bootstrapping
+
+The `bootstrap_config` MCP tool makes a first-ever run set up its own `.orchestrate/` configuration with no manual steps. On a fresh run — when the repository has no `.orchestrate/` directory — the orchestrator calls it before planning the backlog. It:
+
+- Composes the **capability detector** above and writes a project-appropriate `.orchestrate/commands.json`. The shipped `templates/commands.json` is an empty `{}` safe default — the bootstrapper is the canonical source of a project-aware config. For an npm project it also sets `install: ["npm", "ci"]`; for cargo, Python, Make, or an unrecognized project it omits `install` (a wrong install command is worse than none).
+- Writes `.orchestrate/handoff.json` with a context-window size **derived from the running model**, not a static 200k constant. The model id (or an explicit token count) is passed as a tool input — the MCP process cannot see the calling LLM's model. A small explicit table maps the model to its window; an unknown or absent model falls back to `200000`.
+- Writes `.orchestrate/routing.json` from the shipped defaults.
+- Creates `.orchestrate/runs/` and idempotently appends `.orchestrate/runs/` to the repository's `.gitignore` — exactly once, even across repeated bootstraps.
+
+Every step is individually idempotent: a committed config file is never overwritten, the run directory `mkdir` is recursive, and the `.gitignore` line is never duplicated. Running `bootstrap_config` against an already-configured repository is a safe no-op.
+
+**Usage example.** The orchestrate skill calls the tool on a fresh run:
+
+```jsonc
+// bootstrap_config tool input
+{
+  "repoPath": "/path/to/repo",
+  "model": "claude-opus-4-7[1m]"   // or, e.g., "contextWindowTokens": 1000000
+}
+// → { "status": "ok", "projectType": "npm",
+//     "contextWindowTokens": 1000000, "contextWindowSource": "model-table",
+//     "files": { "commandsJson": "written", "routingJson": "written",
+//                "handoffJson": "written" },
+//     "runsDir": "created", "gitignore": "created-with-line" }
+```
+
 ### Context handoff
 
 A long backlog can fill the orchestrator session's context window before every wave is done. The bundled `context-watchdog` hook (a `PostToolUse` hook) estimates context usage from the session transcript and, past a configurable threshold (default 40%), writes the active run's `.orchestrate/runs/<runId>/context-flag.json`. The orchestrator finishes the current slice, checkpoints, and calls `spawn_successor` to launch a new interactive Claude Code session that resumes from `run-state.json` — then the predecessor exits. The successor clears the stale flag on startup, so there is no handoff loop.
@@ -138,18 +165,18 @@ To run orchestrate against another repository, that repository needs:
 - **The `gh` CLI**, installed and authenticated (`gh auth status`) — the orchestrator uses it for every GitHub operation.
 - **An `origin/development` branch** — the integration base every umbrella branch is cut from.
 - **Branch protection that does not block** merges into `orchestrate/umbrella-*` and `orchestrate/slice-*` branches — the auto-merge needs them open.
-- **Capability configuration** — copy this plugin's `templates/commands.json` and `templates/routing.json` into the target repository's `.orchestrate/` directory and fill them in. Optionally copy `templates/handoff.json` to tune the context-handoff behavior.
+- **Capability configuration** — handled automatically on the first run. When the repository has no `.orchestrate/` directory, the orchestrator calls the `bootstrap_config` MCP tool, which detects the project type and writes a project-appropriate `.orchestrate/commands.json`, `.orchestrate/routing.json`, and `.orchestrate/handoff.json`. To configure ahead of time instead, copy this plugin's `templates/` files into the target repository's `.orchestrate/` directory and fill them in — `templates/commands.json` ships as an empty `{}` starting point. A committed config is never overwritten by the bootstrapper.
 - **A `ready-for-agent` backlog** — issues labelled `ready-for-agent`, each with a **Blocked by** section listing blocker issue numbers (`- #NNN`) and a **Parent** section naming the PRD issue.
 
 Optionally, install the **`ast-grep` CLI** to enable the investigator and reviewer subagents' structural code search; without it, they fall back to text search.
 
-Add the run's generated, ephemeral files to the target repository's `.gitignore`. Every run keeps its `run-state.json`, `context-flag.json`, and rendered HTML artifacts under a per-run directory, `.orchestrate/runs/<runId>/`, so one gitignore line covers them all:
+The run's generated, ephemeral files must be gitignored. Every run keeps its `run-state.json`, `context-flag.json`, and rendered HTML artifacts under a per-run directory, `.orchestrate/runs/<runId>/`, so one gitignore line covers them all:
 
 ```gitignore
 .orchestrate/runs/
 ```
 
-The committed `.orchestrate/commands.json`, `.orchestrate/routing.json`, and `.orchestrate/handoff.json` stay flat at the `.orchestrate/` top level — they are configuration and stay tracked.
+`bootstrap_config` adds this line to the repository's `.gitignore` automatically — idempotently, never duplicating it — so a first-ever run needs no manual gitignore edit. The committed `.orchestrate/commands.json`, `.orchestrate/routing.json`, and `.orchestrate/handoff.json` stay flat at the `.orchestrate/` top level — they are configuration and stay tracked.
 
 ## Configuration Reference
 
@@ -157,16 +184,19 @@ All configuration lives in the target repository's `.orchestrate/` directory.
 
 ### `.orchestrate/commands.json`
 
-Maps each capability verb to the **argv array** that runs it. The argv form is executed with no shell, so a command can never be word-split or glob-expanded. A missing verb is tolerated — that capability tool reports `not-configured`.
+Maps each capability verb to the **argv array** that runs it. The argv form is executed with no shell, so a command can never be word-split or glob-expanded. A missing verb is tolerated — that capability tool reports `not-configured`. On a first-ever run `bootstrap_config` writes this file project-aware; the example below shows the npm form.
 
 ```json
 {
   "tests": ["npm", "test"],
   "typecheck": ["npm", "run", "typecheck"],
   "build": ["npm", "run", "build"],
-  "lint": ["npm", "run", "lint"]
+  "lint": ["npm", "run", "lint"],
+  "install": ["npm", "ci"]
 }
 ```
+
+The optional `install` verb runs once in each fresh worktree before the capability commands. `bootstrap_config` sets it to `["npm", "ci"]` for an npm project and omits it for every other project type — a wrong install command is worse than none.
 
 ### `.orchestrate/routing.json`
 
@@ -197,7 +227,7 @@ Maps each complexity tier to the model and effort variant for each role. `invest
 
 ### `.orchestrate/handoff.json`
 
-Optional. Tunes the context-watchdog threshold and the successor-session launcher. When absent, built-in defaults apply.
+Optional. Tunes the context-watchdog threshold and the successor-session launcher. When absent, built-in defaults apply. On a first-ever run `bootstrap_config` writes this file with `watchdog.contextWindowTokens` derived from the running model — `1000000` for a 1M-context model, `200000` otherwise.
 
 ```json
 {

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -3226,8 +3226,8 @@ var require_utils = __commonJS({
       }
       return ind;
     }
-    function removeDotSegments(path7) {
-      let input = path7;
+    function removeDotSegments(path8) {
+      let input = path8;
       const output = [];
       let nextSlash = -1;
       let len = 0;
@@ -3479,8 +3479,8 @@ var require_schemes = __commonJS({
         wsComponent.secure = void 0;
       }
       if (wsComponent.resourceName) {
-        const [path7, query] = wsComponent.resourceName.split("?");
-        wsComponent.path = path7 && path7 !== "/" ? path7 : void 0;
+        const [path8, query] = wsComponent.resourceName.split("?");
+        wsComponent.path = path8 && path8 !== "/" ? path8 : void 0;
         wsComponent.query = query;
         wsComponent.resourceName = void 0;
       }
@@ -6873,12 +6873,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs7, exportName) {
+    function addFormats(ajv, list, fs9, exportName) {
       var _a;
       var _b;
       (_a = (_b = ajv.opts.code).formats) !== null && _a !== void 0 ? _a : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs7[f]);
+        ajv.addFormat(f, fs9[f]);
     }
     module2.exports = exports2 = formatsPlugin;
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -7364,8 +7364,8 @@ function getErrorMap() {
 
 // node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
-  const { data, path: path7, errorMaps, issueData } = params;
-  const fullPath = [...path7, ...issueData.path || []];
+  const { data, path: path8, errorMaps, issueData } = params;
+  const fullPath = [...path8, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -7481,11 +7481,11 @@ var errorUtil;
 
 // node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path7, key) {
+  constructor(parent, value, path8, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path7;
+    this._path = path8;
     this._key = key;
   }
   get path() {
@@ -11123,10 +11123,10 @@ function assignProp(target, prop, value) {
     configurable: true
   });
 }
-function getElementAtPath(obj, path7) {
-  if (!path7)
+function getElementAtPath(obj, path8) {
+  if (!path8)
     return obj;
-  return path7.reduce((acc, key) => acc?.[key], obj);
+  return path8.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -11446,11 +11446,11 @@ function aborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path7, issues) {
+function prefixIssues(path8, issues) {
   return issues.map((iss) => {
     var _a;
     (_a = iss).path ?? (_a.path = []);
-    iss.path.unshift(path7);
+    iss.path.unshift(path8);
     return iss;
   });
 }
@@ -21176,14 +21176,14 @@ function optionInjectionError(field, value) {
 }
 function cleanGitError(err) {
   if (err instanceof GitExecError && err.stderr.trim().length > 0) {
-    const firstLine8 = err.stderr.split("\n").map((l) => l.trim()).find((l) => l.length > 0);
-    if (firstLine8) {
-      return firstLine8;
+    const firstLine9 = err.stderr.split("\n").map((l) => l.trim()).find((l) => l.length > 0);
+    if (firstLine9) {
+      return firstLine9;
     }
   }
   const message = err instanceof Error ? err.message : String(err);
-  const firstLine7 = message.split("\n").map((l) => l.trim()).find((l) => l.length > 0);
-  return firstLine7 ?? "Unknown git error";
+  const firstLine8 = message.split("\n").map((l) => l.trim()).find((l) => l.length > 0);
+  return firstLine8 ?? "Unknown git error";
 }
 
 // src/tools/run-command.ts
@@ -23325,6 +23325,356 @@ async function recoverChangedFiles(input) {
   };
 }
 
+// src/tools/bootstrap-config.ts
+var path7 = __toESM(require("path"));
+var fs8 = __toESM(require("fs"));
+
+// src/tools/detect-project.ts
+var fs7 = __toESM(require("fs"));
+var DETECTION_RULES = [
+  { manifest: "package.json", type: "npm" },
+  { manifest: "Cargo.toml", type: "cargo" },
+  { manifest: "pyproject.toml", type: "python" },
+  { manifest: "Makefile", type: "make" }
+];
+var COMMAND_MAPS = {
+  npm: {
+    tests: ["npm", "test"],
+    typecheck: ["npm", "run", "typecheck"],
+    build: ["npm", "run", "build"],
+    lint: ["npm", "run", "lint"]
+  },
+  cargo: {
+    tests: ["cargo", "test"],
+    typecheck: ["cargo", "check"],
+    build: ["cargo", "build"],
+    lint: ["cargo", "clippy"]
+  },
+  python: {
+    tests: ["pytest"],
+    typecheck: ["mypy", "."],
+    build: ["python", "-m", "build"],
+    lint: ["ruff", "check", "."]
+  },
+  make: {
+    tests: ["make", "test"],
+    typecheck: ["make", "typecheck"],
+    build: ["make", "build"],
+    lint: ["make", "lint"]
+  }
+};
+function detectProjectType(manifestsPresent) {
+  const present = new Set(manifestsPresent);
+  for (const rule of DETECTION_RULES) {
+    if (present.has(rule.manifest)) {
+      return rule.type;
+    }
+  }
+  return "none";
+}
+function buildCommandMap(type) {
+  if (type === "none") {
+    return {};
+  }
+  return { ...COMMAND_MAPS[type] };
+}
+function detectCommandMap(repoRoot) {
+  let entries;
+  try {
+    entries = fs7.readdirSync(repoRoot);
+  } catch {
+    return {};
+  }
+  const manifests = DETECTION_RULES.map((r) => r.manifest);
+  const presentManifests = entries.filter((e) => manifests.includes(e));
+  const projectType = detectProjectType(presentManifests);
+  return buildCommandMap(projectType);
+}
+
+// src/tools/bootstrap-config.ts
+var DEFAULT_CONTEXT_WINDOW_TOKENS = 2e5;
+var ONE_MILLION_TOKENS = 1e6;
+var MODEL_CONTEXT_WINDOW = {
+  opus: DEFAULT_CONTEXT_WINDOW_TOKENS,
+  sonnet: DEFAULT_CONTEXT_WINDOW_TOKENS,
+  haiku: DEFAULT_CONTEXT_WINDOW_TOKENS,
+  "claude-opus-4-7[1m]": ONE_MILLION_TOKENS,
+  "claude-opus-4-1[1m]": ONE_MILLION_TOKENS,
+  "claude-sonnet-4-5[1m]": ONE_MILLION_TOKENS,
+  "claude-sonnet-4[1m]": ONE_MILLION_TOKENS
+};
+var DEFAULT_ROUTING_CONFIG = {
+  trivial: {
+    investigator: null,
+    implementer: { model: "sonnet", effort: "standard" },
+    reviewer: { model: "sonnet", effort: "standard" },
+    "conflict-resolver": { model: "sonnet", effort: "standard" }
+  },
+  standard: {
+    investigator: null,
+    implementer: { model: "sonnet", effort: "standard" },
+    reviewer: { model: "opus", effort: "standard" },
+    "conflict-resolver": { model: "opus", effort: "standard" }
+  },
+  complex: {
+    investigator: { model: "opus", effort: "deep" },
+    implementer: { model: "opus", effort: "deep" },
+    reviewer: { model: "opus", effort: "deep" },
+    "conflict-resolver": { model: "opus", effort: "deep" }
+  }
+};
+var RUNS_GITIGNORE_LINE = ".orchestrate/runs/";
+var bootstrapConfigInputSchema = external_exports.object({
+  repoPath: external_exports.string().optional().describe(
+    "Path to the project root the .orchestrate/ configuration is bootstrapped into. Defaults to the MCP server process's current working directory \u2014 callers should pass this explicitly rather than rely on the default, which is not guaranteed to be the project root."
+  ),
+  model: external_exports.string().optional().describe(
+    "The model identifier of the running orchestrator session (e.g. 'opus' or 'claude-opus-4-7[1m]'). The MCP process cannot see the calling LLM's model, so the caller passes it. It is mapped to a context-window token count via an explicit table; an unknown or absent model falls back to 200000. Ignored when contextWindowTokens is set."
+  ),
+  contextWindowTokens: external_exports.number().optional().describe(
+    "An explicit context-window token count for the running session. When supplied as a positive integer it takes precedence over the model table. A non-positive or non-integer value is ignored and the run falls back to the model table, then to 200000."
+  )
+});
+var bootstrapConfigOutputSchema = external_exports.object({
+  status: external_exports.enum(["ok", "error"]).describe(
+    "Outcome discriminant. 'ok' = the bootstrap completed (every file either written or already present); 'error' = a filesystem write failed and the configuration is incomplete."
+  ),
+  projectType: external_exports.enum(["npm", "cargo", "python", "make", "none"]).optional().describe(
+    "The detected project type. 'none' means no recognized manifest \u2014 commands.json is written empty. Present when status='ok'."
+  ),
+  contextWindowTokens: external_exports.number().optional().describe(
+    "The context-window token count written into handoff.json. Always a positive integer \u2014 never NaN. Present when status='ok'."
+  ),
+  contextWindowSource: external_exports.enum(["explicit", "model-table", "default"]).optional().describe(
+    "How contextWindowTokens was resolved. 'explicit' = a valid contextWindowTokens input; 'model-table' = a recognized model id; 'default' = an unknown/absent model fell back to 200000. Present when status='ok'."
+  ),
+  files: external_exports.object({
+    commandsJson: external_exports.enum(["written", "already-present"]),
+    routingJson: external_exports.enum(["written", "already-present"]),
+    handoffJson: external_exports.enum(["written", "already-present"])
+  }).optional().describe(
+    "Per-config-file outcome. 'written' = the bootstrapper created it; 'already-present' = it existed and was left untouched (a committed config is never overwritten). Present when status='ok'."
+  ),
+  runsDir: external_exports.enum(["created", "already-present"]).optional().describe(
+    "Outcome for the .orchestrate/runs/ directory. Present when status='ok'."
+  ),
+  gitignore: external_exports.enum(["created-with-line", "line-added", "already-present"]).optional().describe(
+    "Outcome for the .gitignore entry. 'created-with-line' = no .gitignore existed, one was created with the .orchestrate/runs/ line; 'line-added' = the line was appended to an existing file; 'already-present' = the line was already there. Present when status='ok'."
+  ),
+  errorCode: external_exports.enum(["WRITE_FAILED"]).optional().describe(
+    "Machine-readable failure category. Present when status='error'. 'WRITE_FAILED' = a filesystem operation (mkdir or write) failed."
+  ),
+  errorMessage: external_exports.string().optional().describe(
+    "Cleaned, human-readable failure description. Present when status='error'."
+  )
+});
+function firstLine7(message) {
+  const line = message.split("\n").map((l) => l.trim()).find((l) => l.length > 0);
+  return line ?? message.trim();
+}
+function toJsonFile(value) {
+  return `${JSON.stringify(value, null, 2)}
+`;
+}
+function resolveContextWindow(input) {
+  const explicit = input.contextWindowTokens;
+  if (typeof explicit === "number" && Number.isInteger(explicit) && explicit > 0) {
+    return { tokens: explicit, source: "explicit" };
+  }
+  if (input.model !== void 0) {
+    const fromTable = MODEL_CONTEXT_WINDOW[input.model];
+    if (fromTable !== void 0) {
+      return { tokens: fromTable, source: "model-table" };
+    }
+  }
+  return { tokens: DEFAULT_CONTEXT_WINDOW_TOKENS, source: "default" };
+}
+function buildCommandsConfig(repoRoot) {
+  let entries;
+  try {
+    entries = fs8.readdirSync(repoRoot);
+  } catch {
+    entries = [];
+  }
+  const projectType = detectProjectType(entries);
+  const capabilities = detectCommandMap(repoRoot);
+  const config2 = { ...capabilities };
+  if (projectType === "npm") {
+    config2.install = ["npm", "ci"];
+  }
+  return { config: config2, projectType };
+}
+function writeIfAbsent(filePath, content) {
+  if (fs8.existsSync(filePath)) {
+    return { kind: "already-present" };
+  }
+  try {
+    fs8.writeFileSync(filePath, content);
+    return { kind: "written" };
+  } catch (err) {
+    return {
+      kind: "error",
+      message: firstLine7(err instanceof Error ? err.message : String(err))
+    };
+  }
+}
+function ensureGitignoreEntry(repoRoot) {
+  const gitignorePath = path7.join(repoRoot, ".gitignore");
+  let existing;
+  try {
+    existing = fs8.readFileSync(gitignorePath, "utf8");
+  } catch {
+    existing = null;
+  }
+  if (existing === null) {
+    try {
+      fs8.writeFileSync(gitignorePath, `${RUNS_GITIGNORE_LINE}
+`);
+      return { kind: "created-with-line" };
+    } catch (err) {
+      return {
+        kind: "error",
+        message: firstLine7(err instanceof Error ? err.message : String(err))
+      };
+    }
+  }
+  const alreadyListed = existing.split("\n").map((l) => l.trim()).some((l) => l === ".orchestrate/runs/" || l === ".orchestrate/runs");
+  if (alreadyListed) {
+    return { kind: "already-present" };
+  }
+  const separator = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+  try {
+    fs8.appendFileSync(
+      gitignorePath,
+      `${separator}${RUNS_GITIGNORE_LINE}
+`
+    );
+    return { kind: "line-added" };
+  } catch (err) {
+    return {
+      kind: "error",
+      message: firstLine7(err instanceof Error ? err.message : String(err))
+    };
+  }
+}
+function bootstrapConfig(input) {
+  const repoRoot = input.repoPath ?? process.cwd();
+  const orchestrateDir = path7.join(repoRoot, ".orchestrate");
+  const runsDir = path7.join(orchestrateDir, "runs");
+  const runsDirExisted = fs8.existsSync(runsDir);
+  try {
+    fs8.mkdirSync(runsDir, { recursive: true });
+  } catch (err) {
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Failed to create ${runsDir}: ${firstLine7(
+        err instanceof Error ? err.message : String(err)
+      )}`
+    };
+  }
+  const { config: commandsConfig, projectType } = buildCommandsConfig(repoRoot);
+  const contextWindow = resolveContextWindow(input);
+  const validatedCommands = commandsConfigSchema.safeParse(commandsConfig);
+  if (!validatedCommands.success) {
+    const detail = validatedCommands.error.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`).join("; ");
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Derived commands.json failed schema validation: ${detail}`
+    };
+  }
+  const commandsResult = writeIfAbsent(
+    path7.join(orchestrateDir, "commands.json"),
+    toJsonFile(validatedCommands.data)
+  );
+  if (commandsResult.kind === "error") {
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Failed to write commands.json: ${commandsResult.message}`
+    };
+  }
+  const routingResult = writeIfAbsent(
+    path7.join(orchestrateDir, "routing.json"),
+    toJsonFile(DEFAULT_ROUTING_CONFIG)
+  );
+  if (routingResult.kind === "error") {
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Failed to write routing.json: ${routingResult.message}`
+    };
+  }
+  const handoffConfig = {
+    watchdog: {
+      thresholdPercent: 40,
+      contextWindowTokens: contextWindow.tokens
+    },
+    successor: {
+      claudeArgs: [
+        "--remote-control",
+        "orchestrate-successor",
+        "--permission-mode",
+        "auto"
+      ],
+      resumePrompt: "/orchestrate",
+      terminals: [
+        {
+          name: "windows-terminal",
+          argv: [
+            "wt.exe",
+            "new-tab",
+            "--title",
+            "orchestrate-successor",
+            "wsl.exe",
+            "--",
+            "bash",
+            "-lc",
+            "{claudeCommand}"
+          ]
+        },
+        {
+          name: "warp",
+          argv: ["warp-terminal", "--", "bash", "-lc", "{claudeCommand}"]
+        }
+      ]
+    }
+  };
+  const handoffResult = writeIfAbsent(
+    path7.join(orchestrateDir, "handoff.json"),
+    toJsonFile(handoffConfig)
+  );
+  if (handoffResult.kind === "error") {
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Failed to write handoff.json: ${handoffResult.message}`
+    };
+  }
+  const gitignoreResult = ensureGitignoreEntry(repoRoot);
+  if (gitignoreResult.kind === "error") {
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Failed to update .gitignore: ${gitignoreResult.message}`
+    };
+  }
+  return {
+    status: "ok",
+    projectType,
+    contextWindowTokens: contextWindow.tokens,
+    contextWindowSource: contextWindow.source,
+    files: {
+      commandsJson: commandsResult.kind,
+      routingJson: routingResult.kind,
+      handoffJson: handoffResult.kind
+    },
+    runsDir: runsDirExisted ? "already-present" : "created",
+    gitignore: gitignoreResult.kind
+  };
+}
+
 // src/index.ts
 var server = new McpServer({
   name: "orchestrate",
@@ -23673,6 +24023,38 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleRecoverChangedFiles
+);
+var handleBootstrapConfig = async (input) => {
+  const result = bootstrapConfig(input);
+  let text;
+  if (result.status === "ok") {
+    const f = result.files;
+    const written = [
+      f.commandsJson === "written" ? "commands.json" : null,
+      f.routingJson === "written" ? "routing.json" : null,
+      f.handoffJson === "written" ? "handoff.json" : null
+    ].filter((n) => n !== null);
+    const filesNote = written.length > 0 ? `wrote ${written.join(", ")}` : "all config files already present";
+    text = `Bootstrapped .orchestrate/ config for a ${result.projectType} project (${filesNote}; context window ${result.contextWindowTokens} tokens, source: ${result.contextWindowSource}; runs dir ${result.runsDir}; .gitignore ${result.gitignore}).`;
+  } else {
+    text = `Bootstrap failed [${result.errorCode}]: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text", text }]
+  };
+};
+registerTool(
+  "bootstrap_config",
+  {
+    title: "Bootstrap Orchestrate Configuration",
+    description: "Sets up a repository's .orchestrate/ configuration for a first-ever orchestrate run. Detects the project type and writes a project-aware commands.json (with `install` for npm only, empty for an unrecognized project), writes routing.json from the shipped defaults, and writes handoff.json with a context-window size derived from the running model \u2014 pass the model id (or an explicit contextWindowTokens) as input; the MCP process cannot see the calling LLM's model. An unknown or absent model falls back to 200000. Creates .orchestrate/runs/ and idempotently adds it to the repository's .gitignore. Every step is idempotent: an existing config file is never overwritten and the .gitignore line is never duplicated. Returns a discriminated `status` of 'ok' or 'error'.",
+    inputSchema: bootstrapConfigInputSchema.shape,
+    outputSchema: bootstrapConfigOutputSchema.shape
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleBootstrapConfig
 );
 async function main() {
   const transport = new StdioServerTransport();

--- a/plugins/orchestrate/orchestrate-mcp/src/index.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/index.ts
@@ -85,6 +85,13 @@ import {
   type RecoverChangedFilesInput,
   type RecoverChangedFilesOutput,
 } from "./tools/recover-changed-files.js";
+import {
+  bootstrapConfig,
+  bootstrapConfigInputSchema,
+  bootstrapConfigOutputSchema,
+  type BootstrapConfigInput,
+  type BootstrapConfigOutput,
+} from "./tools/bootstrap-config.js";
 
 const server = new McpServer({
   name: "orchestrate",
@@ -687,6 +694,63 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleRecoverChangedFiles as unknown as AnyToolHandler
+);
+
+// ─── bootstrap_config ─────────────────────────────────────────────────────────
+
+const handleBootstrapConfig: ToolHandler<
+  BootstrapConfigInput,
+  BootstrapConfigOutput
+> = async (input) => {
+  const result = bootstrapConfig(input);
+  let text: string;
+  if (result.status === "ok") {
+    const f = result.files!;
+    const written = [
+      f.commandsJson === "written" ? "commands.json" : null,
+      f.routingJson === "written" ? "routing.json" : null,
+      f.handoffJson === "written" ? "handoff.json" : null,
+    ].filter((n): n is string => n !== null);
+    const filesNote =
+      written.length > 0
+        ? `wrote ${written.join(", ")}`
+        : "all config files already present";
+    text =
+      `Bootstrapped .orchestrate/ config for a ${result.projectType} project ` +
+      `(${filesNote}; context window ${result.contextWindowTokens} tokens, ` +
+      `source: ${result.contextWindowSource}; runs dir ${result.runsDir}; ` +
+      `.gitignore ${result.gitignore}).`;
+  } else {
+    text = `Bootstrap failed [${result.errorCode}]: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text" as const, text }],
+  };
+};
+
+registerTool(
+  "bootstrap_config",
+  {
+    title: "Bootstrap Orchestrate Configuration",
+    description:
+      "Sets up a repository's .orchestrate/ configuration for a first-ever " +
+      "orchestrate run. Detects the project type and writes a project-aware " +
+      "commands.json (with `install` for npm only, empty for an unrecognized " +
+      "project), writes routing.json from the shipped defaults, and writes " +
+      "handoff.json with a context-window size derived from the running model " +
+      "— pass the model id (or an explicit contextWindowTokens) as input; the " +
+      "MCP process cannot see the calling LLM's model. An unknown or absent " +
+      "model falls back to 200000. Creates .orchestrate/runs/ and idempotently " +
+      "adds it to the repository's .gitignore. Every step is idempotent: an " +
+      "existing config file is never overwritten and the .gitignore line is " +
+      "never duplicated. Returns a discriminated `status` of 'ok' or 'error'.",
+    inputSchema: bootstrapConfigInputSchema.shape,
+    outputSchema: bootstrapConfigOutputSchema.shape,
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleBootstrapConfig as unknown as AnyToolHandler
 );
 
 // ─── Start server ─────────────────────────────────────────────────────────────

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
@@ -1,0 +1,517 @@
+import * as path from "path";
+import * as fs from "fs";
+import { z } from "zod";
+import {
+  detectCommandMap,
+  detectProjectType,
+  type ProjectType,
+} from "./detect-project.js";
+import { commandsConfigSchema, type CommandsConfig } from "./run-command.js";
+
+// ─── Overview ─────────────────────────────────────────────────────────────────
+//
+// The config bootstrapper makes a first-ever orchestrate run set up its own
+// `.orchestrate/` configuration. On a fresh repository it:
+//   1. Detects the project type and writes a project-appropriate `commands.json`.
+//   2. Writes `handoff.json` with a context-window size derived from the running
+//      model (passed as input — the MCP process cannot see the calling LLM's
+//      model), and `routing.json` with the shipped defaults.
+//   3. Creates `.orchestrate/runs/` and idempotently appends it to the target
+//      repository's `.gitignore`.
+//
+// Every step is individually idempotent: an existing config file is never
+// overwritten (a user may have customized it), the runs directory mkdir is
+// recursive, and the `.gitignore` append checks for an existing matching line.
+// The core function never throws — every failure mode is a structured result.
+
+// ─── Model → context-window table ─────────────────────────────────────────────
+
+/**
+ * The default context window (tokens) used when no model is recognized and no
+ * explicit `contextWindowTokens` is supplied. This is the conservative value
+ * the watchdog schema also defaults to.
+ */
+const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
+
+/** The context window of a 1M-token session. */
+const ONE_MILLION_TOKENS = 1_000_000;
+
+/**
+ * Explicit, exact-match model → context-window table. Lookup is exact-match
+ * only — no substring or regex matching, which would misclassify unrelated
+ * ids silently. Any model not listed here resolves to
+ * {@link DEFAULT_CONTEXT_WINDOW_TOKENS}.
+ */
+const MODEL_CONTEXT_WINDOW: Readonly<Record<string, number>> = {
+  opus: DEFAULT_CONTEXT_WINDOW_TOKENS,
+  sonnet: DEFAULT_CONTEXT_WINDOW_TOKENS,
+  haiku: DEFAULT_CONTEXT_WINDOW_TOKENS,
+  "claude-opus-4-7[1m]": ONE_MILLION_TOKENS,
+  "claude-opus-4-1[1m]": ONE_MILLION_TOKENS,
+  "claude-sonnet-4-5[1m]": ONE_MILLION_TOKENS,
+  "claude-sonnet-4[1m]": ONE_MILLION_TOKENS,
+};
+
+// ─── Shipped defaults ─────────────────────────────────────────────────────────
+
+/**
+ * The default `routing.json` content the bootstrapper writes. Routing has no
+ * project-type axis, so this is a fixed literal — kept byte-for-byte equivalent
+ * (modulo formatting) to `templates/routing.json`.
+ */
+const DEFAULT_ROUTING_CONFIG = {
+  trivial: {
+    investigator: null,
+    implementer: { model: "sonnet", effort: "standard" },
+    reviewer: { model: "sonnet", effort: "standard" },
+    "conflict-resolver": { model: "sonnet", effort: "standard" },
+  },
+  standard: {
+    investigator: null,
+    implementer: { model: "sonnet", effort: "standard" },
+    reviewer: { model: "opus", effort: "standard" },
+    "conflict-resolver": { model: "opus", effort: "standard" },
+  },
+  complex: {
+    investigator: { model: "opus", effort: "deep" },
+    implementer: { model: "opus", effort: "deep" },
+    reviewer: { model: "opus", effort: "deep" },
+    "conflict-resolver": { model: "opus", effort: "deep" },
+  },
+} as const;
+
+/** The `.gitignore` entry covering every run's ephemeral per-run directory. */
+const RUNS_GITIGNORE_LINE = ".orchestrate/runs/";
+
+// ─── Schemas — z.object is the single source of truth; TS types via z.infer ───
+
+export const bootstrapConfigInputSchema = z.object({
+  repoPath: z
+    .string()
+    .optional()
+    .describe(
+      "Path to the project root the .orchestrate/ configuration is " +
+        "bootstrapped into. Defaults to the MCP server process's current " +
+        "working directory — callers should pass this explicitly rather than " +
+        "rely on the default, which is not guaranteed to be the project root."
+    ),
+  model: z
+    .string()
+    .optional()
+    .describe(
+      "The model identifier of the running orchestrator session (e.g. 'opus' " +
+        "or 'claude-opus-4-7[1m]'). The MCP process cannot see the calling " +
+        "LLM's model, so the caller passes it. It is mapped to a context-" +
+        "window token count via an explicit table; an unknown or absent " +
+        "model falls back to 200000. Ignored when contextWindowTokens is set."
+    ),
+  contextWindowTokens: z
+    .number()
+    .optional()
+    .describe(
+      "An explicit context-window token count for the running session. When " +
+        "supplied as a positive integer it takes precedence over the model " +
+        "table. A non-positive or non-integer value is ignored and the run " +
+        "falls back to the model table, then to 200000."
+    ),
+});
+
+export const bootstrapConfigOutputSchema = z.object({
+  status: z
+    .enum(["ok", "error"])
+    .describe(
+      "Outcome discriminant. 'ok' = the bootstrap completed (every file " +
+        "either written or already present); 'error' = a filesystem write " +
+        "failed and the configuration is incomplete."
+    ),
+  projectType: z
+    .enum(["npm", "cargo", "python", "make", "none"])
+    .optional()
+    .describe(
+      "The detected project type. 'none' means no recognized manifest — " +
+        "commands.json is written empty. Present when status='ok'."
+    ),
+  contextWindowTokens: z
+    .number()
+    .optional()
+    .describe(
+      "The context-window token count written into handoff.json. Always a " +
+        "positive integer — never NaN. Present when status='ok'."
+    ),
+  contextWindowSource: z
+    .enum(["explicit", "model-table", "default"])
+    .optional()
+    .describe(
+      "How contextWindowTokens was resolved. 'explicit' = a valid " +
+        "contextWindowTokens input; 'model-table' = a recognized model id; " +
+        "'default' = an unknown/absent model fell back to 200000. Present " +
+        "when status='ok'."
+    ),
+  files: z
+    .object({
+      commandsJson: z.enum(["written", "already-present"]),
+      routingJson: z.enum(["written", "already-present"]),
+      handoffJson: z.enum(["written", "already-present"]),
+    })
+    .optional()
+    .describe(
+      "Per-config-file outcome. 'written' = the bootstrapper created it; " +
+        "'already-present' = it existed and was left untouched (a committed " +
+        "config is never overwritten). Present when status='ok'."
+    ),
+  runsDir: z
+    .enum(["created", "already-present"])
+    .optional()
+    .describe(
+      "Outcome for the .orchestrate/runs/ directory. Present when status='ok'."
+    ),
+  gitignore: z
+    .enum(["created-with-line", "line-added", "already-present"])
+    .optional()
+    .describe(
+      "Outcome for the .gitignore entry. 'created-with-line' = no .gitignore " +
+        "existed, one was created with the .orchestrate/runs/ line; " +
+        "'line-added' = the line was appended to an existing file; " +
+        "'already-present' = the line was already there. Present when " +
+        "status='ok'."
+    ),
+  errorCode: z
+    .enum(["WRITE_FAILED"])
+    .optional()
+    .describe(
+      "Machine-readable failure category. Present when status='error'. " +
+        "'WRITE_FAILED' = a filesystem operation (mkdir or write) failed."
+    ),
+  errorMessage: z
+    .string()
+    .optional()
+    .describe(
+      "Cleaned, human-readable failure description. Present when status='error'."
+    ),
+});
+
+// ─── TS types — derived from the schemas (single source of truth) ─────────────
+
+export type BootstrapConfigInput = z.infer<typeof bootstrapConfigInputSchema>;
+export type BootstrapConfigOutput = z.infer<typeof bootstrapConfigOutputSchema>;
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/** Returns the first non-empty trimmed line of a (possibly multi-line) string. */
+function firstLine(message: string): string {
+  const line = message
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  return line ?? message.trim();
+}
+
+/** Serializes a value as 2-space-indented JSON with a trailing newline. */
+function toJsonFile(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+/** How the context-window token count was resolved. */
+type ContextWindowResolution = {
+  tokens: number;
+  source: "explicit" | "model-table" | "default";
+};
+
+/**
+ * Resolves the context-window token count from the bootstrap input. Precedence:
+ *   1. An explicit `contextWindowTokens` that is a positive integer.
+ *   2. An exact model-table hit.
+ *   3. The {@link DEFAULT_CONTEXT_WINDOW_TOKENS} fallback.
+ *
+ * Always returns a positive integer — never NaN — so a malformed input can
+ * never write a broken value into handoff.json.
+ */
+export function resolveContextWindow(
+  input: BootstrapConfigInput
+): ContextWindowResolution {
+  const explicit = input.contextWindowTokens;
+  if (
+    typeof explicit === "number" &&
+    Number.isInteger(explicit) &&
+    explicit > 0
+  ) {
+    return { tokens: explicit, source: "explicit" };
+  }
+
+  if (input.model !== undefined) {
+    const fromTable = MODEL_CONTEXT_WINDOW[input.model];
+    if (fromTable !== undefined) {
+      return { tokens: fromTable, source: "model-table" };
+    }
+  }
+
+  return { tokens: DEFAULT_CONTEXT_WINDOW_TOKENS, source: "default" };
+}
+
+/**
+ * Builds the `commands.json` content for a detected project. The four
+ * capability verbs come from the capability detector. `install: ["npm", "ci"]`
+ * is added for an npm project only — a fresh worktree needs the dependency
+ * install, and a wrong install command for another toolchain is worse than
+ * none. A manifest-less ('none') project yields an empty object.
+ */
+export function buildCommandsConfig(repoRoot: string): {
+  config: CommandsConfig;
+  projectType: ProjectType;
+} {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(repoRoot);
+  } catch {
+    entries = [];
+  }
+  const projectType = detectProjectType(entries);
+  const capabilities = detectCommandMap(repoRoot);
+
+  const config: CommandsConfig = { ...capabilities };
+  if (projectType === "npm") {
+    config.install = ["npm", "ci"];
+  }
+  return { config, projectType };
+}
+
+/** Outcome of one config-file write attempt. */
+type FileWriteResult =
+  | { kind: "written" }
+  | { kind: "already-present" }
+  | { kind: "error"; message: string };
+
+/**
+ * Writes `content` to `filePath` only when the file does not already exist. An
+ * existing file is left untouched — a committed, possibly user-customized
+ * config is never overwritten.
+ */
+function writeIfAbsent(filePath: string, content: string): FileWriteResult {
+  if (fs.existsSync(filePath)) {
+    return { kind: "already-present" };
+  }
+  try {
+    fs.writeFileSync(filePath, content);
+    return { kind: "written" };
+  } catch (err) {
+    return {
+      kind: "error",
+      message: firstLine(err instanceof Error ? err.message : String(err)),
+    };
+  }
+}
+
+/** Outcome of the idempotent `.gitignore` append. */
+type GitignoreResult =
+  | { kind: "created-with-line" }
+  | { kind: "line-added" }
+  | { kind: "already-present" }
+  | { kind: "error"; message: string };
+
+/**
+ * Idempotently ensures `.orchestrate/runs/` is listed in the repository's
+ * `.gitignore`. The line is considered present when any trimmed line of the
+ * file equals `.orchestrate/runs/` or `.orchestrate/runs` (with or without the
+ * trailing slash). When absent it is appended; the file is guaranteed to end
+ * with a newline both before and after the appended line. A missing file is
+ * created with just the line.
+ */
+function ensureGitignoreEntry(repoRoot: string): GitignoreResult {
+  const gitignorePath = path.join(repoRoot, ".gitignore");
+
+  let existing: string | null;
+  try {
+    existing = fs.readFileSync(gitignorePath, "utf8");
+  } catch {
+    existing = null;
+  }
+
+  if (existing === null) {
+    try {
+      fs.writeFileSync(gitignorePath, `${RUNS_GITIGNORE_LINE}\n`);
+      return { kind: "created-with-line" };
+    } catch (err) {
+      return {
+        kind: "error",
+        message: firstLine(err instanceof Error ? err.message : String(err)),
+      };
+    }
+  }
+
+  const alreadyListed = existing
+    .split("\n")
+    .map((l) => l.trim())
+    .some((l) => l === ".orchestrate/runs/" || l === ".orchestrate/runs");
+  if (alreadyListed) {
+    return { kind: "already-present" };
+  }
+
+  // Append the line, guaranteeing exactly one separating newline and a
+  // trailing newline regardless of how the existing file ended.
+  const separator = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+  try {
+    fs.appendFileSync(
+      gitignorePath,
+      `${separator}${RUNS_GITIGNORE_LINE}\n`
+    );
+    return { kind: "line-added" };
+  } catch (err) {
+    return {
+      kind: "error",
+      message: firstLine(err instanceof Error ? err.message : String(err)),
+    };
+  }
+}
+
+// ─── Core ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Bootstraps a repository's `.orchestrate/` configuration for a first-ever
+ * orchestrate run.
+ *
+ * Writes the three config files (`commands.json`, `routing.json`,
+ * `handoff.json`) with project- and model-appropriate values, creates
+ * `.orchestrate/runs/`, and idempotently adds `.orchestrate/runs/` to the
+ * repository's `.gitignore`. Every step is individually idempotent: an existing
+ * config file is never overwritten, the runs directory mkdir is recursive, and
+ * the `.gitignore` append never duplicates the line.
+ *
+ * Never throws — every failure mode is returned as a structured result.
+ */
+export function bootstrapConfig(
+  input: BootstrapConfigInput
+): BootstrapConfigOutput {
+  const repoRoot = input.repoPath ?? process.cwd();
+  const orchestrateDir = path.join(repoRoot, ".orchestrate");
+
+  // The .orchestrate/ directory and its runs/ subdirectory. `mkdirSync` with
+  // `recursive: true` creates both in one call and is itself idempotent.
+  const runsDir = path.join(orchestrateDir, "runs");
+  const runsDirExisted = fs.existsSync(runsDir);
+  try {
+    fs.mkdirSync(runsDir, { recursive: true });
+  } catch (err) {
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Failed to create ${runsDir}: ${firstLine(
+        err instanceof Error ? err.message : String(err)
+      )}`,
+    };
+  }
+
+  // Resolve the per-project and per-model values.
+  const { config: commandsConfig, projectType } = buildCommandsConfig(repoRoot);
+  const contextWindow = resolveContextWindow(input);
+
+  // commands.json — project-type-aware, validated against its own schema so a
+  // malformed map can never be written. `safeParse` keeps the never-throws
+  // contract intact even though the inputs come from a closed-set map.
+  const validatedCommands = commandsConfigSchema.safeParse(commandsConfig);
+  if (!validatedCommands.success) {
+    const detail = validatedCommands.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Derived commands.json failed schema validation: ${detail}`,
+    };
+  }
+  const commandsResult = writeIfAbsent(
+    path.join(orchestrateDir, "commands.json"),
+    toJsonFile(validatedCommands.data)
+  );
+  if (commandsResult.kind === "error") {
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Failed to write commands.json: ${commandsResult.message}`,
+    };
+  }
+
+  // routing.json — shipped defaults (no project-type axis).
+  const routingResult = writeIfAbsent(
+    path.join(orchestrateDir, "routing.json"),
+    toJsonFile(DEFAULT_ROUTING_CONFIG)
+  );
+  if (routingResult.kind === "error") {
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Failed to write routing.json: ${routingResult.message}`,
+    };
+  }
+
+  // handoff.json — context window derived from the running model.
+  const handoffConfig = {
+    watchdog: {
+      thresholdPercent: 40,
+      contextWindowTokens: contextWindow.tokens,
+    },
+    successor: {
+      claudeArgs: [
+        "--remote-control",
+        "orchestrate-successor",
+        "--permission-mode",
+        "auto",
+      ],
+      resumePrompt: "/orchestrate",
+      terminals: [
+        {
+          name: "windows-terminal",
+          argv: [
+            "wt.exe",
+            "new-tab",
+            "--title",
+            "orchestrate-successor",
+            "wsl.exe",
+            "--",
+            "bash",
+            "-lc",
+            "{claudeCommand}",
+          ],
+        },
+        {
+          name: "warp",
+          argv: ["warp-terminal", "--", "bash", "-lc", "{claudeCommand}"],
+        },
+      ],
+    },
+  };
+  const handoffResult = writeIfAbsent(
+    path.join(orchestrateDir, "handoff.json"),
+    toJsonFile(handoffConfig)
+  );
+  if (handoffResult.kind === "error") {
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Failed to write handoff.json: ${handoffResult.message}`,
+    };
+  }
+
+  // .gitignore — idempotently list the per-run directory.
+  const gitignoreResult = ensureGitignoreEntry(repoRoot);
+  if (gitignoreResult.kind === "error") {
+    return {
+      status: "error",
+      errorCode: "WRITE_FAILED",
+      errorMessage: `Failed to update .gitignore: ${gitignoreResult.message}`,
+    };
+  }
+
+  return {
+    status: "ok",
+    projectType,
+    contextWindowTokens: contextWindow.tokens,
+    contextWindowSource: contextWindow.source,
+    files: {
+      commandsJson: commandsResult.kind,
+      routingJson: routingResult.kind,
+      handoffJson: handoffResult.kind,
+    },
+    runsDir: runsDirExisted ? "already-present" : "created",
+    gitignore: gitignoreResult.kind,
+  };
+}

--- a/plugins/orchestrate/orchestrate-mcp/test/bootstrap-config.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/bootstrap-config.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import { bootstrapConfig } from "../src/tools/bootstrap-config.js";
+import { commandsConfigSchema } from "../src/tools/run-command.js";
+import { handoffConfigSchema } from "../src/handoff-config.js";
+import { routingConfigSchema } from "../src/tools/routing.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+const created: string[] = [];
+
+/**
+ * Creates an empty temp repository directory. When `manifest` is given, an empty
+ * file of that name is written at the top level so the capability detector
+ * resolves the corresponding project type.
+ */
+function repo(manifest?: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-bootstrap-"));
+  created.push(dir);
+  if (manifest) {
+    fs.writeFileSync(path.join(dir, manifest), "");
+  }
+  return dir;
+}
+
+/** Reads and JSON-parses a file under the repo's `.orchestrate/` directory. */
+function readConfig(repoDir: string, name: string): unknown {
+  return JSON.parse(
+    fs.readFileSync(path.join(repoDir, ".orchestrate", name), "utf8")
+  );
+}
+
+afterEach(() => {
+  for (const dir of created) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  created.length = 0;
+});
+
+// ─── Fresh-run bootstrap ──────────────────────────────────────────────────────
+
+describe("bootstrapConfig — fresh run", () => {
+  it("writes all three config files and reports status='ok'", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.status).toBe("ok");
+    expect(r.files).toEqual({
+      commandsJson: "written",
+      routingJson: "written",
+      handoffJson: "written",
+    });
+    expect(fs.existsSync(path.join(dir, ".orchestrate", "commands.json"))).toBe(
+      true
+    );
+    expect(fs.existsSync(path.join(dir, ".orchestrate", "routing.json"))).toBe(
+      true
+    );
+    expect(fs.existsSync(path.join(dir, ".orchestrate", "handoff.json"))).toBe(
+      true
+    );
+  });
+
+  it("writes config files that satisfy their schemas", () => {
+    const dir = repo("Cargo.toml");
+    bootstrapConfig({ repoPath: dir });
+
+    expect(() =>
+      commandsConfigSchema.parse(readConfig(dir, "commands.json"))
+    ).not.toThrow();
+    expect(() =>
+      routingConfigSchema.parse(readConfig(dir, "routing.json"))
+    ).not.toThrow();
+    expect(() =>
+      handoffConfigSchema.parse(readConfig(dir, "handoff.json"))
+    ).not.toThrow();
+  });
+
+  it("writes JSON with 2-space indent and a trailing newline", () => {
+    const dir = repo("package.json");
+    bootstrapConfig({ repoPath: dir });
+
+    const raw = fs.readFileSync(
+      path.join(dir, ".orchestrate", "commands.json"),
+      "utf8"
+    );
+    expect(raw.endsWith("\n")).toBe(true);
+    expect(raw).toContain('\n  "tests"');
+  });
+});
+
+// ─── Project-type-aware commands.json ─────────────────────────────────────────
+
+describe("bootstrapConfig — commands.json per project type", () => {
+  it("derives npm commands and includes install for an npm project", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.projectType).toBe("npm");
+    const cmds = readConfig(dir, "commands.json") as Record<string, unknown>;
+    expect(cmds.tests).toEqual(["npm", "test"]);
+    expect(cmds.typecheck).toEqual(["npm", "run", "typecheck"]);
+    expect(cmds.build).toEqual(["npm", "run", "build"]);
+    expect(cmds.lint).toEqual(["npm", "run", "lint"]);
+    expect(cmds.install).toEqual(["npm", "ci"]);
+  });
+
+  it("derives cargo commands and omits install for a cargo project", () => {
+    const dir = repo("Cargo.toml");
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.projectType).toBe("cargo");
+    const cmds = readConfig(dir, "commands.json") as Record<string, unknown>;
+    expect(cmds.tests).toEqual(["cargo", "test"]);
+    expect(cmds.install).toBeUndefined();
+  });
+
+  it("derives python commands and omits install for a python project", () => {
+    const dir = repo("pyproject.toml");
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.projectType).toBe("python");
+    const cmds = readConfig(dir, "commands.json") as Record<string, unknown>;
+    expect(cmds.tests).toEqual(["pytest"]);
+    expect(cmds.install).toBeUndefined();
+  });
+
+  it("derives make commands and omits install for a make project", () => {
+    const dir = repo("Makefile");
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.projectType).toBe("make");
+    const cmds = readConfig(dir, "commands.json") as Record<string, unknown>;
+    expect(cmds.tests).toEqual(["make", "test"]);
+    expect(cmds.install).toBeUndefined();
+  });
+
+  it("writes an empty commands.json for a manifest-less project", () => {
+    const dir = repo();
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.projectType).toBe("none");
+    const cmds = readConfig(dir, "commands.json");
+    expect(cmds).toEqual({});
+  });
+});
+
+// ─── Model-derived context window ─────────────────────────────────────────────
+
+describe("bootstrapConfig — model-derived context window", () => {
+  it("maps a recognized 1M model to 1000000 tokens", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "claude-opus-4-7[1m]",
+    });
+
+    expect(r.contextWindowTokens).toBe(1000000);
+    expect(r.contextWindowSource).toBe("model-table");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(1000000);
+  });
+
+  it("maps a recognized standard model to 200000 tokens", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({ repoPath: dir, model: "opus" });
+
+    expect(r.contextWindowTokens).toBe(200000);
+    expect(r.contextWindowSource).toBe("model-table");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(200000);
+  });
+
+  it("falls back to 200000 for an unknown model", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({ repoPath: dir, model: "some-future-model" });
+
+    expect(r.contextWindowTokens).toBe(200000);
+    expect(r.contextWindowSource).toBe("default");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(200000);
+  });
+
+  it("falls back to 200000 when no model is supplied", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.contextWindowTokens).toBe(200000);
+    expect(r.contextWindowSource).toBe("default");
+  });
+
+  it("uses an explicit contextWindowTokens over the model table", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "opus",
+      contextWindowTokens: 500000,
+    });
+
+    expect(r.contextWindowTokens).toBe(500000);
+    expect(r.contextWindowSource).toBe("explicit");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(500000);
+  });
+
+  it("never writes NaN — a non-positive explicit value falls back", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "some-future-model",
+      contextWindowTokens: 0,
+    });
+
+    expect(Number.isInteger(r.contextWindowTokens)).toBe(true);
+    expect(r.contextWindowTokens).toBe(200000);
+    expect(r.contextWindowSource).toBe("default");
+  });
+});
+
+// ─── Config-file idempotence ──────────────────────────────────────────────────
+
+describe("bootstrapConfig — config-file idempotence", () => {
+  it("does not overwrite an existing user-modified commands.json", () => {
+    const dir = repo("package.json");
+    fs.mkdirSync(path.join(dir, ".orchestrate"));
+    const userConfig = '{ "tests": ["my", "custom", "runner"] }\n';
+    fs.writeFileSync(
+      path.join(dir, ".orchestrate", "commands.json"),
+      userConfig
+    );
+
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.files.commandsJson).toBe("already-present");
+    expect(
+      fs.readFileSync(path.join(dir, ".orchestrate", "commands.json"), "utf8")
+    ).toBe(userConfig);
+  });
+
+  it("writes only the missing files in a mixed state", () => {
+    const dir = repo("package.json");
+    fs.mkdirSync(path.join(dir, ".orchestrate"));
+    fs.writeFileSync(
+      path.join(dir, ".orchestrate", "commands.json"),
+      "{}\n"
+    );
+
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.files.commandsJson).toBe("already-present");
+    expect(r.files.routingJson).toBe("written");
+    expect(r.files.handoffJson).toBe("written");
+  });
+
+  it("is fully idempotent — a second run writes nothing", () => {
+    const dir = repo("package.json");
+    bootstrapConfig({ repoPath: dir });
+    const second = bootstrapConfig({ repoPath: dir });
+
+    expect(second.status).toBe("ok");
+    expect(second.files).toEqual({
+      commandsJson: "already-present",
+      routingJson: "already-present",
+      handoffJson: "already-present",
+    });
+  });
+});
+
+// ─── runs/ directory ──────────────────────────────────────────────────────────
+
+describe("bootstrapConfig — runs directory", () => {
+  it("creates .orchestrate/runs/ on a fresh run", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.runsDir).toBe("created");
+    expect(
+      fs.statSync(path.join(dir, ".orchestrate", "runs")).isDirectory()
+    ).toBe(true);
+  });
+
+  it("reports already-present and never throws when runs/ exists", () => {
+    const dir = repo("package.json");
+    fs.mkdirSync(path.join(dir, ".orchestrate", "runs"), { recursive: true });
+
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.runsDir).toBe("already-present");
+    expect(
+      fs.statSync(path.join(dir, ".orchestrate", "runs")).isDirectory()
+    ).toBe(true);
+  });
+});
+
+// ─── .gitignore idempotence ───────────────────────────────────────────────────
+
+describe("bootstrapConfig — .gitignore idempotence", () => {
+  it("creates .gitignore with the runs line when none exists", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.gitignore).toBe("created-with-line");
+    const gi = fs.readFileSync(path.join(dir, ".gitignore"), "utf8");
+    expect(gi.split("\n").map((l) => l.trim())).toContain(".orchestrate/runs/");
+    expect(gi.endsWith("\n")).toBe(true);
+  });
+
+  it("appends the runs line to an existing .gitignore", () => {
+    const dir = repo("package.json");
+    fs.writeFileSync(path.join(dir, ".gitignore"), "node_modules/\ndist/\n");
+
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.gitignore).toBe("line-added");
+    const gi = fs.readFileSync(path.join(dir, ".gitignore"), "utf8");
+    expect(gi).toContain("node_modules/");
+    expect(gi.split("\n").map((l) => l.trim())).toContain(".orchestrate/runs/");
+  });
+
+  it("appends a leading newline when the existing file lacks a trailing one", () => {
+    const dir = repo("package.json");
+    fs.writeFileSync(path.join(dir, ".gitignore"), "node_modules/");
+
+    bootstrapConfig({ repoPath: dir });
+
+    const gi = fs.readFileSync(path.join(dir, ".gitignore"), "utf8");
+    expect(gi).toBe("node_modules/\n.orchestrate/runs/\n");
+  });
+
+  it("does not duplicate an existing .orchestrate/runs/ line", () => {
+    const dir = repo("package.json");
+    fs.writeFileSync(
+      path.join(dir, ".gitignore"),
+      "node_modules/\n.orchestrate/runs/\n"
+    );
+
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.gitignore).toBe("already-present");
+    const gi = fs.readFileSync(path.join(dir, ".gitignore"), "utf8");
+    const matches = gi
+      .split("\n")
+      .filter((l) => l.trim() === ".orchestrate/runs/");
+    expect(matches.length).toBe(1);
+  });
+
+  it("recognizes the line without a trailing slash and does not duplicate", () => {
+    const dir = repo("package.json");
+    fs.writeFileSync(
+      path.join(dir, ".gitignore"),
+      "node_modules/\n.orchestrate/runs\n"
+    );
+
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.gitignore).toBe("already-present");
+    const gi = fs.readFileSync(path.join(dir, ".gitignore"), "utf8");
+    expect(gi).toBe("node_modules/\n.orchestrate/runs\n");
+  });
+
+  it("is idempotent across repeated bootstraps", () => {
+    const dir = repo("package.json");
+    bootstrapConfig({ repoPath: dir });
+    const second = bootstrapConfig({ repoPath: dir });
+
+    expect(second.gitignore).toBe("already-present");
+    const gi = fs.readFileSync(path.join(dir, ".gitignore"), "utf8");
+    const matches = gi
+      .split("\n")
+      .filter((l) => l.trim() === ".orchestrate/runs/");
+    expect(matches.length).toBe(1);
+  });
+});

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -51,15 +51,18 @@ Check these before starting. If one is missing, report it and stop.
 - Branch protection does not block merges into `orchestrate/umbrella-*` or
   `orchestrate/slice-*` branches — the auto-merge needs them open.
 
-The target project should also have committed `.orchestrate/commands.json` and
-`.orchestrate/routing.json` (see the plugin's `templates/`). Without
+The target project's `.orchestrate/` configuration — `commands.json`,
+`routing.json`, and the optional `handoff.json` — may be **bootstrapped on the
+first run** by the `bootstrap_config` MCP tool (section 1, Fresh run, step 1),
+or committed ahead of time from the plugin's `templates/`. Without
 `commands.json` the capability tools return `not-configured`, which is
-tolerated. If the project's capability commands need installed dependencies,
+tolerated. When the project's capability commands need installed dependencies,
 `commands.json` must also set an `install` command — `create_worktree` runs it
 in every fresh worktree, which checks out only tracked files and so has no
-dependency directory of its own. Without `routing.json` the `resolve_routing`
-tool errors and the run falls back to the `-standard` variant of every role
-with no model override.
+dependency directory of its own; the bootstrapper sets `install` automatically
+for an npm project. Without `routing.json` the `resolve_routing` tool errors
+and the run falls back to the `-standard` variant of every role with no model
+override.
 An optional `.orchestrate/handoff.json` tunes the context-watchdog threshold
 and the successor launcher; without it, built-in defaults apply (see
 `references/context-handoff.md`). Installing the `ast-grep` CLI is optional —
@@ -106,6 +109,15 @@ whose `status` is `in-progress`.
 
 1. Resolve the run context:
    - Repository root: `git rev-parse --show-toplevel`.
+   - **Bootstrap the configuration if this is a first-ever run.** If the
+     repository has no `.orchestrate/` directory, call the `bootstrap_config`
+     MCP tool with the repository root as `repoPath` and this session's model
+     id as `model` (or an explicit `contextWindowTokens`). It detects the
+     project type, writes a project-appropriate `commands.json`,
+     `routing.json`, and `handoff.json`, creates `.orchestrate/runs/`, and adds
+     `.orchestrate/runs/` to the repository's `.gitignore`. Every step is
+     idempotent — an existing committed config is never overwritten — so this
+     is also a safe no-op on a repository already configured by hand.
    - Fetch so branch operations use current refs: `git fetch origin`.
    - Confirm the integration base: `git rev-parse --verify origin/development`.
    - Generate a `runId` from the current timestamp including seconds, e.g.

--- a/plugins/orchestrate/templates/commands.json
+++ b/plugins/orchestrate/templates/commands.json
@@ -1,7 +1,1 @@
-{
-  "tests": ["npm", "test"],
-  "typecheck": ["npm", "run", "typecheck"],
-  "build": ["npm", "run", "build"],
-  "lint": ["npm", "run", "lint"],
-  "install": ["npm", "ci"]
-}
+{}

--- a/plugins/orchestrate/templates/handoff.json
+++ b/plugins/orchestrate/templates/handoff.json
@@ -1,7 +1,6 @@
 {
   "watchdog": {
-    "thresholdPercent": 40,
-    "contextWindowTokens": 200000
+    "thresholdPercent": 40
   },
   "successor": {
     "claudeArgs": [


### PR DESCRIPTION
Implements #192.

A first-ever orchestrate run bootstraps its own configuration: composes the project capability detector, derives the context-window from the running model, writes the three config files with project-appropriate values, creates `.orchestrate/runs/` and idempotently appends it to `.gitignore`. Shipped templates de-hardcoded (npm-only removed, static 200k dropped). New `bootstrap_config` MCP tool. 25 new vitest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)