### PR TITLE
chore(orchestrate): bump plugin + marketplace version (PRD #181 cascade)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-engineering-toolkit",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Multi-plugin marketplace for evidence-based Claude Code artifact engineering. Provides plugins for configuration initialization (AGENTS.md, CLAUDE.md), artifact creation/optimization (skills, hooks, rules, subagents), and autonomous backlog orchestration.",
   "owner": {
     "name": "rodrigorjsf",
@@ -33,7 +33,7 @@
     {
       "name": "orchestrate",
       "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"

--- a/plugins/orchestrate/.claude-plugin/plugin.json
+++ b/plugins/orchestrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestrate",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
   "author": {
     "name": "rodrigorjsf"


### PR DESCRIPTION
Closes #198

Final atomic commit of PRD #181 — the marketplace version cascade. PRD #181 shipped six new orchestrate features across the skill, agents, templates, and MCP server, so the orchestrate plugin version bumps minor (`1.1.0` → `1.2.0`) and the root Claude marketplace manifest mirrors the magnitude (`1.5.0` → `1.6.0`); the orchestrate marketplace entry is kept in sync (`1.1.0` → `1.2.0`). The Cursor marketplace is unaffected — orchestrate is a Claude Code plugin.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>