### PR TITLE
feat(orchestrate): backlog partition by parent PRD with disjointness and resume

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -137,6 +137,10 @@ _Avoid_: backlog slice, batch (slice is reserved for a single issue's work)
 The per-run `.orchestrate/runs/<runId>/` directory holding that run's ephemeral state — the run-state checkpoint, the context-flag, and rendered HTML artifacts. Gitignored; the committed config files stay at the `.orchestrate/` top level.
 _Avoid_: run folder, state dir
 
+**runId format**:
+A run's identifier in one of two minted forms — `prd<N>-<timestamp>` for a partitioned run scoped to PRD `<N>`'s children (`/orchestrate <PRD#>`), and `backlog-<timestamp>` for a no-argument whole-backlog run. The `prd<N>-` / `backlog-` prefix is durable, persisted in `run-state.json`, and is the match key the startup scan parses to decide which in-progress run a re-invocation resumes. It also flows into the **Run directory** path and the umbrella branch name, keeping two concurrent runs disjoint.
+_Avoid_: timestamp id, run name (the prefix is load-bearing, not decoration)
+
 **Driver session**:
 The Claude Code session executing a run's orchestrator. Its identity is recorded in the run's run-state so the global context-watchdog binds the correct run when several runs proceed concurrently.
 _Avoid_: orchestrator window, owner session

--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -131,6 +131,27 @@ If the plugin is installed at user scope (the default), the namespace prefix is 
 
 The run is autonomous — it processes the whole backlog, resolves conflicts, checkpoints, hands off if its context fills, and ends by opening the final umbrella pull request. To resume an interrupted run, invoke `/orchestrate` again in the same repository: it scans `.orchestrate/runs/*/run-state.json` for an in-progress run and continues from the last checkpoint.
 
+### Scoping a run to one parent PRD
+
+Pass a parent-PRD issue number to scope the run to that PRD's children only:
+
+```bash
+/orchestrate 195
+```
+
+This runs just the issues whose **Parent** section names PRD #195 — the run's *partition*. Its `runId` is `prd195-<timestamp>` and its umbrella branch is `orchestrate/umbrella-prd195-<timestamp>`. A no-argument `/orchestrate` runs the whole backlog as one partition, with a `backlog-<timestamp>` runId, exactly as before.
+
+Because each partitioned run owns a disjoint set of issues and its own run directory and umbrella branch, you can run **two orchestrations concurrently** in the same repository — one per parent PRD:
+
+```bash
+/orchestrate 195      # window A — PRD #195's children
+/orchestrate 210      # window B — PRD #210's children
+```
+
+On startup the orchestrator scans every in-progress run and matches it by the `prd<N>-` / `backlog-` prefix of its `runId`. Invoking `/orchestrate 195` again while a `prd195-` run is still in progress **resumes** that run rather than starting a duplicate; the resumed run reloads only its own partition and never widens its scope. Two in-progress runs for the same PRD is reported as a loud error, never silently resolved.
+
+When a partitioned run's child issue is blocked by an issue **outside** the partition, the orchestrator verifies that external blocker's real state on the tracker before the dependent slice runs — if the blocker is still open, the dependent slice is skipped with a reason naming it.
+
 ## Importing Into Another Project
 
 To run orchestrate against another repository, that repository needs:

--- a/plugins/orchestrate/orchestrate-mcp/src/run-dir.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/run-dir.ts
@@ -14,10 +14,15 @@ import * as path from "path";
 // run ids can never resolve to a shared path.
 
 /**
- * Allowed `runId` shape. The skill mints run ids as `YYYYMMDD-HHMMSS`
- * timestamps, which this pattern admits. The pattern is also the path-traversal
- * guard: a `runId` flows into `path.join`, so an id like `../../etc` or one
- * carrying a separator must be rejected before it can escape the run directory.
+ * Allowed `runId` shape. The skill mints run ids in two prefixed forms:
+ * `prd<N>-<timestamp>` for a run partitioned to one parent PRD's children
+ * (e.g. `prd195-20260521-015143`), and `backlog-<timestamp>` for a
+ * no-argument whole-backlog run (e.g. `backlog-20260521-015143`). Both reduce
+ * to letters, digits, and hyphens, which this pattern admits — the `prd<N>-`
+ * prefix is also what the startup scan parses to disambiguate which run to
+ * resume. The pattern is also the path-traversal guard: a `runId` flows into
+ * `path.join`, so an id like `../../etc` or one carrying a separator must be
+ * rejected before it can escape the run directory.
  */
 const RUN_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
@@ -44,8 +49,11 @@ export type ResolveRunDirResult =
 
 /**
  * Returns true when `runId` is a safe run-directory name: a non-empty string of
- * letters, digits, underscores, and hyphens only. Anything that could traverse
- * out of the run directory (`..`, a path separator, a dot) is rejected. Pure.
+ * letters, digits, underscores, and hyphens only. This admits both prefixed
+ * forms the skill mints — `prd<N>-<timestamp>` and `backlog-<timestamp>` —
+ * since neither introduces a character outside that class. Anything that could
+ * traverse out of the run directory (`..`, a path separator, a dot) is
+ * rejected, prefix or no prefix. Pure.
  */
 export function isValidRunId(runId: string): boolean {
   return RUN_ID_PATTERN.test(runId);
@@ -53,8 +61,11 @@ export function isValidRunId(runId: string): boolean {
 
 /**
  * Resolves a `runId` to its ephemeral paths under
- * `<repoPath>/.orchestrate/runs/<runId>/`. Pure — performs no filesystem I/O;
- * the caller is responsible for `mkdirSync` before any write.
+ * `<repoPath>/.orchestrate/runs/<runId>/`. The `runId` is one of the skill's
+ * minted forms — `prd<N>-<timestamp>` or `backlog-<timestamp>` — so two
+ * concurrent runs (one partitioned, one whole-backlog) always resolve to
+ * disjoint run directories. Pure — performs no filesystem I/O; the caller is
+ * responsible for `mkdirSync` before any write.
  *
  * A malformed `runId` (one that fails {@link isValidRunId}) is returned as a
  * structured `RUN_ID_INVALID` error rather than throwing — the resolver never

--- a/plugins/orchestrate/orchestrate-mcp/test/run-dir.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/run-dir.test.ts
@@ -18,6 +18,21 @@ describe("isValidRunId", () => {
     expect(isValidRunId("A")).toBe(true);
   });
 
+  it("accepts the prd<N>-<timestamp> id of a partitioned run", () => {
+    expect(isValidRunId("prd195-20260521-015143")).toBe(true);
+  });
+
+  it("accepts the backlog-<timestamp> id of a no-argument run", () => {
+    expect(isValidRunId("backlog-20260521-015143")).toBe(true);
+  });
+
+  it("rejects a path-traversal id even with the prd<N>- prefix", () => {
+    // The prefixed forms must not weaken the path-traversal guard: a runId
+    // carrying `..` or a separator stays rejected regardless of its prefix.
+    expect(isValidRunId("prd195-../etc")).toBe(false);
+    expect(isValidRunId("backlog-../../etc")).toBe(false);
+  });
+
   it("rejects an empty string", () => {
     expect(isValidRunId("")).toBe(false);
   });
@@ -142,6 +157,23 @@ describe("resolveRunDir — per-run path isolation", () => {
           expect(ap).not.toBe(bp);
         }
       }
+    }
+  });
+
+  it("resolves a prd<N>- and a backlog- runId to disjoint run directories", () => {
+    // Two concurrent runs in one repository — one partitioned, one whole-backlog
+    // — must never resolve to a shared run directory.
+    const partitioned = resolveRunDir("/repo", "prd195-20260521-015143");
+    const wholeBacklog = resolveRunDir("/repo", "backlog-20260521-015143");
+    expect(partitioned.ok && wholeBacklog.ok).toBe(true);
+    if (partitioned.ok && wholeBacklog.ok) {
+      expect(partitioned.paths.runDir).not.toBe(wholeBacklog.paths.runDir);
+      expect(partitioned.paths.runDir).toBe(
+        path.join("/repo", ".orchestrate", "runs", "prd195-20260521-015143")
+      );
+      expect(wholeBacklog.paths.runDir).toBe(
+        path.join("/repo", ".orchestrate", "runs", "backlog-20260521-015143")
+      );
     }
   });
 

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -81,26 +81,64 @@ Every run keeps its ephemeral state in a **per-run directory**,
 `.orchestrate/` top level. The run directory's schema and rationale are in
 `references/run-state.md`.
 
-**Discover the active run.** Scan `.orchestrate/runs/*/run-state.json` for a run
-whose `status` is `in-progress`.
+**Read the invocation argument.** `/orchestrate` accepts an optional parent-PRD
+issue number — `/orchestrate <PRD#>` scopes this run to that PRD's children
+(the **run partition**); `/orchestrate` with no argument runs the whole backlog
+as one partition, unchanged. The argument decides both the `runId` form and how
+the run-discovery scan below matches:
 
-- **A run directory with an `in-progress` `run-state.json` exists** — resume it.
-  Its `runId` is the directory name. First clear that run's stale handoff flag:
-  if `.orchestrate/runs/<runId>/context-flag.json` exists, delete it — it is the
+- **`/orchestrate <PRD#>`** — a **partitioned run**. Its `runId` is
+  `prd<N>-<timestamp>` (the invoked `<PRD#>` as `<N>`). It owns only that PRD's
+  child issues.
+- **`/orchestrate` with no argument** — a **whole-backlog run**. Its `runId` is
+  `backlog-<timestamp>`. It owns the entire `ready-for-agent` backlog.
+
+The `prd<N>-` / `backlog-` prefix is durable, persisted in the `runId`, and
+self-documenting — it is the key the run-discovery scan parses to decide which
+in-progress run a new invocation matches.
+
+**Discover the active run.** Scan **every** `.orchestrate/runs/*/run-state.json`
+whose `status` is `in-progress`. For each, parse the run's match key from its
+`runId` directory name — the `prd<N>-` prefix names a partitioned run for PRD
+`<N>`, the `backlog-` prefix names a whole-backlog run. Then match against the
+current invocation:
+
+- **`/orchestrate <PRD#>`** — collect every in-progress run whose `runId`
+  starts `prd<N>-` for the invoked `<N>`.
+- **`/orchestrate` with no argument** — collect every in-progress run whose
+  `runId` starts `backlog-`.
+
+A bare-timestamp `runId` (no `prd<N>-`/`backlog-` prefix — a legacy run from
+before this scheme) matches neither and is invisible to the scan; the new
+prefixes are the only match keys. Then act on the count of matches:
+
+- **Zero matches** — no in-progress run for this invocation. Start a fresh run
+  below.
+- **Exactly one match** — resume it. Its `runId` is the directory name. First
+  clear that run's stale handoff flag: if
+  `.orchestrate/runs/<runId>/context-flag.json` exists, delete it — it is the
   predecessor's handoff trigger, now consumed, and leaving it would make this
   session hand off immediately (section 2, step 4). Then load the whole
   `run-state.json`, preserving every top-level field — `runId`,
   `umbrellaBranch`, `parentIssue`, `waves`, `completedWaves`,
-  `finalPullRequest`, and `slices`. Every slice in a terminal state (`passed`,
-  `failed`, `skipped`) is left untouched — completed work is never redone. Every
-  slice still `in-progress` was interrupted before finishing: discard its
-  partial artifacts so it re-processes cleanly — if it has a `worktreePath`,
-  call `remove_worktree` (`force: true`); delete its `sliceBranch` if it exists
-  (locally, and on the remote if it was pushed) — deleting the remote branch
-  also auto-closes any orphaned slice pull request GitHub opened for it, so
-  re-processing produces a clean branch and PR with no manual PR cleanup needed
-  — then coerce that slice back to `pending`. Skip to section 2.
-- **No run directory holds an `in-progress` run** — start a fresh run below.
+  `finalPullRequest`, and `slices`. **Resume reloads only the matched run's
+  partition and run directory** — the `slices` and `waves` already persisted in
+  its `run-state.json` are the run's scope, fixed at fresh-run time. Do **not**
+  re-fetch the backlog, do **not** re-call `filter_to_one_parent_prd` or
+  `partition_backlog`: a resumed run never widens or re-derives its own scope.
+  Every slice in a terminal state (`passed`, `failed`, `skipped`) is left
+  untouched — completed work is never redone. Every slice still `in-progress`
+  was interrupted before finishing: discard its partial artifacts so it
+  re-processes cleanly — if it has a `worktreePath`, call `remove_worktree`
+  (`force: true`); delete its `sliceBranch` if it exists (locally, and on the
+  remote if it was pushed) — deleting the remote branch also auto-closes any
+  orphaned slice pull request GitHub opened for it, so re-processing produces a
+  clean branch and PR with no manual PR cleanup needed — then coerce that slice
+  back to `pending`. Skip to section 2.
+- **Two or more matches** — a **loud error**. Two in-progress runs for the same
+  PRD (or two in-progress whole-backlog runs) must never be silently resolved
+  by picking one. Report every matching `runId` and stop. The operator resolves
+  the ambiguity — finishing or cleaning up one of the runs — before re-invoking.
 
 ### Fresh run
 
@@ -108,8 +146,12 @@ whose `status` is `in-progress`.
    - Repository root: `git rev-parse --show-toplevel`.
    - Fetch so branch operations use current refs: `git fetch origin`.
    - Confirm the integration base: `git rev-parse --verify origin/development`.
-   - Generate a `runId` from the current timestamp including seconds, e.g.
-     `20260521-015143`.
+   - Generate a `runId` by joining the invocation prefix to the current
+     timestamp including seconds. For `/orchestrate <PRD#>` the prefix is
+     `prd<N>-` (the invoked `<PRD#>` as `<N>`), so the `runId` is
+     `prd195-20260521-015143`. For `/orchestrate` with no argument the prefix
+     is `backlog-`, so the `runId` is `backlog-20260521-015143`. The prefix is
+     never omitted — it is what the run-discovery scan (above) keys on.
 2. Read the whole backlog — every open issue with the `ready-for-agent` label.
    Always use `--json`; plain `gh issue view` can fail on the projectCards
    deprecation:
@@ -129,27 +171,38 @@ whose `status` is `in-progress`.
    work). Base the tier on the issue's scope, the number of files it likely
    touches, and its risk. The tier drives routing in section 3.
 
-   Once every issue is parsed, call the **`partition_backlog` MCP tool** to
-   split the backlog into `slices` and `parentIssue`:
+   Once every issue is parsed, narrow the backlog if this is a partitioned run,
+   then call the **`partition_backlog` MCP tool** to split it into `slices` and
+   `parentIssue`:
 
-   - Pass the full backlog as the `issues` array to `partition_backlog`. It
-     returns `{ slices, parentIssue }`.
-   - `slices` is the subset of issues to process as implementation work — any
-     issue detected as the parent PRD is automatically excluded.
-   - `parentIssue` is the detected parent PRD, or `null`. The parent PRD is
-     only the progress-comment target (section 2 step 6) — it is **never**
-     enrolled as a slice.
+   - **Partitioned run (`/orchestrate <PRD#>`)** — first call the
+     **`filter_to_one_parent_prd` MCP tool**: pass the full backlog as `issues`
+     and the invoked `<PRD#>` as `prdNumber`. It returns only the issues whose
+     `parent` field equals `<PRD#>` — the run partition. If that filtered set
+     is **empty** (a wrong PRD number, or a PRD whose children are not yet
+     `ready-for-agent`), report "PRD #<PRD#> has no ready-for-agent children"
+     and stop — the same clean no-op as an empty backlog. Otherwise pass the
+     **filtered** set as the `issues` array to `partition_backlog`.
+   - **Whole-backlog run (`/orchestrate` no argument)** — pass the full backlog
+     directly as the `issues` array to `partition_backlog`; no filter step.
+   - `partition_backlog` returns `{ slices, parentIssue }`. `slices` is the
+     subset of issues to process as implementation work — any issue detected as
+     the parent PRD is automatically excluded. `parentIssue` is the detected
+     parent PRD, or `null` — only the progress-comment target (section 2
+     step 6), **never** enrolled as a slice.
    - Detection uses two signals in order: (1) a `Parent` field reference — if
      any issue names another backlog issue as its parent, that issue is the
      parent PRD; (2) the `PRD:` title heuristic — if no explicit parent
      reference exists, any issue whose title starts with `PRD:` (case-
      insensitive) is treated as the parent PRD. This ensures a decomposed PRD
      is never accidentally implemented as a slice.
-
-   To scope a run to one parent PRD's children (e.g. `/orchestrate <PRD#>`),
-   call the **`filter_to_one_parent_prd` MCP tool** first — pass the full
-   backlog and the `prdNumber`; it returns only the issues whose `parent` field
-   equals `prdNumber`, which you then pass to `partition_backlog`.
+   - **Partitioned run — hard-set `parentIssue`.** For a `/orchestrate <PRD#>`
+     run, `filter_to_one_parent_prd` has already removed the parent PRD from
+     the input, so the `parentIssue` `partition_backlog` returns may be `null`
+     or a mis-detected child. Ignore that value and use the invoked `<PRD#>` as
+     the run's `parentIssue` — write `<PRD#>` into `run-state.parentIssue`
+     (step 6) regardless of what `partition_backlog` returned. For a
+     whole-backlog run, keep the `parentIssue` `partition_backlog` returned.
 
 4. Call the `plan_waves` MCP tool with one entry per **slice** (not the full
    backlog — the parent PRD is excluded):
@@ -168,9 +221,13 @@ whose `status` is `in-progress`.
    `run-state.json` into it as `.orchestrate/runs/<runId>/run-state.json` with
    **every field the schema declares** (see `references/run-state.md`):
    - Top level: `runId`, `status: "in-progress"`, `umbrellaBranch`,
-     `integrationBase: "development"`, `parentIssue` (the parent PRD number, or
-     null), `startedAt` and `updatedAt` (current UTC time), the `waves` from
-     `plan_waves`, `completedWaves: 0`, `finalPullRequest: null`.
+     `integrationBase: "development"`, `parentIssue`, `startedAt` and
+     `updatedAt` (current UTC time), the `waves` from `plan_waves`,
+     `completedWaves: 0`, `finalPullRequest: null`. For a partitioned run,
+     `parentIssue` is the invoked `<PRD#>` (the hard-set value from step 3 —
+     never the value `partition_backlog` returned on the already-filtered set).
+     For a whole-backlog run, `parentIssue` is the parent PRD `partition_backlog`
+     detected, or `null`.
    - One `slices` entry per issue: `issue`, `title`, `wave` (its index in
      `waves`), `tier`, `blockedBy`, `state: "pending"`, `sliceBranch:
      "orchestrate/slice-<N>"`, `worktreePath: null`, `pullRequest: null`,
@@ -199,10 +256,31 @@ Process waves in order, starting at index `completedWaves`. For each wave:
    no-op fast-forward — and on a resumed run, since the wave loop is re-entered
    from this step.
 2. **Select the processable slices.** A slice in this wave is processable when
-   its state is `pending` and every id in its `blockedBy` that belongs to the
-   backlog reached `passed`. If any such blocker is `failed` or `skipped`, mark
-   this slice `skipped` with a `failureReason` naming the blocker, checkpoint,
-   and do not process it.
+   its state is `pending`, every **in-partition** blocker it depends on reached
+   `passed`, and every **out-of-partition** blocker is verified resolved.
+
+   - **In-partition blockers** — a `blockedBy` id that is itself a slice in
+     this run's `slices` map. The slice is processable only when every such
+     blocker reached `passed`. If any is `failed` or `skipped`, mark this slice
+     `skipped` with a `failureReason` naming the blocker, checkpoint, and do not
+     process it.
+   - **Out-of-partition blockers** — a `blockedBy` id that is **not** a slice
+     in this run's `slices` map. This happens on a partitioned run: a child
+     issue may be blocked by an issue outside its parent PRD. `plan_waves` does
+     not order such a blocker — it treats any id outside its input set as
+     already satisfied — so the orchestrator must verify the blocker's **real**
+     tracker state itself before the dependent slice runs:
+
+     ```
+     gh issue view <blocker-id> --json state
+     ```
+
+     A `state` of `CLOSED` (the issue is merged or closed) → the blocker is
+     resolved; the dependent slice proceeds. A `state` of `OPEN` → the external
+     blocker is unmet; mark the dependent slice `skipped` with a `failureReason`
+     naming the external blocker issue (e.g. "blocked by #<id>, an issue
+     outside this run's partition that is still open"), checkpoint, and do not
+     process it. Never silently assume an out-of-partition blocker is done.
 3. **Process the slices.** Run section 3 for every processable slice. Slices in
    a wave are independent, so parallelize: when several slices are at the same
    subagent stage (investigation, implementation, review), spawn those
@@ -465,7 +543,9 @@ A slice is **SKIPPED** (state `skipped`) when one of its blockers did not reach
 `failureReason` and checkpoint. Its tracker label stays `ready-for-agent` so a
 later run can retry it once the blocker is resolved.
 
-Other stop conditions: an empty backlog is a clean no-op; a `plan_waves`
+Other stop conditions: an empty backlog is a clean no-op, as is a
+`/orchestrate <PRD#>` run whose PRD has no `ready-for-agent` children
+(`filter_to_one_parent_prd` returns an empty set); a `plan_waves`
 `CYCLE_DETECTED` result stops the run before any branch is created.
 
 ## Tracker updates

--- a/plugins/orchestrate/skills/orchestrate/references/run-state.md
+++ b/plugins/orchestrate/skills/orchestrate/references/run-state.md
@@ -7,12 +7,15 @@ reads it on startup to resume an interrupted run instead of restarting.
 ## The per-run directory
 
 Every run keeps its ephemeral state in a **per-run directory**,
-`.orchestrate/runs/<runId>/`, where `<runId>` is the run's timestamp id. That
-directory holds the run's `run-state.json`, its `context-flag.json` (the
-context-handoff signal), and the rendered HTML artifacts (`dashboard.html`,
-`graph.html`, `report.html`). Two distinct runs never share a directory, so
-their ephemeral state never collides — the per-run layout is the structural
-foundation for concurrent runs.
+`.orchestrate/runs/<runId>/`. The `<runId>` is the run's identifier in one of
+two minted forms: `prd<N>-<timestamp>` for a **partitioned run** scoped to one
+parent PRD's children (`/orchestrate <PRD#>`), and `backlog-<timestamp>` for a
+**whole-backlog run** (`/orchestrate` with no argument). That directory holds
+the run's `run-state.json`, its `context-flag.json` (the context-handoff
+signal), and the rendered HTML artifacts (`dashboard.html`, `graph.html`,
+`report.html`). Two distinct runs never share a directory, so their ephemeral
+state never collides — the per-run layout is the structural foundation for
+concurrent runs.
 
 The committed config files — `commands.json`, `routing.json`, and
 `handoff.json` — stay flat at the `.orchestrate/` top level; they are
@@ -24,25 +27,27 @@ the target project should gitignore the `.orchestrate/runs/` directory.
 
 ```text
 .orchestrate/
-├── commands.json                 # committed config (flat, shared)
-├── routing.json                  # committed config (flat, shared)
-├── handoff.json                  # committed config (flat, shared)
+├── commands.json                      # committed config (flat, shared)
+├── routing.json                       # committed config (flat, shared)
+├── handoff.json                       # committed config (flat, shared)
 └── runs/
-    └── 20260521-015143/          # one per-run directory per run
-        ├── run-state.json        # the run checkpoint
-        ├── context-flag.json     # the context-handoff signal (when raised)
-        ├── dashboard.html        # rendered artifact
-        ├── graph.html            # rendered artifact
-        └── report.html           # rendered artifact
+    ├── prd195-20260521-015143/         # a partitioned run (PRD #195's children)
+    │   ├── run-state.json              # the run checkpoint
+    │   ├── context-flag.json           # the context-handoff signal (when raised)
+    │   ├── dashboard.html              # rendered artifact
+    │   ├── graph.html                  # rendered artifact
+    │   └── report.html                 # rendered artifact
+    └── backlog-20260521-022540/        # a concurrent whole-backlog run
+        └── run-state.json
 ```
 
 ## Schema
 
 ```json
 {
-  "runId": "20260521-015143",
+  "runId": "prd153-20260521-015143",
   "status": "in-progress",
-  "umbrellaBranch": "orchestrate/umbrella-20260521-015143",
+  "umbrellaBranch": "orchestrate/umbrella-prd153-20260521-015143",
   "integrationBase": "development",
   "parentIssue": 153,
   "startedAt": "2026-05-21T01:51:43Z",
@@ -59,7 +64,7 @@ the target project should gitignore the `.orchestrate/runs/` directory.
       "blockedBy": ["155"],
       "state": "passed",
       "sliceBranch": "orchestrate/slice-157",
-      "worktreePath": "/abs/path/.orchestrate-worktrees/20260521-015143/slice-157",
+      "worktreePath": "/abs/path/.orchestrate-worktrees/prd153-20260521-015143/slice-157",
       "pullRequest": "https://github.com/owner/repo/pull/200",
       "failureReason": null,
       "updatedAt": "2026-05-21T02:05:00Z"
@@ -70,12 +75,20 @@ the target project should gitignore the `.orchestrate/runs/` directory.
 
 ### Top-level fields
 
-- `runId` — the run's timestamp id, also embedded in the umbrella branch name.
+- `runId` — the run's identifier, also embedded in the umbrella branch name. It
+  is `prd<N>-<timestamp>` for a partitioned run (`/orchestrate <PRD#>`) and
+  `backlog-<timestamp>` for a whole-backlog run (`/orchestrate` with no
+  argument). The `prd<N>-` / `backlog-` prefix is the match key the startup
+  scan parses to decide whether a new invocation resumes this run.
 - `status` — `in-progress` while waves remain, `completed` when the run finishes.
-- `umbrellaBranch` — the branch all slice pull requests merge into.
+- `umbrellaBranch` — the branch all slice pull requests merge into. It carries
+  the `runId` (`orchestrate/umbrella-<runId>`), so two concurrent runs never
+  collide on a branch name.
 - `integrationBase` — the branch the umbrella was cut from (always `development`).
 - `parentIssue` — the parent PRD issue number the run reports progress to, or
-  `null` if the backlog issues name no parent.
+  `null` if the backlog issues name no parent. For a partitioned run it is the
+  invoked `<PRD#>`, hard-set by the skill rather than re-detected from the
+  already-filtered slice set.
 - `startedAt` / `updatedAt` — ISO-8601 UTC timestamps.
 - `waves` — the `plan_waves` output: an ordered array of waves, each an array of
   issue-id strings.
@@ -116,10 +129,27 @@ re-processed on resume.
 
 ## Resume
 
-On startup the orchestrator scans `.orchestrate/runs/*/run-state.json` for a run
-whose `status` is `in-progress`. If one is found, the run resumes: every slice
-already in a terminal state is left untouched; every `in-progress` slice has its
-partial artifacts discarded (worktree removed, slice branch deleted) and is
-coerced back to `pending` before re-processing — it is not merely continued.
-When no run directory holds an `in-progress` run — none exist, or every run's
-`status` is `completed` — a fresh run starts.
+On startup the orchestrator scans **every** `.orchestrate/runs/*/run-state.json`
+whose `status` is `in-progress` and parses each run's match key from its `runId`
+prefix — `prd<N>-` names a partitioned run for PRD `<N>`, `backlog-` names a
+whole-backlog run. It then matches against the current invocation:
+`/orchestrate <PRD#>` matches in-progress runs whose `runId` starts `prd<N>-`
+for the invoked `<N>`; `/orchestrate` with no argument matches in-progress runs
+whose `runId` starts `backlog-`. A bare-timestamp `runId` from before this
+scheme matches neither and is ignored.
+
+- **Zero matches** — a fresh run starts.
+- **Exactly one match** — that run resumes. Every slice already in a terminal
+  state is left untouched; every `in-progress` slice has its partial artifacts
+  discarded (worktree removed, slice branch deleted) and is coerced back to
+  `pending` before re-processing — it is not merely continued. Resume reloads
+  **only** the matched run's persisted `slices` and `waves`; it never re-fetches
+  the backlog or re-derives the partition, so a resumed run never widens its own
+  scope.
+- **Two or more matches** — a loud error. Two in-progress runs for the same PRD
+  (or two in-progress whole-backlog runs) is never resolved by a silent pick;
+  the orchestrator reports every matching `runId` and stops.
+
+This per-PRD match is what keeps two concurrent runs disjoint: each owns one
+parent PRD's children, recorded in its own run directory, and a re-invocation
+resumes the right one instead of duplicating it.


### PR DESCRIPTION
Closes #195

Partitions the orchestrate backlog by parent PRD so a run only picks up issues belonging to the invoked PRD, with disjointness guarantees across partitions and resume-safe partition identity. Updates run-dir documentation and the run-state reference accordingly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>