### PR TITLE
chore(claude): note npm-in-non-interactive-bash workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,5 +80,6 @@ When something fails repeatedly, when User has to re-explain, or when a workarou
 
 - Agents fail silently on wrong paths. Always verify hardcoded paths.
 - Before creating a new project artifact, check if an existing one can be extended or merged.
+- npm broken in non-interactive bash (mise inactive); prepend real node bin dir before npm.
 
 


### PR DESCRIPTION
One-line addition to CLAUDE.md § Applied Learning, surfaced during the PRD #241 AFK run: npm's mise shim breaks in non-interactive bash (every workflow/subagent shell), so prepend the real node bin dir (`export PATH="$(dirname "$(readlink -f "$(command -v node)")"):$PATH"`) before any npm command. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)