### PR TITLE
feat(orchestrate): scope-aware turn budget and tier policy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,6 +177,14 @@ _Avoid_: command config, verb table, command dictionary
 The machine-checkable structured result every orchestrate subagent emits as the last of its turn — a fenced ` ```orchestrate-envelope ` JSON block conforming to a per-role schema (a `discriminatedUnion` on `role`). Worker roles (implementer, reviewer, conflict-resolver) carry `status`, `filesChanged`, `verification`, and `notes`; the read-only investigator carries a research brief and no `status`/`filesChanged`. It is the orchestrator's only source of a subagent's status and changed-file set — the orchestrator never parses subagent prose.
 _Avoid_: result blob, subagent summary, return payload
 
+**Implementer `incomplete` status**:
+The third value of the implementer **Result envelope**'s `status` enum — alongside `completed` and `blocked`, and unique to the implementer role. It is the implementer's *graceful* turn-budget self-report: when the implementer foresees it cannot finish every acceptance criterion within its remaining turns, it stops cleanly and emits `status: "incomplete"` with the partial work recorded, rather than being cut off mid-sentence. Distinct from `blocked` (an unrecoverable obstacle — more turns would not help) and from a hard turn-limit cutoff (which truncates the envelope into an unclosed fence the **Envelope validator** reports `invalid`). The orchestrator treats an `incomplete` slice as a FAILED slice with a `failureReason` naming the turn-limit cutoff — partial, resumable work — never a new `run-state.json` slice `state` value.
+_Avoid_: partial status, timed-out status (it is a proactive self-report, not a passively-observed timeout)
+
+**Changeset scope check**:
+The orchestrator's post-implementer verification, the `verify_changeset` MCP tool, run after every implementer returns and before a `completed` envelope is trusted. It inspects the slice worktree directly with `git status` and compares the implementer's declared `filesChanged` against what actually changed on disk, returning a `match` verdict — `matched`, `clean`, `mismatch`, `empty-but-declared` (the implementer's edits never landed), or `suspiciously-empty` (the work was under-reported). It is a cheap set comparison, not a semantic scope check: it never parses the issue body and never judges whether the changed files are the *right* files.
+_Avoid_: scope validator, diff checker (it compares declared-vs-actual file sets, it does not validate semantic scope)
+
 **Envelope validator**:
 The deterministic `validate_envelope` MCP tool that classifies a subagent's returned text into exactly one of `valid` (a schema-conforming envelope for the expected role), `invalid` (an envelope was attempted but is truncated, malformed, or off-schema), or `missing` (no envelope block found). A truncated envelope is always reported `invalid`, never silently accepted.
 _Avoid_: envelope parser, schema checker (validator is the contract name; it classifies, it does not merely parse)
@@ -208,6 +216,8 @@ _Avoid_: no-advisor rule, advisor ban (the policy is positive — advisor respon
 - **Run cleanup** acts on an **Orchestration run** only after its final pull request has merged into the **Integration base**.
 - Every orchestrate subagent returns exactly one **Result envelope**; the **Envelope validator** classifies it, and the orchestrator acts only on that classification — never on subagent prose.
 - The **Worktree fallback** runs only when the **Envelope validator** reports a worker subagent's **Result envelope** `invalid` or `missing` — it never substitutes for a `valid` envelope.
+- The **Changeset scope check** runs after every implementer returns a `valid` `completed` envelope — it cross-checks the declared `filesChanged` against the worktree before the orchestrator trusts the result; the **Worktree fallback** instead runs only when the envelope itself was `invalid` or `missing`.
+- The **Implementer `incomplete` status** is the graceful counterpart to a hard turn-limit cutoff: the cutoff truncates the envelope into an `invalid` classification, while `incomplete` is a clean, schema-conforming self-report — both FAIL the slice, distinguished by the `failureReason`.
 
 ## Example dialogue
 

--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -16,7 +16,7 @@ The run checkpoints after every step, so an interrupted run resumes instead of r
 
 Given a repository with open issues labelled `ready-for-agent`, one `/orchestrate` invocation:
 
-1. **Reads the backlog** — every open `ready-for-agent` issue, with its **Blocked by** dependencies and an assessed complexity tier (`trivial`, `standard`, `complex`).
+1. **Reads the backlog** — every open `ready-for-agent` issue, with its **Blocked by** dependencies and an assessed complexity tier (`trivial`, `standard`, `complex`). The tier weighs two axes — conceptual difficulty and *fan-out* (the number of independent targets the slice touches) — so a wide-but-simple slice is tiered up purely for the larger turn budget and an investigation pass.
 2. **Plans dependency waves** — a topological sort so every issue's blockers resolve in an earlier wave; a dependency cycle is reported and stops the run cleanly.
 3. **Cuts an umbrella branch** from `development` — every slice's pull request merges into it, never directly into `development`.
 4. **Processes each slice** in its own isolated worktree — routed investigator (complex tier only), implementer, then reviewer; then commit, push, open a slice pull request, and squash-merge it into the umbrella branch.
@@ -54,8 +54,9 @@ The plugin bundles `orchestrate-mcp`, a Model Context Protocol server providing 
 | `run_tests` / `run_typecheck` / `run_build` / `run_lint` | Run the project's configured capability commands |
 | `plan_waves` | Topologically sort issues into dependency waves; detects cycles |
 | `resolve_routing` | Resolve the model and effort variant for each role from a complexity tier |
-| `validate_envelope` | Validate a subagent's result envelope against its role schema — distinguishes a valid, a truncated/invalid, and a missing envelope |
+| `validate_envelope` | Validate a subagent's result envelope against its role schema — distinguishes a valid, a truncated/invalid, and a missing envelope. The implementer status carries `completed`, `incomplete` (a graceful turn-budget self-report), and `blocked` |
 | `recover_changed_files` | Recover a worktree's changed-file set by inspecting it directly — the orchestrator's fallback when an envelope is missing or invalid |
+| `verify_changeset` | Compare a worktree's actual changeset against the file set an implementer declared — the post-implementer scope check before a `completed` envelope is trusted |
 | `render_dashboard` / `render_graph` / `render_report` | Render standalone HTML artifacts from the run state |
 | `spawn_successor` | Launch a fresh Claude Code session that resumes the run |
 | `search_structural` | Syntax-aware (ast-grep) code search, with a text-search fallback |

--- a/plugins/orchestrate/agents/implementer-deep.md
+++ b/plugins/orchestrate/agents/implementer-deep.md
@@ -90,16 +90,32 @@ or missing envelope is treated as a FAILED slice.
 The envelope object has exactly these fields:
 
 - **role** — the string `"implementer"`.
-- **status** — `"completed"` (acceptance criteria met and all configured
-  capability tools pass) or `"blocked"` (you could not finish).
+- **status** — one of three values:
+  - `"completed"` — acceptance criteria met and all configured capability tools
+    pass.
+  - `"incomplete"` — the **graceful turn-budget self-report**. When you foresee
+    you cannot finish every acceptance criterion within your remaining turns,
+    stop *cleanly* on your own terms: emit a `"incomplete"` envelope that
+    records the partial work in `filesChanged` and explains in `notes` exactly
+    what is done, what is left, and how to resume. This is the right path when
+    the work is simply larger than the budget — it is recoverable and resumable.
+    It is distinct from `"blocked"`. Choosing `"incomplete"` is always better
+    than running out of turns mid-sentence: a hard turn-limit cutoff truncates
+    your envelope, which the orchestrator can only treat as an invalid (FAILED)
+    slice — the `"incomplete"` self-report is the loud, structured alternative.
+  - `"blocked"` — you hit an **unrecoverable obstacle** (a missing dependency, a
+    contradictory acceptance criterion, an environment failure) and could not
+    finish. Unlike `"incomplete"`, more turns would not have helped.
 - **filesChanged** — an array of the files you created or edited, as paths
-  relative to the worktree root (`[]` if you changed nothing).
+  relative to the worktree root (`[]` if you changed nothing). Report this
+  accurately even for `"incomplete"` or `"blocked"` — the orchestrator verifies
+  it against the worktree.
 - **verification** — an array of objects, one per capability tool you ran, each
   `{ "capability": "tests" | "typecheck" | "build" | "lint", "result":
   "passed" | "failed" | "not-configured" }`.
 - **notes** — a string: anything the orchestrator or a later reviewer must know
-  — assumptions you made, partial work, or, if `blocked`, exactly what stopped
-  you and what was tried.
+  — assumptions you made, partial work, or, if `incomplete` or `blocked`,
+  exactly what stopped you and what was tried.
 
 Example:
 

--- a/plugins/orchestrate/agents/implementer-standard.md
+++ b/plugins/orchestrate/agents/implementer-standard.md
@@ -3,7 +3,7 @@ name: implementer-standard
 description: Implements a single tracked issue inside an isolated git worktree — edits files and verifies the work through the orchestrate capability tools. Standard-effort variant for trivial- and standard-tier issues. Spawned by the orchestrate skill; not invoked directly.
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_orchestrate_orchestrate__run_tests, mcp__plugin_orchestrate_orchestrate__run_typecheck, mcp__plugin_orchestrate_orchestrate__run_build, mcp__plugin_orchestrate_orchestrate__run_lint
 model: sonnet
-maxTurns: 50
+maxTurns: 65
 ---
 
 # Implementer (Standard)
@@ -12,9 +12,14 @@ You implement exactly one tracked issue inside an isolated git worktree. The
 `orchestrate` skill spawns you — you never run directly.
 
 This is the **standard-effort variant**, spawned for trivial- and standard-tier
-issues. `maxTurns` is 50 because implementation is multi-file editing plus
-iterative capability-tool verification, which needs more turns than read-only
-analysis.
+issues. `maxTurns` is 65 because implementation is multi-file editing plus
+iterative capability-tool verification — exploration, edits, and re-runs after
+every fix — which needs substantially more turns than read-only analysis. The
+budget is generous enough that a standard-tier slice finishes inside it; if the
+issue still proves wider than expected, the right response is the `incomplete`
+self-report below, not a silent stop. A wide-but-simple slice that touches many
+independent targets is tiered up to the deep variant for its larger budget
+rather than being squeezed into this one.
 
 ## What you receive
 
@@ -68,16 +73,32 @@ or missing envelope is treated as a FAILED slice.
 The envelope object has exactly these fields:
 
 - **role** — the string `"implementer"`.
-- **status** — `"completed"` (acceptance criteria met and all configured
-  capability tools pass) or `"blocked"` (you could not finish).
+- **status** — one of three values:
+  - `"completed"` — acceptance criteria met and all configured capability tools
+    pass.
+  - `"incomplete"` — the **graceful turn-budget self-report**. When you foresee
+    you cannot finish every acceptance criterion within your remaining turns,
+    stop *cleanly* on your own terms: emit a `"incomplete"` envelope that
+    records the partial work in `filesChanged` and explains in `notes` exactly
+    what is done, what is left, and how to resume. This is the right path when
+    the work is simply larger than the budget — it is recoverable and resumable.
+    It is distinct from `"blocked"`. Choosing `"incomplete"` is always better
+    than running out of turns mid-sentence: a hard turn-limit cutoff truncates
+    your envelope, which the orchestrator can only treat as an invalid (FAILED)
+    slice — the `"incomplete"` self-report is the loud, structured alternative.
+  - `"blocked"` — you hit an **unrecoverable obstacle** (a missing dependency, a
+    contradictory acceptance criterion, an environment failure) and could not
+    finish. Unlike `"incomplete"`, more turns would not have helped.
 - **filesChanged** — an array of the files you created or edited, as paths
-  relative to the worktree root (`[]` if you changed nothing).
+  relative to the worktree root (`[]` if you changed nothing). Report this
+  accurately even for `"incomplete"` or `"blocked"` — the orchestrator verifies
+  it against the worktree.
 - **verification** — an array of objects, one per capability tool you ran, each
   `{ "capability": "tests" | "typecheck" | "build" | "lint", "result":
   "passed" | "failed" | "not-configured" }`.
 - **notes** — a string: anything the orchestrator or a later reviewer must know
-  — assumptions you made, partial work, or, if `blocked`, exactly what stopped
-  you and what was tried.
+  — assumptions you made, partial work, or, if `incomplete` or `blocked`,
+  exactly what stopped you and what was tried.
 
 Example:
 

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -6873,12 +6873,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs7, exportName) {
+    function addFormats(ajv, list, fs8, exportName) {
       var _a;
       var _b;
       (_a = (_b = ajv.opts.code).formats) !== null && _a !== void 0 ? _a : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs7[f]);
+        ajv.addFormat(f, fs8[f]);
     }
     module2.exports = exports2 = formatsPlugin;
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -23084,8 +23084,8 @@ var verificationEntrySchema = external_exports.object({
 });
 var implementerEnvelopeSchema = external_exports.object({
   role: external_exports.literal("implementer").describe("Discriminant \u2014 the implementer role."),
-  status: external_exports.enum(["completed", "blocked"]).describe(
-    "Outcome. 'completed' = acceptance criteria met and every configured capability tool passed; 'blocked' = the implementer could not finish."
+  status: external_exports.enum(["completed", "incomplete", "blocked"]).describe(
+    "Outcome. 'completed' = acceptance criteria met and every configured capability tool passed; 'incomplete' = the implementer's graceful turn-budget self-report \u2014 it foresaw it could not finish within the remaining turns and stopped cleanly with the partial work recorded, rather than being cut off mid-sentence (a hard turn-limit cutoff instead leaves an unclosed fence and is reported 'invalid'); 'blocked' = the implementer hit an unrecoverable obstacle and could not finish. 'incomplete' and 'blocked' are both non-success outcomes but stay distinct: 'incomplete' is partial and resumable, 'blocked' is an obstacle that must be cleared first."
   ),
   filesChanged: external_exports.array(external_exports.string()).describe(
     "Files the implementer created or edited, as paths relative to the worktree root. An empty array means no file was changed."
@@ -23323,6 +23323,111 @@ async function recoverChangedFiles(input) {
     status: "ok",
     changedFiles: parsePorcelainZ(porcelain)
   };
+}
+
+// src/tools/verify-changeset.ts
+var fs7 = __toESM(require("fs"));
+var verifyChangesetInputSchema = external_exports.object({
+  worktreePath: external_exports.string().describe(
+    "Absolute path to the slice worktree to inspect. The verification treats this worktree as the source of truth for what was actually changed."
+  ),
+  declaredFiles: external_exports.array(external_exports.string()).describe(
+    "The changed-file set the implementer DECLARED in its result envelope (`filesChanged`), as paths relative to the worktree root. An empty array means the implementer claimed it changed nothing. Order and duplicates are ignored \u2014 the comparison is set-based."
+  )
+});
+var verifyChangesetOutputSchema = external_exports.object({
+  status: external_exports.enum(["ok", "error"]).describe(
+    "Outcome discriminant. 'ok' = the worktree was inspected and the comparison ran; 'error' = the worktree could not be inspected."
+  ),
+  match: external_exports.enum([
+    "matched",
+    "mismatch",
+    "clean",
+    "empty-but-declared",
+    "suspiciously-empty"
+  ]).optional().describe(
+    "The set-comparison verdict. Present when status='ok'. 'matched' = the declared set equals the worktree changeset; 'clean' = nothing was declared and the worktree is clean (a no-op slice); 'mismatch' = the declared set and the worktree changeset differ in at least one direction (see declaredButAbsent and presentButUndeclared); 'empty-but-declared' = files were declared but the worktree is entirely clean \u2014 the implementer's edits never landed on disk; 'suspiciously-empty' = nothing was declared but the worktree DOES have changes \u2014 the implementer under-reported its work. Only 'matched' and 'clean' mean the declared set can be trusted as-is."
+  ),
+  actualFiles: external_exports.array(external_exports.string()).optional().describe(
+    "Every changed path the worktree actually carries \u2014 tracked modifications, staged changes, and untracked files alike (build artifacts NOT filtered). A rename emits both its source and destination path, never an 'old -> new' composite. Present when status='ok' (an empty array means a clean worktree)."
+  ),
+  declaredButAbsent: external_exports.array(external_exports.string()).optional().describe(
+    "Files the implementer declared in `filesChanged` that are NOT in the worktree changeset \u2014 declared but never actually changed on disk. Present when status='ok'; empty when every declared file is real."
+  ),
+  presentButUndeclared: external_exports.array(external_exports.string()).optional().describe(
+    "Files the worktree actually changed that the implementer did NOT declare \u2014 undeclared collateral the orchestrator would otherwise miss when staging only the declared set. Present when status='ok'; empty when the implementer declared everything it touched."
+  ),
+  errorCode: external_exports.enum(["INVALID_INPUT", "PATH_NOT_FOUND", "GIT_ERROR"]).optional().describe(
+    "Machine-readable failure category. Present when status='error'. 'INVALID_INPUT' = the path would be parsed by git as an option flag; 'PATH_NOT_FOUND' = the worktree path does not exist on disk; 'GIT_ERROR' = git could not report status (e.g. not a git worktree)."
+  ),
+  errorMessage: external_exports.string().optional().describe(
+    "Cleaned, human-readable failure description. Present when status='error'."
+  )
+});
+async function verifyChangeset(input) {
+  const { worktreePath, declaredFiles } = input;
+  const guardErr = optionInjectionError("worktreePath", worktreePath);
+  if (guardErr) {
+    return {
+      status: "error",
+      errorCode: "INVALID_INPUT",
+      errorMessage: guardErr
+    };
+  }
+  if (!fs7.existsSync(worktreePath)) {
+    return {
+      status: "error",
+      errorCode: "PATH_NOT_FOUND",
+      errorMessage: `Worktree path does not exist: ${worktreePath}`
+    };
+  }
+  let porcelain;
+  try {
+    const { stdout } = await gitExecFile(
+      ["status", "--porcelain", "-z"],
+      worktreePath
+    );
+    porcelain = stdout;
+  } catch (err) {
+    return {
+      status: "error",
+      errorCode: "GIT_ERROR",
+      errorMessage: cleanGitError(err)
+    };
+  }
+  const actualFiles = parsePorcelainZ(porcelain);
+  const declaredSet = new Set(declaredFiles);
+  const actualSet = new Set(actualFiles);
+  const declaredButAbsent = [...declaredSet].filter((f) => !actualSet.has(f)).sort();
+  const presentButUndeclared = [...actualSet].filter((f) => !declaredSet.has(f)).sort();
+  const match = classifyMatch(
+    declaredSet.size,
+    actualSet.size,
+    declaredButAbsent.length,
+    presentButUndeclared.length
+  );
+  return {
+    status: "ok",
+    match,
+    actualFiles,
+    declaredButAbsent,
+    presentButUndeclared
+  };
+}
+function classifyMatch(declaredCount, actualCount, absentCount, undeclaredCount) {
+  if (declaredCount === 0 && actualCount === 0) {
+    return "clean";
+  }
+  if (declaredCount > 0 && actualCount === 0) {
+    return "empty-but-declared";
+  }
+  if (declaredCount === 0 && actualCount > 0) {
+    return "suspiciously-empty";
+  }
+  if (absentCount === 0 && undeclaredCount === 0) {
+    return "matched";
+  }
+  return "mismatch";
 }
 
 // src/index.ts
@@ -23673,6 +23778,32 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleRecoverChangedFiles
+);
+var handleVerifyChangeset = async (input) => {
+  const result = await verifyChangeset(input);
+  let text;
+  if (result.status === "ok") {
+    const counts = `${result.declaredButAbsent.length} declared-but-absent, ${result.presentButUndeclared.length} present-but-undeclared`;
+    text = `Changeset verification: ${result.match} (${counts}).`;
+  } else {
+    text = `Changeset verification failed [${result.errorCode}]: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text", text }]
+  };
+};
+registerTool(
+  "verify_changeset",
+  {
+    title: "Verify a Worktree Changeset Against the Declared File Set",
+    description: "Compares a slice worktree's ACTUAL changeset \u2014 inspected with 'git status --porcelain -z' \u2014 against the changed-file set the implementer DECLARED in its result envelope. The orchestrator calls this after every implementer returns, before trusting a 'completed' envelope. The comparison is a cheap set comparison, not a semantic scope check: order and duplicates are ignored, and the issue body is never parsed. Returns a `match` verdict \u2014 'matched', 'clean', 'mismatch', 'empty-but-declared' (edits never landed), or 'suspiciously-empty' (work under-reported) \u2014 plus the divergent paths in `declaredButAbsent` and `presentButUndeclared`. Discriminated `status` of 'ok' or 'error'.",
+    inputSchema: verifyChangesetInputSchema.shape,
+    outputSchema: verifyChangesetOutputSchema.shape
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleVerifyChangeset
 );
 async function main() {
   const transport = new StdioServerTransport();

--- a/plugins/orchestrate/orchestrate-mcp/src/index.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/index.ts
@@ -85,6 +85,13 @@ import {
   type RecoverChangedFilesInput,
   type RecoverChangedFilesOutput,
 } from "./tools/recover-changed-files.js";
+import {
+  verifyChangeset,
+  verifyChangesetInputSchema,
+  verifyChangesetOutputSchema,
+  type VerifyChangesetInput,
+  type VerifyChangesetOutput,
+} from "./tools/verify-changeset.js";
 
 const server = new McpServer({
   name: "orchestrate",
@@ -687,6 +694,52 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleRecoverChangedFiles as unknown as AnyToolHandler
+);
+
+// ─── verify_changeset ─────────────────────────────────────────────────────────
+
+const handleVerifyChangeset: ToolHandler<
+  VerifyChangesetInput,
+  VerifyChangesetOutput
+> = async (input) => {
+  const result = await verifyChangeset(input);
+  let text: string;
+  if (result.status === "ok") {
+    const counts =
+      `${result.declaredButAbsent!.length} declared-but-absent, ` +
+      `${result.presentButUndeclared!.length} present-but-undeclared`;
+    text = `Changeset verification: ${result.match} (${counts}).`;
+  } else {
+    text = `Changeset verification failed [${result.errorCode}]: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text" as const, text }],
+  };
+};
+
+registerTool(
+  "verify_changeset",
+  {
+    title: "Verify a Worktree Changeset Against the Declared File Set",
+    description:
+      "Compares a slice worktree's ACTUAL changeset — inspected with " +
+      "'git status --porcelain -z' — against the changed-file set the " +
+      "implementer DECLARED in its result envelope. The orchestrator calls " +
+      "this after every implementer returns, before trusting a 'completed' " +
+      "envelope. The comparison is a cheap set comparison, not a semantic " +
+      "scope check: order and duplicates are ignored, and the issue body is " +
+      "never parsed. Returns a `match` verdict — 'matched', 'clean', " +
+      "'mismatch', 'empty-but-declared' (edits never landed), or " +
+      "'suspiciously-empty' (work under-reported) — plus the divergent paths " +
+      "in `declaredButAbsent` and `presentButUndeclared`. Discriminated " +
+      "`status` of 'ok' or 'error'.",
+    inputSchema: verifyChangesetInputSchema.shape,
+    outputSchema: verifyChangesetOutputSchema.shape,
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleVerifyChangeset as unknown as AnyToolHandler
 );
 
 // ─── Start server ─────────────────────────────────────────────────────────────

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/validate-envelope.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/validate-envelope.ts
@@ -26,16 +26,24 @@ const verificationEntrySchema = z.object({
 });
 
 /**
- * Result envelope for the implementer role. `status` keeps the implementer's
- * existing vocabulary: 'completed' or 'blocked'.
+ * Result envelope for the implementer role. `status` carries the implementer's
+ * three-value vocabulary: 'completed', 'incomplete', or 'blocked'.
  */
 export const implementerEnvelopeSchema = z.object({
   role: z.literal("implementer").describe("Discriminant — the implementer role."),
   status: z
-    .enum(["completed", "blocked"])
+    .enum(["completed", "incomplete", "blocked"])
     .describe(
       "Outcome. 'completed' = acceptance criteria met and every configured " +
-        "capability tool passed; 'blocked' = the implementer could not finish."
+        "capability tool passed; 'incomplete' = the implementer's graceful " +
+        "turn-budget self-report — it foresaw it could not finish within the " +
+        "remaining turns and stopped cleanly with the partial work recorded, " +
+        "rather than being cut off mid-sentence (a hard turn-limit cutoff " +
+        "instead leaves an unclosed fence and is reported 'invalid'); " +
+        "'blocked' = the implementer hit an unrecoverable obstacle and could " +
+        "not finish. 'incomplete' and 'blocked' are both non-success outcomes " +
+        "but stay distinct: 'incomplete' is partial and resumable, 'blocked' " +
+        "is an obstacle that must be cleared first."
     ),
   filesChanged: z
     .array(z.string())

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/verify-changeset.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/verify-changeset.ts
@@ -1,0 +1,225 @@
+import * as fs from "fs";
+import { z } from "zod";
+import { gitExecFile, optionInjectionError, cleanGitError } from "../git.js";
+import { parsePorcelainZ } from "./worktree.js";
+
+// ─── Schemas — z.object is the single source of truth; TS types via z.infer ───
+
+export const verifyChangesetInputSchema = z.object({
+  worktreePath: z
+    .string()
+    .describe(
+      "Absolute path to the slice worktree to inspect. The verification " +
+        "treats this worktree as the source of truth for what was actually " +
+        "changed."
+    ),
+  declaredFiles: z
+    .array(z.string())
+    .describe(
+      "The changed-file set the implementer DECLARED in its result envelope " +
+        "(`filesChanged`), as paths relative to the worktree root. An empty " +
+        "array means the implementer claimed it changed nothing. Order and " +
+        "duplicates are ignored — the comparison is set-based."
+    ),
+});
+
+export const verifyChangesetOutputSchema = z.object({
+  status: z
+    .enum(["ok", "error"])
+    .describe(
+      "Outcome discriminant. 'ok' = the worktree was inspected and the " +
+        "comparison ran; 'error' = the worktree could not be inspected."
+    ),
+  match: z
+    .enum([
+      "matched",
+      "mismatch",
+      "clean",
+      "empty-but-declared",
+      "suspiciously-empty",
+    ])
+    .optional()
+    .describe(
+      "The set-comparison verdict. Present when status='ok'. " +
+        "'matched' = the declared set equals the worktree changeset; " +
+        "'clean' = nothing was declared and the worktree is clean (a no-op " +
+        "slice); 'mismatch' = the declared set and the worktree changeset " +
+        "differ in at least one direction (see declaredButAbsent and " +
+        "presentButUndeclared); 'empty-but-declared' = files were declared " +
+        "but the worktree is entirely clean — the implementer's edits never " +
+        "landed on disk; 'suspiciously-empty' = nothing was declared but the " +
+        "worktree DOES have changes — the implementer under-reported its work. " +
+        "Only 'matched' and 'clean' mean the declared set can be trusted as-is."
+    ),
+  actualFiles: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Every changed path the worktree actually carries — tracked " +
+        "modifications, staged changes, and untracked files alike (build " +
+        "artifacts NOT filtered). A rename emits both its source and " +
+        "destination path, never an 'old -> new' composite. Present when " +
+        "status='ok' (an empty array means a clean worktree)."
+    ),
+  declaredButAbsent: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Files the implementer declared in `filesChanged` that are NOT in the " +
+        "worktree changeset — declared but never actually changed on disk. " +
+        "Present when status='ok'; empty when every declared file is real."
+    ),
+  presentButUndeclared: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Files the worktree actually changed that the implementer did NOT " +
+        "declare — undeclared collateral the orchestrator would otherwise " +
+        "miss when staging only the declared set. Present when status='ok'; " +
+        "empty when the implementer declared everything it touched."
+    ),
+  errorCode: z
+    .enum(["INVALID_INPUT", "PATH_NOT_FOUND", "GIT_ERROR"])
+    .optional()
+    .describe(
+      "Machine-readable failure category. Present when status='error'. " +
+        "'INVALID_INPUT' = the path would be parsed by git as an option flag; " +
+        "'PATH_NOT_FOUND' = the worktree path does not exist on disk; " +
+        "'GIT_ERROR' = git could not report status (e.g. not a git worktree)."
+    ),
+  errorMessage: z
+    .string()
+    .optional()
+    .describe(
+      "Cleaned, human-readable failure description. Present when status='error'."
+    ),
+});
+
+// ─── TS types — derived from the schemas (single source of truth) ─────────────
+
+export type VerifyChangesetInput = z.infer<typeof verifyChangesetInputSchema>;
+export type VerifyChangesetOutput = z.infer<typeof verifyChangesetOutputSchema>;
+
+// ─── verify_changeset ─────────────────────────────────────────────────────────
+
+/**
+ * Verifies a slice worktree's ACTUAL changeset against the changed-file set the
+ * implementer DECLARED in its result envelope — the orchestrator's scope check
+ * after every implementer returns, so a `completed` envelope is not trusted
+ * before the disk has been compared against it.
+ *
+ * The worktree is inspected with `git status --porcelain -z` (the same
+ * machinery `recover_changed_files` uses) and the declared set is compared to it
+ * as a SET: order and duplicates are irrelevant. This is a cheap set comparison,
+ * not a semantic scope check — it does NOT parse the issue body, does not judge
+ * whether the changed files are the "right" files for the issue, and does not
+ * read file contents. It answers only: do the declared files and the real
+ * changeset agree?
+ *
+ * The `match` verdict classifies the comparison so the orchestrator can act:
+ *  - 'clean'               — nothing declared, worktree clean (a no-op slice)
+ *  - 'matched'             — declared set == worktree changeset (trustworthy)
+ *  - 'empty-but-declared'  — files declared, worktree entirely clean (edits
+ *                            never landed)
+ *  - 'suspiciously-empty'  — nothing declared, worktree HAS changes (work
+ *                            under-reported)
+ *  - 'mismatch'            — the two sets differ in at least one direction
+ *
+ * Never throws — every failure mode is a structured result.
+ */
+export async function verifyChangeset(
+  input: VerifyChangesetInput
+): Promise<VerifyChangesetOutput> {
+  const { worktreePath, declaredFiles } = input;
+
+  // Option-injection guard: reject a path git would treat as a flag.
+  const guardErr = optionInjectionError("worktreePath", worktreePath);
+  if (guardErr) {
+    return {
+      status: "error",
+      errorCode: "INVALID_INPUT",
+      errorMessage: guardErr,
+    };
+  }
+
+  // The path must exist on disk before git can be run against it.
+  if (!fs.existsSync(worktreePath)) {
+    return {
+      status: "error",
+      errorCode: "PATH_NOT_FOUND",
+      errorMessage: `Worktree path does not exist: ${worktreePath}`,
+    };
+  }
+
+  // `-z` emits NUL-terminated records with no C-style quoting; rename/copy
+  // entries split cleanly into both real paths via parsePorcelainZ.
+  let porcelain: string;
+  try {
+    const { stdout } = await gitExecFile(
+      ["status", "--porcelain", "-z"],
+      worktreePath
+    );
+    porcelain = stdout;
+  } catch (err) {
+    return {
+      status: "error",
+      errorCode: "GIT_ERROR",
+      errorMessage: cleanGitError(err),
+    };
+  }
+
+  const actualFiles = parsePorcelainZ(porcelain);
+
+  // Set-based comparison — order and duplicates do not matter.
+  const declaredSet = new Set(declaredFiles);
+  const actualSet = new Set(actualFiles);
+
+  const declaredButAbsent = [...declaredSet]
+    .filter((f) => !actualSet.has(f))
+    .sort();
+  const presentButUndeclared = [...actualSet]
+    .filter((f) => !declaredSet.has(f))
+    .sort();
+
+  const match = classifyMatch(
+    declaredSet.size,
+    actualSet.size,
+    declaredButAbsent.length,
+    presentButUndeclared.length
+  );
+
+  return {
+    status: "ok",
+    match,
+    actualFiles,
+    declaredButAbsent,
+    presentButUndeclared,
+  };
+}
+
+/**
+ * Maps the four comparison counts to a single `match` verdict. The two
+ * "empty side" cases are called out specifically because they are the loud
+ * turn-limit / under-report signals the orchestrator most needs to catch; any
+ * other divergence collapses into the generic 'mismatch'.
+ */
+function classifyMatch(
+  declaredCount: number,
+  actualCount: number,
+  absentCount: number,
+  undeclaredCount: number
+): NonNullable<VerifyChangesetOutput["match"]> {
+  if (declaredCount === 0 && actualCount === 0) {
+    return "clean";
+  }
+  if (declaredCount > 0 && actualCount === 0) {
+    return "empty-but-declared";
+  }
+  if (declaredCount === 0 && actualCount > 0) {
+    return "suspiciously-empty";
+  }
+  if (absentCount === 0 && undeclaredCount === 0) {
+    return "matched";
+  }
+  return "mismatch";
+}

--- a/plugins/orchestrate/orchestrate-mcp/test/validate-envelope.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/validate-envelope.test.ts
@@ -117,6 +117,23 @@ describe("validateEnvelope — valid envelopes", () => {
     expect(r.status).toBe("valid");
     expect(r.envelope!.role).toBe("implementer");
   });
+
+  it("accepts an implementer envelope with status='incomplete'", () => {
+    // 'incomplete' is the implementer's graceful turn-budget self-report —
+    // distinct from 'completed' (done) and 'blocked' (unrecoverable obstacle).
+    const env = {
+      ...implementerEnvelope(),
+      status: "incomplete" as const,
+      notes:
+        "Foresaw the remaining acceptance criteria would not fit the turn " +
+        "budget; reporting incomplete with the partial work above.",
+    };
+    const r = validateEnvelope({ text: fenced(env), role: "implementer" });
+
+    expect(r.status).toBe("valid");
+    expect(r.envelope!.role).toBe("implementer");
+    expect((r.envelope as { status: string }).status).toBe("incomplete");
+  });
 });
 
 // ─── truncated envelopes ──────────────────────────────────────────────────────

--- a/plugins/orchestrate/orchestrate-mcp/test/verify-changeset.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/verify-changeset.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import { verifyChangeset } from "../src/tools/verify-changeset.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { encoding: "utf8", cwd }).trim();
+}
+
+/** Creates a temporary git repository with one commit and returns its path. */
+function createTempRepo(): string {
+  const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-test-"));
+
+  git(["init"], repoPath);
+  git(["config", "user.email", "test@test.local"], repoPath);
+  git(["config", "user.name", "Test User"], repoPath);
+
+  fs.writeFileSync(path.join(repoPath, "README.md"), "# Test repo\n");
+  git(["add", "README.md"], repoPath);
+  git(["commit", "-m", "Initial commit"], repoPath);
+
+  return repoPath;
+}
+
+/** Recursively remove a directory. */
+function rmrf(dirPath: string) {
+  if (fs.existsSync(dirPath)) {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  }
+}
+
+// ─── Test state ───────────────────────────────────────────────────────────────
+
+let repoPath: string;
+
+beforeEach(() => {
+  repoPath = createTempRepo();
+});
+
+afterEach(() => {
+  rmrf(repoPath);
+});
+
+// ─── verify_changeset ─────────────────────────────────────────────────────────
+
+describe("verify_changeset — matching changesets", () => {
+  it("reports 'clean' when nothing was declared and the worktree is clean", async () => {
+    const r = await verifyChangeset({
+      worktreePath: repoPath,
+      declaredFiles: [],
+    });
+
+    expect(r.status).toBe("ok");
+    expect(r.match).toBe("clean");
+    expect(r.actualFiles).toEqual([]);
+    expect(r.declaredButAbsent).toEqual([]);
+    expect(r.presentButUndeclared).toEqual([]);
+  });
+
+  it("reports 'matched' when the declared set equals the worktree changeset", async () => {
+    fs.appendFileSync(path.join(repoPath, "README.md"), "\nmodified line\n");
+    fs.writeFileSync(path.join(repoPath, "a.ts"), "export const a = 1;\n");
+
+    const r = await verifyChangeset({
+      worktreePath: repoPath,
+      declaredFiles: ["README.md", "a.ts"],
+    });
+
+    expect(r.status).toBe("ok");
+    expect(r.match).toBe("matched");
+    expect(r.declaredButAbsent).toEqual([]);
+    expect(r.presentButUndeclared).toEqual([]);
+  });
+
+  it("treats declared-file order as irrelevant to a 'matched' result", async () => {
+    fs.writeFileSync(path.join(repoPath, "a.ts"), "a\n");
+    fs.writeFileSync(path.join(repoPath, "b.ts"), "b\n");
+
+    const r = await verifyChangeset({
+      worktreePath: repoPath,
+      declaredFiles: ["b.ts", "a.ts"],
+    });
+
+    expect(r.status).toBe("ok");
+    expect(r.match).toBe("matched");
+  });
+
+  it("ignores duplicate entries in the declared list", async () => {
+    fs.writeFileSync(path.join(repoPath, "a.ts"), "a\n");
+
+    const r = await verifyChangeset({
+      worktreePath: repoPath,
+      declaredFiles: ["a.ts", "a.ts"],
+    });
+
+    expect(r.status).toBe("ok");
+    expect(r.match).toBe("matched");
+  });
+});
+
+describe("verify_changeset — mismatching changesets", () => {
+  it("reports 'empty-but-declared' when files were declared but the worktree is clean", async () => {
+    const r = await verifyChangeset({
+      worktreePath: repoPath,
+      declaredFiles: ["src/foo.ts"],
+    });
+
+    expect(r.status).toBe("ok");
+    expect(r.match).toBe("empty-but-declared");
+    expect(r.declaredButAbsent).toEqual(["src/foo.ts"]);
+    expect(r.presentButUndeclared).toEqual([]);
+  });
+
+  it("reports 'mismatch' with declaredButAbsent when a declared file was never changed", async () => {
+    fs.writeFileSync(path.join(repoPath, "a.ts"), "a\n");
+
+    const r = await verifyChangeset({
+      worktreePath: repoPath,
+      declaredFiles: ["a.ts", "never-touched.ts"],
+    });
+
+    expect(r.status).toBe("ok");
+    expect(r.match).toBe("mismatch");
+    expect(r.declaredButAbsent).toEqual(["never-touched.ts"]);
+    expect(r.presentButUndeclared).toEqual([]);
+  });
+
+  it("reports 'mismatch' with presentButUndeclared when the worktree changed an undeclared file", async () => {
+    fs.writeFileSync(path.join(repoPath, "a.ts"), "a\n");
+    fs.writeFileSync(path.join(repoPath, "surprise.ts"), "surprise\n");
+
+    const r = await verifyChangeset({
+      worktreePath: repoPath,
+      declaredFiles: ["a.ts"],
+    });
+
+    expect(r.status).toBe("ok");
+    expect(r.match).toBe("mismatch");
+    expect(r.declaredButAbsent).toEqual([]);
+    expect(r.presentButUndeclared).toEqual(["surprise.ts"]);
+  });
+
+  it("reports both directions of mismatch together", async () => {
+    fs.writeFileSync(path.join(repoPath, "present.ts"), "present\n");
+
+    const r = await verifyChangeset({
+      worktreePath: repoPath,
+      declaredFiles: ["absent.ts"],
+    });
+
+    expect(r.status).toBe("ok");
+    expect(r.match).toBe("mismatch");
+    expect(r.declaredButAbsent).toEqual(["absent.ts"]);
+    expect(r.presentButUndeclared).toEqual(["present.ts"]);
+  });
+
+  it("reports 'suspiciously-empty' when nothing was declared but the worktree has changes", async () => {
+    fs.writeFileSync(path.join(repoPath, "stray.ts"), "stray\n");
+
+    const r = await verifyChangeset({
+      worktreePath: repoPath,
+      declaredFiles: [],
+    });
+
+    expect(r.status).toBe("ok");
+    expect(r.match).toBe("suspiciously-empty");
+    expect(r.presentButUndeclared).toEqual(["stray.ts"]);
+    expect(r.declaredButAbsent).toEqual([]);
+  });
+
+  it("surfaces both real paths of a rename as actualFiles", async () => {
+    git(["mv", "README.md", "RENAMED.md"], repoPath);
+
+    const r = await verifyChangeset({
+      worktreePath: repoPath,
+      declaredFiles: ["README.md", "RENAMED.md"],
+    });
+
+    expect(r.status).toBe("ok");
+    expect(r.match).toBe("matched");
+    expect(r.actualFiles).toEqual(
+      expect.arrayContaining(["README.md", "RENAMED.md"])
+    );
+  });
+});
+
+describe("verify_changeset — error handling", () => {
+  it("returns errorCode=PATH_NOT_FOUND when the worktree path does not exist", async () => {
+    const r = await verifyChangeset({
+      worktreePath: path.join(repoPath, "does-not-exist"),
+      declaredFiles: [],
+    });
+
+    expect(r.status).toBe("error");
+    expect(r.errorCode).toBe("PATH_NOT_FOUND");
+    expect(r.errorMessage).toMatch(/does not exist/i);
+  });
+
+  it("returns errorCode=GIT_ERROR for a non-git directory", async () => {
+    const plainDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-plain-"));
+    try {
+      const r = await verifyChangeset({
+        worktreePath: plainDir,
+        declaredFiles: [],
+      });
+
+      expect(r.status).toBe("error");
+      expect(r.errorCode).toBe("GIT_ERROR");
+      expect(r.errorMessage).toBeDefined();
+    } finally {
+      rmrf(plainDir);
+    }
+  });
+
+  it("refuses a worktreePath starting with '-' with errorCode=INVALID_INPUT", async () => {
+    const r = await verifyChangeset({
+      worktreePath: "--git-dir",
+      declaredFiles: [],
+    });
+
+    expect(r.status).toBe("error");
+    expect(r.errorCode).toBe("INVALID_INPUT");
+    expect(r.errorMessage).toMatch(/worktreePath/);
+  });
+});

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -126,8 +126,26 @@ whose `status` is `in-progress`.
    a single parent issue number (`PRD #NNN` line) or `null`. Then assess its
    **complexity tier** — `trivial` (a small, localized change), `standard` (an
    ordinary feature or fix), or `complex` (broad, cross-cutting, or high-risk
-   work). Base the tier on the issue's scope, the number of files it likely
-   touches, and its risk. The tier drives routing in section 3.
+   work). The tier drives routing in section 3.
+
+   Weigh **two independent axes** when assessing the tier, and take the higher
+   of the two:
+
+   - **Conceptual difficulty** — how hard the change is to reason about: subtle
+     logic, non-obvious interactions, high risk if it goes wrong.
+   - **Fan-out** — the number of *independent targets* the slice touches: files,
+     modules, subagent definitions, config entries, or doc surfaces that each
+     need their own edit and their own verification. A slice can be
+     conceptually simple yet have large fan-out — e.g. applying the same small
+     change across many files, or updating a schema plus every definition,
+     skill section, and doc that references it.
+
+   A **wide-but-simple** slice — low conceptual difficulty but high fan-out — is
+   legitimately tiered **up** (e.g. `standard` → `complex`) purely to buy the
+   larger implementer turn budget and an investigation pass: many independent
+   edits plus a capability-tool re-run after each one consume turns regardless
+   of how easy any single edit is. Do not tier a slice down just because each
+   target is trivial; the count of targets is itself a cost.
 
    Once every issue is parsed, call the **`partition_backlog` MCP tool** to
    split the backlog into `slices` and `parentIssue`:
@@ -297,17 +315,50 @@ subagent's verbatim returned text and its `role`:
    instruction to verify with the capability tools using the worktree path as
    `repoPath`, and a reminder not to commit, push, or run git. Validate its
    returned text with `validate_envelope` (role `implementer`). On a `valid`
-   envelope, an envelope `status` of `blocked` means the slice has **FAILED**;
-   `completed` proceeds. An `invalid` or `missing` envelope also means the slice
-   has **FAILED**.
+   envelope, classify the envelope `status`:
+   - `completed` — proceed to the worktree scope check in step 4a.
+   - `incomplete` — the implementer's graceful turn-budget self-report: it
+     foresaw it could not finish within its remaining turns and stopped cleanly
+     with partial work recorded. The slice has **FAILED** — record a
+     `failureReason` that names the turn-limit cutoff explicitly (e.g.
+     "implementer reported `incomplete` — exhausted its turn budget; partial
+     work preserved in the worktree for resumption"). See *Failure handling*.
+   - `blocked` — the implementer hit an unrecoverable obstacle: the slice has
+     **FAILED**.
+
+   An `invalid` or `missing` envelope also means the slice has **FAILED** — a
+   hard turn-limit cutoff that truncates the envelope mid-emission lands here as
+   `invalid`, distinct from the graceful `incomplete` self-report above.
+4a. **Verify the changeset against the worktree.** After a `completed`
+   implementer envelope — and before trusting it — call the `verify_changeset`
+   MCP tool with the slice's `worktreePath` and the implementer envelope's
+   `filesChanged` as `declaredFiles`. It inspects the worktree directly with
+   `git status` and compares the declared file set against what actually
+   changed on disk:
+   - `match: "matched"` or `"clean"` — the declared set agrees with the
+     worktree; proceed to step 5.
+   - `match: "empty-but-declared"` — the implementer declared files but the
+     worktree is clean: its edits never landed. The slice has **FAILED**.
+   - `match: "suspiciously-empty"` — the implementer declared nothing but the
+     worktree HAS changes: the work was under-reported. The slice has
+     **FAILED**; record the `presentButUndeclared` paths in the `failureReason`.
+   - `match: "mismatch"` — the declared set and the worktree changeset diverge.
+     Trust the worktree: use the **union** of the implementer's declared
+     `filesChanged` and the tool's `actualFiles` as the changed-file set for the
+     reviewer and the commit (step 6), and note the divergence
+     (`declaredButAbsent` / `presentButUndeclared`) so the reviewer sees it.
+   - `status: "error"` — the worktree could not be inspected; the slice has
+     **FAILED**.
 5. **Run the reviewer.** Spawn the `orchestrate:reviewer-<effort>` subagent —
    `<effort>` and the `model` override from `routing.reviewer` — in the same
-   worktree. Its prompt must carry the issue, the worktree path, the implementer
-   envelope's `filesChanged` and `notes`, and the investigator's brief if one
-   was produced. Validate its returned text with `validate_envelope` (role
-   `reviewer`). On a `valid` envelope, an envelope `status` of `failed` means
-   the slice has **FAILED**; `passed` proceeds. An `invalid` or `missing`
-   envelope also means the slice has **FAILED**.
+   worktree. Its prompt must carry the issue, the worktree path, the
+   changed-file set agreed on by step 4a — the implementer envelope's
+   `filesChanged` when `verify_changeset` matched, the union of declared and
+   `actualFiles` on a `mismatch` — the implementer envelope's `notes`, and the
+   investigator's brief if one was produced. Validate its returned text with
+   `validate_envelope` (role `reviewer`). On a `valid` envelope, an envelope
+   `status` of `failed` means the slice has **FAILED**; `passed` proceeds. An
+   `invalid` or `missing` envelope also means the slice has **FAILED**.
 6. **Commit and push.** Stage only the files the subagents reported changing —
    the union of the `filesChanged` arrays from the validated implementer and
    reviewer envelopes. Never `git add -A`: the capability tools leave untracked
@@ -433,17 +484,32 @@ To hand off:
 
 A slice **FAILS** when `create_worktree` errors, a subagent's result envelope
 is invalid or missing (`validate_envelope` returns `invalid` or `missing`), a
-validated implementer envelope has `status: "blocked"`, a validated reviewer
-envelope has `status: "failed"`, the staged changeset is empty, or a merge
-conflict the `conflict-resolver` cannot fix. The orchestrator decides FAILURE
-**only** from the validated envelope and tool results — never from a subagent's
-prose. An invalid or missing envelope is always a FAILED slice; it is never
-treated as success.
+validated implementer envelope has `status: "blocked"` or `status: "incomplete"`,
+a validated reviewer envelope has `status: "failed"`, `verify_changeset` reports
+the implementer's declared file set does not match the worktree
+(`empty-but-declared` or `suspiciously-empty`, or a `status: "error"`), the
+staged changeset is empty, or a merge conflict the `conflict-resolver` cannot
+fix. The orchestrator decides FAILURE **only** from the validated envelope and
+tool results — never from a subagent's prose. An invalid or missing envelope is
+always a FAILED slice; it is never treated as success.
+
+The implementer envelope's `incomplete` status is a **distinct** failure flavor:
+it is the implementer's graceful turn-budget self-report — partial, resumable
+work — as opposed to `blocked` (an unrecoverable obstacle) or an `invalid`
+envelope (a hard turn-limit cutoff that truncated the envelope). All three FAIL
+the slice, but the `failureReason` must name the cause precisely so a developer
+can tell a resumable budget exhaustion apart from a genuine blocker. An
+`incomplete` slice's worktree holds usable partial work — preserve it (as every
+FAILED slice's worktree is preserved) so the slice can be resumed.
 
 On a FAILED slice:
 
 - Set its `state` to `failed` with a `failureReason`, checkpoint, and
-  transition the issue's tracker label:
+  transition the issue's tracker label. For a slice that failed because the
+  implementer reported `incomplete` — partial, resumable work — `needs-info`
+  better signals "resume me" than `needs-triage`:
+  `gh issue edit <N> --remove-label ready-for-agent --add-label needs-info`.
+  For every other failure cause, use `needs-triage`:
   `gh issue edit <N> --remove-label ready-for-agent --add-label needs-triage`.
 - Do **not** merge it. **Preserve its worktree** — leave it on disk for a
   developer to inspect. Do not call `remove_worktree`.


### PR DESCRIPTION
Closes #193

Scope-aware turn budget and tier policy for orchestrate slices: adds an `incomplete` status to the implementer envelope schema as a graceful proactive self-report path, introduces a `verify-changeset` tool that compares the declared vs actual changed-file set, and raises the implementer turn budget.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>