### PR TITLE
feat(orchestrate): driver-session watchdog binding

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -138,7 +138,7 @@ The per-run `.orchestrate/runs/<runId>/` directory holding that run's ephemeral 
 _Avoid_: run folder, state dir
 
 **Driver session**:
-The Claude Code session executing a run's orchestrator. Its identity is recorded in the run's run-state so the global context-watchdog binds the correct run when several runs proceed concurrently.
+The Claude Code session executing a run's orchestrator. Its `session_id` is recorded in `run-state.json` as the `driverSessionId` field — captured by the orchestrate `SessionStart` hook into `$ORCHESTRATE_SESSION_ID`, written on run start, and refreshed on resume (a successor session has a new `session_id`). The global `context-watchdog` matches `driverSessionId` against in-progress runs to bind itself to the correct run when several runs proceed concurrently; when it cannot disambiguate, or when `driverSessionId` is `null` (identity unavailable), it safely no-ops and the run loses only automatic context-handoff.
 _Avoid_: orchestrator window, owner session
 
 **Integration base**:

--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -99,6 +99,8 @@ A manifest-less repository yields `{}` — never an npm fallback — so no capab
 
 A long backlog can fill the orchestrator session's context window before every wave is done. The bundled `context-watchdog` hook (a `PostToolUse` hook) estimates context usage from the session transcript and, past a configurable threshold (default 40%), writes the active run's `.orchestrate/runs/<runId>/context-flag.json`. The orchestrator finishes the current slice, checkpoints, and calls `spawn_successor` to launch a new interactive Claude Code session that resumes from `run-state.json` — then the predecessor exits. The successor clears the stale flag on startup, so there is no handoff loop.
 
+When several runs proceed concurrently in one repository, the watchdog binds to the correct run by **driver-session identity**: a companion `SessionStart` hook captures the session's `session_id` into `$ORCHESTRATE_SESSION_ID`, the orchestrator records it as `driverSessionId` in `run-state.json` (refreshed on resume), and the watchdog matches the event's `session_id` against each in-progress run — writing the flag only under the matching run's directory. If it cannot disambiguate, or the identity is unavailable, the watchdog safely writes nothing: the run stays correct and merely loses automatic handoff, remaining manually resumable with `/orchestrate`.
+
 ## Installation
 
 ```bash
@@ -271,7 +273,8 @@ plugins/orchestrate/
 ├── .mcp.json                    # Registers the orchestrate-mcp server
 ├── README.md                    # This file
 ├── hooks/
-│   └── hooks.json               # The context-watchdog PostToolUse hook
+│   └── hooks.json               # context-watchdog (PostToolUse) +
+│                                #   session-start (SessionStart) hooks
 ├── skills/
 │   └── orchestrate/
 │       ├── SKILL.md             # The orchestrator skill
@@ -282,7 +285,8 @@ plugins/orchestrate/
 └── orchestrate-mcp/             # The MCP server (TypeScript)
     ├── src/                     # Tool implementations
     ├── test/                    # Unit suite
-    └── dist/                    # Bundled server + context-watchdog hook
+    └── dist/                    # Bundled server + context-watchdog +
+                                 #   session-start hooks
 ```
 
 ## Contributing to orchestrate-mcp
@@ -292,7 +296,7 @@ The `orchestrate-mcp/` directory contains a TypeScript MCP server whose compiled
 ```bash
 cd plugins/orchestrate/orchestrate-mcp
 npm ci          # if node_modules is stale
-npm run build   # regenerates dist/index.js and dist/context-watchdog.js
+npm run build   # regenerates dist/index.js, dist/context-watchdog.js, dist/session-start.js
 git add dist/
 ```
 

--- a/plugins/orchestrate/hooks/hooks.json
+++ b/plugins/orchestrate/hooks/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/orchestrate-mcp/dist/session-start.js\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": ".*",

--- a/plugins/orchestrate/orchestrate-mcp/dist/context-watchdog.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/context-watchdog.js
@@ -4251,14 +4251,15 @@ function readTranscriptText(transcriptPath) {
     fs2.closeSync(fd);
   }
 }
-function discoverActiveRunId(cwd) {
+function scanInProgressRuns(cwd) {
   const runsDir = path3.join(cwd, ".orchestrate", "runs");
   let entries;
   try {
     entries = fs2.readdirSync(runsDir, { withFileTypes: true });
   } catch {
-    return null;
+    return [];
   }
+  const runs = [];
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const statePath = path3.join(runsDir, entry.name, "run-state.json");
@@ -4268,10 +4269,25 @@ function discoverActiveRunId(cwd) {
     } catch {
       continue;
     }
-    if (typeof runState === "object" && runState !== null && runState.status === "in-progress") {
-      return entry.name;
+    if (typeof runState !== "object" || runState === null || runState.status !== "in-progress") {
+      continue;
     }
+    const rawId = runState.driverSessionId;
+    runs.push({
+      runId: entry.name,
+      driverSessionId: typeof rawId === "string" ? rawId : null
+    });
   }
+  return runs;
+}
+function findActiveRunForSession(cwd, sessionId) {
+  const runs = scanInProgressRuns(cwd);
+  if (runs.length === 0) return null;
+  if (typeof sessionId === "string" && sessionId.length > 0) {
+    const matches = runs.filter((r) => r.driverSessionId === sessionId);
+    if (matches.length === 1) return matches[0].runId;
+  }
+  if (runs.length === 1) return runs[0].runId;
   return null;
 }
 function runWatchdog(input) {
@@ -4345,7 +4361,8 @@ async function main() {
   try {
     const event = raw ? JSON.parse(raw) : {};
     const cwd = typeof event.cwd === "string" ? event.cwd : process.cwd();
-    const runId = discoverActiveRunId(cwd);
+    const sessionId = typeof event.session_id === "string" ? event.session_id : void 0;
+    const runId = findActiveRunForSession(cwd, sessionId);
     if (runId === null) {
       process.exit(0);
     }

--- a/plugins/orchestrate/orchestrate-mcp/dist/session-start.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/session-start.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+"use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+
+// src/hooks/session-start-cli.ts
+var fs = __toESM(require("fs"));
+
+// src/hooks/session-start.ts
+var SESSION_ID_ENV_VAR = "ORCHESTRATE_SESSION_ID";
+function shellQuote(value) {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+function buildSessionEnvLine(sessionId) {
+  if (typeof sessionId !== "string" || sessionId.length === 0) {
+    return null;
+  }
+  return `export ${SESSION_ID_ENV_VAR}=${shellQuote(sessionId)}
+`;
+}
+
+// src/hooks/session-start-cli.ts
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", () => resolve(data));
+  });
+}
+async function main() {
+  let raw = "";
+  try {
+    raw = await readStdin();
+  } catch {
+    process.exit(0);
+  }
+  try {
+    const envFile = process.env.CLAUDE_ENV_FILE;
+    if (typeof envFile !== "string" || envFile.length === 0) {
+      process.exit(0);
+    }
+    const event = raw ? JSON.parse(raw) : {};
+    const sessionId = typeof event.session_id === "string" ? event.session_id : void 0;
+    const line = buildSessionEnvLine(sessionId);
+    if (line === null) {
+      process.exit(0);
+    }
+    fs.appendFileSync(envFile, line);
+  } catch {
+  }
+  process.exit(0);
+}
+void main();

--- a/plugins/orchestrate/orchestrate-mcp/package.json
+++ b/plugins/orchestrate/orchestrate-mcp/package.json
@@ -4,7 +4,7 @@
   "description": "MCP server providing worktree lifecycle and orchestration tools for parallel Claude Code agents.",
   "main": "dist/index.js",
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/index.js && esbuild src/hooks/context-watchdog-cli.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/context-watchdog.js",
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/index.js && esbuild src/hooks/context-watchdog-cli.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/context-watchdog.js && esbuild src/hooks/session-start-cli.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/session-start.js",
     "typecheck": "node --max-old-space-size=4096 ./node_modules/typescript/bin/tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/plugins/orchestrate/orchestrate-mcp/src/hooks/context-watchdog-cli.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/hooks/context-watchdog-cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { runWatchdog, discoverActiveRunId } from "./context-watchdog.js";
+import { runWatchdog, findActiveRunForSession } from "./context-watchdog.js";
 
 // Entry point for the `context-watchdog` PostToolUse hook. Claude Code pipes
 // the hook event JSON on stdin; this script estimates the session's context
@@ -7,11 +7,15 @@ import { runWatchdog, discoverActiveRunId } from "./context-watchdog.js";
 // exits 0 — a hook must never fail a tool call — and only emits output on the
 // turn the flag is first raised, so it stays silent in unrelated sessions.
 //
-// The hook event carries only `cwd` and `transcript_path` — never a runId.
-// Run state now lives in per-run directories (.orchestrate/runs/<runId>/), so
-// the hook first discovers the active run by scanning for the single
-// in-progress run-state.json, then runs the watchdog against it. With no
-// active run, it is a silent no-op.
+// The hook event carries `cwd`, `transcript_path`, and `session_id` — never a
+// runId. Run state lives in per-run directories (.orchestrate/runs/<runId>/),
+// so the hook first discovers the active run by matching the event's
+// `session_id` against each in-progress run's recorded driver-session identity
+// (`findActiveRunForSession`), then runs the watchdog against that run. When
+// several runs proceed concurrently and the session cannot be disambiguated,
+// discovery returns null and the hook is a silent no-op — the run stays
+// correct and merely loses automatic context-handoff for this invocation.
+// With no active run at all, it is likewise a silent no-op.
 
 /** Reads all of stdin as a string. Resolves with whatever arrived on error. */
 function readStdin(): Promise<string> {
@@ -37,9 +41,13 @@ async function main(): Promise<void> {
   try {
     const event = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
     const cwd = typeof event.cwd === "string" ? event.cwd : process.cwd();
+    const sessionId =
+      typeof event.session_id === "string" ? event.session_id : undefined;
 
-    // Discover the active run; with none, the watchdog has nothing to do.
-    const runId = discoverActiveRunId(cwd);
+    // Discover the run this session drives. With concurrent runs, the session
+    // identity disambiguates; when it cannot, discovery returns null and the
+    // watchdog has nothing safe to do.
+    const runId = findActiveRunForSession(cwd, sessionId);
     if (runId === null) {
       process.exit(0);
     }

--- a/plugins/orchestrate/orchestrate-mcp/src/hooks/context-watchdog.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/hooks/context-watchdog.ts
@@ -168,26 +168,35 @@ interface ContextFlag {
   usagePercent: number;
 }
 
+/** One in-progress run discovered by {@link scanInProgressRuns}. */
+interface InProgressRun {
+  /** The run directory name — the `runId`. */
+  runId: string;
+  /**
+   * The run's recorded driver-session identity, or null when the run-state
+   * file carries no `driverSessionId` (a legacy/older checkpoint) or it is
+   * not a string.
+   */
+  driverSessionId: string | null;
+}
+
 /**
- * Scans `.orchestrate/runs/*` for the single run whose `run-state.json` has
- * `status: "in-progress"` and returns its `runId`, or null when none is found.
- * Pure-ish — reads the filesystem but never throws.
- *
- * The `PostToolUse` hook receives only the session `cwd`, not a `runId`, so the
- * watchdog must discover the active run before it can resolve the per-run
- * paths. This deliberately handles only the single-active-run case: a session
- * drives exactly one orchestration run. Disambiguating concurrent runs is a
- * separate concern and out of scope here.
+ * Scans `.orchestrate/runs/*` and returns one {@link InProgressRun} per run
+ * whose `run-state.json` has `status: "in-progress"`. Reads the filesystem but
+ * never throws — a missing runs directory yields `[]`, and a malformed or
+ * unreadable `run-state.json` is silently skipped. The `status` gate is the
+ * only inclusion rule: completed runs are never returned.
  */
-export function discoverActiveRunId(cwd: string): string | null {
+function scanInProgressRuns(cwd: string): InProgressRun[] {
   const runsDir = path.join(cwd, ".orchestrate", "runs");
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(runsDir, { withFileTypes: true });
   } catch {
-    return null;
+    return [];
   }
 
+  const runs: InProgressRun[] = [];
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const statePath = path.join(runsDir, entry.name, "run-state.json");
@@ -198,13 +207,80 @@ export function discoverActiveRunId(cwd: string): string | null {
       continue;
     }
     if (
-      typeof runState === "object" &&
-      runState !== null &&
-      (runState as Record<string, unknown>).status === "in-progress"
+      typeof runState !== "object" ||
+      runState === null ||
+      (runState as Record<string, unknown>).status !== "in-progress"
     ) {
-      return entry.name;
+      continue;
     }
+    // A missing or non-string driverSessionId degrades to null — never a
+    // crash. Legacy run-state files predate this field entirely.
+    const rawId = (runState as Record<string, unknown>).driverSessionId;
+    runs.push({
+      runId: entry.name,
+      driverSessionId: typeof rawId === "string" ? rawId : null,
+    });
   }
+  return runs;
+}
+
+/**
+ * Scans `.orchestrate/runs/*` for the single run whose `run-state.json` has
+ * `status: "in-progress"` and returns its `runId`, or null when none is found.
+ * Pure-ish — reads the filesystem but never throws.
+ *
+ * The `PostToolUse` hook receives only the session `cwd`, not a `runId`, so the
+ * watchdog must discover the active run before it can resolve the per-run
+ * paths. This handles only the single-active-run case and is retained for that
+ * path; {@link findActiveRunForSession} extends it to disambiguate concurrent
+ * runs by the driver-session identity (#196).
+ */
+export function discoverActiveRunId(cwd: string): string | null {
+  const runs = scanInProgressRuns(cwd);
+  return runs.length > 0 ? runs[0].runId : null;
+}
+
+/**
+ * Resolves which in-progress run a watchdog invocation belongs to, given the
+ * session id the hook event carried. Reads the filesystem but never throws.
+ *
+ * The decision binds the global `PostToolUse` watchdog to the correct run when
+ * several runs proceed concurrently in one repository (#196):
+ *
+ * - Only runs whose `run-state.json` `status` is `in-progress` are considered.
+ * - When `sessionId` is given and **exactly one** in-progress run records a
+ *   matching `driverSessionId`, that run is returned — the positive identity
+ *   match.
+ * - Otherwise, when **exactly one** run is in-progress at all, it is returned:
+ *   with a single run there is no "wrong run" to mistakenly flag, so the
+ *   watchdog still acts even if no session identity is available or matched
+ *   (this also covers legacy run-state files with no `driverSessionId`).
+ * - In every other case — two or more in-progress runs with no unambiguous
+ *   single match — the watchdog cannot disambiguate and `null` is returned, so
+ *   the caller safely no-ops rather than risk flagging the wrong run.
+ *
+ * Returning `null` is always safe: the run stays correct and merely loses
+ * automatic context-handoff for this invocation.
+ */
+export function findActiveRunForSession(
+  cwd: string,
+  sessionId: string | undefined
+): string | null {
+  const runs = scanInProgressRuns(cwd);
+  if (runs.length === 0) return null;
+
+  // Positive identity match: exactly one in-progress run claims this session.
+  if (typeof sessionId === "string" && sessionId.length > 0) {
+    const matches = runs.filter((r) => r.driverSessionId === sessionId);
+    if (matches.length === 1) return matches[0].runId;
+    // matches.length >= 2 — the same session id binds multiple runs, which is
+    // ambiguous; fall through to the single-run fast path, which also fails.
+  }
+
+  // Single-run fast path: one in-progress run means no "wrong run" exists.
+  if (runs.length === 1) return runs[0].runId;
+
+  // Two or more in-progress runs and no unambiguous match — cannot decide.
   return null;
 }
 

--- a/plugins/orchestrate/orchestrate-mcp/src/hooks/session-start-cli.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/hooks/session-start-cli.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import * as fs from "fs";
+import { buildSessionEnvLine } from "./session-start.js";
+
+// Entry point for the orchestrate `SessionStart` hook. Claude Code pipes the
+// hook event JSON on stdin and exposes a `CLAUDE_ENV_FILE` env var pointing at
+// a file whose `export` lines are sourced into every subsequent Bash command of
+// the session.
+//
+// This hook captures the session's own `session_id` and persists it as
+// `ORCHESTRATE_SESSION_ID`, so the orchestrator — the sole Bash owner — can
+// read `$ORCHESTRATE_SESSION_ID` at run start and record it in run-state as the
+// run's driver-session identity. The context-watchdog later matches that
+// identity to bind itself to the correct run when several runs proceed
+// concurrently in one repository.
+//
+// It always exits 0 — a hook must never fail a session — and is a silent no-op
+// when `CLAUDE_ENV_FILE` is unset or `session_id` is absent. That negative path
+// is safe: the orchestrator simply finds `$ORCHESTRATE_SESSION_ID` empty,
+// records no identity, and the run proceeds without automatic context-handoff.
+
+/** Reads all of stdin as a string. Resolves with whatever arrived on error. */
+function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", () => resolve(data));
+  });
+}
+
+async function main(): Promise<void> {
+  let raw = "";
+  try {
+    raw = await readStdin();
+  } catch {
+    process.exit(0);
+  }
+
+  try {
+    const envFile = process.env.CLAUDE_ENV_FILE;
+    // No env file to persist into — nothing to do. The orchestrator's
+    // safe-no-op fallback covers the missing-identity case.
+    if (typeof envFile !== "string" || envFile.length === 0) {
+      process.exit(0);
+    }
+
+    const event = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+    const sessionId =
+      typeof event.session_id === "string" ? event.session_id : undefined;
+
+    const line = buildSessionEnvLine(sessionId);
+    if (line === null) {
+      process.exit(0);
+    }
+
+    // Append (not overwrite) — other SessionStart hooks may share the file.
+    fs.appendFileSync(envFile, line);
+  } catch {
+    // Any failure is swallowed — the hook must not disrupt the session.
+  }
+  process.exit(0);
+}
+
+void main();

--- a/plugins/orchestrate/orchestrate-mcp/src/hooks/session-start.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/hooks/session-start.ts
@@ -1,0 +1,35 @@
+// Pure core for the orchestrate `SessionStart` hook. The hook captures the
+// session's own `session_id` so the orchestrator can record it in run-state as
+// the run's driver-session identity — the key the context-watchdog matches to
+// bind itself to the correct run when several runs proceed concurrently.
+//
+// The functions here are pure (no I/O) and so directly unit-testable; the CLI
+// shell (`session-start-cli.ts`) wires them to stdin and `CLAUDE_ENV_FILE`.
+
+/** The env var the orchestrator reads to learn its own session identity. */
+export const SESSION_ID_ENV_VAR = "ORCHESTRATE_SESSION_ID";
+
+/**
+ * Single-quotes a value for safe inclusion in a POSIX shell `export`. Any
+ * embedded single quote is escaped as `'\''` — close, escaped quote, reopen —
+ * so an unexpected `session_id` shape can never break the shell parse of the
+ * `CLAUDE_ENV_FILE`. Pure.
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Builds the `export` line to append to `CLAUDE_ENV_FILE` for the given
+ * `session_id`, or null when the id is absent or empty — in which case the hook
+ * writes nothing and the orchestrator's safe-no-op fallback applies. The line
+ * is newline-terminated and shell-quoted. Pure.
+ */
+export function buildSessionEnvLine(
+  sessionId: string | undefined
+): string | null {
+  if (typeof sessionId !== "string" || sessionId.length === 0) {
+    return null;
+  }
+  return `export ${SESSION_ID_ENV_VAR}=${shellQuote(sessionId)}\n`;
+}

--- a/plugins/orchestrate/orchestrate-mcp/test/context-watchdog.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/context-watchdog.test.ts
@@ -8,6 +8,7 @@ import {
   evaluateWatchdog,
   runWatchdog,
   discoverActiveRunId,
+  findActiveRunForSession,
 } from "../src/hooks/context-watchdog.js";
 
 // ─── Transcript fixtures ──────────────────────────────────────────────────────
@@ -245,6 +246,186 @@ describe("discoverActiveRunId", () => {
   });
 });
 
+// ─── findActiveRunForSession ──────────────────────────────────────────────────
+
+/**
+ * Writes one per-run directory with a `run-state.json` carrying the given
+ * `status` and (optionally) `driverSessionId`, inside an existing project dir.
+ */
+function writeRun(
+  dir: string,
+  runId: string,
+  status: string,
+  driverSessionId?: string
+): void {
+  const runDir = path.join(dir, ".orchestrate", "runs", runId);
+  fs.mkdirSync(runDir, { recursive: true });
+  const state: Record<string, unknown> = { runId, status };
+  if (driverSessionId !== undefined) state.driverSessionId = driverSessionId;
+  fs.writeFileSync(
+    path.join(runDir, "run-state.json"),
+    JSON.stringify(state)
+  );
+}
+
+/** A bare temp project dir with no run directories yet. */
+function emptyProject(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-watchdog-"));
+  created.push(dir);
+  return dir;
+}
+
+describe("findActiveRunForSession — identity match", () => {
+  it("returns the run whose driverSessionId matches the given session", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "in-progress", "session-A");
+    writeRun(dir, "20260202-000000", "in-progress", "session-B");
+
+    expect(findActiveRunForSession(dir, "session-A")).toBe("20260101-000000");
+    expect(findActiveRunForSession(dir, "session-B")).toBe("20260202-000000");
+  });
+
+  it("matches by identity even when one run-state lacks driverSessionId", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "in-progress", "session-A");
+    writeRun(dir, "20260202-000000", "in-progress"); // legacy: no field
+
+    expect(findActiveRunForSession(dir, "session-A")).toBe("20260101-000000");
+  });
+});
+
+describe("findActiveRunForSession — safe no-op on ambiguity", () => {
+  it("returns null when 2 in-progress runs and no session is given", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "in-progress", "session-A");
+    writeRun(dir, "20260202-000000", "in-progress", "session-B");
+
+    expect(findActiveRunForSession(dir, undefined)).toBeNull();
+  });
+
+  it("returns null when 2 in-progress runs and the session matches none", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "in-progress", "session-A");
+    writeRun(dir, "20260202-000000", "in-progress", "session-B");
+
+    expect(findActiveRunForSession(dir, "session-Z")).toBeNull();
+  });
+
+  it("returns null when 2 in-progress runs both lack driverSessionId", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "in-progress");
+    writeRun(dir, "20260202-000000", "in-progress");
+
+    expect(findActiveRunForSession(dir, "session-A")).toBeNull();
+  });
+
+  it("returns null when a session matches two in-progress runs", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "in-progress", "session-A");
+    writeRun(dir, "20260202-000000", "in-progress", "session-A");
+
+    expect(findActiveRunForSession(dir, "session-A")).toBeNull();
+  });
+});
+
+describe("findActiveRunForSession — single in-progress fast path", () => {
+  it("returns the sole in-progress run when no session is given", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "in-progress", "session-A");
+
+    expect(findActiveRunForSession(dir, undefined)).toBe("20260101-000000");
+  });
+
+  it("returns the sole in-progress run when the session does not match", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "in-progress", "session-A");
+
+    expect(findActiveRunForSession(dir, "session-Z")).toBe("20260101-000000");
+  });
+
+  it("returns the sole in-progress run when it has no driverSessionId", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "in-progress"); // legacy run-state
+
+    expect(findActiveRunForSession(dir, "session-A")).toBe("20260101-000000");
+    expect(findActiveRunForSession(dir, undefined)).toBe("20260101-000000");
+  });
+});
+
+describe("findActiveRunForSession — in-progress-only scan", () => {
+  it("never selects a completed run, even when its session matches", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "completed", "session-A");
+    writeRun(dir, "20260202-000000", "in-progress", "session-B");
+
+    // The completed run carries session-A. Called with session-A, the
+    // completed run is excluded from the scan entirely; the only in-progress
+    // run (session-B) is then returned by the single-run fast path — the
+    // completed run is never the answer.
+    expect(findActiveRunForSession(dir, "session-A")).toBe("20260202-000000");
+    expect(findActiveRunForSession(dir, "session-B")).toBe("20260202-000000");
+  });
+
+  it("returns null when a completed run matches and 2+ runs are in-progress", () => {
+    const dir = emptyProject();
+    // A completed run carries session-A; two distinct in-progress runs exist.
+    writeRun(dir, "20260101-000000", "completed", "session-A");
+    writeRun(dir, "20260202-000000", "in-progress", "session-B");
+    writeRun(dir, "20260303-000000", "in-progress", "session-C");
+
+    // session-A matches only the completed (excluded) run — no in-progress
+    // match, and 2 in-progress runs is ambiguous, so the result is null. The
+    // completed run is never selected.
+    expect(findActiveRunForSession(dir, "session-A")).toBeNull();
+  });
+
+  it("the lone in-progress run wins when the other run is completed", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "completed", "session-A");
+    writeRun(dir, "20260202-000000", "in-progress", "session-B");
+
+    // Only one in-progress run, so the fast path applies even with no session.
+    expect(findActiveRunForSession(dir, undefined)).toBe("20260202-000000");
+  });
+
+  it("returns null when no run is in-progress", () => {
+    const dir = emptyProject();
+    writeRun(dir, "20260101-000000", "completed", "session-A");
+
+    expect(findActiveRunForSession(dir, "session-A")).toBeNull();
+  });
+
+  it("returns null when there is no .orchestrate/runs directory", () => {
+    const dir = emptyProject();
+    expect(findActiveRunForSession(dir, "session-A")).toBeNull();
+  });
+
+  it("ignores a malformed run-state.json without crashing", () => {
+    const dir = emptyProject();
+    const runDir = path.join(dir, ".orchestrate", "runs", "20260101-000000");
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(path.join(runDir, "run-state.json"), "{ not json");
+    writeRun(dir, "20260202-000000", "in-progress", "session-B");
+
+    expect(findActiveRunForSession(dir, "session-B")).toBe("20260202-000000");
+  });
+
+  it("ignores a non-string driverSessionId without crashing", () => {
+    const dir = emptyProject();
+    const runDir = path.join(dir, ".orchestrate", "runs", "20260101-000000");
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(runDir, "run-state.json"),
+      JSON.stringify({ status: "in-progress", driverSessionId: 42 })
+    );
+    writeRun(dir, "20260202-000000", "in-progress", "session-B");
+
+    // The numeric driverSessionId can never match a string session id.
+    expect(findActiveRunForSession(dir, "session-B")).toBe("20260202-000000");
+    expect(findActiveRunForSession(dir, "session-A")).toBeNull();
+  });
+});
+
 // ─── runWatchdog ──────────────────────────────────────────────────────────────
 
 describe("runWatchdog — no active run", () => {
@@ -415,5 +596,91 @@ describe("runWatchdog — active run", () => {
 
     expect(result.flagRaised).toBe(true);
     expect(result.evaluation!.usedTokens).toBe(108002);
+  });
+});
+
+// ─── concurrent-run binding: discovery + runWatchdog end to end ────────────────
+//
+// These cover the acceptance criteria as the CLI exercises them: discover the
+// run for a session id, then raise that run's flag — and only that run's flag.
+
+describe("session-bound watchdog — concurrent runs", () => {
+  /**
+   * Builds a project with two concurrent in-progress runs, each with its own
+   * over-threshold transcript, distinct `driverSessionId`s, and per-run dirs.
+   */
+  function twoRunProject(): {
+    dir: string;
+    transcriptPath: string;
+    runA: string;
+    runB: string;
+  } {
+    const dir = emptyProject();
+    const runA = "20260101-000000";
+    const runB = "20260202-000000";
+    writeRun(dir, runA, "in-progress", "session-A");
+    writeRun(dir, runB, "in-progress", "session-B");
+    const transcriptPath = path.join(dir, "transcript.jsonl");
+    fs.writeFileSync(transcriptPath, assistantLine(2, 8000, 100000));
+    return { dir, transcriptPath, runA, runB };
+  }
+
+  it("raises only the matching run's flag and never the other run's", () => {
+    const { dir, transcriptPath, runA, runB } = twoRunProject();
+
+    const runId = findActiveRunForSession(dir, "session-A");
+    expect(runId).toBe(runA);
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: runId! });
+
+    expect(result.flagRaised).toBe(true);
+    expect(fs.existsSync(flagPath(dir, runA))).toBe(true);
+    // The wrong run's flag is never written.
+    expect(fs.existsSync(flagPath(dir, runB))).toBe(false);
+  });
+
+  it("writes no flag for any run when the session is unknown (ambiguous)", () => {
+    const { dir, runA, runB } = twoRunProject();
+
+    const runId = findActiveRunForSession(dir, "session-unknown");
+    expect(runId).toBeNull();
+    // The CLI would exit(0) here — no run is selected, so no flag is written.
+    expect(fs.existsSync(flagPath(dir, runA))).toBe(false);
+    expect(fs.existsSync(flagPath(dir, runB))).toBe(false);
+  });
+
+  it("writes no flag for any run when no session is available (ambiguous)", () => {
+    const { dir, runA, runB } = twoRunProject();
+
+    const runId = findActiveRunForSession(dir, undefined);
+    expect(runId).toBeNull();
+    expect(fs.existsSync(flagPath(dir, runA))).toBe(false);
+    expect(fs.existsSync(flagPath(dir, runB))).toBe(false);
+  });
+
+  it("never raises a completed run's flag even when its session matches", () => {
+    const dir = emptyProject();
+    const done = "20260101-000000";
+    const activeB = "20260202-000000";
+    const activeC = "20260303-000000";
+    // A completed run carries session-A; two concurrent runs are in-progress.
+    writeRun(dir, done, "completed", "session-A");
+    writeRun(dir, activeB, "in-progress", "session-B");
+    writeRun(dir, activeC, "in-progress", "session-C");
+    const transcriptPath = path.join(dir, "transcript.jsonl");
+    fs.writeFileSync(transcriptPath, assistantLine(2, 8000, 100000));
+
+    // session-A matches only the completed (scan-excluded) run. With two
+    // in-progress runs and no positive match, discovery returns null.
+    const runId = findActiveRunForSession(dir, "session-A");
+    expect(runId).toBeNull();
+    // No flag is written anywhere — least of all the completed run's.
+    expect(fs.existsSync(flagPath(dir, done))).toBe(false);
+    expect(fs.existsSync(flagPath(dir, activeB))).toBe(false);
+    expect(fs.existsSync(flagPath(dir, activeC))).toBe(false);
+
+    // runWatchdog also refuses to act on a non-in-progress run directly.
+    const result = runWatchdog({ transcriptPath, cwd: dir, runId: done });
+    expect(result.acted).toBe(false);
+    expect(fs.existsSync(flagPath(dir, done))).toBe(false);
   });
 });

--- a/plugins/orchestrate/orchestrate-mcp/test/session-start.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/session-start.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  SESSION_ID_ENV_VAR,
+  shellQuote,
+  buildSessionEnvLine,
+} from "../src/hooks/session-start.js";
+
+// ─── shellQuote ───────────────────────────────────────────────────────────────
+
+describe("shellQuote", () => {
+  it("wraps an ordinary value in single quotes", () => {
+    expect(shellQuote("abc123")).toBe("'abc123'");
+  });
+
+  it("escapes an embedded single quote as '\\'' ", () => {
+    // close-quote, escaped quote, reopen-quote.
+    expect(shellQuote("a'b")).toBe("'a'\\''b'");
+  });
+
+  it("leaves shell metacharacters inert inside the quotes", () => {
+    const quoted = shellQuote("$(rm -rf /); `whoami`");
+    expect(quoted).toBe("'$(rm -rf /); `whoami`'");
+  });
+
+  it("quotes an empty string", () => {
+    expect(shellQuote("")).toBe("''");
+  });
+});
+
+// ─── buildSessionEnvLine ──────────────────────────────────────────────────────
+
+describe("buildSessionEnvLine", () => {
+  it("builds an export line for a normal session id", () => {
+    expect(buildSessionEnvLine("abc123")).toBe(
+      `export ${SESSION_ID_ENV_VAR}='abc123'\n`
+    );
+  });
+
+  it("uses ORCHESTRATE_SESSION_ID as the variable name", () => {
+    expect(SESSION_ID_ENV_VAR).toBe("ORCHESTRATE_SESSION_ID");
+    expect(buildSessionEnvLine("s")).toContain("ORCHESTRATE_SESSION_ID=");
+  });
+
+  it("terminates the line with a newline so it appends cleanly", () => {
+    expect(buildSessionEnvLine("s")!.endsWith("\n")).toBe(true);
+  });
+
+  it("shell-quotes a session id carrying a single quote", () => {
+    expect(buildSessionEnvLine("a'b")).toBe(
+      `export ${SESSION_ID_ENV_VAR}='a'\\''b'\n`
+    );
+  });
+
+  it("returns null for an undefined session id", () => {
+    expect(buildSessionEnvLine(undefined)).toBeNull();
+  });
+
+  it("returns null for an empty session id", () => {
+    expect(buildSessionEnvLine("")).toBeNull();
+  });
+});

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -91,7 +91,13 @@ whose `status` is `in-progress`.
   session hand off immediately (section 2, step 4). Then load the whole
   `run-state.json`, preserving every top-level field — `runId`,
   `umbrellaBranch`, `parentIssue`, `waves`, `completedWaves`,
-  `finalPullRequest`, and `slices`. Every slice in a terminal state (`passed`,
+  `finalPullRequest`, and `slices`. **Refresh the `driverSessionId` field** —
+  this resuming session is a new Claude Code session with a *new* `session_id`,
+  so overwrite `driverSessionId` with the current `$ORCHESTRATE_SESSION_ID`
+  (or `null` if it is empty or unset — applying the same operator notice as the
+  fresh-run step 6). Without this refresh the `context-watchdog` would keep
+  matching the predecessor's stale identity and automatic context-handoff would
+  be lost for the rest of the run. Every slice in a terminal state (`passed`,
   `failed`, `skipped`) is left untouched — completed work is never redone. Every
   slice still `in-progress` was interrupted before finishing: discard its
   partial artifacts so it re-processes cleanly — if it has a `worktreePath`,
@@ -99,7 +105,8 @@ whose `status` is `in-progress`.
   (locally, and on the remote if it was pushed) — deleting the remote branch
   also auto-closes any orphaned slice pull request GitHub opened for it, so
   re-processing produces a clean branch and PR with no manual PR cleanup needed
-  — then coerce that slice back to `pending`. Skip to section 2.
+  — then coerce that slice back to `pending`. Checkpoint the refreshed
+  `run-state.json`, then skip to section 2.
 - **No run directory holds an `in-progress` run** — start a fresh run below.
 
 ### Fresh run
@@ -167,10 +174,23 @@ whose `status` is `in-progress`.
 6. Create the run directory `.orchestrate/runs/<runId>/`, then write the initial
    `run-state.json` into it as `.orchestrate/runs/<runId>/run-state.json` with
    **every field the schema declares** (see `references/run-state.md`):
-   - Top level: `runId`, `status: "in-progress"`, `umbrellaBranch`,
-     `integrationBase: "development"`, `parentIssue` (the parent PRD number, or
-     null), `startedAt` and `updatedAt` (current UTC time), the `waves` from
-     `plan_waves`, `completedWaves: 0`, `finalPullRequest: null`.
+   - Top level: `runId`, `status: "in-progress"`, `driverSessionId` (see the
+     paragraph below), `umbrellaBranch`, `integrationBase: "development"`,
+     `parentIssue` (the parent PRD number, or null), `startedAt` and
+     `updatedAt` (current UTC time), the `waves` from `plan_waves`,
+     `completedWaves: 0`, `finalPullRequest: null`.
+
+   **Record the driver-session identity.** Read the environment variable
+   `$ORCHESTRATE_SESSION_ID` — the orchestrate `SessionStart` hook captures the
+   session's own `session_id` and persists it there. Write its value as
+   `driverSessionId` in `run-state.json`. This binds the global
+   `context-watchdog` to this run when several runs proceed concurrently in one
+   repository (see section 4). If `$ORCHESTRATE_SESSION_ID` is **empty or
+   unset** — the hook did not run, or the environment did not surface it — set
+   `driverSessionId` to `null` and **tell the operator**: the run proceeds
+   normally but **without automatic context-handoff**; should this session's
+   context fill, the operator must resume the run manually by invoking
+   `/orchestrate` in a new session.
    - One `slices` entry per issue: `issue`, `title`, `wave` (its index in
      `waves`), `tier`, `blockedBy`, `state: "pending"`, `sliceBranch:
      "orchestrate/slice-<N>"`, `worktreePath: null`, `pullRequest: null`,
@@ -410,6 +430,16 @@ When the wave loop (section 2, step 4) sees that flag, hand the run off to a
 fresh Claude Code session instead of continuing — the successor resumes from
 the `run-state.json` checkpoint exactly as section 1 describes. See
 `references/context-handoff.md` for the full mechanism.
+
+The watchdog binds to the correct run by matching this session's identity:
+it compares the hook event's `session_id` against each in-progress run's
+`driverSessionId`, and writes the flag only under the matching run's directory.
+When several runs proceed concurrently and the session cannot be disambiguated,
+the watchdog writes no flag — that run stays correct and merely loses automatic
+context-handoff. The same **degraded mode** applies when `driverSessionId` is
+`null` because `$ORCHESTRATE_SESSION_ID` was unavailable at run start (section 1,
+step 6): the run is unaffected except that it will not hand off automatically,
+and the operator was already told to resume it manually if needed.
 
 To hand off:
 

--- a/plugins/orchestrate/skills/orchestrate/references/context-handoff.md
+++ b/plugins/orchestrate/skills/orchestrate/references/context-handoff.md
@@ -11,23 +11,47 @@ checkpoint, and the predecessor exits. This file documents the three pieces.
 (`hooks/hooks.json`). It runs after every tool call, asynchronously, and is a
 **silent no-op unless an orchestration run is in progress**.
 
-The hook event carries only the session `cwd` and `transcript_path` — never a
-runId. The watchdog therefore first **discovers the active run**: it scans
-`.orchestrate/runs/*/run-state.json` for the single run whose `status` is
-`in-progress`. With no active run it does nothing, so it is harmless in
-unrelated sessions even though the plugin is always enabled.
+The hook event carries the session `cwd`, `transcript_path`, and `session_id`
+— never a runId. The watchdog therefore first **discovers the run this session
+drives**:
 
-When a run is active it:
+- It scans `.orchestrate/runs/*/run-state.json` and considers **only** runs
+  whose `status` is `in-progress` — a completed run is never selected.
+- When the event's `session_id` matches exactly one in-progress run's
+  `driverSessionId`, that run is selected — the positive identity match. This
+  is what binds the watchdog to the right run when several runs proceed
+  concurrently in one repository.
+- When exactly one run is in-progress at all, it is selected even with no
+  identity match: with a single run there is no "wrong run" to flag, so the
+  watchdog still acts (this also covers a legacy `run-state.json` with no
+  `driverSessionId`).
+- Otherwise — two or more in-progress runs with no unambiguous single match —
+  the watchdog **cannot disambiguate and writes no flag**. The run stays
+  correct; it merely loses automatic context-handoff for that invocation. The
+  watchdog never writes the wrong run's `context-flag.json`.
+
+The session's own identity is supplied by a companion `SessionStart` hook (also
+in `hooks/hooks.json`): it captures the session `session_id` and persists it as
+`ORCHESTRATE_SESSION_ID` into `CLAUDE_ENV_FILE`. The orchestrator reads
+`$ORCHESTRATE_SESSION_ID` at run start and records it as `driverSessionId` in
+`run-state.json`; a resuming successor session refreshes the field with its own
+new `session_id`. When the identity is unavailable, `driverSessionId` is `null`
+and the run runs in the degraded, no-auto-handoff mode described above.
+
+With no active run the watchdog does nothing, so it is harmless in unrelated
+sessions even though the plugin is always enabled.
+
+When a run is selected it:
 
 1. Reads the session transcript and finds the latest assistant turn's token
    usage (`input_tokens` + `cache_creation_input_tokens` +
    `cache_read_input_tokens`).
 2. Compares that against the context window and threshold from
    `.orchestrate/handoff.json` (defaults: 40% of a 200000-token window).
-3. On the first sample that reaches the threshold, writes the discovered run's
-   `.orchestrate/runs/<runId>/context-flag.json` and surfaces a `systemMessage`.
-   The flag is written **at most once per run** — once it exists, later samples
-   are no-ops.
+3. On the first sample that reaches the threshold, writes the selected run's
+   `.orchestrate/runs/<runId>/context-flag.json` — under that run's own run
+   directory, never another's — and surfaces a `systemMessage`. The flag is
+   written **at most once per run** — once it exists, later samples are no-ops.
 
 The hook never throws and never blocks a tool call; a watchdog that disrupts
 the session would be worse than one that misses.

--- a/plugins/orchestrate/skills/orchestrate/references/run-state.md
+++ b/plugins/orchestrate/skills/orchestrate/references/run-state.md
@@ -42,6 +42,7 @@ the target project should gitignore the `.orchestrate/runs/` directory.
 {
   "runId": "20260521-015143",
   "status": "in-progress",
+  "driverSessionId": "abc123-session-uuid",
   "umbrellaBranch": "orchestrate/umbrella-20260521-015143",
   "integrationBase": "development",
   "parentIssue": 153,
@@ -72,6 +73,14 @@ the target project should gitignore the `.orchestrate/runs/` directory.
 
 - `runId` — the run's timestamp id, also embedded in the umbrella branch name.
 - `status` — `in-progress` while waves remain, `completed` when the run finishes.
+- `driverSessionId` — the Claude Code `session_id` of the session executing
+  this run's orchestrator. Written on run start from `$ORCHESTRATE_SESSION_ID`
+  (set by the `SessionStart` hook) and **refreshed on resume** — a successor
+  session resumes under a new `session_id`, so the field is overwritten when
+  the run is picked up. It binds the global `context-watchdog` to the correct
+  run when several runs proceed concurrently. May be **absent** on a legacy
+  checkpoint or when the orchestrator could not read its own session identity;
+  the watchdog degrades to a safe no-op rather than crashing when it is missing.
 - `umbrellaBranch` — the branch all slice pull requests merge into.
 - `integrationBase` — the branch the umbrella was cut from (always `development`).
 - `parentIssue` — the parent PRD issue number the run reports progress to, or


### PR DESCRIPTION
Closes #196

Binds the context watchdog to the driver session via a new SessionStart hook so the watchdog raises the context flag only for the run owned by the active driver session, with a safe no-op fallback when multiple in-progress runs cannot be disambiguated.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>