### PR TITLE
feat(orchestrate): investigator scope guard

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -189,6 +189,10 @@ _Avoid_: git-status recovery, changed-file scan (worktree fallback is the precis
 The deliberate decision that all eight orchestrate subagents (`investigator`, `implementer`, `reviewer`, `conflict-resolver`, both `-standard` and `-deep` variants) do **not** call an advisor tool. The `advisor` tool is intentionally absent from every subagent's `tools:` frontmatter. Advisor passes, when used, run at the **orchestrator boundary** (the driver session running the `orchestrate` skill), not inside any subagent. The policy is expressed as an explicit `## Advisor policy` section — word-for-word identical between the `-standard` and `-deep` variant of each role — so the decision is self-evident from the definition file. See ADR-0009.
 _Avoid_: no-advisor rule, advisor ban (the policy is positive — advisor responsibility lives at the orchestrator boundary, not absent from the system)
 
+**Investigator scope guard**:
+The standing constraint — expressed as a `## Scope-boundary guard` section in both `investigator-standard.md` and `investigator-deep.md` — that limits the investigator's brief to work traceable to the slice's acceptance criteria. Every item in `relevantFiles`, `approach`, and `notes` must trace to at least one acceptance criterion; work belonging to a sibling or downstream slice must be dropped. Enforced at the orchestrator boundary by a brief-scope diff: after `validate_envelope` returns `valid`, the orchestrator compares the brief against the acceptance criteria it supplied as the hard scope boundary, and treats an over-scoped brief as a failed investigation pass (the slice **FAILS** before the implementer runs).
+_Avoid_: scope check, brief filter (the guard is a positive constraint on what the brief may contain, enforced at two points — inside the investigator definition and at the orchestrator boundary)
+
 ## Relationships
 
 - A **Distribution** owns at most one **Initializer** and at most one **Customizer**.

--- a/plugins/orchestrate/agents/investigator-deep.md
+++ b/plugins/orchestrate/agents/investigator-deep.md
@@ -58,6 +58,18 @@ always acceptable.
 - Do not attempt to implement, fix, or change anything. Investigate only.
 - Do not edit the issue, open pull requests, or change tracker labels.
 
+## Scope-boundary guard
+
+Your brief must be scoped **exactly** to the acceptance criteria you receive.
+Do not include investigation of, analysis of, or implementation suggestions for
+work that belongs to a sibling or downstream slice. If the issue body references
+other issues, other slices, or future work, treat those references as context
+only — never fold them into your `relevantFiles`, `approach`, or `notes`.
+
+The acceptance criteria are the hard boundary: every item in your brief must
+trace to at least one acceptance criterion. If you find yourself documenting a
+file, pattern, or risk that no acceptance criterion touches, drop it.
+
 ## Advisor policy
 
 This subagent does not call an advisor tool. The `advisor` tool is intentionally

--- a/plugins/orchestrate/agents/investigator-standard.md
+++ b/plugins/orchestrate/agents/investigator-standard.md
@@ -55,6 +55,18 @@ always acceptable.
 - Do not attempt to implement, fix, or change anything. Investigate only.
 - Do not edit the issue, open pull requests, or change tracker labels.
 
+## Scope-boundary guard
+
+Your brief must be scoped **exactly** to the acceptance criteria you receive.
+Do not include investigation of, analysis of, or implementation suggestions for
+work that belongs to a sibling or downstream slice. If the issue body references
+other issues, other slices, or future work, treat those references as context
+only — never fold them into your `relevantFiles`, `approach`, or `notes`.
+
+The acceptance criteria are the hard boundary: every item in your brief must
+trace to at least one acceptance criterion. If you find yourself documenting a
+file, pattern, or risk that no acceptance criterion touches, drop it.
+
 ## Advisor policy
 
 This subagent does not call an advisor tool. The `advisor` tool is intentionally

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -284,12 +284,22 @@ subagent's verbatim returned text and its `role`:
 3. **Run the investigator (higher tiers only).** If `routing.investigator` is
    non-null, spawn the `orchestrate:investigator-<effort>` subagent — `<effort>`
    and the Agent `model` override both come from `routing.investigator`. Its
-   prompt carries the issue and the repository root. Validate its returned text
-   with `validate_envelope` (role `investigator`); a `valid` envelope is the
-   research brief to keep for the implementer. An `invalid` or `missing`
-   envelope is a failed investigation pass — the slice has **FAILED** (the
-   investigator is read-only, so no worktree fallback applies). If
-   `routing.investigator` is null, skip this step.
+   prompt must carry the issue number/title/body **and the slice's acceptance
+   criteria explicitly named as the hard scope boundary** — the canonical per-
+   slice scope established by the backlog partitioner. The investigator must
+   not propose work that falls outside those acceptance criteria. Validate its
+   returned text with `validate_envelope` (role `investigator`); on `valid`,
+   **diff the returned brief against the acceptance criteria before forwarding
+   it to the implementer**: inspect the brief's `relevantFiles`, `approach`,
+   and `notes` for any work that does not trace to at least one acceptance
+   criterion. If the brief includes work from a sibling or downstream slice —
+   files, approaches, or recommendations that the acceptance criteria do not
+   require — the brief is over-scoped: treat it as a failed investigation pass
+   (the slice has **FAILED**). A brief that is correctly scoped to the
+   acceptance criteria is forwarded to the implementer as the research brief.
+   An `invalid` or `missing` envelope is a failed investigation pass — the
+   slice has **FAILED** (the investigator is read-only, so no worktree fallback
+   applies). If `routing.investigator` is null, skip this step.
 4. **Run the implementer.** Spawn the `orchestrate:implementer-<effort>`
    subagent — `<effort>` and the `model` override from `routing.implementer`. Its
    prompt must carry the issue number/title/body, the worktree path (every


### PR DESCRIPTION
Closes #194

Adds a scope guard to the orchestrate investigator subagents (deep and standard) and the SKILL.md investigation step, keeping investigators within the slice's declared file and concern boundaries rather than drifting into adjacent code.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>