### PR TITLE
feat(orchestrate): run cleanup — sweep and /orchestrate-clean

### DIFF
--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -56,6 +56,7 @@ The plugin bundles `orchestrate-mcp`, a Model Context Protocol server providing 
 | `resolve_routing` | Resolve the model and effort variant for each role from a complexity tier |
 | `validate_envelope` | Validate a subagent's result envelope against its role schema — distinguishes a valid, a truncated/invalid, and a missing envelope |
 | `recover_changed_files` | Recover a worktree's changed-file set by inspecting it directly — the orchestrator's fallback when an envelope is missing or invalid |
+| `clean_runs` | Remove a concluded run's worktrees, branches, and run directory once its final pull request has merged — git + filesystem only |
 | `render_dashboard` / `render_graph` / `render_report` | Render standalone HTML artifacts from the run state |
 | `spawn_successor` | Launch a fresh Claude Code session that resumes the run |
 | `search_structural` | Syntax-aware (ast-grep) code search, with a text-search fallback |
@@ -130,6 +131,28 @@ If the plugin is installed at user scope (the default), the namespace prefix is 
 ```
 
 The run is autonomous — it processes the whole backlog, resolves conflicts, checkpoints, hands off if its context fills, and ends by opening the final umbrella pull request. To resume an interrupted run, invoke `/orchestrate` again in the same repository: it scans `.orchestrate/runs/*/run-state.json` for an in-progress run and continues from the last checkpoint.
+
+### Cleaning up concluded runs
+
+Each run leaves a footprint behind — its run directory under `.orchestrate/runs/`, its worktrees, and its umbrella and slice branches. Every `/orchestrate` invocation begins with a **start-of-run sweep** that removes the footprint of any run whose final integration pull request has already merged into `development`, so leftovers do not accumulate.
+
+To run the same cleanup on demand without starting a run, invoke the `clean` mode:
+
+```bash
+/orchestrate clean
+```
+
+`/orchestrate clean` enumerates every run under `.orchestrate/runs/`, checks each one's final pull request, and:
+
+- **Removes** a run whose final pull request has **merged** into `development` — its run directory, its worktrees, and its umbrella and slice branches (locally and on the remote).
+- **Leaves intact and reports** a run whose final pull request is still open or was closed unmerged — cleanup is gated strictly on the merge.
+- **Preserves** a failed slice's worktree (and keeps that run's directory) so you can still inspect it. Pass `--force` to remove failed-slice worktrees too:
+
+```bash
+/orchestrate clean --force
+```
+
+`/orchestrate clean` never starts an orchestration run — it cleans up and stops. The merge check is best-effort and idempotent, so re-running it is always safe.
 
 ## Importing Into Another Project
 

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -3226,8 +3226,8 @@ var require_utils = __commonJS({
       }
       return ind;
     }
-    function removeDotSegments(path7) {
-      let input = path7;
+    function removeDotSegments(path8) {
+      let input = path8;
       const output = [];
       let nextSlash = -1;
       let len = 0;
@@ -3479,8 +3479,8 @@ var require_schemes = __commonJS({
         wsComponent.secure = void 0;
       }
       if (wsComponent.resourceName) {
-        const [path7, query] = wsComponent.resourceName.split("?");
-        wsComponent.path = path7 && path7 !== "/" ? path7 : void 0;
+        const [path8, query] = wsComponent.resourceName.split("?");
+        wsComponent.path = path8 && path8 !== "/" ? path8 : void 0;
         wsComponent.query = query;
         wsComponent.resourceName = void 0;
       }
@@ -6873,12 +6873,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs7, exportName) {
+    function addFormats(ajv, list, fs8, exportName) {
       var _a;
       var _b;
       (_a = (_b = ajv.opts.code).formats) !== null && _a !== void 0 ? _a : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs7[f]);
+        ajv.addFormat(f, fs8[f]);
     }
     module2.exports = exports2 = formatsPlugin;
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -7364,8 +7364,8 @@ function getErrorMap() {
 
 // node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
-  const { data, path: path7, errorMaps, issueData } = params;
-  const fullPath = [...path7, ...issueData.path || []];
+  const { data, path: path8, errorMaps, issueData } = params;
+  const fullPath = [...path8, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -7481,11 +7481,11 @@ var errorUtil;
 
 // node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path7, key) {
+  constructor(parent, value, path8, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path7;
+    this._path = path8;
     this._key = key;
   }
   get path() {
@@ -11123,10 +11123,10 @@ function assignProp(target, prop, value) {
     configurable: true
   });
 }
-function getElementAtPath(obj, path7) {
-  if (!path7)
+function getElementAtPath(obj, path8) {
+  if (!path8)
     return obj;
-  return path7.reduce((acc, key) => acc?.[key], obj);
+  return path8.reduce((acc, key) => acc?.[key], obj);
 }
 function promiseAllObject(promisesObj) {
   const keys = Object.keys(promisesObj);
@@ -11446,11 +11446,11 @@ function aborted(x, startIndex = 0) {
   }
   return false;
 }
-function prefixIssues(path7, issues) {
+function prefixIssues(path8, issues) {
   return issues.map((iss) => {
     var _a;
     (_a = iss).path ?? (_a.path = []);
-    iss.path.unshift(path7);
+    iss.path.unshift(path8);
     return iss;
   });
 }
@@ -23325,6 +23325,351 @@ async function recoverChangedFiles(input) {
   };
 }
 
+// src/tools/clean-runs.ts
+var path7 = __toESM(require("path"));
+var fs7 = __toESM(require("fs"));
+var runVerdictSchema = external_exports.enum([
+  "merged",
+  "open",
+  "closed-unmerged",
+  "unknown"
+]);
+var cleanRunsInputSchema = external_exports.object({
+  repoPath: external_exports.string().optional().describe(
+    "Path to the git repository whose `.orchestrate/runs/` directory is swept. Defaults to the current working directory."
+  ),
+  verdicts: external_exports.record(external_exports.string(), runVerdictSchema).describe(
+    "Per-run merge-verdict map keyed by runId. Each value is the verdict the orchestrator resolved for that run's final pull request via `gh pr view`: 'merged' (the PR merged into the integration base \u2014 the only verdict that triggers cleanup), 'open' (still open), 'closed-unmerged' (closed without merging), or 'unknown' (the verdict could not be determined). A run found on disk but ABSENT from this map is left strictly intact \u2014 its absence is the orchestrator's signal not to touch it (e.g. the current run or a concurrently-in-progress run)."
+  ),
+  force: external_exports.boolean().optional().describe(
+    "When true, a merged run's `failed`-state slice worktrees are removed too and the run directory is always removed. Default false \u2014 a failed-slice worktree is preserved for developer inspection and the run directory is kept whenever any worktree was preserved."
+  )
+});
+var runActionSchema = external_exports.enum(["removed", "preserved", "skipped"]);
+var runReasonSchema = external_exports.enum([
+  // ── removed / preserved ──
+  "merged-and-clean",
+  "merged-with-preserved-worktrees",
+  // ── skipped ──
+  "final-pr-open",
+  "final-pr-closed-unmerged",
+  "verdict-unknown",
+  "no-verdict-from-orchestrator",
+  "run-not-completed",
+  "malformed-run-state",
+  "missing-run-state",
+  "invalid-run-id"
+]);
+var branchErrorSchema = external_exports.object({
+  branch: external_exports.string().describe("The branch whose deletion failed."),
+  scope: external_exports.enum(["local", "remote"]).describe("Whether the failure was deleting the local or remote ref."),
+  error: external_exports.string().describe("Cleaned, human-readable reason the deletion failed.")
+});
+var runReportSchema = external_exports.object({
+  runId: external_exports.string().describe("The run's timestamp id (its directory name)."),
+  action: runActionSchema.describe(
+    "What was done: 'removed' (run directory and all resources gone), 'preserved' (a merged run cleaned partially \u2014 some worktrees and the run directory kept), or 'skipped' (the run was not eligible and nothing was touched)."
+  ),
+  reason: runReasonSchema.describe(
+    "The keyed reason explaining the action."
+  ),
+  removedWorktrees: external_exports.array(external_exports.string()).describe("Absolute paths of the slice worktrees that were removed."),
+  preservedWorktrees: external_exports.array(external_exports.string()).describe(
+    "Absolute paths of the slice worktrees that were preserved \u2014 `failed`-state worktrees kept for inspection when force is false."
+  ),
+  removedBranches: external_exports.array(external_exports.string()).describe(
+    "Branch names whose local and/or remote refs were deleted (or were already absent \u2014 an absent ref counts as a successful removal)."
+  ),
+  branchErrors: external_exports.array(branchErrorSchema).describe(
+    "Branch deletions that genuinely failed (not merely an absent ref). Empty when every branch was removed cleanly."
+  ),
+  runDirRemoved: external_exports.boolean().describe(
+    "True when the run directory `.orchestrate/runs/<runId>/` was removed."
+  )
+});
+var cleanRunsOutputSchema = external_exports.object({
+  status: external_exports.enum(["ok", "error"]).describe(
+    "Outcome discriminant. 'ok' = the sweep ran (individual runs may still have been skipped or partially cleaned \u2014 see each run's report); 'error' = the sweep itself could not run."
+  ),
+  runs: external_exports.array(runReportSchema).describe(
+    "One report per run directory found under `.orchestrate/runs/`. Empty when no runs directory exists or it holds no run directories."
+  ),
+  errorCode: external_exports.enum(["INVALID_INPUT", "FS_ERROR"]).optional().describe(
+    "Machine-readable failure category. Present when status='error'."
+  ),
+  errorMessage: external_exports.string().optional().describe(
+    "Cleaned, human-readable failure description. Present when status='error'."
+  )
+});
+function extractSlices(slices) {
+  if (slices === null || typeof slices !== "object" || Array.isArray(slices)) {
+    return [];
+  }
+  const out = [];
+  for (const value of Object.values(slices)) {
+    if (value === null || typeof value !== "object") {
+      continue;
+    }
+    const s = value;
+    out.push({
+      sliceBranch: typeof s.sliceBranch === "string" ? s.sliceBranch : null,
+      worktreePath: typeof s.worktreePath === "string" ? s.worktreePath : null,
+      state: typeof s.state === "string" ? s.state : null
+    });
+  }
+  return out;
+}
+function isAbsentRefError(message) {
+  const m = message.toLowerCase();
+  return m.includes("remote ref does not exist") || m.includes("not found") || m.includes("does not exist") || m.includes("couldn't find remote ref") || /branch .* not found/.test(m);
+}
+async function deleteLocalBranch(branch, repoPath) {
+  const guardErr = optionInjectionError("branch", branch);
+  if (guardErr) {
+    return { branch, scope: "local", error: guardErr };
+  }
+  try {
+    await gitExecFile(["branch", "-D", "--", branch], repoPath);
+    return null;
+  } catch (err) {
+    const message = cleanGitError(err);
+    if (isAbsentRefError(message)) {
+      return null;
+    }
+    return { branch, scope: "local", error: message };
+  }
+}
+async function deleteRemoteBranch(branch, repoPath) {
+  const guardErr = optionInjectionError("branch", branch);
+  if (guardErr) {
+    return { branch, scope: "remote", error: guardErr };
+  }
+  try {
+    const { stdout } = await gitExecFile(["remote"], repoPath);
+    if (!stdout.split("\n").some((r) => r.trim() === "origin")) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  try {
+    await gitExecFile(
+      ["push", "origin", "--delete", "--", branch],
+      repoPath
+    );
+    return null;
+  } catch (err) {
+    const message = cleanGitError(err);
+    if (isAbsentRefError(message)) {
+      return null;
+    }
+    return { branch, scope: "remote", error: message };
+  }
+}
+async function deleteBranch(branch, repoPath, report) {
+  const local = await deleteLocalBranch(branch, repoPath);
+  const remote = await deleteRemoteBranch(branch, repoPath);
+  if (local) {
+    report.branchErrors.push(local);
+  }
+  if (remote) {
+    report.branchErrors.push(remote);
+  }
+  if (!local && !remote) {
+    report.removedBranches.push(branch);
+  }
+}
+function readRunState(runStatePath) {
+  if (!fs7.existsSync(runStatePath)) {
+    return { ok: false, reason: "missing-run-state" };
+  }
+  let raw;
+  try {
+    raw = fs7.readFileSync(runStatePath, "utf8");
+  } catch {
+    return { ok: false, reason: "malformed-run-state" };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, reason: "malformed-run-state" };
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    return { ok: false, reason: "malformed-run-state" };
+  }
+  const obj = parsed;
+  return {
+    ok: true,
+    state: {
+      status: obj.status,
+      umbrellaBranch: obj.umbrellaBranch,
+      slices: obj.slices
+    }
+  };
+}
+function skippedReport(runId, reason) {
+  return {
+    runId,
+    action: "skipped",
+    reason,
+    removedWorktrees: [],
+    preservedWorktrees: [],
+    removedBranches: [],
+    branchErrors: [],
+    runDirRemoved: false
+  };
+}
+async function cleanMergedRun(runId, runDir, state, repoPath, force) {
+  const report = {
+    runId,
+    action: "removed",
+    reason: "merged-and-clean",
+    removedWorktrees: [],
+    preservedWorktrees: [],
+    removedBranches: [],
+    branchErrors: [],
+    runDirRemoved: false
+  };
+  const slices = extractSlices(state.slices);
+  const preservedSliceBranches = /* @__PURE__ */ new Set();
+  for (const slice of slices) {
+    if (!slice.worktreePath) {
+      continue;
+    }
+    if (slice.state === "failed" && !force) {
+      report.preservedWorktrees.push(slice.worktreePath);
+      if (slice.sliceBranch) {
+        preservedSliceBranches.add(slice.sliceBranch);
+      }
+      continue;
+    }
+    const removed = await removeWorktree({
+      worktreePath: slice.worktreePath,
+      repoPath,
+      force: true
+    });
+    if (removed.status === "ok" || removed.errorCode === "PATH_NOT_FOUND") {
+      report.removedWorktrees.push(slice.worktreePath);
+    } else {
+      report.preservedWorktrees.push(slice.worktreePath);
+      if (slice.sliceBranch) {
+        preservedSliceBranches.add(slice.sliceBranch);
+      }
+    }
+  }
+  const branchNames = /* @__PURE__ */ new Set();
+  if (typeof state.umbrellaBranch === "string" && state.umbrellaBranch) {
+    branchNames.add(state.umbrellaBranch);
+  }
+  for (const slice of slices) {
+    if (slice.sliceBranch && !preservedSliceBranches.has(slice.sliceBranch)) {
+      branchNames.add(slice.sliceBranch);
+    }
+  }
+  for (const branch of branchNames) {
+    await deleteBranch(branch, repoPath, report);
+  }
+  const anyPreserved = report.preservedWorktrees.length > 0;
+  if (anyPreserved && !force) {
+    report.action = "preserved";
+    report.reason = "merged-with-preserved-worktrees";
+    report.runDirRemoved = false;
+  } else {
+    try {
+      fs7.rmSync(runDir, { recursive: true, force: true });
+      report.runDirRemoved = true;
+    } catch {
+      report.runDirRemoved = false;
+    }
+    report.action = report.runDirRemoved ? "removed" : "preserved";
+    report.reason = "merged-and-clean";
+  }
+  return report;
+}
+async function cleanRuns(input) {
+  const repoPath = input.repoPath ?? process.cwd();
+  const force = input.force ?? false;
+  const guardErr = optionInjectionError("repoPath", repoPath);
+  if (guardErr) {
+    return {
+      status: "error",
+      runs: [],
+      errorCode: "INVALID_INPUT",
+      errorMessage: guardErr
+    };
+  }
+  const runsRoot = path7.join(repoPath, ".orchestrate", "runs");
+  if (!fs7.existsSync(runsRoot)) {
+    return { status: "ok", runs: [] };
+  }
+  let entries;
+  try {
+    entries = fs7.readdirSync(runsRoot, { withFileTypes: true });
+  } catch (err) {
+    return {
+      status: "error",
+      runs: [],
+      errorCode: "FS_ERROR",
+      errorMessage: err instanceof Error ? err.message : "Cannot read the runs directory."
+    };
+  }
+  const runs = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const runId = entry.name;
+    if (!isValidRunId(runId)) {
+      runs.push(skippedReport(runId, "invalid-run-id"));
+      continue;
+    }
+    const runDir = path7.join(runsRoot, runId);
+    const runStatePath = path7.join(runDir, "run-state.json");
+    const verdict = input.verdicts[runId];
+    if (verdict === void 0) {
+      runs.push(skippedReport(runId, "no-verdict-from-orchestrator"));
+      continue;
+    }
+    if (verdict === "open") {
+      runs.push(skippedReport(runId, "final-pr-open"));
+      continue;
+    }
+    if (verdict === "closed-unmerged") {
+      runs.push(skippedReport(runId, "final-pr-closed-unmerged"));
+      continue;
+    }
+    if (verdict === "unknown") {
+      runs.push(skippedReport(runId, "verdict-unknown"));
+      continue;
+    }
+    const stateResult = readRunState(runStatePath);
+    if (!stateResult.ok) {
+      runs.push(skippedReport(runId, stateResult.reason));
+      continue;
+    }
+    if (stateResult.state.status !== "completed") {
+      runs.push(skippedReport(runId, "run-not-completed"));
+      continue;
+    }
+    try {
+      runs.push(
+        await cleanMergedRun(
+          runId,
+          runDir,
+          stateResult.state,
+          repoPath,
+          force
+        )
+      );
+    } catch (err) {
+      runs.push(skippedReport(runId, "malformed-run-state"));
+      void err;
+    }
+  }
+  return { status: "ok", runs };
+}
+
 // src/index.ts
 var server = new McpServer({
   name: "orchestrate",
@@ -23673,6 +24018,36 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleRecoverChangedFiles
+);
+var handleCleanRuns = async (input) => {
+  const result = await cleanRuns(input);
+  let text;
+  if (result.status === "ok") {
+    const removed = result.runs.filter((r) => r.action === "removed").length;
+    const preserved = result.runs.filter(
+      (r) => r.action === "preserved"
+    ).length;
+    const skipped = result.runs.filter((r) => r.action === "skipped").length;
+    text = `Cleanup swept ${result.runs.length} run(s): ${removed} removed, ${preserved} preserved, ${skipped} skipped.`;
+  } else {
+    text = `Run cleanup failed [${result.errorCode}]: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text", text }]
+  };
+};
+registerTool(
+  "clean_runs",
+  {
+    title: "Clean Up Concluded Runs",
+    description: "Sweeps `.orchestrate/runs/` and removes the on-disk and git footprint of every run whose final integration pull request has merged \u2014 its worktrees, its umbrella and slice branches (local and remote), and its run directory. The merged/open/closed-unmerged verdict is GitHub state and is NOT read by this tool: the orchestrator resolves each run's verdict with `gh pr view` and passes a per-run `verdicts` map; this tool is purely git + filesystem. A run absent from the map, or one whose run-state is not `completed`, is left strictly intact. Failed-slice worktrees are preserved (and the run directory kept) unless `force` is set. Every removal is best-effort and idempotent \u2014 an already-absent resource is success, not error. Never throws.",
+    inputSchema: cleanRunsInputSchema.shape,
+    outputSchema: cleanRunsOutputSchema.shape
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleCleanRuns
 );
 async function main() {
   const transport = new StdioServerTransport();

--- a/plugins/orchestrate/orchestrate-mcp/src/index.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/index.ts
@@ -85,6 +85,13 @@ import {
   type RecoverChangedFilesInput,
   type RecoverChangedFilesOutput,
 } from "./tools/recover-changed-files.js";
+import {
+  cleanRuns,
+  cleanRunsInputSchema,
+  cleanRunsOutputSchema,
+  type CleanRunsInput,
+  type CleanRunsOutput,
+} from "./tools/clean-runs.js";
 
 const server = new McpServer({
   name: "orchestrate",
@@ -687,6 +694,55 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleRecoverChangedFiles as unknown as AnyToolHandler
+);
+
+// ─── clean_runs ────────────────────────────────────────────────────────────────
+
+const handleCleanRuns: ToolHandler<CleanRunsInput, CleanRunsOutput> = async (
+  input
+) => {
+  const result = await cleanRuns(input);
+  let text: string;
+  if (result.status === "ok") {
+    const removed = result.runs.filter((r) => r.action === "removed").length;
+    const preserved = result.runs.filter(
+      (r) => r.action === "preserved"
+    ).length;
+    const skipped = result.runs.filter((r) => r.action === "skipped").length;
+    text =
+      `Cleanup swept ${result.runs.length} run(s): ` +
+      `${removed} removed, ${preserved} preserved, ${skipped} skipped.`;
+  } else {
+    text = `Run cleanup failed [${result.errorCode}]: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text" as const, text }],
+  };
+};
+
+registerTool(
+  "clean_runs",
+  {
+    title: "Clean Up Concluded Runs",
+    description:
+      "Sweeps `.orchestrate/runs/` and removes the on-disk and git footprint " +
+      "of every run whose final integration pull request has merged — its " +
+      "worktrees, its umbrella and slice branches (local and remote), and its " +
+      "run directory. The merged/open/closed-unmerged verdict is GitHub state " +
+      "and is NOT read by this tool: the orchestrator resolves each run's " +
+      "verdict with `gh pr view` and passes a per-run `verdicts` map; this " +
+      "tool is purely git + filesystem. A run absent from the map, or one " +
+      "whose run-state is not `completed`, is left strictly intact. Failed-" +
+      "slice worktrees are preserved (and the run directory kept) unless " +
+      "`force` is set. Every removal is best-effort and idempotent — an " +
+      "already-absent resource is success, not error. Never throws.",
+    inputSchema: cleanRunsInputSchema.shape,
+    outputSchema: cleanRunsOutputSchema.shape,
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleCleanRuns as unknown as AnyToolHandler
 );
 
 // ─── Start server ─────────────────────────────────────────────────────────────

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/clean-runs.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/clean-runs.ts
@@ -1,0 +1,610 @@
+import * as path from "path";
+import * as fs from "fs";
+import { z } from "zod";
+import { gitExecFile, optionInjectionError, cleanGitError } from "../git.js";
+import { isValidRunId } from "../run-dir.js";
+import { removeWorktree } from "./worktree.js";
+
+// ─── clean_runs — run cleanup sweep ───────────────────────────────────────────
+//
+// Removes the on-disk and git footprint of an orchestration run whose final
+// integration pull request has merged into the integration base: its worktrees,
+// its umbrella and slice branches (local and remote), and its run directory.
+//
+// The merged/open/closed-unmerged verdict is GitHub state, which only the `gh`
+// CLI can read — and no MCP tool shells `gh`. So the orchestrator (the skill)
+// computes each run's verdict with `gh pr view` and passes the verdict map in;
+// this tool is purely git + filesystem, exactly like every other tool. A run
+// the orchestrator did not supply a verdict for is left strictly intact — that
+// is the orchestrator's signal that the run must not be touched (e.g. it is
+// the current run, or another concurrently-in-progress run).
+//
+// Defense-in-depth: even when the verdict map says `merged`, this tool re-reads
+// the run's `run-state.json` and refuses to act unless `status` is `completed`.
+// An `in-progress` run is never cleaned, whatever the verdict says.
+//
+// Every removal is best-effort and independently reported: an already-absent
+// resource is success, not error, so the sweep is idempotent and one run's
+// failure never aborts the others.
+
+// ─── Schemas — z.object is the single source of truth; TS types via z.infer ───
+
+/** A per-run merge verdict, as resolved by the orchestrator via `gh pr view`. */
+export const runVerdictSchema = z.enum([
+  "merged",
+  "open",
+  "closed-unmerged",
+  "unknown",
+]);
+
+export const cleanRunsInputSchema = z.object({
+  repoPath: z
+    .string()
+    .optional()
+    .describe(
+      "Path to the git repository whose `.orchestrate/runs/` directory is " +
+        "swept. Defaults to the current working directory."
+    ),
+  verdicts: z
+    .record(z.string(), runVerdictSchema)
+    .describe(
+      "Per-run merge-verdict map keyed by runId. Each value is the verdict " +
+        "the orchestrator resolved for that run's final pull request via " +
+        "`gh pr view`: 'merged' (the PR merged into the integration base — " +
+        "the only verdict that triggers cleanup), 'open' (still open), " +
+        "'closed-unmerged' (closed without merging), or 'unknown' (the " +
+        "verdict could not be determined). A run found on disk but ABSENT " +
+        "from this map is left strictly intact — its absence is the " +
+        "orchestrator's signal not to touch it (e.g. the current run or a " +
+        "concurrently-in-progress run)."
+    ),
+  force: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, a merged run's `failed`-state slice worktrees are removed " +
+        "too and the run directory is always removed. Default false — a " +
+        "failed-slice worktree is preserved for developer inspection and the " +
+        "run directory is kept whenever any worktree was preserved."
+    ),
+});
+
+/** What clean_runs decided to do with one run. */
+export const runActionSchema = z.enum(["removed", "preserved", "skipped"]);
+
+/** The keyed reason explaining a run's action. */
+export const runReasonSchema = z.enum([
+  // ── removed / preserved ──
+  "merged-and-clean",
+  "merged-with-preserved-worktrees",
+  // ── skipped ──
+  "final-pr-open",
+  "final-pr-closed-unmerged",
+  "verdict-unknown",
+  "no-verdict-from-orchestrator",
+  "run-not-completed",
+  "malformed-run-state",
+  "missing-run-state",
+  "invalid-run-id",
+]);
+
+/** A best-effort branch-deletion failure, scoped to local or remote. */
+export const branchErrorSchema = z.object({
+  branch: z.string().describe("The branch whose deletion failed."),
+  scope: z
+    .enum(["local", "remote"])
+    .describe("Whether the failure was deleting the local or remote ref."),
+  error: z
+    .string()
+    .describe("Cleaned, human-readable reason the deletion failed."),
+});
+
+/** The cleanup report for one run. */
+export const runReportSchema = z.object({
+  runId: z.string().describe("The run's timestamp id (its directory name)."),
+  action: runActionSchema.describe(
+    "What was done: 'removed' (run directory and all resources gone), " +
+      "'preserved' (a merged run cleaned partially — some worktrees and the " +
+      "run directory kept), or 'skipped' (the run was not eligible and " +
+      "nothing was touched)."
+  ),
+  reason: runReasonSchema.describe(
+    "The keyed reason explaining the action."
+  ),
+  removedWorktrees: z
+    .array(z.string())
+    .describe("Absolute paths of the slice worktrees that were removed."),
+  preservedWorktrees: z
+    .array(z.string())
+    .describe(
+      "Absolute paths of the slice worktrees that were preserved — " +
+        "`failed`-state worktrees kept for inspection when force is false."
+    ),
+  removedBranches: z
+    .array(z.string())
+    .describe(
+      "Branch names whose local and/or remote refs were deleted (or were " +
+        "already absent — an absent ref counts as a successful removal)."
+    ),
+  branchErrors: z
+    .array(branchErrorSchema)
+    .describe(
+      "Branch deletions that genuinely failed (not merely an absent ref). " +
+        "Empty when every branch was removed cleanly."
+    ),
+  runDirRemoved: z
+    .boolean()
+    .describe(
+      "True when the run directory `.orchestrate/runs/<runId>/` was removed."
+    ),
+});
+
+export const cleanRunsOutputSchema = z.object({
+  status: z
+    .enum(["ok", "error"])
+    .describe(
+      "Outcome discriminant. 'ok' = the sweep ran (individual runs may still " +
+        "have been skipped or partially cleaned — see each run's report); " +
+        "'error' = the sweep itself could not run."
+    ),
+  runs: z
+    .array(runReportSchema)
+    .describe(
+      "One report per run directory found under `.orchestrate/runs/`. Empty " +
+        "when no runs directory exists or it holds no run directories."
+    ),
+  errorCode: z
+    .enum(["INVALID_INPUT", "FS_ERROR"])
+    .optional()
+    .describe(
+      "Machine-readable failure category. Present when status='error'."
+    ),
+  errorMessage: z
+    .string()
+    .optional()
+    .describe(
+      "Cleaned, human-readable failure description. Present when status='error'."
+    ),
+});
+
+// ─── TS types — derived from the schemas (single source of truth) ─────────────
+
+export type RunVerdict = z.infer<typeof runVerdictSchema>;
+export type CleanRunsInput = z.infer<typeof cleanRunsInputSchema>;
+export type CleanRunsOutput = z.infer<typeof cleanRunsOutputSchema>;
+export type RunReport = z.infer<typeof runReportSchema>;
+export type BranchError = z.infer<typeof branchErrorSchema>;
+
+// ─── Internal types ───────────────────────────────────────────────────────────
+
+/** The subset of run-state fields the cleanup gate and removal steps read. */
+interface ParsedRunState {
+  status: unknown;
+  umbrellaBranch: unknown;
+  slices: unknown;
+}
+
+/** One slice's cleanup-relevant fields. */
+interface SliceInfo {
+  sliceBranch: string | null;
+  worktreePath: string | null;
+  state: string | null;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Returns the slice records of a parsed run-state as a normalized array. A
+ * malformed `slices` value yields an empty array — the caller still cleans the
+ * umbrella branch and run directory.
+ */
+function extractSlices(slices: unknown): SliceInfo[] {
+  if (slices === null || typeof slices !== "object" || Array.isArray(slices)) {
+    return [];
+  }
+  const out: SliceInfo[] = [];
+  for (const value of Object.values(slices as Record<string, unknown>)) {
+    if (value === null || typeof value !== "object") {
+      continue;
+    }
+    const s = value as Record<string, unknown>;
+    out.push({
+      sliceBranch: typeof s.sliceBranch === "string" ? s.sliceBranch : null,
+      worktreePath:
+        typeof s.worktreePath === "string" ? s.worktreePath : null,
+      state: typeof s.state === "string" ? s.state : null,
+    });
+  }
+  return out;
+}
+
+/**
+ * True when a `cleanGitError` string indicates the ref simply did not exist —
+ * which, for a cleanup tool, is success, not failure. Idempotency depends on
+ * this: a re-run, or a run whose branches were never pushed, must not error.
+ */
+function isAbsentRefError(message: string): boolean {
+  const m = message.toLowerCase();
+  return (
+    m.includes("remote ref does not exist") ||
+    m.includes("not found") ||
+    m.includes("does not exist") ||
+    m.includes("couldn't find remote ref") ||
+    /branch .* not found/.test(m)
+  );
+}
+
+/**
+ * Deletes a branch's local ref. An already-absent local ref is success. Returns
+ * null on success, or a {@link BranchError} when the deletion genuinely failed.
+ */
+async function deleteLocalBranch(
+  branch: string,
+  repoPath: string
+): Promise<BranchError | null> {
+  const guardErr = optionInjectionError("branch", branch);
+  if (guardErr) {
+    return { branch, scope: "local", error: guardErr };
+  }
+  try {
+    // `--` terminates option parsing; the branch name is a positional.
+    await gitExecFile(["branch", "-D", "--", branch], repoPath);
+    return null;
+  } catch (err) {
+    const message = cleanGitError(err);
+    if (isAbsentRefError(message)) {
+      return null; // never created, or already deleted — success.
+    }
+    return { branch, scope: "local", error: message };
+  }
+}
+
+/**
+ * Deletes a branch's remote ref on `origin`. An already-absent remote ref, and
+ * the absence of an `origin` remote entirely, are both treated as success.
+ * Returns null on success, or a {@link BranchError} when it genuinely failed.
+ */
+async function deleteRemoteBranch(
+  branch: string,
+  repoPath: string
+): Promise<BranchError | null> {
+  const guardErr = optionInjectionError("branch", branch);
+  if (guardErr) {
+    return { branch, scope: "remote", error: guardErr };
+  }
+  // No `origin` remote — nothing to delete remotely; that is success.
+  try {
+    const { stdout } = await gitExecFile(["remote"], repoPath);
+    if (!stdout.split("\n").some((r) => r.trim() === "origin")) {
+      return null;
+    }
+  } catch {
+    return null; // cannot enumerate remotes — treat remote cleanup as a no-op.
+  }
+  try {
+    // `--delete` removes the remote branch; `--` terminates option parsing.
+    await gitExecFile(
+      ["push", "origin", "--delete", "--", branch],
+      repoPath
+    );
+    return null;
+  } catch (err) {
+    const message = cleanGitError(err);
+    if (isAbsentRefError(message)) {
+      return null; // remote ref already gone — success.
+    }
+    return { branch, scope: "remote", error: message };
+  }
+}
+
+/**
+ * Deletes a branch both locally and on the remote, best-effort. Mutates the
+ * accumulating `removedBranches` / `branchErrors` lists in the run report.
+ */
+async function deleteBranch(
+  branch: string,
+  repoPath: string,
+  report: { removedBranches: string[]; branchErrors: BranchError[] }
+): Promise<void> {
+  const local = await deleteLocalBranch(branch, repoPath);
+  const remote = await deleteRemoteBranch(branch, repoPath);
+  if (local) {
+    report.branchErrors.push(local);
+  }
+  if (remote) {
+    report.branchErrors.push(remote);
+  }
+  // The branch counts as removed when neither scope reported a genuine error
+  // (an absent ref is not an error — it is the idempotent success case).
+  if (!local && !remote) {
+    report.removedBranches.push(branch);
+  }
+}
+
+/**
+ * Reads and JSON-parses a run's `run-state.json`. Returns a discriminated
+ * result so the caller can map the failure modes to keyed reasons.
+ */
+function readRunState(
+  runStatePath: string
+):
+  | { ok: true; state: ParsedRunState }
+  | { ok: false; reason: "missing-run-state" | "malformed-run-state" } {
+  if (!fs.existsSync(runStatePath)) {
+    return { ok: false, reason: "missing-run-state" };
+  }
+  let raw: string;
+  try {
+    raw = fs.readFileSync(runStatePath, "utf8");
+  } catch {
+    return { ok: false, reason: "malformed-run-state" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, reason: "malformed-run-state" };
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    return { ok: false, reason: "malformed-run-state" };
+  }
+  const obj = parsed as Record<string, unknown>;
+  return {
+    ok: true,
+    state: {
+      status: obj.status,
+      umbrellaBranch: obj.umbrellaBranch,
+      slices: obj.slices,
+    },
+  };
+}
+
+/** Builds a `skipped` run report with no resources touched. */
+function skippedReport(
+  runId: string,
+  reason: z.infer<typeof runReasonSchema>
+): RunReport {
+  return {
+    runId,
+    action: "skipped",
+    reason,
+    removedWorktrees: [],
+    preservedWorktrees: [],
+    removedBranches: [],
+    branchErrors: [],
+    runDirRemoved: false,
+  };
+}
+
+/**
+ * Cleans one merged run: removes its `passed`-slice worktrees (and `failed`
+ * ones too when `force`), deletes its umbrella and slice branches, and removes
+ * the run directory unless a worktree was preserved (and not `force`).
+ */
+async function cleanMergedRun(
+  runId: string,
+  runDir: string,
+  state: ParsedRunState,
+  repoPath: string,
+  force: boolean
+): Promise<RunReport> {
+  const report: RunReport = {
+    runId,
+    action: "removed",
+    reason: "merged-and-clean",
+    removedWorktrees: [],
+    preservedWorktrees: [],
+    removedBranches: [],
+    branchErrors: [],
+    runDirRemoved: false,
+  };
+
+  const slices = extractSlices(state.slices);
+
+  // Slice branches whose worktree was preserved: their branch is left fully
+  // intact — local AND remote — so the inspecting developer can still check it
+  // out and push from the preserved worktree. Deleting only the remote half
+  // would leave that worktree's local branch unpushable.
+  const preservedSliceBranches = new Set<string>();
+
+  // ── Step 1: remove worktrees ──
+  // A `failed`-state slice keeps its worktree on disk for inspection unless
+  // `force`. Worktree removal must run before branch deletion: `git branch -D`
+  // refuses to delete a checked-out branch, so a still-present worktree would
+  // turn into a (correctly reported) branch error.
+  for (const slice of slices) {
+    if (!slice.worktreePath) {
+      continue;
+    }
+    if (slice.state === "failed" && !force) {
+      report.preservedWorktrees.push(slice.worktreePath);
+      if (slice.sliceBranch) {
+        preservedSliceBranches.add(slice.sliceBranch);
+      }
+      continue;
+    }
+    // force:true — a slice worktree carries untracked build artifacts, so it
+    // is removed even when dirty. An already-absent worktree is success: the
+    // PATH_NOT_FOUND result is tolerated, not reported as an error.
+    const removed = await removeWorktree({
+      worktreePath: slice.worktreePath,
+      repoPath,
+      force: true,
+    });
+    if (removed.status === "ok" || removed.errorCode === "PATH_NOT_FOUND") {
+      report.removedWorktrees.push(slice.worktreePath);
+    } else {
+      // The worktree could not be removed; keep it reported as preserved so
+      // the run directory is conservatively retained, and its branch intact.
+      report.preservedWorktrees.push(slice.worktreePath);
+      if (slice.sliceBranch) {
+        preservedSliceBranches.add(slice.sliceBranch);
+      }
+    }
+  }
+
+  // ── Step 2: delete branches (local then remote, best-effort) ──
+  // A slice branch whose worktree was preserved is skipped entirely — the
+  // branch belongs to a worktree a developer still needs to inspect.
+  const branchNames = new Set<string>();
+  if (typeof state.umbrellaBranch === "string" && state.umbrellaBranch) {
+    branchNames.add(state.umbrellaBranch);
+  }
+  for (const slice of slices) {
+    if (slice.sliceBranch && !preservedSliceBranches.has(slice.sliceBranch)) {
+      branchNames.add(slice.sliceBranch);
+    }
+  }
+  for (const branch of branchNames) {
+    await deleteBranch(branch, repoPath, report);
+  }
+
+  // ── Step 3: remove the run directory ──
+  // Keep the run directory whenever a worktree was preserved — the preserved
+  // worktree's run-state.json must survive for the inspecting developer.
+  // Remove it fully only when nothing was preserved or `force`.
+  const anyPreserved = report.preservedWorktrees.length > 0;
+  if (anyPreserved && !force) {
+    report.action = "preserved";
+    report.reason = "merged-with-preserved-worktrees";
+    report.runDirRemoved = false;
+  } else {
+    try {
+      fs.rmSync(runDir, { recursive: true, force: true });
+      report.runDirRemoved = true;
+    } catch {
+      // The run directory could not be removed; the branches and worktrees
+      // are already gone — report the run dir as retained, not a hard error.
+      report.runDirRemoved = false;
+    }
+    report.action = report.runDirRemoved ? "removed" : "preserved";
+    report.reason = "merged-and-clean";
+  }
+  return report;
+}
+
+// ─── clean_runs ────────────────────────────────────────────────────────────────
+
+/**
+ * Sweeps `.orchestrate/runs/` and cleans up every run the orchestrator's
+ * verdict map reports as `merged`. A run that is open, closed-unmerged, of
+ * unknown verdict, absent from the map, not `completed`, or whose run-state is
+ * malformed/absent is left strictly intact and only reported.
+ *
+ * Never throws — every failure mode is a structured result; one run's failure
+ * never aborts the sweep of the others.
+ */
+export async function cleanRuns(
+  input: CleanRunsInput
+): Promise<CleanRunsOutput> {
+  const repoPath = input.repoPath ?? process.cwd();
+  const force = input.force ?? false;
+
+  // Option-injection guard: reject a repoPath git would parse as a flag.
+  const guardErr = optionInjectionError("repoPath", repoPath);
+  if (guardErr) {
+    return {
+      status: "error",
+      runs: [],
+      errorCode: "INVALID_INPUT",
+      errorMessage: guardErr,
+    };
+  }
+
+  const runsRoot = path.join(repoPath, ".orchestrate", "runs");
+  if (!fs.existsSync(runsRoot)) {
+    // No runs directory — a clean no-op.
+    return { status: "ok", runs: [] };
+  }
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(runsRoot, { withFileTypes: true });
+  } catch (err) {
+    return {
+      status: "error",
+      runs: [],
+      errorCode: "FS_ERROR",
+      errorMessage:
+        err instanceof Error ? err.message : "Cannot read the runs directory.",
+    };
+  }
+
+  const runs: RunReport[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const runId = entry.name;
+
+    // Path-traversal guard: a directory name that is not a valid runId must
+    // never flow into a path join — skip it, leaving it untouched.
+    if (!isValidRunId(runId)) {
+      runs.push(skippedReport(runId, "invalid-run-id"));
+      continue;
+    }
+
+    const runDir = path.join(runsRoot, runId);
+    const runStatePath = path.join(runDir, "run-state.json");
+
+    // A run absent from the verdict map is left strictly intact — its absence
+    // is the orchestrator's signal not to touch it.
+    const verdict = input.verdicts[runId];
+    if (verdict === undefined) {
+      runs.push(skippedReport(runId, "no-verdict-from-orchestrator"));
+      continue;
+    }
+
+    // A non-merged verdict: leave intact, report the verdict-keyed reason.
+    if (verdict === "open") {
+      runs.push(skippedReport(runId, "final-pr-open"));
+      continue;
+    }
+    if (verdict === "closed-unmerged") {
+      runs.push(skippedReport(runId, "final-pr-closed-unmerged"));
+      continue;
+    }
+    if (verdict === "unknown") {
+      runs.push(skippedReport(runId, "verdict-unknown"));
+      continue;
+    }
+
+    // verdict === "merged" — re-read run-state and gate on it.
+    const stateResult = readRunState(runStatePath);
+    if (!stateResult.ok) {
+      runs.push(skippedReport(runId, stateResult.reason));
+      continue;
+    }
+
+    // Defense-in-depth: never clean a run that is not `completed`, even when
+    // the orchestrator's verdict says `merged`. An `in-progress` run is still
+    // active — removing it would destroy a live run's worktrees and branches.
+    if (stateResult.state.status !== "completed") {
+      runs.push(skippedReport(runId, "run-not-completed"));
+      continue;
+    }
+
+    // The gate is satisfied — clean the run. A failure here is contained to
+    // this run's report; the sweep continues with the next run.
+    try {
+      runs.push(
+        await cleanMergedRun(
+          runId,
+          runDir,
+          stateResult.state,
+          repoPath,
+          force
+        )
+      );
+    } catch (err) {
+      // cleanMergedRun is best-effort and should not throw, but if some
+      // unforeseen failure escapes, contain it: report the run as skipped and
+      // keep sweeping the rest.
+      runs.push(skippedReport(runId, "malformed-run-state"));
+      void err;
+    }
+  }
+
+  return { status: "ok", runs };
+}

--- a/plugins/orchestrate/orchestrate-mcp/test/clean-runs.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/clean-runs.test.ts
@@ -1,0 +1,720 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import { cleanRuns } from "../src/tools/clean-runs.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { encoding: "utf8", cwd }).trim();
+}
+
+/** Creates a temporary git repository with one commit and returns its path. */
+function createTempRepo(): string {
+  const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-test-"));
+
+  git(["init"], repoPath);
+  git(["config", "user.email", "test@test.local"], repoPath);
+  git(["config", "user.name", "Test User"], repoPath);
+
+  fs.writeFileSync(path.join(repoPath, "README.md"), "# Test repo\n");
+  git(["add", "README.md"], repoPath);
+  git(["commit", "-m", "Initial commit"], repoPath);
+
+  return repoPath;
+}
+
+/** Recursively remove a directory. */
+function rmrf(dirPath: string) {
+  if (fs.existsSync(dirPath)) {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  }
+}
+
+/** Returns true when a local branch ref resolves in the repo. */
+function localBranchExists(branch: string, repo: string): boolean {
+  try {
+    git(["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`], repo);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Returns true when a remote branch ref appears in `git ls-remote origin`. */
+function remoteBranchExists(branch: string, repo: string): boolean {
+  const out = git(["ls-remote", "--heads", "origin", branch], repo);
+  return out.length > 0;
+}
+
+/** Writes a run-state.json into `.orchestrate/runs/<runId>/`. */
+function writeRunState(repo: string, runId: string, state: unknown): void {
+  const runDir = path.join(repo, ".orchestrate", "runs", runId);
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(runDir, "run-state.json"),
+    typeof state === "string" ? state : JSON.stringify(state, null, 2)
+  );
+}
+
+/** Path to a run directory. */
+function runDirPath(repo: string, runId: string): string {
+  return path.join(repo, ".orchestrate", "runs", runId);
+}
+
+// ─── Test state ───────────────────────────────────────────────────────────────
+
+let repoPath: string;
+let worktreesDir: string;
+
+beforeEach(() => {
+  repoPath = createTempRepo();
+  worktreesDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-wt-"));
+});
+
+afterEach(() => {
+  rmrf(repoPath);
+  rmrf(worktreesDir);
+});
+
+// ─── Fixture builders ─────────────────────────────────────────────────────────
+
+/**
+ * Sets up a repo with a bare clone registered as `origin`, so remote branch
+ * deletion (`git push origin --delete`) and `git ls-remote` are exercised
+ * against a real remote.
+ */
+function withRemote(): { remoteDir: string } {
+  const remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-remote-"));
+  const remoteBare = path.join(remoteDir, "remote.git");
+  git(["clone", "--bare", repoPath, remoteBare], remoteDir);
+  git(["remote", "add", "origin", remoteBare], repoPath);
+  return { remoteDir };
+}
+
+/**
+ * Creates an umbrella branch + one slice branch for `runId`, optionally
+ * pushing them to `origin`. Returns the branch names.
+ */
+function makeBranches(
+  runId: string,
+  sliceIssue: string,
+  opts: { push: boolean }
+): { umbrellaBranch: string; sliceBranch: string } {
+  const umbrellaBranch = `orchestrate/umbrella-${runId}`;
+  const sliceBranch = `orchestrate/slice-${sliceIssue}`;
+  git(["branch", umbrellaBranch], repoPath);
+  git(["branch", sliceBranch], repoPath);
+  if (opts.push) {
+    git(["push", "origin", umbrellaBranch], repoPath);
+    git(["push", "origin", sliceBranch], repoPath);
+  }
+  return { umbrellaBranch, sliceBranch };
+}
+
+/**
+ * Creates a slice worktree on `sliceBranch` and returns its absolute path.
+ * The branch must already exist.
+ */
+function makeWorktree(sliceBranch: string, name: string): string {
+  const wtPath = path.join(worktreesDir, name);
+  git(["worktree", "add", wtPath, sliceBranch], repoPath);
+  return wtPath;
+}
+
+/** Builds a complete run-state object with one slice. */
+function buildRunState(opts: {
+  runId: string;
+  status: string;
+  umbrellaBranch: string;
+  finalPullRequest: string | null;
+  slices: Record<
+    string,
+    {
+      sliceBranch: string;
+      worktreePath: string | null;
+      state: string;
+    }
+  >;
+}): Record<string, unknown> {
+  return {
+    runId: opts.runId,
+    status: opts.status,
+    umbrellaBranch: opts.umbrellaBranch,
+    integrationBase: "development",
+    parentIssue: null,
+    startedAt: "2026-05-22T00:00:00Z",
+    updatedAt: "2026-05-22T01:00:00Z",
+    waves: [Object.keys(opts.slices)],
+    completedWaves: 1,
+    finalPullRequest: opts.finalPullRequest,
+    slices: Object.fromEntries(
+      Object.entries(opts.slices).map(([id, s]) => [
+        id,
+        {
+          issue: Number(id),
+          title: `Slice ${id}`,
+          wave: 0,
+          tier: "standard",
+          blockedBy: [],
+          state: s.state,
+          sliceBranch: s.sliceBranch,
+          worktreePath: s.worktreePath,
+          pullRequest: null,
+          failureReason: null,
+          updatedAt: "2026-05-22T01:00:00Z",
+        },
+      ])
+    ),
+  };
+}
+
+// ─── merged run — full cleanup ────────────────────────────────────────────────
+
+describe("clean_runs — merged run", () => {
+  it("removes worktrees, branches, and the run directory of a merged run", async () => {
+    const runId = "20260522-100000";
+    withRemote();
+    const { umbrellaBranch, sliceBranch } = makeBranches(runId, "201", {
+      push: true,
+    });
+    const wtPath = makeWorktree(sliceBranch, "slice-201");
+    writeRunState(
+      repoPath,
+      runId,
+      buildRunState({
+        runId,
+        status: "completed",
+        umbrellaBranch,
+        finalPullRequest: "https://github.com/o/r/pull/9",
+        slices: { "201": { sliceBranch, worktreePath: wtPath, state: "passed" } },
+      })
+    );
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "merged" },
+    });
+
+    expect(result.status).toBe("ok");
+    const run = result.runs.find((r) => r.runId === runId)!;
+    expect(run.action).toBe("removed");
+    expect(run.reason).toBe("merged-and-clean");
+    expect(run.runDirRemoved).toBe(true);
+
+    // Worktree gone from disk.
+    expect(fs.existsSync(wtPath)).toBe(false);
+    // Run directory gone from disk.
+    expect(fs.existsSync(runDirPath(repoPath, runId))).toBe(false);
+    // Branches gone — local AND remote.
+    expect(localBranchExists(umbrellaBranch, repoPath)).toBe(false);
+    expect(localBranchExists(sliceBranch, repoPath)).toBe(false);
+    expect(remoteBranchExists(umbrellaBranch, repoPath)).toBe(false);
+    expect(remoteBranchExists(sliceBranch, repoPath)).toBe(false);
+    // The removed worktree + branches are reported.
+    expect(run.removedWorktrees).toContain(wtPath);
+    expect(run.removedBranches).toContain(umbrellaBranch);
+    expect(run.removedBranches).toContain(sliceBranch);
+  });
+});
+
+// ─── open / closed-unmerged / unknown — preserved ─────────────────────────────
+
+describe("clean_runs — open final PR", () => {
+  it("leaves an open-PR run intact and reports it as skipped", async () => {
+    const runId = "20260522-110000";
+    const { umbrellaBranch, sliceBranch } = makeBranches(runId, "202", {
+      push: false,
+    });
+    const wtPath = makeWorktree(sliceBranch, "slice-202");
+    writeRunState(
+      repoPath,
+      runId,
+      buildRunState({
+        runId,
+        status: "completed",
+        umbrellaBranch,
+        finalPullRequest: "https://github.com/o/r/pull/10",
+        slices: { "202": { sliceBranch, worktreePath: wtPath, state: "passed" } },
+      })
+    );
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "open" },
+    });
+
+    expect(result.status).toBe("ok");
+    const run = result.runs.find((r) => r.runId === runId)!;
+    expect(run.action).toBe("skipped");
+    expect(run.reason).toBe("final-pr-open");
+    expect(run.runDirRemoved).toBe(false);
+
+    // Nothing removed.
+    expect(fs.existsSync(wtPath)).toBe(true);
+    expect(fs.existsSync(runDirPath(repoPath, runId))).toBe(true);
+    expect(localBranchExists(umbrellaBranch, repoPath)).toBe(true);
+    expect(localBranchExists(sliceBranch, repoPath)).toBe(true);
+  });
+});
+
+describe("clean_runs — closed-unmerged final PR", () => {
+  it("leaves a closed-unmerged run intact and reports it as skipped", async () => {
+    const runId = "20260522-120000";
+    const { umbrellaBranch, sliceBranch } = makeBranches(runId, "203", {
+      push: false,
+    });
+    const wtPath = makeWorktree(sliceBranch, "slice-203");
+    writeRunState(
+      repoPath,
+      runId,
+      buildRunState({
+        runId,
+        status: "completed",
+        umbrellaBranch,
+        finalPullRequest: "https://github.com/o/r/pull/11",
+        slices: { "203": { sliceBranch, worktreePath: wtPath, state: "passed" } },
+      })
+    );
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "closed-unmerged" },
+    });
+
+    const run = result.runs.find((r) => r.runId === runId)!;
+    expect(run.action).toBe("skipped");
+    expect(run.reason).toBe("final-pr-closed-unmerged");
+
+    expect(fs.existsSync(wtPath)).toBe(true);
+    expect(fs.existsSync(runDirPath(repoPath, runId))).toBe(true);
+    expect(localBranchExists(umbrellaBranch, repoPath)).toBe(true);
+  });
+});
+
+describe("clean_runs — unknown verdict", () => {
+  it("leaves a run with an unknown verdict intact and reports it as skipped", async () => {
+    const runId = "20260522-130000";
+    const { umbrellaBranch, sliceBranch } = makeBranches(runId, "204", {
+      push: false,
+    });
+    writeRunState(
+      repoPath,
+      runId,
+      buildRunState({
+        runId,
+        status: "completed",
+        umbrellaBranch,
+        finalPullRequest: "https://github.com/o/r/pull/12",
+        slices: { "204": { sliceBranch, worktreePath: null, state: "passed" } },
+      })
+    );
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "unknown" },
+    });
+
+    const run = result.runs.find((r) => r.runId === runId)!;
+    expect(run.action).toBe("skipped");
+    expect(run.reason).toBe("verdict-unknown");
+    expect(fs.existsSync(runDirPath(repoPath, runId))).toBe(true);
+    expect(localBranchExists(umbrellaBranch, repoPath)).toBe(true);
+  });
+});
+
+// ─── run absent from verdict map — preserved ──────────────────────────────────
+
+describe("clean_runs — no verdict from orchestrator", () => {
+  it("leaves a run absent from the verdict map intact", async () => {
+    const runId = "20260522-140000";
+    const { umbrellaBranch, sliceBranch } = makeBranches(runId, "205", {
+      push: false,
+    });
+    writeRunState(
+      repoPath,
+      runId,
+      buildRunState({
+        runId,
+        status: "completed",
+        umbrellaBranch,
+        finalPullRequest: "https://github.com/o/r/pull/13",
+        slices: { "205": { sliceBranch, worktreePath: null, state: "passed" } },
+      })
+    );
+
+    // Empty verdict map — the orchestrator supplied no verdict for this run.
+    const result = await cleanRuns({ repoPath, verdicts: {} });
+
+    const run = result.runs.find((r) => r.runId === runId)!;
+    expect(run.action).toBe("skipped");
+    expect(run.reason).toBe("no-verdict-from-orchestrator");
+    expect(fs.existsSync(runDirPath(repoPath, runId))).toBe(true);
+    expect(localBranchExists(umbrellaBranch, repoPath)).toBe(true);
+  });
+});
+
+// ─── defense-in-depth: in-progress run never cleaned ──────────────────────────
+
+describe("clean_runs — in-progress defense", () => {
+  it("refuses to clean a run whose run-state.status is in-progress, even with a merged verdict", async () => {
+    const runId = "20260522-150000";
+    const { umbrellaBranch, sliceBranch } = makeBranches(runId, "206", {
+      push: false,
+    });
+    const wtPath = makeWorktree(sliceBranch, "slice-206");
+    writeRunState(
+      repoPath,
+      runId,
+      buildRunState({
+        runId,
+        status: "in-progress",
+        umbrellaBranch,
+        finalPullRequest: null,
+        slices: { "206": { sliceBranch, worktreePath: wtPath, state: "passed" } },
+      })
+    );
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "merged" },
+    });
+
+    const run = result.runs.find((r) => r.runId === runId)!;
+    expect(run.action).toBe("skipped");
+    expect(run.reason).toBe("run-not-completed");
+
+    // Nothing removed — the run is still active.
+    expect(fs.existsSync(wtPath)).toBe(true);
+    expect(fs.existsSync(runDirPath(repoPath, runId))).toBe(true);
+    expect(localBranchExists(umbrellaBranch, repoPath)).toBe(true);
+  });
+});
+
+// ─── failed-slice worktree preservation ───────────────────────────────────────
+
+describe("clean_runs — failed-slice worktree preservation", () => {
+  it("preserves a failed-slice worktree and keeps the run directory by default", async () => {
+    const runId = "20260522-160000";
+    withRemote();
+    const umbrellaBranch = `orchestrate/umbrella-${runId}`;
+    const passedSlice = "orchestrate/slice-301";
+    const failedSlice = "orchestrate/slice-302";
+    git(["branch", umbrellaBranch], repoPath);
+    git(["branch", passedSlice], repoPath);
+    git(["branch", failedSlice], repoPath);
+    git(["push", "origin", umbrellaBranch], repoPath);
+    git(["push", "origin", passedSlice], repoPath);
+    git(["push", "origin", failedSlice], repoPath);
+    const passedWt = makeWorktree(passedSlice, "slice-301");
+    const failedWt = makeWorktree(failedSlice, "slice-302");
+
+    writeRunState(
+      repoPath,
+      runId,
+      buildRunState({
+        runId,
+        status: "completed",
+        umbrellaBranch,
+        finalPullRequest: "https://github.com/o/r/pull/14",
+        slices: {
+          "301": {
+            sliceBranch: passedSlice,
+            worktreePath: passedWt,
+            state: "passed",
+          },
+          "302": {
+            sliceBranch: failedSlice,
+            worktreePath: failedWt,
+            state: "failed",
+          },
+        },
+      })
+    );
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "merged" },
+    });
+
+    const run = result.runs.find((r) => r.runId === runId)!;
+    expect(run.action).toBe("preserved");
+    expect(run.reason).toBe("merged-with-preserved-worktrees");
+
+    // The passed slice's worktree is removed; its branch deleted both sides.
+    expect(fs.existsSync(passedWt)).toBe(false);
+    expect(run.removedWorktrees).toContain(passedWt);
+    expect(run.removedBranches).toContain(passedSlice);
+    expect(localBranchExists(passedSlice, repoPath)).toBe(false);
+    expect(remoteBranchExists(passedSlice, repoPath)).toBe(false);
+    // The failed slice's worktree is PRESERVED and reported.
+    expect(fs.existsSync(failedWt)).toBe(true);
+    expect(run.preservedWorktrees).toContain(failedWt);
+    // The failed slice's branch is left FULLY intact — local AND remote — so
+    // the inspecting developer can still check it out and push from the
+    // preserved worktree. It is neither removed nor reported as an error.
+    expect(localBranchExists(failedSlice, repoPath)).toBe(true);
+    expect(remoteBranchExists(failedSlice, repoPath)).toBe(true);
+    expect(run.removedBranches).not.toContain(failedSlice);
+    expect(run.branchErrors).toEqual([]);
+    // The umbrella branch is still deleted — it is not a preserved worktree.
+    expect(localBranchExists(umbrellaBranch, repoPath)).toBe(false);
+    // The run directory is KEPT — the preserved worktree's state survives.
+    expect(run.runDirRemoved).toBe(false);
+    expect(fs.existsSync(runDirPath(repoPath, runId))).toBe(true);
+  });
+
+  it("removes a failed-slice worktree and the run directory when force=true", async () => {
+    const runId = "20260522-170000";
+    withRemote();
+    const umbrellaBranch = `orchestrate/umbrella-${runId}`;
+    const passedSlice = "orchestrate/slice-401";
+    const failedSlice = "orchestrate/slice-402";
+    git(["branch", umbrellaBranch], repoPath);
+    git(["branch", passedSlice], repoPath);
+    git(["branch", failedSlice], repoPath);
+    git(["push", "origin", umbrellaBranch], repoPath);
+    git(["push", "origin", passedSlice], repoPath);
+    git(["push", "origin", failedSlice], repoPath);
+    const passedWt = makeWorktree(passedSlice, "slice-401");
+    const failedWt = makeWorktree(failedSlice, "slice-402");
+
+    writeRunState(
+      repoPath,
+      runId,
+      buildRunState({
+        runId,
+        status: "completed",
+        umbrellaBranch,
+        finalPullRequest: "https://github.com/o/r/pull/15",
+        slices: {
+          "401": {
+            sliceBranch: passedSlice,
+            worktreePath: passedWt,
+            state: "passed",
+          },
+          "402": {
+            sliceBranch: failedSlice,
+            worktreePath: failedWt,
+            state: "failed",
+          },
+        },
+      })
+    );
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "merged" },
+      force: true,
+    });
+
+    const run = result.runs.find((r) => r.runId === runId)!;
+    expect(run.action).toBe("removed");
+    expect(run.reason).toBe("merged-and-clean");
+
+    // Both worktrees removed under force.
+    expect(fs.existsSync(passedWt)).toBe(false);
+    expect(fs.existsSync(failedWt)).toBe(false);
+    expect(run.removedWorktrees).toContain(passedWt);
+    expect(run.removedWorktrees).toContain(failedWt);
+    expect(run.preservedWorktrees).toEqual([]);
+    // The run directory is removed.
+    expect(run.runDirRemoved).toBe(true);
+    expect(fs.existsSync(runDirPath(repoPath, runId))).toBe(false);
+    // Branches gone — local and remote.
+    expect(localBranchExists(failedSlice, repoPath)).toBe(false);
+    expect(remoteBranchExists(failedSlice, repoPath)).toBe(false);
+  });
+});
+
+// ─── malformed / absent run-state ─────────────────────────────────────────────
+
+describe("clean_runs — malformed run-state", () => {
+  it("tolerates a malformed run-state.json, leaves the run intact, and reports it", async () => {
+    const runId = "20260522-180000";
+    writeRunState(repoPath, runId, "{ not valid json");
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "merged" },
+    });
+
+    expect(result.status).toBe("ok");
+    const run = result.runs.find((r) => r.runId === runId)!;
+    expect(run.action).toBe("skipped");
+    expect(run.reason).toBe("malformed-run-state");
+    expect(fs.existsSync(runDirPath(repoPath, runId))).toBe(true);
+  });
+
+  it("tolerates a run directory with no run-state.json", async () => {
+    const runId = "20260522-190000";
+    fs.mkdirSync(runDirPath(repoPath, runId), { recursive: true });
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "merged" },
+    });
+
+    expect(result.status).toBe("ok");
+    const run = result.runs.find((r) => r.runId === runId)!;
+    expect(run.action).toBe("skipped");
+    expect(run.reason).toBe("missing-run-state");
+    expect(fs.existsSync(runDirPath(repoPath, runId))).toBe(true);
+  });
+});
+
+// ─── idempotency ──────────────────────────────────────────────────────────────
+
+describe("clean_runs — idempotency", () => {
+  it("succeeds when a run's branches are already deleted (absent ref is not an error)", async () => {
+    const runId = "20260522-200000";
+    withRemote();
+    const umbrellaBranch = `orchestrate/umbrella-${runId}`;
+    const sliceBranch = `orchestrate/slice-501`;
+    // run-state names branches that were never created — the absent-ref case.
+    writeRunState(
+      repoPath,
+      runId,
+      buildRunState({
+        runId,
+        status: "completed",
+        umbrellaBranch,
+        finalPullRequest: "https://github.com/o/r/pull/16",
+        slices: {
+          "501": { sliceBranch, worktreePath: null, state: "passed" },
+        },
+      })
+    );
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "merged" },
+    });
+
+    expect(result.status).toBe("ok");
+    const run = result.runs.find((r) => r.runId === runId)!;
+    // Absent branches are not errors — the run is still cleaned.
+    expect(run.action).toBe("removed");
+    expect(run.branchErrors).toEqual([]);
+    expect(run.runDirRemoved).toBe(true);
+  });
+
+  it("re-running clean on an already-clean run does not error", async () => {
+    const runId = "20260522-210000";
+    withRemote();
+    const { umbrellaBranch, sliceBranch } = makeBranches(runId, "601", {
+      push: true,
+    });
+    writeRunState(
+      repoPath,
+      runId,
+      buildRunState({
+        runId,
+        status: "completed",
+        umbrellaBranch,
+        finalPullRequest: "https://github.com/o/r/pull/17",
+        slices: {
+          "601": { sliceBranch, worktreePath: null, state: "passed" },
+        },
+      })
+    );
+
+    const first = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "merged" },
+    });
+    expect(first.status).toBe("ok");
+    expect(first.runs[0].runDirRemoved).toBe(true);
+
+    // Second run: the run directory is already gone — clean reports no runs.
+    const second = await cleanRuns({
+      repoPath,
+      verdicts: { [runId]: "merged" },
+    });
+    expect(second.status).toBe("ok");
+    expect(second.runs.find((r) => r.runId === runId)).toBeUndefined();
+  });
+});
+
+// ─── path-traversal guard ─────────────────────────────────────────────────────
+
+describe("clean_runs — runId validation", () => {
+  it("skips a run directory whose name is not a valid runId", async () => {
+    // Manually create a malformed directory name under runs/.
+    const badDir = path.join(repoPath, ".orchestrate", "runs", "bad.name");
+    fs.mkdirSync(badDir, { recursive: true });
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { "bad.name": "merged" },
+    });
+
+    expect(result.status).toBe("ok");
+    const run = result.runs.find((r) => r.runId === "bad.name")!;
+    expect(run.action).toBe("skipped");
+    expect(run.reason).toBe("invalid-run-id");
+    // The directory is untouched.
+    expect(fs.existsSync(badDir)).toBe(true);
+  });
+});
+
+// ─── no runs directory ────────────────────────────────────────────────────────
+
+describe("clean_runs — empty / absent runs directory", () => {
+  it("returns status='ok' with an empty runs array when no runs directory exists", async () => {
+    const result = await cleanRuns({ repoPath, verdicts: {} });
+    expect(result.status).toBe("ok");
+    expect(result.runs).toEqual([]);
+  });
+
+  it("returns errorCode=INVALID_INPUT when repoPath starts with '-'", async () => {
+    const result = await cleanRuns({ repoPath: "--bad", verdicts: {} });
+    expect(result.status).toBe("error");
+    expect(result.errorCode).toBe("INVALID_INPUT");
+  });
+});
+
+// ─── one run's failure does not abort the sweep ───────────────────────────────
+
+describe("clean_runs — sweep continues past one run's failure", () => {
+  it("cleans a healthy merged run even when another run is malformed", async () => {
+    const goodRun = "20260522-220000";
+    const badRun = "20260522-230000";
+    withRemote();
+    const { umbrellaBranch } = makeBranches(goodRun, "701", { push: true });
+    writeRunState(
+      repoPath,
+      goodRun,
+      buildRunState({
+        runId: goodRun,
+        status: "completed",
+        umbrellaBranch,
+        finalPullRequest: "https://github.com/o/r/pull/18",
+        slices: {
+          "701": {
+            sliceBranch: "orchestrate/slice-701",
+            worktreePath: null,
+            state: "passed",
+          },
+        },
+      })
+    );
+    writeRunState(repoPath, badRun, "}{ broken");
+
+    const result = await cleanRuns({
+      repoPath,
+      verdicts: { [goodRun]: "merged", [badRun]: "merged" },
+    });
+
+    expect(result.status).toBe("ok");
+    const good = result.runs.find((r) => r.runId === goodRun)!;
+    const bad = result.runs.find((r) => r.runId === badRun)!;
+    expect(good.action).toBe("removed");
+    expect(good.runDirRemoved).toBe(true);
+    expect(bad.action).toBe("skipped");
+    expect(bad.reason).toBe("malformed-run-state");
+    expect(fs.existsSync(runDirPath(repoPath, badRun))).toBe(true);
+  });
+});

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrate
-description: Implement a backlog of ready-for-agent GitHub issues end to end — order them into dependency waves, run implementer and reviewer subagents in isolated worktrees, merge slice pull requests into an umbrella branch, and checkpoint progress so an interrupted run resumes. Use when the user wants to autonomously orchestrate agent-driven implementation of tracked issues, or invokes /orchestrate.
+description: Implement a backlog of ready-for-agent GitHub issues end to end — order them into dependency waves, run implementer and reviewer subagents in isolated worktrees, merge slice pull requests into an umbrella branch, and checkpoint progress so an interrupted run resumes. Use when the user wants to autonomously orchestrate agent-driven implementation of tracked issues, or invokes /orchestrate — including /orchestrate clean to remove the footprint of concluded runs.
 ---
 
 # Orchestrate
@@ -66,6 +66,33 @@ and the successor launcher; without it, built-in defaults apply (see
 it enables the investigator and reviewer subagents' structural code search,
 which otherwise falls back to text search.
 
+## 0. Modes — run vs. clean
+
+This skill has two modes, selected by the invocation argument.
+
+- **No `clean` argument** (`/orchestrate` or `/orchestrate <PRD#>`) — the normal
+  orchestration run. Proceed through sections 1–4 below.
+- **The `clean` argument** (`/orchestrate clean`, optionally
+  `/orchestrate clean --force`) — the **`/orchestrate-clean` mode**. Run **only**
+  the cleanup path described here, then **stop**. Do **not** discover or start a
+  run, do not read the backlog, do not create branches.
+
+### `/orchestrate-clean` mode
+
+`/orchestrate clean` removes the leftover footprint of concluded runs on demand
+— the same cleanup the start-of-run sweep (section 1) performs automatically.
+When invoked with the `clean` argument:
+
+1. Resolve the repository root: `git rev-parse --show-toplevel`.
+2. Run the **cleanup sweep** exactly as section 1 describes it below — enumerate
+   `.orchestrate/runs/*/run-state.json`, resolve each run's merge verdict with
+   `gh pr view`, and call the `clean_runs` MCP tool with the verdict map. If the
+   `--force` argument was passed, set `force: true` in the `clean_runs` call.
+3. Report the `clean_runs` result to the user — per run, its `action`
+   (`removed`, `preserved`, or `skipped`), its `reason`, and the removed or
+   preserved worktrees and branches — then **stop**. `/orchestrate clean` never
+   starts an orchestration run.
+
 ## 1. Start or resume the run
 
 On startup, set a completion goal with `/goal` so the session keeps working
@@ -73,6 +100,41 @@ turn after turn and does not yield control before the run is done. Phrase it
 as a checkable end-state, e.g. `/goal the orchestrate run has opened its final
 integration pull request, or a successor session has been launched`. An
 autonomous run must not stop mid-wave.
+
+### Start-of-run cleanup sweep
+
+Before discovering or starting a run, sweep away the footprint of concluded
+runs so the `.orchestrate/runs/` directory does not accumulate. This same sweep
+is what `/orchestrate clean` (section 0) runs on demand.
+
+1. Enumerate every `.orchestrate/runs/*/run-state.json`. For each run whose
+   `status` is `completed` and whose `finalPullRequest` is **non-null**, resolve
+   the run's **merge verdict** — the gate is strictly the final pull request
+   having **merged** into the integration base, not merely being open:
+
+   ```
+   gh pr view <finalPullRequest> --json state,mergedAt
+   ```
+
+   - `state` is `MERGED` and `mergedAt` is non-null → verdict `merged`.
+   - `state` is `OPEN` → verdict `open`.
+   - `state` is `CLOSED` and `mergedAt` is null → verdict `closed-unmerged`.
+   - The command errors or the result cannot be parsed → verdict `unknown`.
+
+   A run whose `status` is **not** `completed`, or whose `finalPullRequest` is
+   `null`, is **never** swept — it has not concluded. **Never** include the
+   current run, or any run still `in-progress`, in the verdict map: omitting a
+   run from the map tells `clean_runs` to leave it strictly intact.
+2. Call the **`clean_runs` MCP tool** with the repository root as `repoPath` and
+   the per-run `verdicts` map you built. The tool removes each `merged` run's
+   worktrees, its umbrella and slice branches (local and remote), and its run
+   directory; it leaves every other run intact and reports it. A `failed`-slice
+   worktree is preserved (and that run's directory kept) so a developer can
+   still inspect it. `clean_runs` is git + filesystem only — it never shells
+   `gh`; the merge verdict you resolved above is the GitHub half of the gate.
+3. The sweep is best-effort and idempotent — an already-absent branch or
+   worktree is success, not error. Note the result, then continue to discover
+   or start the run; a cleanup hiccup never blocks the run itself.
 
 Every run keeps its ephemeral state in a **per-run directory**,
 `.orchestrate/runs/<runId>/`, holding that run's `run-state.json`,

--- a/plugins/orchestrate/skills/orchestrate/references/run-state.md
+++ b/plugins/orchestrate/skills/orchestrate/references/run-state.md
@@ -123,3 +123,36 @@ partial artifacts discarded (worktree removed, slice branch deleted) and is
 coerced back to `pending` before re-processing — it is not merely continued.
 When no run directory holds an `in-progress` run — none exist, or every run's
 `status` is `completed` — a fresh run starts.
+
+## Cleanup lifecycle
+
+A `completed` run still leaves a footprint on disk and in git — its run
+directory, any preserved worktrees, and its umbrella and slice branches. **Run
+cleanup** removes that footprint once the run has fully concluded.
+
+A run is eligible for cleanup only when **both** conditions hold:
+
+- Its `status` is `completed` — necessary, but not sufficient on its own.
+- Its `finalPullRequest` has **merged** into the integration base
+  (`development`). A non-null `finalPullRequest` means only that the pull
+  request was *opened*; the gate is its **merged** state. A run whose final pull
+  request is still open or was closed unmerged is left intact and only reported.
+
+The merge verdict is GitHub state. The orchestrator resolves it with
+`gh pr view <finalPullRequest> --json state,mergedAt` and passes a per-run
+verdict map (`runId → merged | open | closed-unmerged | unknown`) to the
+`clean_runs` MCP tool, which is itself git + filesystem only. For a `merged`
+run, `clean_runs` removes its `passed`-slice worktrees, deletes its
+`umbrellaBranch` and every `sliceBranch` (local and remote), and removes the run
+directory.
+
+A `failed`-state slice's worktree is **preserved** by default — a developer may
+still need to inspect it. When a slice worktree is preserved, its `sliceBranch`
+is left fully intact too (local **and** remote), so the developer can still
+check it out and push from the preserved worktree; only the branches of removed
+worktrees, plus the `umbrellaBranch`, are deleted. The run directory is **kept**
+whenever any worktree was preserved, so the preserved worktree's `run-state.json`
+survives. The `--force` option removes failed-slice worktrees too, deletes every
+branch, and always removes the run directory. Cleanup runs both as a sweep at the
+start of every run and on demand via `/orchestrate clean`; it never touches an
+`in-progress` run.


### PR DESCRIPTION
Closes #197

Adds run-cleanup support: a `clean_runs` MCP tool that sweeps stale worktrees and run directories, and an ARGUMENTS-dispatched `/orchestrate-clean` mode of the orchestrate skill. Failed-slice worktrees are preserved by default; cleanup is best-effort and idempotent, and never touches an in-progress run.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>