### PR TITLE
orchestrate-mcp: finalize_slice tool — slice git + run-state finalization mechanics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-engineering-toolkit",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Multi-plugin marketplace for evidence-based Claude Code artifact engineering. Provides plugins for configuration initialization (AGENTS.md, CLAUDE.md), artifact creation/optimization (skills, hooks, rules, subagents), and autonomous backlog orchestration.",
   "owner": {
     "name": "rodrigorjsf",
@@ -33,7 +33,7 @@
     {
       "name": "orchestrate",
       "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"

--- a/plugins/orchestrate/.claude-plugin/plugin.json
+++ b/plugins/orchestrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestrate",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
   "author": {
     "name": "rodrigorjsf"

--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -53,6 +53,7 @@ The plugin bundles `orchestrate-mcp`, a Model Context Protocol server providing 
 | `bootstrap_config` | Set up a repository's `.orchestrate/` config on a first-ever run — project-aware `commands.json`, model-derived `handoff.json`, default `routing.json`, the run directory, and the `.gitignore` entry |
 | `create_worktree` / `remove_worktree` | Git worktree lifecycle — isolated per-slice checkouts |
 | `push_and_verify` | Push a slice branch and verify it actually landed on the remote (SHA-match `git ls-remote` check + bounded backoff) — fails loud when an exit-0 push never lands; git-only, never shells `gh` |
+| `finalize_slice` | Land one reviewed slice's git + run-state mechanics in two phases: `commit-push` (stage exactly the named files, guard an empty changeset, commit with `Closes #<N>`, compose `push_and_verify`, checkpoint `subState: pushed`) and `post-merge` (checkpoint `subState: merged`, remove the worktree, reclaim the local branch). Forge ops and the `pr-open` checkpoint stay in the spine; git-only, never shells `gh` |
 | `run_tests` / `run_typecheck` / `run_build` / `run_lint` | Run the project's configured capability commands |
 | `plan_waves` | Topologically sort issues into dependency waves; detects cycles |
 | `resolve_routing` | Resolve the model and effort variant for each role from a complexity tier |

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -6873,12 +6873,12 @@ var require_dist = __commonJS({
         throw new Error(`Unknown format "${name}"`);
       return f;
     };
-    function addFormats(ajv, list, fs13, exportName) {
+    function addFormats(ajv, list, fs14, exportName) {
       var _a;
       var _b;
       (_a = (_b = ajv.opts.code).formats) !== null && _a !== void 0 ? _a : _b.formats = (0, codegen_1._)`require("ajv-formats/dist/formats").${exportName}`;
       for (const f of list)
-        ajv.addFormat(f, fs13[f]);
+        ajv.addFormat(f, fs14[f]);
     }
     module2.exports = exports2 = formatsPlugin;
     Object.defineProperty(exports2, "__esModule", { value: true });
@@ -22085,6 +22085,14 @@ function resolveRunDir(repoPath, runId) {
 // src/tools/render.ts
 var sliceStateEnum = external_exports.enum(["pending", "in-progress", "passed", "failed", "skipped"]);
 var tierEnum = external_exports.enum(["trivial", "standard", "complex"]);
+var subStateEnum = external_exports.enum([
+  "implemented",
+  "verified",
+  "reviewed",
+  "pushed",
+  "pr-open",
+  "merged"
+]);
 var sliceSchema = external_exports.object({
   issue: external_exports.number().int(),
   title: external_exports.string(),
@@ -22092,6 +22100,7 @@ var sliceSchema = external_exports.object({
   tier: tierEnum,
   blockedBy: external_exports.array(external_exports.string()),
   state: sliceStateEnum,
+  subState: subStateEnum.optional(),
   sliceBranch: external_exports.string(),
   worktreePath: external_exports.string().nullable(),
   pullRequest: external_exports.string().nullable(),
@@ -24619,6 +24628,288 @@ async function validateRunState(input) {
   return { status: "valid" };
 }
 
+// src/tools/finalize-slice.ts
+var fs13 = __toESM(require("fs"));
+var finalizeSliceInputSchema = external_exports.object({
+  phase: external_exports.enum(["commit-push", "post-merge"]).describe(
+    "Which finalization phase to run. 'commit-push' = \xA73 step 6: stage the named file set, guard an empty changeset, commit (subject + `Closes #<N>`), push-and-verify, and write `subState:'pushed'` on a confirmed landing. 'post-merge' = \xA73 step 9 (the thin tail): write `subState:'merged'`, remove the worktree, then force-reclaim the local slice branch (idempotent). Forge ops and the `pr-open` checkpoint stay in the spine."
+  ),
+  worktreePath: external_exports.string().describe(
+    "Absolute path of the slice WORKTREE. In 'commit-push' the stage/commit/push run here; in 'post-merge' it is the worktree removed. NOT where run-state.json lives \u2014 that is under `repoPath` (the main repo root)."
+  ),
+  repoPath: external_exports.string().describe(
+    "Absolute path of the MAIN repository root \u2014 the canonical run-state.json lives under it at `.orchestrate/runs/<runId>/run-state.json`, NOT under the slice worktree (a fresh checkout that gitignores `.orchestrate/runs/`). In 'post-merge' the worktree removal and the local `branch -D` are also driven from here (the worktree is gone by then)."
+  ),
+  runId: external_exports.string().describe(
+    "The orchestration run's id (`prd<N>-<timestamp>` or `backlog-<timestamp>`). Selects the per-run directory `.orchestrate/runs/<runId>/` under `repoPath` whose run-state.json this tool mutates."
+  ),
+  sliceId: external_exports.string().describe(
+    "The issue-id-string key of this slice in run-state's `slices` map. Its `subState` is the field this tool advances ('pushed' then 'merged')."
+  ),
+  branch: external_exports.string().describe(
+    "The slice's local branch name (e.g. `orchestrate/slice-7`). In 'commit-push' it is the branch pushed and verified; in 'post-merge' it is the local branch force-reclaimed after worktree removal."
+  ),
+  remote: external_exports.string().optional().default("origin").describe(
+    "Remote to push to and verify against in 'commit-push'. Defaults to `origin`. Unused in 'post-merge' (local reclaim only)."
+  ),
+  setUpstream: external_exports.boolean().optional().default(true).describe(
+    "When true, the 'commit-push' push sets the upstream tracking ref (`-u`) \u2014 the first push of a new slice branch. Default true."
+  ),
+  files: external_exports.array(external_exports.string()).optional().describe(
+    "The spine-computed EXACT file set to stage in 'commit-push' (the union of the validated implementer + reviewer `filesChanged`). Staged via `git add -- ...files` \u2014 NEVER `git add -A`/`-u`/`.`, so untracked build artifacts in the worktree are never committed. Required for 'commit-push'; ignored in 'post-merge'."
+  ),
+  commitSubject: external_exports.string().optional().describe(
+    "The commit subject line for 'commit-push' (e.g. `feat(x): <issue title>`). Committed via a first `-m`; the `Closes #<issueNumber>` trailer is the second `-m`. Required for 'commit-push'."
+  ),
+  issueNumber: external_exports.number().int().optional().describe(
+    "The GitHub issue number for the `Closes #<N>` commit trailer in 'commit-push'. Required for 'commit-push'."
+  )
+});
+var finalizeSliceOutputSchema = external_exports.object({
+  status: external_exports.enum(["ok", "failed"]).describe(
+    "Outcome discriminant. 'ok' = the requested phase completed (commit + verified push, or the merged-tail removal); 'failed' = a git or run-state step failed \u2014 see `errorCode`."
+  ),
+  verdict: external_exports.enum(["committed-pushed", "failed"]).describe(
+    "The slice-finalization verdict. 'committed-pushed' on a successful phase (both phases report it \u2014 'commit-push' on a confirmed landing, 'post-merge' on the merged-tail completion); 'failed' otherwise."
+  ),
+  branch: external_exports.string().optional().describe("The branch acted on. Present when status='ok'."),
+  remote: external_exports.string().optional().describe(
+    "The remote the branch landed on. Present in a successful 'commit-push'."
+  ),
+  sha: external_exports.string().optional().describe(
+    "The commit SHA confirmed on the remote (matches the local branch tip). Present in a successful 'commit-push'."
+  ),
+  attempts: external_exports.number().optional().describe(
+    "How many landing-verification polls ran before the remote ref matched (>=1). Present in a successful 'commit-push'."
+  ),
+  worktreeRemoved: external_exports.boolean().optional().describe(
+    "True when the worktree was removed (or was already absent \u2014 idempotent). Present in a successful 'post-merge'."
+  ),
+  branchReclaimed: external_exports.boolean().optional().describe(
+    "True when the local slice branch was deleted (or was already absent \u2014 idempotent). Present in a successful 'post-merge'."
+  ),
+  errorCode: external_exports.enum([
+    "INVALID_INPUT",
+    "EMPTY_CHANGESET",
+    "PUSH_FAILED",
+    "BRANCH_NOT_ON_REMOTE",
+    "RUN_ID_INVALID",
+    "RUN_STATE_NOT_FOUND",
+    "RUN_STATE_INVALID",
+    "SLICE_NOT_IN_RUN_STATE",
+    "RUN_STATE_WRITE_FAILED",
+    "WORKTREE_REMOVE_FAILED",
+    "GIT_ERROR"
+  ]).optional().describe(
+    "Machine-readable failure category (git-only). 'INVALID_INPUT' = a branch/remote/path would be parsed by git as an option flag, or a required phase field is missing; 'EMPTY_CHANGESET' = nothing was staged (`git diff --cached --quiet` clean) \u2014 the slice produced no changes; 'PUSH_FAILED'/'BRANCH_NOT_ON_REMOTE' = bubbled from pushAndVerify (the push exited non-zero, or exited 0 but never landed at the expected SHA \u2014 the silent-failure mode); 'RUN_ID_INVALID' = the runId is malformed; 'RUN_STATE_NOT_FOUND'/'RUN_STATE_INVALID' = run-state.json is absent or not parseable; 'SLICE_NOT_IN_RUN_STATE' = `sliceId` is not a key in the `slices` map; 'RUN_STATE_WRITE_FAILED' = the checkpoint write failed; 'WORKTREE_REMOVE_FAILED' = the worktree could not be removed; 'GIT_ERROR' = another git command could not run."
+  ),
+  errorMessage: external_exports.string().optional().describe(
+    "Cleaned, human-readable failure description. Present when status='failed'."
+  )
+});
+function writeSubState(repoPath, runId, sliceId, subState) {
+  const resolved = resolveRunDir(repoPath, runId);
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      errorCode: "RUN_ID_INVALID",
+      errorMessage: resolved.errorMessage
+    };
+  }
+  const statePath = resolved.paths.runStatePath;
+  let raw;
+  try {
+    raw = fs13.readFileSync(statePath, "utf8");
+  } catch {
+    return {
+      ok: false,
+      errorCode: "RUN_STATE_NOT_FOUND",
+      errorMessage: `No run-state.json found at ${statePath}.`
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      errorCode: "RUN_STATE_INVALID",
+      errorMessage: `run-state.json is not valid JSON: ${err instanceof Error ? err.message.split("\n")[0] : String(err)}`
+    };
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errorCode: "RUN_STATE_INVALID",
+      errorMessage: "run-state.json is not a JSON object."
+    };
+  }
+  const obj = parsed;
+  const slices = obj.slices;
+  if (slices === null || typeof slices !== "object" || Array.isArray(slices)) {
+    return {
+      ok: false,
+      errorCode: "RUN_STATE_INVALID",
+      errorMessage: "run-state.json `slices` is not a map keyed by issue id."
+    };
+  }
+  const sliceMap = slices;
+  const slice = sliceMap[sliceId];
+  if (slice === null || typeof slice !== "object" || Array.isArray(slice)) {
+    return {
+      ok: false,
+      errorCode: "SLICE_NOT_IN_RUN_STATE",
+      errorMessage: `Slice '${sliceId}' is not a key in run-state.json's slices map.`
+    };
+  }
+  const nowIso = (/* @__PURE__ */ new Date()).toISOString();
+  slice.subState = subState;
+  slice.updatedAt = nowIso;
+  obj.updatedAt = nowIso;
+  try {
+    fs13.writeFileSync(statePath, JSON.stringify(obj, null, 2), "utf8");
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      errorCode: "RUN_STATE_WRITE_FAILED",
+      errorMessage: `Could not write run-state.json at ${statePath}: ${err instanceof Error ? err.message.split("\n")[0] : String(err)}`
+    };
+  }
+}
+function isAbsentRefError2(message) {
+  const m = message.toLowerCase();
+  return m.includes("remote ref does not exist") || m.includes("not found") || m.includes("does not exist") || m.includes("couldn't find remote ref") || /branch .* not found/.test(m);
+}
+async function deleteLocalBranch2(branch, repoPath) {
+  try {
+    await gitExecFile(["branch", "-D", "--", branch], repoPath);
+    return null;
+  } catch (err) {
+    const message = cleanGitError(err);
+    if (isAbsentRefError2(message)) {
+      return null;
+    }
+    return message;
+  }
+}
+async function finalizeSlice(input, opts) {
+  if (input.phase === "commit-push") {
+    return finalizeCommitPush(input, opts);
+  }
+  return finalizePostMerge(input);
+}
+async function finalizeCommitPush(input, opts) {
+  const { worktreePath, repoPath, runId, sliceId, branch } = input;
+  const remote = input.remote ?? "origin";
+  const setUpstream = input.setUpstream ?? true;
+  if (!input.files || input.commitSubject === void 0 || input.issueNumber === void 0) {
+    return failed(
+      "INVALID_INPUT",
+      "phase 'commit-push' requires `files`, `commitSubject`, and `issueNumber`."
+    );
+  }
+  const { files, commitSubject, issueNumber } = input;
+  const branchGuard = optionInjectionError("branch", branch);
+  if (branchGuard) return failed("INVALID_INPUT", branchGuard);
+  const remoteGuard = optionInjectionError("remote", remote);
+  if (remoteGuard) return failed("INVALID_INPUT", remoteGuard);
+  try {
+    await gitExecFile(["add", "--", ...files], worktreePath);
+  } catch (err) {
+    return failed("GIT_ERROR", cleanGitError(err));
+  }
+  let hasStaged = false;
+  try {
+    await gitExecFile(["diff", "--cached", "--quiet"], worktreePath);
+    hasStaged = false;
+  } catch {
+    hasStaged = true;
+  }
+  if (!hasStaged) {
+    return failed(
+      "EMPTY_CHANGESET",
+      "Nothing was staged \u2014 the slice produced no changes; not committing."
+    );
+  }
+  try {
+    await gitExecFile(
+      ["commit", "-m", commitSubject, "-m", `Closes #${issueNumber}`],
+      worktreePath
+    );
+  } catch (err) {
+    return failed("GIT_ERROR", cleanGitError(err));
+  }
+  const push = await pushAndVerify(
+    { repoPath: worktreePath, branch, remote, setUpstream },
+    opts
+  );
+  if (push.status === "error") {
+    return {
+      status: "failed",
+      verdict: "failed",
+      errorCode: push.errorCode ?? "GIT_ERROR",
+      errorMessage: push.errorMessage
+    };
+  }
+  const write = writeSubState(repoPath, runId, sliceId, "pushed");
+  if (!write.ok) {
+    return failed(write.errorCode, write.errorMessage);
+  }
+  return {
+    status: "ok",
+    verdict: "committed-pushed",
+    branch: push.branch,
+    remote: push.remote,
+    sha: push.sha,
+    attempts: push.attempts
+  };
+}
+async function finalizePostMerge(input) {
+  const { worktreePath, repoPath, runId, sliceId, branch } = input;
+  const branchGuard = optionInjectionError("branch", branch);
+  if (branchGuard) return failed("INVALID_INPUT", branchGuard);
+  const write = writeSubState(repoPath, runId, sliceId, "merged");
+  if (!write.ok) {
+    return failed(write.errorCode, write.errorMessage);
+  }
+  let worktreeRemoved = false;
+  const removed = await removeWorktree({
+    worktreePath,
+    repoPath,
+    force: true
+  });
+  if (removed.status === "ok" || removed.errorCode === "PATH_NOT_FOUND") {
+    worktreeRemoved = true;
+  } else {
+    return {
+      status: "failed",
+      verdict: "failed",
+      errorCode: "WORKTREE_REMOVE_FAILED",
+      errorMessage: removed.status === "refused" ? removed.refusalReason ?? "Worktree removal was refused." : removed.errorMessage ?? "Worktree removal failed."
+    };
+  }
+  const branchErr = await deleteLocalBranch2(branch, repoPath);
+  if (branchErr) {
+    return failed("GIT_ERROR", branchErr);
+  }
+  return {
+    status: "ok",
+    verdict: "committed-pushed",
+    branch,
+    worktreeRemoved,
+    branchReclaimed: true
+  };
+}
+function failed(errorCode, errorMessage) {
+  return {
+    status: "failed",
+    verdict: "failed",
+    errorCode,
+    errorMessage
+  };
+}
+
 // src/index.ts
 var server = new McpServer({
   name: "orchestrate",
@@ -25172,6 +25463,31 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleValidateRunState
+);
+var handleFinalizeSlice = async (input) => {
+  const result = await finalizeSlice(input);
+  let text;
+  if (result.status === "ok") {
+    text = input.phase === "commit-push" ? `Slice committed and pushed: ${result.branch} landed at ${result.sha} on ${result.remote} (${result.attempts} verify attempt(s)); subState 'pushed' checkpointed.` : `Slice merged-tail finalized: subState 'merged' checkpointed, worktree removed (${result.worktreeRemoved}), local branch ${result.branch} reclaimed (${result.branchReclaimed}).`;
+  } else {
+    text = `finalize_slice failed [${result.errorCode}]: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text", text }]
+  };
+};
+registerTool(
+  "finalize_slice",
+  {
+    title: "Finalize a Reviewed Slice (git + run-state mechanics)",
+    description: "Owns the deterministic git + run-state machinery of landing one reviewed slice \u2014 the git-only half of \xA73 (Processing one slice), in two phases behind one tool. phase 'commit-push' (step 6): stages EXACTLY the spine-computed `files` set ('git add -- ...files', never 'git add -A'/'-u'/'.'), guards an empty changeset ('git diff --cached --quiet' \u2192 EMPTY_CHANGESET, no commit), commits with the two-`-m` form (subject + 'Closes #<N>' trailer), composes the push_and_verify landing check, and writes `subState:'pushed'` ONLY after the push is confirmed landed (a never-landing push bubbles PUSH_FAILED / BRANCH_NOT_ON_REMOTE). phase 'post-merge' (step 9, the thin tail): writes `subState:'merged'`, removes the worktree, then force-reclaims the local slice branch (ordered after removal, idempotent if already gone). run-state.json lives under the MAIN repo `repoPath`, NOT the slice `worktreePath`. Git-only via the hardened exec seam \u2014 it never shells `gh`; the forge ops (PR create, mergeability poll, squash-merge, label edit), the `pr-open` checkpoint, and the conflict-resolver path stay in the spine. Returns a discriminated `status` of 'ok' or 'failed' with a git-only `errorCode`, and never throws.",
+    inputSchema: finalizeSliceInputSchema.shape,
+    outputSchema: finalizeSliceOutputSchema.shape
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleFinalizeSlice
 );
 async function main() {
   const transport = new StdioServerTransport();

--- a/plugins/orchestrate/orchestrate-mcp/src/index.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/index.ts
@@ -129,6 +129,13 @@ import {
   type ValidateRunStateInput,
   type ValidateRunStateOutput,
 } from "./tools/validate-run-state.js";
+import {
+  finalizeSlice,
+  finalizeSliceInputSchema,
+  finalizeSliceOutputSchema,
+  type FinalizeSliceInput,
+  type FinalizeSliceOutput,
+} from "./tools/finalize-slice.js";
 
 const server = new McpServer({
   name: "orchestrate",
@@ -1098,6 +1105,58 @@ registerTool(
   // Handler is typed against its concrete input/output contract;
   // widen to the flat SDK-boundary `AnyToolHandler` for registration.
   handleValidateRunState as unknown as AnyToolHandler
+);
+
+// ─── finalize_slice ───────────────────────────────────────────────────────────
+
+const handleFinalizeSlice: ToolHandler<
+  FinalizeSliceInput,
+  FinalizeSliceOutput
+> = async (input) => {
+  const result = await finalizeSlice(input);
+  let text: string;
+  if (result.status === "ok") {
+    text =
+      input.phase === "commit-push"
+        ? `Slice committed and pushed: ${result.branch} landed at ${result.sha} on ${result.remote} (${result.attempts} verify attempt(s)); subState 'pushed' checkpointed.`
+        : `Slice merged-tail finalized: subState 'merged' checkpointed, worktree removed (${result.worktreeRemoved}), local branch ${result.branch} reclaimed (${result.branchReclaimed}).`;
+  } else {
+    text = `finalize_slice failed [${result.errorCode}]: ${result.errorMessage}`;
+  }
+  return {
+    structuredContent: result,
+    content: [{ type: "text" as const, text }],
+  };
+};
+
+registerTool(
+  "finalize_slice",
+  {
+    title: "Finalize a Reviewed Slice (git + run-state mechanics)",
+    description:
+      "Owns the deterministic git + run-state machinery of landing one reviewed " +
+      "slice — the git-only half of §3 (Processing one slice), in two phases " +
+      "behind one tool. phase 'commit-push' (step 6): stages EXACTLY the " +
+      "spine-computed `files` set ('git add -- ...files', never 'git add -A'/" +
+      "'-u'/'.'), guards an empty changeset ('git diff --cached --quiet' → " +
+      "EMPTY_CHANGESET, no commit), commits with the two-`-m` form (subject + " +
+      "'Closes #<N>' trailer), composes the push_and_verify landing check, and " +
+      "writes `subState:'pushed'` ONLY after the push is confirmed landed (a " +
+      "never-landing push bubbles PUSH_FAILED / BRANCH_NOT_ON_REMOTE). phase " +
+      "'post-merge' (step 9, the thin tail): writes `subState:'merged'`, removes " +
+      "the worktree, then force-reclaims the local slice branch (ordered after " +
+      "removal, idempotent if already gone). run-state.json lives under the MAIN " +
+      "repo `repoPath`, NOT the slice `worktreePath`. Git-only via the hardened " +
+      "exec seam — it never shells `gh`; the forge ops (PR create, mergeability " +
+      "poll, squash-merge, label edit), the `pr-open` checkpoint, and the " +
+      "conflict-resolver path stay in the spine. Returns a discriminated " +
+      "`status` of 'ok' or 'failed' with a git-only `errorCode`, and never throws.",
+    inputSchema: finalizeSliceInputSchema.shape,
+    outputSchema: finalizeSliceOutputSchema.shape,
+  },
+  // Handler is typed against its concrete input/output contract;
+  // widen to the flat SDK-boundary `AnyToolHandler` for registration.
+  handleFinalizeSlice as unknown as AnyToolHandler
 );
 
 // ─── Start server ─────────────────────────────────────────────────────────────

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/finalize-slice.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/finalize-slice.ts
@@ -1,0 +1,591 @@
+import * as fs from "fs";
+import { z } from "zod";
+import { gitExecFile, optionInjectionError, cleanGitError } from "../git.js";
+import { resolveRunDir } from "../run-dir.js";
+import { pushAndVerify, type VerifyOptions } from "./push-and-verify.js";
+import { removeWorktree } from "./worktree.js";
+
+// ─── finalize_slice — the slice git + run-state finalization mechanics ─────────
+//
+// finalize_slice owns the deterministic git + run-state machinery of landing one
+// reviewed slice — the half of §3 (Processing one slice) that is pure git and
+// run-state writes, never forge state. It runs in two PHASES, both registered
+// behind this one tool so the SKILL narrates one tool at steps 6 and 9:
+//
+//   phase 'commit-push' (step 6): stage ONLY the spine-computed file set
+//     (`git add -- ...files`, never `add -A`/`-u`/`.`), guard an empty changeset,
+//     commit with the two-`-m` form (subject + `Closes #<N>` trailer), compose
+//     the exported `pushAndVerify` landing check, and write the `pushed`
+//     checkpoint into run-state.json ONLY after the push is confirmed landed.
+//
+//   phase 'post-merge' (step 9, the thin tail): write the `merged` anchor into
+//     run-state.json, remove the slice worktree, then force-reclaim the local
+//     slice branch (ordered AFTER worktree removal — a checked-out branch refuses
+//     `branch -D` — and idempotent if the branch is already gone).
+//
+// WHAT STAYS IN THE SPINE (never here, per the no-gh-in-MCP invariant): every
+// forge op — `gh pr create`, the mergeability poll, `gh pr merge --squash`, the
+// label edit — and the `pr-open` checkpoint, and the conflict-resolver path.
+// finalize_slice is git-only, routed through the hardened exec seam (`src/git.ts`),
+// and never throws — every failure mode is a structured `failed{errorCode}`.
+//
+// PATH DISCIPLINE — two distinct paths, never conflated:
+//   `worktreePath` — the slice worktree; stage/commit/push and the worktree
+//     removal target run here. It is a fresh checkout: `.orchestrate/runs/` is
+//     gitignored and absent from it.
+//   `repoPath`     — the MAIN repository root; the canonical run-state.json lives
+//     under it (`resolveRunDir(repoPath, runId)`), and the post-merge worktree
+//     removal + local `branch -D` are driven from it (by step 9 the worktree is
+//     gone, so the main root is the only valid cwd for the branch reclaim).
+
+// ─── Schemas — z.object is the single source of truth; TS types via z.infer ───
+
+export const finalizeSliceInputSchema = z.object({
+  phase: z
+    .enum(["commit-push", "post-merge"])
+    .describe(
+      "Which finalization phase to run. 'commit-push' = §3 step 6: stage the " +
+        "named file set, guard an empty changeset, commit (subject + `Closes " +
+        "#<N>`), push-and-verify, and write `subState:'pushed'` on a confirmed " +
+        "landing. 'post-merge' = §3 step 9 (the thin tail): write " +
+        "`subState:'merged'`, remove the worktree, then force-reclaim the local " +
+        "slice branch (idempotent). Forge ops and the `pr-open` checkpoint stay " +
+        "in the spine."
+    ),
+  worktreePath: z
+    .string()
+    .describe(
+      "Absolute path of the slice WORKTREE. In 'commit-push' the stage/commit/" +
+        "push run here; in 'post-merge' it is the worktree removed. NOT where " +
+        "run-state.json lives — that is under `repoPath` (the main repo root)."
+    ),
+  repoPath: z
+    .string()
+    .describe(
+      "Absolute path of the MAIN repository root — the canonical run-state.json " +
+        "lives under it at `.orchestrate/runs/<runId>/run-state.json`, NOT under " +
+        "the slice worktree (a fresh checkout that gitignores `.orchestrate/" +
+        "runs/`). In 'post-merge' the worktree removal and the local `branch -D` " +
+        "are also driven from here (the worktree is gone by then)."
+    ),
+  runId: z
+    .string()
+    .describe(
+      "The orchestration run's id (`prd<N>-<timestamp>` or `backlog-" +
+        "<timestamp>`). Selects the per-run directory `.orchestrate/runs/<runId>/` " +
+        "under `repoPath` whose run-state.json this tool mutates."
+    ),
+  sliceId: z
+    .string()
+    .describe(
+      "The issue-id-string key of this slice in run-state's `slices` map. Its " +
+        "`subState` is the field this tool advances ('pushed' then 'merged')."
+    ),
+  branch: z
+    .string()
+    .describe(
+      "The slice's local branch name (e.g. `orchestrate/slice-7`). In " +
+        "'commit-push' it is the branch pushed and verified; in 'post-merge' it " +
+        "is the local branch force-reclaimed after worktree removal."
+    ),
+  remote: z
+    .string()
+    .optional()
+    .default("origin")
+    .describe(
+      "Remote to push to and verify against in 'commit-push'. Defaults to " +
+        "`origin`. Unused in 'post-merge' (local reclaim only)."
+    ),
+  setUpstream: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      "When true, the 'commit-push' push sets the upstream tracking ref (`-u`) " +
+        "— the first push of a new slice branch. Default true."
+    ),
+  files: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "The spine-computed EXACT file set to stage in 'commit-push' (the union " +
+        "of the validated implementer + reviewer `filesChanged`). Staged via " +
+        "`git add -- ...files` — NEVER `git add -A`/`-u`/`.`, so untracked build " +
+        "artifacts in the worktree are never committed. Required for " +
+        "'commit-push'; ignored in 'post-merge'."
+    ),
+  commitSubject: z
+    .string()
+    .optional()
+    .describe(
+      "The commit subject line for 'commit-push' (e.g. `feat(x): <issue " +
+        "title>`). Committed via a first `-m`; the `Closes #<issueNumber>` " +
+        "trailer is the second `-m`. Required for 'commit-push'."
+    ),
+  issueNumber: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      "The GitHub issue number for the `Closes #<N>` commit trailer in " +
+        "'commit-push'. Required for 'commit-push'."
+    ),
+});
+
+export const finalizeSliceOutputSchema = z.object({
+  status: z
+    .enum(["ok", "failed"])
+    .describe(
+      "Outcome discriminant. 'ok' = the requested phase completed (commit + " +
+        "verified push, or the merged-tail removal); 'failed' = a git or " +
+        "run-state step failed — see `errorCode`."
+    ),
+  verdict: z
+    .enum(["committed-pushed", "failed"])
+    .describe(
+      "The slice-finalization verdict. 'committed-pushed' on a successful phase " +
+        "(both phases report it — 'commit-push' on a confirmed landing, " +
+        "'post-merge' on the merged-tail completion); 'failed' otherwise."
+    ),
+  branch: z
+    .string()
+    .optional()
+    .describe("The branch acted on. Present when status='ok'."),
+  remote: z
+    .string()
+    .optional()
+    .describe(
+      "The remote the branch landed on. Present in a successful 'commit-push'."
+    ),
+  sha: z
+    .string()
+    .optional()
+    .describe(
+      "The commit SHA confirmed on the remote (matches the local branch tip). " +
+        "Present in a successful 'commit-push'."
+    ),
+  attempts: z
+    .number()
+    .optional()
+    .describe(
+      "How many landing-verification polls ran before the remote ref matched " +
+        "(>=1). Present in a successful 'commit-push'."
+    ),
+  worktreeRemoved: z
+    .boolean()
+    .optional()
+    .describe(
+      "True when the worktree was removed (or was already absent — idempotent). " +
+        "Present in a successful 'post-merge'."
+    ),
+  branchReclaimed: z
+    .boolean()
+    .optional()
+    .describe(
+      "True when the local slice branch was deleted (or was already absent — " +
+        "idempotent). Present in a successful 'post-merge'."
+    ),
+  errorCode: z
+    .enum([
+      "INVALID_INPUT",
+      "EMPTY_CHANGESET",
+      "PUSH_FAILED",
+      "BRANCH_NOT_ON_REMOTE",
+      "RUN_ID_INVALID",
+      "RUN_STATE_NOT_FOUND",
+      "RUN_STATE_INVALID",
+      "SLICE_NOT_IN_RUN_STATE",
+      "RUN_STATE_WRITE_FAILED",
+      "WORKTREE_REMOVE_FAILED",
+      "GIT_ERROR",
+    ])
+    .optional()
+    .describe(
+      "Machine-readable failure category (git-only). 'INVALID_INPUT' = a " +
+        "branch/remote/path would be parsed by git as an option flag, or a " +
+        "required phase field is missing; 'EMPTY_CHANGESET' = nothing was staged " +
+        "(`git diff --cached --quiet` clean) — the slice produced no changes; " +
+        "'PUSH_FAILED'/'BRANCH_NOT_ON_REMOTE' = bubbled from pushAndVerify (the " +
+        "push exited non-zero, or exited 0 but never landed at the expected SHA " +
+        "— the silent-failure mode); 'RUN_ID_INVALID' = the runId is malformed; " +
+        "'RUN_STATE_NOT_FOUND'/'RUN_STATE_INVALID' = run-state.json is absent or " +
+        "not parseable; 'SLICE_NOT_IN_RUN_STATE' = `sliceId` is not a key in the " +
+        "`slices` map; 'RUN_STATE_WRITE_FAILED' = the checkpoint write failed; " +
+        "'WORKTREE_REMOVE_FAILED' = the worktree could not be removed; " +
+        "'GIT_ERROR' = another git command could not run."
+    ),
+  errorMessage: z
+    .string()
+    .optional()
+    .describe(
+      "Cleaned, human-readable failure description. Present when status='failed'."
+    ),
+});
+
+// ─── TS types — derived from the schemas (single source of truth) ─────────────
+
+export type FinalizeSliceInput = z.infer<typeof finalizeSliceInputSchema>;
+export type FinalizeSliceOutput = z.infer<typeof finalizeSliceOutputSchema>;
+
+// ─── Internal: run-state read/mutate/write (raw JSON, schema-faithful) ─────────
+//
+// The run-state write deliberately round-trips RAW JSON — read, mutate exactly
+// `slices[sliceId].subState` (+ the two `updatedAt` timestamps), stringify back —
+// rather than parsing through render.ts's `runStateSchema`. The schema omits live
+// keys (e.g. `driverSessionId`, which binds the context-watchdog to its run), so a
+// parse→reserialize round-trip would silently DROP them. Raw mutation preserves
+// the full object.
+
+type RunStateWriteResult =
+  | { ok: true }
+  | {
+      ok: false;
+      errorCode:
+        | "RUN_ID_INVALID"
+        | "RUN_STATE_NOT_FOUND"
+        | "RUN_STATE_INVALID"
+        | "SLICE_NOT_IN_RUN_STATE"
+        | "RUN_STATE_WRITE_FAILED";
+      errorMessage: string;
+    };
+
+/**
+ * Reads `.orchestrate/runs/<runId>/run-state.json` under `repoPath` (the MAIN
+ * repo root — NEVER the worktree), sets `slices[sliceId].subState` to `subState`,
+ * refreshes that slice's `updatedAt` and the top-level `updatedAt`, and writes
+ * the whole object back as raw JSON. Never throws — every failure is a keyed
+ * result. The full object is preserved (no schema round-trip), so live keys the
+ * canonical schema omits (e.g. `driverSessionId`) survive.
+ */
+function writeSubState(
+  repoPath: string,
+  runId: string,
+  sliceId: string,
+  subState: "pushed" | "merged"
+): RunStateWriteResult {
+  const resolved = resolveRunDir(repoPath, runId);
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      errorCode: "RUN_ID_INVALID",
+      errorMessage: resolved.errorMessage,
+    };
+  }
+  const statePath = resolved.paths.runStatePath;
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(statePath, "utf8");
+  } catch {
+    return {
+      ok: false,
+      errorCode: "RUN_STATE_NOT_FOUND",
+      errorMessage: `No run-state.json found at ${statePath}.`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      errorCode: "RUN_STATE_INVALID",
+      errorMessage: `run-state.json is not valid JSON: ${
+        err instanceof Error ? err.message.split("\n")[0] : String(err)
+      }`,
+    };
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      errorCode: "RUN_STATE_INVALID",
+      errorMessage: "run-state.json is not a JSON object.",
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const slices = obj.slices;
+  if (
+    slices === null ||
+    typeof slices !== "object" ||
+    Array.isArray(slices)
+  ) {
+    return {
+      ok: false,
+      errorCode: "RUN_STATE_INVALID",
+      errorMessage: "run-state.json `slices` is not a map keyed by issue id.",
+    };
+  }
+  const sliceMap = slices as Record<string, unknown>;
+  const slice = sliceMap[sliceId];
+  if (slice === null || typeof slice !== "object" || Array.isArray(slice)) {
+    return {
+      ok: false,
+      errorCode: "SLICE_NOT_IN_RUN_STATE",
+      errorMessage: `Slice '${sliceId}' is not a key in run-state.json's slices map.`,
+    };
+  }
+
+  const nowIso = new Date().toISOString();
+  (slice as Record<string, unknown>).subState = subState;
+  (slice as Record<string, unknown>).updatedAt = nowIso;
+  obj.updatedAt = nowIso;
+
+  try {
+    fs.writeFileSync(statePath, JSON.stringify(obj, null, 2), "utf8");
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      errorCode: "RUN_STATE_WRITE_FAILED",
+      errorMessage: `Could not write run-state.json at ${statePath}: ${
+        err instanceof Error ? err.message.split("\n")[0] : String(err)
+      }`,
+    };
+  }
+}
+
+// ─── Internal: idempotent local-branch reclaim (cloned from clean-runs.ts) ─────
+//
+// `deleteLocalBranch` / `isAbsentRefError` are module-private in clean-runs.ts;
+// the brief mandates cloning the idempotency pattern rather than importing it.
+
+/**
+ * True when a `cleanGitError` string indicates the ref simply did not exist —
+ * which, for an idempotent reclaim, is success, not failure. A run resumed at
+ * `subState: merged` may find the branch already reclaimed by an earlier pass.
+ */
+function isAbsentRefError(message: string): boolean {
+  const m = message.toLowerCase();
+  return (
+    m.includes("remote ref does not exist") ||
+    m.includes("not found") ||
+    m.includes("does not exist") ||
+    m.includes("couldn't find remote ref") ||
+    /branch .* not found/.test(m)
+  );
+}
+
+/**
+ * Force-deletes a branch's LOCAL ref from `repoPath`. The `-D` force is
+ * mandatory: the squash-merge rewrote the slice's commit SHA, so the branch is
+ * not an ancestor of umbrella and `git branch -d` would refuse it. An
+ * already-absent local ref is success (idempotent). Returns null on success, or a
+ * cleaned error message when the deletion genuinely failed. Never throws.
+ */
+async function deleteLocalBranch(
+  branch: string,
+  repoPath: string
+): Promise<string | null> {
+  try {
+    // `--` terminates option parsing; the branch name is a positional.
+    await gitExecFile(["branch", "-D", "--", branch], repoPath);
+    return null;
+  } catch (err) {
+    const message = cleanGitError(err);
+    if (isAbsentRefError(message)) {
+      return null; // never created, or already deleted — success.
+    }
+    return message;
+  }
+}
+
+// ─── finalize_slice ────────────────────────────────────────────────────────────
+
+/**
+ * Finalizes one reviewed slice's git + run-state mechanics for the requested
+ * `phase`. `opts` injects the backoff `sleep` (and pushAndVerify tuning) for
+ * fast, deterministic tests; the registration handler calls this with no `opts`
+ * (real sleep). It is never a public Zod field. Never throws — every failure mode
+ * is a structured `failed{errorCode}` result.
+ */
+export async function finalizeSlice(
+  input: FinalizeSliceInput,
+  opts?: VerifyOptions
+): Promise<FinalizeSliceOutput> {
+  if (input.phase === "commit-push") {
+    return finalizeCommitPush(input, opts);
+  }
+  return finalizePostMerge(input);
+}
+
+/**
+ * Phase 'commit-push' (§3 step 6): stage the named files, guard an empty
+ * changeset, commit (subject + `Closes #<N>`), push-and-verify, and write
+ * `subState:'pushed'` ONLY after the push is confirmed landed.
+ */
+async function finalizeCommitPush(
+  input: FinalizeSliceInput,
+  opts?: VerifyOptions
+): Promise<FinalizeSliceOutput> {
+  const { worktreePath, repoPath, runId, sliceId, branch } = input;
+  const remote = input.remote ?? "origin";
+  const setUpstream = input.setUpstream ?? true;
+
+  // 0. Required-field guard for this phase.
+  if (
+    !input.files ||
+    input.commitSubject === undefined ||
+    input.issueNumber === undefined
+  ) {
+    return failed(
+      "INVALID_INPUT",
+      "phase 'commit-push' requires `files`, `commitSubject`, and `issueNumber`."
+    );
+  }
+  const { files, commitSubject, issueNumber } = input;
+
+  // 1. Option-injection guards — branch and remote interpolate into git args.
+  //    Guarded BEFORE staging/commit so a `--force` branch never leaves a
+  //    dangling local commit (pushAndVerify guards too, but only after commit).
+  const branchGuard = optionInjectionError("branch", branch);
+  if (branchGuard) return failed("INVALID_INPUT", branchGuard);
+  const remoteGuard = optionInjectionError("remote", remote);
+  if (remoteGuard) return failed("INVALID_INPUT", remoteGuard);
+
+  // 2. Stage EXACTLY the named files. `git add -- ...files` (NEVER -A/-u/.) so
+  //    untracked build artifacts the capability tools leave behind are excluded.
+  try {
+    await gitExecFile(["add", "--", ...files], worktreePath);
+  } catch (err) {
+    return failed("GIT_ERROR", cleanGitError(err));
+  }
+
+  // 3. Empty-changeset guard. `git diff --cached --quiet` exits 0 (no throw) when
+  //    NOTHING is staged, and exits non-zero (gitExecFile THROWS) when there ARE
+  //    staged changes — so the THROW is the success path here.
+  let hasStaged = false;
+  try {
+    await gitExecFile(["diff", "--cached", "--quiet"], worktreePath);
+    hasStaged = false; // exit 0 → index clean → nothing staged.
+  } catch {
+    hasStaged = true; // non-zero exit → staged changes present.
+  }
+  if (!hasStaged) {
+    return failed(
+      "EMPTY_CHANGESET",
+      "Nothing was staged — the slice produced no changes; not committing."
+    );
+  }
+
+  // 4. Commit with the two-`-m` form: subject line + `Closes #<N>` trailer.
+  //    execFile (no shell), so no `--` (no positionals) and no newline trick.
+  try {
+    await gitExecFile(
+      ["commit", "-m", commitSubject, "-m", `Closes #${issueNumber}`],
+      worktreePath
+    );
+  } catch (err) {
+    return failed("GIT_ERROR", cleanGitError(err));
+  }
+
+  // 5. Compose the exported pushAndVerify — do NOT re-implement push/verify. A
+  //    push that never lands bubbles its push-failure code unchanged.
+  const push = await pushAndVerify(
+    { repoPath: worktreePath, branch, remote, setUpstream },
+    opts
+  );
+  if (push.status === "error") {
+    return {
+      status: "failed",
+      verdict: "failed",
+      errorCode: push.errorCode ?? "GIT_ERROR",
+      errorMessage: push.errorMessage,
+    };
+  }
+
+  // 6. Write `subState:'pushed'` ONLY after pushAndVerify returns ok — the
+  //    `pushed` checkpoint attests to a CONFIRMED landing, never a bare exit-0.
+  const write = writeSubState(repoPath, runId, sliceId, "pushed");
+  if (!write.ok) {
+    return failed(write.errorCode, write.errorMessage);
+  }
+
+  return {
+    status: "ok",
+    verdict: "committed-pushed",
+    branch: push.branch,
+    remote: push.remote,
+    sha: push.sha,
+    attempts: push.attempts,
+  };
+}
+
+/**
+ * Phase 'post-merge' (§3 step 9, the thin tail): write `subState:'merged'`,
+ * remove the worktree, then force-reclaim the local branch. The ORDER is
+ * load-bearing: the `merged` anchor is the integration-boundary checkpoint and is
+ * written FIRST, then the worktree is removed (a checked-out branch refuses
+ * `branch -D`), then the local branch is reclaimed. Worktree-already-absent and
+ * branch-already-absent both count as success — a run resumed at
+ * `subState: merged` re-enters here idempotently.
+ */
+async function finalizePostMerge(
+  input: FinalizeSliceInput
+): Promise<FinalizeSliceOutput> {
+  const { worktreePath, repoPath, runId, sliceId, branch } = input;
+
+  // 1. Option-injection guard on the branch (it flows into `branch -D`).
+  const branchGuard = optionInjectionError("branch", branch);
+  if (branchGuard) return failed("INVALID_INPUT", branchGuard);
+
+  // 2. Write `subState:'merged'` FIRST — the integration-boundary anchor, set
+  //    before any removal so a crash between here and the reclaim resumes at
+  //    step 9 and re-runs the idempotent removal, never re-merging.
+  const write = writeSubState(repoPath, runId, sliceId, "merged");
+  if (!write.ok) {
+    return failed(write.errorCode, write.errorMessage);
+  }
+
+  // 3. Remove the worktree (force — it may hold untracked build artifacts). An
+  //    already-absent worktree (PATH_NOT_FOUND) is success: idempotent resume.
+  let worktreeRemoved = false;
+  const removed = await removeWorktree({
+    worktreePath,
+    repoPath,
+    force: true,
+  });
+  if (removed.status === "ok" || removed.errorCode === "PATH_NOT_FOUND") {
+    worktreeRemoved = true;
+  } else {
+    return {
+      status: "failed",
+      verdict: "failed",
+      errorCode: "WORKTREE_REMOVE_FAILED",
+      errorMessage:
+        removed.status === "refused"
+          ? removed.refusalReason ?? "Worktree removal was refused."
+          : removed.errorMessage ?? "Worktree removal failed.",
+    };
+  }
+
+  // 4. Force-reclaim the LOCAL slice branch — AFTER worktree removal (a
+  //    checked-out branch refuses `branch -D`). The `-D` force is mandatory (the
+  //    squash rewrote the SHA). An already-absent branch is success (idempotent).
+  const branchErr = await deleteLocalBranch(branch, repoPath);
+  if (branchErr) {
+    return failed("GIT_ERROR", branchErr);
+  }
+
+  return {
+    status: "ok",
+    verdict: "committed-pushed",
+    branch,
+    worktreeRemoved,
+    branchReclaimed: true,
+  };
+}
+
+/** Builds a structured `failed{errorCode}` result. */
+function failed(
+  errorCode: NonNullable<FinalizeSliceOutput["errorCode"]>,
+  errorMessage: string
+): FinalizeSliceOutput {
+  return {
+    status: "failed",
+    verdict: "failed",
+    errorCode,
+    errorMessage,
+  };
+}

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/render.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/render.ts
@@ -8,6 +8,18 @@ import { resolveRunDir, type RunPaths } from "../run-dir.js";
 const sliceStateEnum = z.enum(["pending", "in-progress", "passed", "failed", "skipped"]);
 const tierEnum = z.enum(["trivial", "standard", "complex"]);
 
+// Fine-grained position WITHIN §3 processing of an in-progress slice — the
+// resume anchor. Optional so it is backward-compatible with a legacy checkpoint
+// written before the subState scheme (and absent before §3 step 4 completes).
+const subStateEnum = z.enum([
+  "implemented",
+  "verified",
+  "reviewed",
+  "pushed",
+  "pr-open",
+  "merged",
+]);
+
 const sliceSchema = z.object({
   issue: z.number().int(),
   title: z.string(),
@@ -15,6 +27,7 @@ const sliceSchema = z.object({
   tier: tierEnum,
   blockedBy: z.array(z.string()),
   state: sliceStateEnum,
+  subState: subStateEnum.optional(),
   sliceBranch: z.string(),
   worktreePath: z.string().nullable(),
   pullRequest: z.string().nullable(),

--- a/plugins/orchestrate/orchestrate-mcp/test/finalize-slice.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/finalize-slice.test.ts
@@ -1,0 +1,543 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import { finalizeSlice } from "../src/tools/finalize-slice.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { encoding: "utf8", cwd }).trim();
+}
+
+/** Creates a bare repo to act as a remote `origin`, returns its path. */
+function createBareRepo(): string {
+  const barePath = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-bare-"));
+  git(["init", "--bare"], barePath);
+  return barePath;
+}
+
+/**
+ * Creates a working repo (acting as the slice WORKTREE for finalize) with one
+ * commit on a named branch and a remote pointing at `bareOrigin`. The branch is
+ * created but NOT pushed — finalize does the staged commit + push.
+ */
+function createWorkRepo(bareOrigin: string, branch: string): string {
+  const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-work-"));
+  git(["init"], repoPath);
+  git(["config", "user.email", "test@test.local"], repoPath);
+  git(["config", "user.name", "Test User"], repoPath);
+  git(["checkout", "-b", branch], repoPath);
+  fs.writeFileSync(path.join(repoPath, "README.md"), "# Test repo\n");
+  git(["add", "README.md"], repoPath);
+  git(["commit", "-m", "Initial commit"], repoPath);
+  git(["remote", "add", "origin", bareOrigin], repoPath);
+  return repoPath;
+}
+
+/** Recursively remove a directory. */
+function rmrf(dirPath: string) {
+  if (fs.existsSync(dirPath)) {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  }
+}
+
+/** No-op sleep so backoff schedules add no real delay in tests. */
+const noopSleep = async (): Promise<void> => {};
+
+/**
+ * Writes a minimal run-state.json under <mainRoot>/.orchestrate/runs/<runId>/
+ * carrying a `driverSessionId` (a key absent from render.ts's runStateSchema —
+ * its survival proves the writer round-trips raw JSON, not the schema) and one
+ * slice keyed by `sliceId`. Returns the run-state path.
+ */
+function writeRunState(
+  mainRoot: string,
+  runId: string,
+  sliceId: string,
+  extra?: Record<string, unknown>
+): string {
+  const runDir = path.join(mainRoot, ".orchestrate", "runs", runId);
+  fs.mkdirSync(runDir, { recursive: true });
+  const statePath = path.join(runDir, "run-state.json");
+  const state = {
+    runId,
+    status: "in-progress",
+    driverSessionId: "session-uuid-keep-me",
+    umbrellaBranch: `orchestrate/umbrella-${runId}`,
+    integrationBase: "development",
+    parentIssue: null,
+    startedAt: "2026-06-04T00:00:00Z",
+    updatedAt: "2026-06-04T00:00:00Z",
+    waves: [[sliceId]],
+    completedWaves: 0,
+    finalPullRequest: null,
+    slices: {
+      [sliceId]: {
+        issue: Number(sliceId),
+        title: "test slice",
+        wave: 0,
+        tier: "standard",
+        blockedBy: [],
+        state: "in-progress",
+        sliceBranch: `orchestrate/slice-${sliceId}`,
+        worktreePath: null,
+        pullRequest: null,
+        failureReason: null,
+        updatedAt: "2026-06-04T00:00:00Z",
+        ...extra,
+      },
+    },
+  };
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2), "utf8");
+  return statePath;
+}
+
+function readRunState(statePath: string): Record<string, any> {
+  return JSON.parse(fs.readFileSync(statePath, "utf8"));
+}
+
+// ─── Test state ───────────────────────────────────────────────────────────────
+
+const tempDirs: string[] = [];
+
+function track(p: string): string {
+  tempDirs.push(p);
+  return p;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmrf(tempDirs.pop()!);
+  }
+});
+
+// ─── finalize_slice — phase A (commit + push) ─────────────────────────────────
+
+describe("finalizeSlice — phase 'commit-push'", () => {
+  it("stages only the named files, commits with the two -m form, pushes, and writes subState='pushed' — verdict committed-pushed", async () => {
+    const bare = track(createBareRepo());
+    const worktree = track(createWorkRepo(bare, "orchestrate/slice-7"));
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+    const statePath = writeRunState(mainRoot, "prd1-20260604-000000", "7");
+
+    // The file finalize must stage.
+    fs.writeFileSync(path.join(worktree, "feature.ts"), "export const x = 1;\n");
+    // An UNTRACKED file that must NOT be committed.
+    fs.writeFileSync(path.join(worktree, "stray.log"), "noise\n");
+
+    const r = await finalizeSlice(
+      {
+        phase: "commit-push",
+        worktreePath: worktree,
+        repoPath: mainRoot,
+        runId: "prd1-20260604-000000",
+        sliceId: "7",
+        branch: "orchestrate/slice-7",
+        remote: "origin",
+        setUpstream: true,
+        files: ["feature.ts"],
+        commitSubject: "feat(x): the slice",
+        issueNumber: 7,
+      },
+      { sleep: noopSleep }
+    );
+
+    expect(r.status).toBe("ok");
+    expect(r.verdict).toBe("committed-pushed");
+
+    // The commit landed and contains the staged file.
+    const committed = git(["show", "--name-only", "--format=", "HEAD"], worktree)
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    expect(committed).toContain("feature.ts");
+    // The untracked file was NOT committed.
+    expect(committed).not.toContain("stray.log");
+    // And it is still untracked in the worktree.
+    const statusOut = git(["status", "--porcelain"], worktree);
+    expect(statusOut).toContain("stray.log");
+
+    // The commit message preserves subject + Closes trailer.
+    const msg = git(["log", "-1", "--format=%B", "HEAD"], worktree);
+    expect(msg).toContain("feat(x): the slice");
+    expect(msg).toContain("Closes #7");
+
+    // The branch landed on the bare origin at the local tip.
+    const localSha = git(["rev-parse", "refs/heads/orchestrate/slice-7"], worktree);
+    expect(r.sha).toBe(localSha);
+    const remoteRefs = git(["ls-remote", "--heads", bare], worktree);
+    expect(remoteRefs).toContain("refs/heads/orchestrate/slice-7");
+
+    // subState 'pushed' written into the MAIN-root run-state (not the worktree).
+    const state = readRunState(statePath);
+    expect(state.slices["7"].subState).toBe("pushed");
+    // The raw-JSON round-trip preserved driverSessionId (absent from the schema).
+    expect(state.driverSessionId).toBe("session-uuid-keep-me");
+    // No run-state was written under the worktree.
+    expect(fs.existsSync(path.join(worktree, ".orchestrate", "runs"))).toBe(false);
+  });
+
+  it("returns failed{EMPTY_CHANGESET} and does NOT commit when nothing is staged", async () => {
+    const bare = track(createBareRepo());
+    const worktree = track(createWorkRepo(bare, "orchestrate/slice-7"));
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+    const statePath = writeRunState(mainRoot, "prd1-20260604-000000", "7");
+
+    const headBefore = git(["rev-parse", "HEAD"], worktree);
+
+    // `files` names a path that exists but is already committed (no change) — so
+    // `git add` stages nothing and `diff --cached --quiet` finds an empty index.
+    const r = await finalizeSlice(
+      {
+        phase: "commit-push",
+        worktreePath: worktree,
+        repoPath: mainRoot,
+        runId: "prd1-20260604-000000",
+        sliceId: "7",
+        branch: "orchestrate/slice-7",
+        remote: "origin",
+        setUpstream: true,
+        files: ["README.md"],
+        commitSubject: "feat(x): the slice",
+        issueNumber: 7,
+      },
+      { sleep: noopSleep }
+    );
+
+    expect(r.status).toBe("failed");
+    expect(r.errorCode).toBe("EMPTY_CHANGESET");
+    // No new commit was made.
+    expect(git(["rev-parse", "HEAD"], worktree)).toBe(headBefore);
+    // No subState was written (still absent).
+    const state = readRunState(statePath);
+    expect(state.slices["7"].subState).toBeUndefined();
+  });
+
+  it("returns failed{INVALID_INPUT} for an option-injection branch (e.g. --force) before staging", async () => {
+    const bare = track(createBareRepo());
+    const worktree = track(createWorkRepo(bare, "orchestrate/slice-7"));
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+    writeRunState(mainRoot, "prd1-20260604-000000", "7");
+
+    fs.writeFileSync(path.join(worktree, "feature.ts"), "export const x = 1;\n");
+    const headBefore = git(["rev-parse", "HEAD"], worktree);
+
+    const r = await finalizeSlice(
+      {
+        phase: "commit-push",
+        worktreePath: worktree,
+        repoPath: mainRoot,
+        runId: "prd1-20260604-000000",
+        sliceId: "7",
+        branch: "--force",
+        remote: "origin",
+        setUpstream: true,
+        files: ["feature.ts"],
+        commitSubject: "feat(x): the slice",
+        issueNumber: 7,
+      },
+      { sleep: noopSleep }
+    );
+
+    expect(r.status).toBe("failed");
+    expect(r.errorCode).toBe("INVALID_INPUT");
+    // Nothing was staged or committed — the guard ran before commit.
+    expect(git(["rev-parse", "HEAD"], worktree)).toBe(headBefore);
+  });
+
+  it("returns failed{INVALID_INPUT} for an option-injection remote", async () => {
+    const bare = track(createBareRepo());
+    const worktree = track(createWorkRepo(bare, "orchestrate/slice-7"));
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+    writeRunState(mainRoot, "prd1-20260604-000000", "7");
+
+    fs.writeFileSync(path.join(worktree, "feature.ts"), "export const x = 1;\n");
+
+    const r = await finalizeSlice(
+      {
+        phase: "commit-push",
+        worktreePath: worktree,
+        repoPath: mainRoot,
+        runId: "prd1-20260604-000000",
+        sliceId: "7",
+        branch: "orchestrate/slice-7",
+        remote: "--upload-pack=x",
+        setUpstream: true,
+        files: ["feature.ts"],
+        commitSubject: "feat(x): the slice",
+        issueNumber: 7,
+      },
+      { sleep: noopSleep }
+    );
+
+    expect(r.status).toBe("failed");
+    expect(r.errorCode).toBe("INVALID_INPUT");
+  });
+
+  it("bubbles PUSH_FAILED when the remote points at a bad path (commit made, push fails)", async () => {
+    const worktree = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-work-")));
+    git(["init"], worktree);
+    git(["config", "user.email", "test@test.local"], worktree);
+    git(["config", "user.name", "Test User"], worktree);
+    git(["checkout", "-b", "orchestrate/slice-7"], worktree);
+    fs.writeFileSync(path.join(worktree, "README.md"), "# Test repo\n");
+    git(["add", "README.md"], worktree);
+    git(["commit", "-m", "Initial commit"], worktree);
+    const badOrigin = path.join(os.tmpdir(), "orchestrate-does-not-exist-" + Date.now());
+    git(["remote", "add", "origin", badOrigin], worktree);
+
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+    const statePath = writeRunState(mainRoot, "prd1-20260604-000000", "7");
+
+    fs.writeFileSync(path.join(worktree, "feature.ts"), "export const x = 1;\n");
+
+    const r = await finalizeSlice(
+      {
+        phase: "commit-push",
+        worktreePath: worktree,
+        repoPath: mainRoot,
+        runId: "prd1-20260604-000000",
+        sliceId: "7",
+        branch: "orchestrate/slice-7",
+        remote: "origin",
+        setUpstream: true,
+        files: ["feature.ts"],
+        commitSubject: "feat(x): the slice",
+        issueNumber: 7,
+      },
+      { sleep: noopSleep }
+    );
+
+    expect(r.status).toBe("failed");
+    expect(r.errorCode).toBe("PUSH_FAILED");
+    // The push failed, so subState 'pushed' was NOT written.
+    const state = readRunState(statePath);
+    expect(state.slices["7"].subState).toBeUndefined();
+  });
+
+  it("bubbles BRANCH_NOT_ON_REMOTE — adversarial stale-SHA-vs-presence: the push lands in pushBare but verification reads fetchBare (absent)", async () => {
+    // Split push vs fetch URLs on a single remote: the push lands in `pushBare`,
+    // but `git ls-remote origin` reads `fetchBare` (where the branch is absent)
+    // — so verification can never see the landed branch → fail loud.
+    const pushBare = track(createBareRepo());
+    const fetchBare = track(createBareRepo());
+    const worktree = track(createWorkRepo(fetchBare, "orchestrate/slice-7"));
+    git(["remote", "set-url", "--push", "origin", pushBare], worktree);
+
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+    const statePath = writeRunState(mainRoot, "prd1-20260604-000000", "7");
+
+    fs.writeFileSync(path.join(worktree, "feature.ts"), "export const x = 1;\n");
+
+    const r = await finalizeSlice(
+      {
+        phase: "commit-push",
+        worktreePath: worktree,
+        repoPath: mainRoot,
+        runId: "prd1-20260604-000000",
+        sliceId: "7",
+        branch: "orchestrate/slice-7",
+        remote: "origin",
+        setUpstream: true,
+        files: ["feature.ts"],
+        commitSubject: "feat(x): the slice",
+        issueNumber: 7,
+      },
+      { attempts: 2, sleep: noopSleep }
+    );
+
+    expect(r.status).toBe("failed");
+    expect(r.errorCode).toBe("BRANCH_NOT_ON_REMOTE");
+    const state = readRunState(statePath);
+    expect(state.slices["7"].subState).toBeUndefined();
+  });
+
+  it("returns failed{RUN_STATE_NOT_FOUND} when the run-state.json does not exist", async () => {
+    const bare = track(createBareRepo());
+    const worktree = track(createWorkRepo(bare, "orchestrate/slice-7"));
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+    // No run-state written.
+
+    fs.writeFileSync(path.join(worktree, "feature.ts"), "export const x = 1;\n");
+
+    const r = await finalizeSlice(
+      {
+        phase: "commit-push",
+        worktreePath: worktree,
+        repoPath: mainRoot,
+        runId: "prd1-20260604-000000",
+        sliceId: "7",
+        branch: "orchestrate/slice-7",
+        remote: "origin",
+        setUpstream: true,
+        files: ["feature.ts"],
+        commitSubject: "feat(x): the slice",
+        issueNumber: 7,
+      },
+      { sleep: noopSleep }
+    );
+
+    expect(r.status).toBe("failed");
+    expect(r.errorCode).toBe("RUN_STATE_NOT_FOUND");
+  });
+});
+
+// ─── finalize_slice — phase B (post-merge tail) ───────────────────────────────
+
+describe("finalizeSlice — phase 'post-merge'", () => {
+  it("writes subState='merged', removes the worktree, then reclaims the local branch — verdict committed-pushed", async () => {
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+    git(["init"], mainRoot);
+    git(["config", "user.email", "test@test.local"], mainRoot);
+    git(["config", "user.name", "Test User"], mainRoot);
+    fs.writeFileSync(path.join(mainRoot, "README.md"), "# Main\n");
+    git(["add", "README.md"], mainRoot);
+    git(["commit", "-m", "Initial commit"], mainRoot);
+
+    // Create a real worktree on a slice branch off the main repo.
+    const worktree = track(path.join(os.tmpdir(), "orchestrate-wt-" + Date.now()));
+    git(["worktree", "add", "-b", "orchestrate/slice-7", worktree, "HEAD"], mainRoot);
+
+    const statePath = writeRunState(mainRoot, "prd1-20260604-000000", "7", {
+      worktreePath: worktree,
+      subState: "pr-open",
+    });
+
+    const r = await finalizeSlice({
+      phase: "post-merge",
+      worktreePath: worktree,
+      repoPath: mainRoot,
+      runId: "prd1-20260604-000000",
+      sliceId: "7",
+      branch: "orchestrate/slice-7",
+    });
+
+    expect(r.status).toBe("ok");
+    expect(r.verdict).toBe("committed-pushed");
+
+    // subState advanced to 'merged'.
+    const state = readRunState(statePath);
+    expect(state.slices["7"].subState).toBe("merged");
+    expect(state.driverSessionId).toBe("session-uuid-keep-me");
+
+    // The worktree was removed.
+    expect(fs.existsSync(worktree)).toBe(false);
+    // The local branch was reclaimed.
+    const branches = git(["branch", "--list", "orchestrate/slice-7"], mainRoot);
+    expect(branches).toBe("");
+  });
+
+  it("is idempotent — a re-run with the worktree already gone and the branch already deleted still returns ok", async () => {
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+    git(["init"], mainRoot);
+    git(["config", "user.email", "test@test.local"], mainRoot);
+    git(["config", "user.name", "Test User"], mainRoot);
+    fs.writeFileSync(path.join(mainRoot, "README.md"), "# Main\n");
+    git(["add", "README.md"], mainRoot);
+    git(["commit", "-m", "Initial commit"], mainRoot);
+
+    const worktree = track(path.join(os.tmpdir(), "orchestrate-wt-" + Date.now()));
+    git(["worktree", "add", "-b", "orchestrate/slice-7", worktree, "HEAD"], mainRoot);
+
+    const statePath = writeRunState(mainRoot, "prd1-20260604-000000", "7", {
+      worktreePath: worktree,
+      subState: "merged",
+    });
+
+    // First pass removes the worktree and branch.
+    const first = await finalizeSlice({
+      phase: "post-merge",
+      worktreePath: worktree,
+      repoPath: mainRoot,
+      runId: "prd1-20260604-000000",
+      sliceId: "7",
+      branch: "orchestrate/slice-7",
+    });
+    expect(first.status).toBe("ok");
+
+    // Second pass — worktree and branch are already gone; still ok (idempotent).
+    const second = await finalizeSlice({
+      phase: "post-merge",
+      worktreePath: worktree,
+      repoPath: mainRoot,
+      runId: "prd1-20260604-000000",
+      sliceId: "7",
+      branch: "orchestrate/slice-7",
+    });
+    expect(second.status).toBe("ok");
+    expect(second.verdict).toBe("committed-pushed");
+
+    const state = readRunState(statePath);
+    expect(state.slices["7"].subState).toBe("merged");
+  });
+
+  it("returns failed{INVALID_INPUT} for an option-injection branch in phase post-merge", async () => {
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+    git(["init"], mainRoot);
+    git(["config", "user.email", "test@test.local"], mainRoot);
+    git(["config", "user.name", "Test User"], mainRoot);
+    fs.writeFileSync(path.join(mainRoot, "README.md"), "# Main\n");
+    git(["add", "README.md"], mainRoot);
+    git(["commit", "-m", "Initial commit"], mainRoot);
+    writeRunState(mainRoot, "prd1-20260604-000000", "7");
+
+    const r = await finalizeSlice({
+      phase: "post-merge",
+      worktreePath: path.join(mainRoot, "wt"),
+      repoPath: mainRoot,
+      runId: "prd1-20260604-000000",
+      sliceId: "7",
+      branch: "--force",
+    });
+
+    expect(r.status).toBe("failed");
+    expect(r.errorCode).toBe("INVALID_INPUT");
+  });
+
+  it("returns failed{SLICE_NOT_IN_RUN_STATE} when sliceId is not a key in slices", async () => {
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+    git(["init"], mainRoot);
+    git(["config", "user.email", "test@test.local"], mainRoot);
+    git(["config", "user.name", "Test User"], mainRoot);
+    fs.writeFileSync(path.join(mainRoot, "README.md"), "# Main\n");
+    git(["add", "README.md"], mainRoot);
+    git(["commit", "-m", "Initial commit"], mainRoot);
+
+    const worktree = track(path.join(os.tmpdir(), "orchestrate-wt-" + Date.now()));
+    git(["worktree", "add", "-b", "orchestrate/slice-7", worktree, "HEAD"], mainRoot);
+    // run-state keyed on a DIFFERENT slice id than the one we finalize.
+    writeRunState(mainRoot, "prd1-20260604-000000", "99", {
+      worktreePath: worktree,
+    });
+
+    const r = await finalizeSlice({
+      phase: "post-merge",
+      worktreePath: worktree,
+      repoPath: mainRoot,
+      runId: "prd1-20260604-000000",
+      sliceId: "7",
+      branch: "orchestrate/slice-7",
+    });
+
+    expect(r.status).toBe("failed");
+    expect(r.errorCode).toBe("SLICE_NOT_IN_RUN_STATE");
+  });
+
+  it("returns failed{RUN_ID_INVALID} for a malformed runId", async () => {
+    const mainRoot = track(fs.mkdtempSync(path.join(os.tmpdir(), "orchestrate-main-")));
+
+    const r = await finalizeSlice({
+      phase: "post-merge",
+      worktreePath: path.join(mainRoot, "wt"),
+      repoPath: mainRoot,
+      runId: "../escape",
+      sliceId: "7",
+      branch: "orchestrate/slice-7",
+    });
+
+    expect(r.status).toBe("failed");
+    expect(r.errorCode).toBe("RUN_ID_INVALID");
+  });
+});

--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -881,46 +881,47 @@ subagent's verbatim returned text and its `role`:
    combination. "Pre-merge" names what the gate controls (whether the merge
    proceeds); mechanically it runs pre-commit, on the same worktree state the
    reviewer validated.
-6. **Commit and push.** Stage only the files the subagents reported changing —
-   the union of the `filesChanged` arrays from the validated implementer and
-   reviewer envelopes. Never `git add -A`: the capability tools leave untracked
-   build artifacts in the worktree. When the implementer fetched a new
-   dependency with `run_install`, install ran **in its turn before this
-   commit** and mutated the lockfile (`pnpm-lock.yaml` / `package-lock.json` /
-   `Cargo.lock`); because the implementer declared that lockfile in
-   `filesChanged`, it is in this staged union and the commit captures it — so
-   the new dependency lands in the slice diff.
+6. **Commit and push.** Run the slice's commit + verified-push mechanics with
+   the **`finalize_slice` MCP tool** in phase `commit-push` — not raw `git`. It
+   stages the file set, guards an empty changeset, commits, composes
+   `push_and_verify`, and writes the `pushed` checkpoint, all git-only. Call it
+   with `phase: "commit-push"`, `worktreePath` = the slice `worktreePath`,
+   `repoPath` = the **main repo root** (where `run-state.json` lives — NOT the
+   worktree), `runId`, `sliceId` = the slice's issue-id-string key, `branch` =
+   `orchestrate/slice-<N>`, `remote` = `origin`, `setUpstream: true`,
+   `commitSubject` = `<type>(<scope>): <issue title>`, `issueNumber` = `<N>`, and
+   `files` = the union of the `filesChanged` arrays from the validated
+   implementer and reviewer envelopes.
 
-   ```
-   git -C <worktree-path> add -- <file> <file> ...
-   ```
+   `finalize_slice` stages **exactly** that `files` set (`git add -- ...files`,
+   never `git add -A` — the capability tools leave untracked build artifacts in
+   the worktree). When the implementer fetched a new dependency with
+   `run_install`, install ran **in its turn before this commit** and mutated the
+   lockfile (`pnpm-lock.yaml` / `package-lock.json` / `Cargo.lock`); because the
+   implementer declared that lockfile in `filesChanged`, it is in this staged
+   union and the commit captures it — so the new dependency lands in the slice
+   diff. The commit preserves the two-`-m` form (subject + `Closes #<N>`
+   trailer), and the push goes through `push_and_verify`'s SHA-matched
+   `git ls-remote` landing check.
 
-   If `git -C <worktree-path> diff --cached --quiet` exits 0, nothing changed —
-   the slice has **FAILED**. Otherwise commit (local; two `-m` flags keep a
-   newline out of the shell argument), then push **with the `push_and_verify`
-   MCP tool** — not a raw `git push`:
+   On `status: "ok"` (`verdict: "committed-pushed"`) the slice's `subState` was
+   set to `pushed` and `run-state.json` checkpointed by the tool — and **only**
+   then, because that status means `push_and_verify`'s SHA-matched
+   `git ls-remote` confirmed the branch actually landed; proceed to step 7. The
+   tool never writes `subState: pushed` on a bare `git push` exit-0 — the landing
+   check is what the `pushed` checkpoint attests to (and what the section-1
+   resume re-validates). On `status: "failed"` the slice has **FAILED** — an
+   `EMPTY_CHANGESET` errorCode means the staged index was empty (nothing changed);
+   a `PUSH_FAILED` / `BRANCH_NOT_ON_REMOTE` errorCode is bubbled from
+   `push_and_verify`; `INVALID_INPUT` / `GIT_ERROR` / the run-state error codes
+   wire the same way as every other MCP-tool error in this section.
 
-   ```
-   git -C <worktree-path> commit -m "<type>(<scope>): <issue title>" -m "Closes #<N>"
-   ```
-
-   Call the **`push_and_verify` MCP tool** with `repoPath` = the slice
-   `worktreePath`, `branch` = `orchestrate/slice-<N>`, `remote` = `origin`,
-   `setUpstream: true`. On `status: "ok"` — and **only** then, because that
-   status means `push_and_verify`'s SHA-matched `git ls-remote` has confirmed the
-   branch actually landed on the remote — set the slice's `subState` to `pushed`,
-   checkpoint `run-state.json`, and proceed to step 7. Never write
-   `subState: pushed` on a bare `git push` exit-0; the landing check is what the
-   `pushed` checkpoint attests to (and what the section-1 resume re-validates).
-   On `status: "error"` (any `errorCode` — `PUSH_FAILED`, `BRANCH_NOT_ON_REMOTE`,
-   `INVALID_INPUT`, `GIT_ERROR`) the slice has **FAILED**, the same wiring as
-   every other MCP-tool error in this section.
-
-   `push_and_verify` gates step 7's `gh pr create`: it pushes the branch and
-   then confirms via SHA-matched `git ls-remote` that it actually landed on the
-   remote. A `git push` that exits 0 but never lands is exactly the
-   confusing-`gh pr create`-error site #230 reports — verifying the branch is on
-   the remote *before* opening the PR removes that silent-failure mode.
+   This gates step 7's `gh pr create`: a `git push` that exits 0 but never lands
+   is exactly the confusing-`gh pr create`-error site #230 reports — verifying
+   the branch is on the remote *before* opening the PR removes that
+   silent-failure mode. The PR open itself (`gh pr create`) and the `pr-open`
+   checkpoint stay in the spine at step 7 — `finalize_slice` is git-only and
+   never shells `gh`.
 
 7. **Open the slice pull request.**
 
@@ -1005,31 +1006,36 @@ subagent's verbatim returned text and its `role`:
 9. **Finish the slice.** Once any of step 8's `gh pr merge --squash` paths
    (`MERGEABLE`, the clean-textual-merge 8a.3 path, or the conflict-resolved
    8a.6 path) has succeeded — the slice PR is now squash-merged into the
-   umbrella — set the slice's `subState` to `merged` and checkpoint
-   `run-state.json` **before** the label transition and worktree removal below.
-   `merged` is the integration-boundary anchor: a run resumed at
-   `subState: merged` skips every subagent and re-enters here at step 9 only,
-   never re-merging. Then set the slice `state` to `passed` and transition the
-   issue's tracker label — it is done and awaiting human review:
+   umbrella — run the merged-tail mechanics with the **`finalize_slice` MCP
+   tool** in phase `post-merge`. Call it with `phase: "post-merge"`,
+   `worktreePath` = the slice `worktreePath`, `repoPath` = the **main repo root**
+   (where `run-state.json` lives), `runId`, `sliceId` = the slice's
+   issue-id-string key, and `branch` = `orchestrate/slice-<N>`. The tool writes
+   the slice's `subState` to `merged` and checkpoints `run-state.json` **first**,
+   then removes the worktree (force — it may hold untracked build artifacts), then
+   force-reclaims the **local** slice branch (`git branch -D`, ordered after the
+   removal because a checked-out branch refuses the delete). `merged` is the
+   integration-boundary anchor: a run resumed at `subState: merged` skips every
+   subagent and re-enters here at step 9 only, never re-merging.
+
+   On `status: "ok"` (`verdict: "committed-pushed"`) the merged checkpoint,
+   worktree removal, and local-branch reclaim are all done. The tool is
+   idempotent: on a run resumed at `subState: merged` the worktree may already be
+   gone and the branch already reclaimed by an earlier pass — both count as
+   success, not failure. The `-D` force is mandatory because the squash-merge
+   rewrote the commit SHA, so the slice branch is **not** an ancestor of umbrella
+   and `git branch -d` would refuse it as "not fully merged." This completes
+   incremental reclamation: the **remote** half was done by `--delete-branch` at
+   step 8, the **local** half here. On `status: "failed"` the slice has
+   **FAILED**, wired like every other MCP-tool error in this section.
+
+   The forge-state half of finishing stays in the spine — it is **not**
+   `finalize_slice`'s concern (the tool is git-only and never shells `gh`). After
+   `finalize_slice` returns ok, set the slice `state` to `passed` and transition
+   the issue's tracker label — it is done and awaiting human review:
    `gh issue edit <N> --remove-label ready-for-agent --add-label ready-for-human`.
-   Then remove its worktree with the `remove_worktree` MCP tool (`worktreePath`,
-   `repoPath`, `force: true` — the worktree may hold untracked build artifacts).
-   Finally, reclaim the **local** slice branch from the repository root:
-
-   ```
-   git branch -D orchestrate/slice-<N>
-   ```
-
-   The `-D` (force) flag is mandatory: the squash-merge rewrote the commit SHA,
-   so the slice branch is **not** an ancestor of umbrella and `git branch -d`
-   would refuse it as "not fully merged." Run this **after** `remove_worktree` —
-   while the worktree still has the branch checked out, the delete is refused.
-   The delete is idempotent: on a run resumed at `subState: merged` the branch
-   may already be gone (an earlier pass reclaimed it), and an already-absent
-   branch is fine, not a failure. This completes incremental reclamation: the
-   **remote** half was done by `--delete-branch` at step 8, the **local** half
-   here. Incremental reclamation fires only on a `passed` / `subState: merged`
-   slice; a failed (preserved) slice's branch is left fully intact.
+   Incremental reclamation fires only on a `passed` / `subState: merged` slice; a
+   failed (preserved) slice's branch is left fully intact.
 
 ## 4. Context handoff
 


### PR DESCRIPTION
Implements #271. Adds the `finalize_slice` orchestrate-mcp tool owning the git + run-state finalization mechanics of one reviewed slice (stage exact file set, empty-changeset guard, commit, compose push-and-verify landing check, write `pushed`/`merged` subState, post-merge worktree removal + idempotent local-branch reclaim). Mirrors push-and-verify (zod single-source, never-throw, git-only via the hardened exec seam, no `gh`). 12 TDD integration tests incl. the adversarial BRANCH_NOT_ON_REMOTE case. SKILL.md §3 steps 6 & 9 rewired to call the tool; forge ops, pr-open checkpoint, and the conflict-resolver path stay in the spine. dist/ rebuilt; version cascade plugin 1.4.0 / marketplace top-level 1.8.0.