### PR TITLE
feat(skills): add prime-issues pre-grill triage skill

### DIFF
--- a/.claude/skills/prime-issues/AFK-GUARDRAILS.md
+++ b/.claude/skills/prime-issues/AFK-GUARDRAILS.md
@@ -1,0 +1,74 @@
+# AFK guardrails
+
+This skill runs unattended and writes to GitHub. These guardrails keep an unattended run
+safe and idempotent. The main thread owns all of this — investigators never touch `gh`.
+
+## Scope echo
+
+After computing the in-scope set, print one line before fanning out:
+
+```
+<N> open issues without the <label> label — processing.
+```
+
+Informational only. Do not wait for confirmation (this is AFK). If `<N>` is 0, report
+"nothing to prime" and stop.
+
+## Label creation (idempotent)
+
+Create the primed label once, up front, before any posting. Tolerate "already exists":
+
+```bash
+gh label create "<label>" --color C5DEF5 --description "Primed with an autonomous pre-grill triage" 2>/dev/null || true
+```
+
+## Dedup gate (run per issue, in the main thread, right before posting)
+
+Skip an issue if **either** is already true — this makes re-runs and partial-failure
+recovery safe:
+
+1. It carries the primed label, or
+2. Any existing comment contains the disclaimer marker substring:
+   `Autonomous pre-grill triage`
+
+The second check catches the case where a previous run posted the comment but failed to
+apply the label — without it, that issue would be double-posted.
+
+## Posting (serial, main thread)
+
+For each returned pointer with `status: "ok"`, in order:
+
+```bash
+gh issue comment <N> --body-file .prime-issues/issue-<N>.md
+gh issue edit <N> --add-label "<label>"
+```
+
+Only after **both** succeed, delete the temp file:
+
+```bash
+rm -f .prime-issues/issue-<N>.md
+```
+
+If the comment posts but the label fails, leave the temp file and record the issue as
+`failed (label)`; the dedup marker will prevent a duplicate comment next run.
+
+## --dry-run
+
+Skip label creation, posting, label application, and temp-file deletion entirely. Leave
+every `.prime-issues/issue-<N>.md` in place and list their paths in the report so the
+content can be inspected before a live run.
+
+## Failure isolation
+
+Each investigator is wrapped so one failure never aborts the batch (see
+[ORCHESTRATION.md](ORCHESTRATION.md)). A `status: "failed"` pointer is recorded and the
+run continues.
+
+## Final report
+
+```
+Primed:  <list of #N posted>
+Skipped: <#N — reason (already primed / dedup marker / dry-run)>
+Failed:  <#N — reason>
+Dry-run paths: <paths, only when --dry-run>
+```

--- a/.claude/skills/prime-issues/COMMENT-TEMPLATE.md
+++ b/.claude/skills/prime-issues/COMMENT-TEMPLATE.md
@@ -1,0 +1,52 @@
+# Pre-grill triage comment
+
+The canonical structure posted to each issue. The investigator fills it in and writes it to `.prime-issues/issue-<N>.md`; the main thread posts it verbatim.
+
+## Rules
+
+- **The disclaimer line is fixed and load-bearing.** It is the dedup marker — the main thread greps existing comments for the substring `Autonomous pre-grill triage` to avoid double-posting. Do not reword it.
+- **Every section is always present.** If a section has nothing, write `_none identified_` — never drop the heading. A predictable shape lets the future griller scan fast.
+- **Grounded, not generic.** Claims cite the file/line or the issue comment they came from. Anything not grounded is cut or explicitly marked `(hypothesis)`.
+- **Adversarial, not cheerleading.** The doubts section must be willing to say the issue may not be worth doing.
+
+## Template
+
+```markdown
+> *Autonomous pre-grill triage — AI-generated insights to seed a future grilling session. Not a decision.*
+
+## Evidence
+
+Grounded, cited findings about this issue against the current repo and docs. Cite `path:line` or the source comment. Mark anything unverified as `(hypothesis)`.
+
+## Ambiguities
+
+What is unclear, underspecified, or open to more than one reading in the issue as written.
+
+## Honest doubts — impact & real value delivery
+
+Adversarial assessment of whether this actually delivers value, and to whom. State the case *against* doing it, not just for. "This may not be worth it because X" is a valid and expected finding.
+
+## Alternative approaches
+
+At least 3 genuinely distinct approaches to the same underlying goal — not three phrasings of one idea. For each: the core idea, and what it trades off versus the others.
+
+1. …
+2. …
+3. …
+
+## Gotchas
+
+Traps, hidden coupling, surprising constraints, or prior decisions that will bite an implementer.
+
+## Points to clarify
+
+Specific, actionable open questions — the kind a maintainer can answer in one line. Not "please provide more info".
+
+## Other analytical lenses
+
+Additional angles or biases worth probing that the sections above did not cover (e.g. cost-of-delay, reversibility, who is *not* asking for this, second-order effects).
+
+## Suggested grilling agenda
+
+The highest-leverage questions, ranked, to open a future grilling session with. Lead with the one that, if answered, collapses the most uncertainty.
+```

--- a/.claude/skills/prime-issues/DOC-DISCOVERY.md
+++ b/.claude/skills/prime-issues/DOC-DISCOVERY.md
@@ -1,0 +1,38 @@
+# Orientation digest
+
+One agent runs once, before the fan-out, and returns a compact map of the repo and its
+documentation. Every investigator receives this digest so none has to re-read the whole
+repo. The digest is shared context, not a deliverable — keep it tight.
+
+## Probe list (ordered, generic)
+
+Probe these in order; skip what is absent. Do not assume any specific repo's layout.
+
+1. `README*` at the repo root — purpose, stack, how it is built and run.
+2. `CONTEXT.md` / `CONTEXT-MAP.md` — domain glossary and context boundaries, if present.
+3. `CONTRIBUTING*`, `ARCHITECTURE*`, `CLAUDE.md`, `AGENTS.md` — working conventions.
+4. `docs/` — table of contents; note the major subtrees, do not read every file.
+5. `docs/adr/` or `docs/decisions/` — list the ADR titles (the decisions, not bodies).
+6. `wiki/` — index/table of contents if one exists.
+7. Package/build manifests (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`,
+   `Gemfile`, …) — language, key dependencies, scripts.
+8. Top-level source layout — the main directories and what each roughly holds.
+
+## What the digest must contain
+
+A compact map an investigator can use to jump straight to the right place:
+
+- One or two sentences on what the project is and its stack.
+- Where the docs live and what each major area covers (paths + one-line descriptions).
+- The list of ADR/decision titles (so investigators can spot prior decisions that bear
+  on an issue without reading every ADR).
+- The source-tree shape: top directories and their responsibility.
+- Any obvious conventions a triage should respect (e.g. "tests live in X", "docs must
+  stay in sync with code").
+
+## What it must NOT be
+
+- Not a file dump. Paths + one-liners, not contents.
+- Not issue-specific. Issue-specific reading is each investigator's own job.
+- Not long. Aim for something an investigator skims in seconds; if it is growing past a
+  page, compress.

--- a/.claude/skills/prime-issues/INVESTIGATOR-PROMPT.md
+++ b/.claude/skills/prime-issues/INVESTIGATOR-PROMPT.md
@@ -1,0 +1,67 @@
+# Investigator role prompt
+
+One investigator runs per in-scope issue, in the background. Its job is to produce an honest, grounded, adversarial pre-grill triage and persist it — **not** to decide the issue's fate, and **not** to post anything.
+
+Compose the per-issue prompt from the parts below. Interpolate the orientation digest, the issue payload, and the temp path.
+
+## Role
+
+```
+You are a pre-grill triage investigator. You analyze ONE GitHub issue against the
+current state of this repository and its documentation, and you write an honest,
+adversarial analysis whose only purpose is to make a FUTURE grilling session on this
+issue as productive as possible.
+
+You do NOT decide whether the issue is good, ready, or worth doing. You do NOT post
+to GitHub. You surface points of view — including the ones nobody asked for.
+
+## Repository orientation (shared digest)
+<INSERT ORIENTATION DIGEST>
+
+## The issue
+Number: <N>
+Title: <TITLE>
+Labels: <LABELS>
+Body:
+<BODY>
+Comments:
+<COMMENTS>
+```
+
+## Method
+
+```
+1. Read the issue closely. Note what it claims, assumes, and leaves unsaid.
+2. Use the digest to jump to the relevant code and docs, then read them directly with
+   Read/Grep/Glob. Ground every claim in something you actually read.
+3. Build the analysis using the canonical section structure (below).
+4. SELF-CRITIQUE before you write the file — this is mandatory, not optional:
+   - For every factual claim: can you cite the `path:line` or the issue comment it
+     came from? If not, either cut it or mark it explicitly as `(hypothesis)`.
+   - For the alternatives: are they 3+ GENUINELY DISTINCT approaches, or the same idea
+     reworded? Reworded padding is a failure — replace it or admit you only found N.
+   - For the doubts: did you actually argue the case AGAINST the issue, or did you
+     soften it? Generic optimism is a failure here.
+   - Cut any sentence that would be true of almost any issue. Slop is worse than a
+     short, honest analysis.
+```
+
+## Sections to produce
+
+Use the exact headings and order from `COMMENT-TEMPLATE.md`:
+Evidence · Ambiguities · Honest doubts (impact & real value) · Alternative approaches (≥3 distinct) · Gotchas · Points to clarify · Other analytical lenses · Suggested grilling agenda.
+
+An empty section is written `_none identified_`, never dropped. Begin the file with the fixed disclaimer line from the template (it is the dedup marker).
+
+## Output contract
+
+```
+1. Write the full markdown analysis to: <TEMP PATH e.g. .prime-issues/issue-<N>.md>
+   using the Write tool. The analysis lives ONLY in that file.
+2. Return a tiny structured pointer — nothing else. Do NOT return the analysis text;
+   the whole point is to keep it out of the orchestrator's context.
+   Fields: { issue: <N>, path: "<TEMP PATH>", status: "ok", summary: "<one line>" }
+3. If you cannot complete the analysis, still return a pointer with status "failed"
+   and a one-line reason in `summary`. Do not end your turn without returning the
+   structured pointer — ending without it aborts the sibling investigators.
+```

--- a/.claude/skills/prime-issues/ORCHESTRATION.md
+++ b/.claude/skills/prime-issues/ORCHESTRATION.md
@@ -1,0 +1,94 @@
+# Orchestration skeleton
+
+A known-good Workflow fan-out for the investigation phase. Adapt it — do not re-derive it
+from scratch. The comments encode lessons that are expensive to relearn.
+
+## Division of labor
+
+- **Main thread (before Workflow):** scope + dedup via `gh` (ground truth), then build a
+  clean array of issue payloads `{ number, title, body, comments, labels }`. The Workflow
+  script cannot run `gh` (no shell/filesystem APIs in the script body), so it must receive
+  ready-made payloads via `args`.
+- **Workflow:** orientation digest agent → fan-out one investigator per issue. Each writes
+  its analysis to a temp file and returns a tiny pointer.
+- **Main thread (after Workflow):** post + label + dedup + cleanup, serially. See
+  [AFK-GUARDRAILS.md](AFK-GUARDRAILS.md).
+
+## Why pointers, not analyses
+
+Investigators return a tiny `{issue, path, status, summary}` object, never the analysis
+text. The markdown lives on disk in `.prime-issues/issue-<N>.md`. This keeps N full
+analyses out of the orchestrator's context window (anti context-rot) — the single most
+important property of this design.
+
+## Skeleton
+
+```javascript
+export const meta = {
+  name: 'prime-issues-investigate',
+  description: 'Fan out one pre-grill triage investigator per open issue',
+  phases: [
+    { title: 'Orient', detail: 'map repo + docs once' },
+    { title: 'Investigate', detail: 'one investigator per issue, writes temp file' },
+  ],
+}
+
+// args arrives stringified or absent depending on the caller — parse defensively.
+const issues = Array.isArray(args) ? args : JSON.parse(args || '[]')
+
+// Tiny FLAT schema. Heavy nested schemas + heavy reading make agents skip
+// StructuredOutput — keep it flat and small. The analysis is NOT a field here.
+const POINTER = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    issue:   { type: 'number' },
+    path:    { type: 'string' },
+    status:  { type: 'string', enum: ['ok', 'failed'] },
+    summary: { type: 'string' },
+  },
+  required: ['issue', 'path', 'status', 'summary'],
+}
+
+// An agent that ends WITHOUT calling StructuredOutput aborts every sibling. safeAgent
+// converts any throw into a 'failed' pointer so one bad issue never kills the batch.
+async function safeAgent(prompt, opts) {
+  try {
+    return await agent(prompt, { schema: POINTER, phase: 'Investigate', ...opts })
+  } catch (e) {
+    return { issue: opts._issue, path: opts._path, status: 'failed', summary: String(e).slice(0, 200) }
+  }
+}
+
+phase('Orient')
+const digest = await agent(
+  'Produce the compact repo + docs orientation digest. Probe README, CONTEXT.md, docs/, ' +
+  'docs/adr, wiki/, manifests in order; return paths + one-liners, not file contents.',
+  { label: 'orient', phase: 'Orient' }
+)
+
+phase('Investigate')
+const pointers = await parallel(issues.map((iss) => () => {
+  const tmp = `.prime-issues/issue-${iss.number}.md`
+  const prompt = [
+    INVESTIGATOR_ROLE,            // from INVESTIGATOR-PROMPT.md, with digest + issue interpolated
+    `\n## Repository orientation (shared digest)\n${digest}`,
+    `\n## The issue\nNumber: ${iss.number}\nTitle: ${iss.title}\n` +
+      `Labels: ${(iss.labels || []).join(', ')}\nBody:\n${iss.body}\n` +
+      `Comments:\n${(iss.comments || []).join('\n---\n')}`,
+    `\n## Output\nWrite the full analysis to ${tmp}. Return ONLY the pointer ` +
+      `{issue:${iss.number}, path:"${tmp}", status, summary}. Do not end your turn ` +
+      `without returning the structured pointer.`,
+  ].join('\n')
+  return safeAgent(prompt, { label: `issue-${iss.number}`, _issue: iss.number, _path: tmp })
+}))
+
+return pointers  // tiny array; main thread posts from the temp files these point to
+```
+
+## Concurrency
+
+`parallel()` here is the simple choice: one stage (investigate), all results collected for
+the serial posting phase. The runtime caps concurrent agents (~`min(16, cores-2)`); passing
+all issues is fine — excess queue and drain. For very large backlogs the cap is the natural
+throttle; no manual batching needed.

--- a/.claude/skills/prime-issues/SKILL.md
+++ b/.claude/skills/prime-issues/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: prime-issues
+description: Autonomous AFK pass that pre-triages every open GitHub issue to seed a future grilling session. Fans out one background investigator per un-primed issue to analyze it against current repo state and docs, then posts an honest, adversarial pre-grill triage comment (evidence, ambiguities, value doubts, >=3 alternatives, gotchas, a prioritized grilling agenda) and applies a "grill-primed" label. Use when the user wants to prime or seed issues for grilling, run an autonomous pre-grill triage over the backlog, enrich open issues with honest points of view before grill-with-docs, or invokes /prime-issues. Agnostic to any GitHub repo via the gh CLI.
+---
+
+# prime-issues
+
+Autonomous (AFK) batch pass that enriches open GitHub issues with an honest, adversarial **pre-grill triage** — so a future grilling session on any one of them opens with the maximum number of realistic points of view already on the table.
+
+## Boundaries
+
+- **Tracker assumption.** "Agnostic" means *any GitHub repo accessed via the `gh` CLI* — not any tracker. GitHub + `gh` is assumed. Infer the repo from `git remote -v`; `gh` does this automatically inside a clone.
+- **Not a disposition decision.** This skill does **not** decide whether an issue is ready, valuable, or rejected, and does **not** touch state/category roles (e.g. `needs-triage`, `ready-for-agent`). It only *enriches*. Its sole mutations are: post one comment + add the primed label. Deciding disposition is a separate, interactive concern.
+- **AFK.** Runs to completion without user feedback. The scope echo at the start is informational, not a gate.
+
+## Arguments
+
+- `--dry-run` — produce analyses and write temp files, but do **not** post comments, apply labels, or delete temp files. Report the temp paths for inspection.
+- `--label <name>` — override the primed-label name (default: `grill-primed`).
+- `#<n> #<m> …` — process only these issues.
+- `--label-filter <name>` — process only open issues carrying this label.
+
+Without narrowing args, process **all** open issues that lack the primed label.
+
+## Flow
+
+1. **Scope.** List open issues (`gh issue list --state open` — gh excludes PRs natively), drop any already carrying the primed label, apply narrowing args. Echo the count: `"<N> open issues without the <label> label — processing."`
+2. **Orientation digest.** One upfront agent probes the repo's docs generically and returns a compact repo+docs map, shared with every investigator so none re-reads the whole repo. See [DOC-DISCOVERY.md](DOC-DISCOVERY.md).
+3. **Fan-out.** Use the **Workflow** tool to run one background investigator per in-scope issue. Each investigator analyzes its issue, **writes** the analysis to `.prime-issues/issue-<N>.md`, and **returns a tiny pointer only** (anti context-rot). Adapt the skeleton in [ORCHESTRATION.md](ORCHESTRATION.md); use the role prompt in [INVESTIGATOR-PROMPT.md](INVESTIGATOR-PROMPT.md).
+4. **Post (main thread, serial).** For each `ok` pointer: run the dedup gate, read the temp file, `gh issue comment`, apply the label, confirm both, delete the temp file. See [AFK-GUARDRAILS.md](AFK-GUARDRAILS.md).
+5. **Report.** Summarize processed / skipped (reason) / failed (reason), plus dry-run paths.
+
+## The two artifacts that carry the quality
+
+The comment the reader receives is only as good as these — invest the rigor here, not in the plumbing:
+
+- [COMMENT-TEMPLATE.md](COMMENT-TEMPLATE.md) — the canonical comment structure posted to each issue.
+- [INVESTIGATOR-PROMPT.md](INVESTIGATOR-PROMPT.md) — the adversarial, self-critiquing investigator role.
+
+## Companion files
+
+- [COMMENT-TEMPLATE.md](COMMENT-TEMPLATE.md) — canonical pre-grill triage comment.
+- [INVESTIGATOR-PROMPT.md](INVESTIGATOR-PROMPT.md) — per-issue investigator role prompt.
+- [DOC-DISCOVERY.md](DOC-DISCOVERY.md) — ordered documentation probe list for the orientation digest.
+- [AFK-GUARDRAILS.md](AFK-GUARDRAILS.md) — scope echo, dry-run, dedup gate, label creation, failure isolation, report.
+- [ORCHESTRATION.md](ORCHESTRATION.md) — known-good Workflow fan-out skeleton.
+
+> Temp files live under `.prime-issues/`. Add that path to the repo's `.gitignore`.

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ next-steps.md
 # Session-local runtime artifacts
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+
+# prime-issues skill: per-run temp analyses (written by investigators, deleted after posting)
+.prime-issues/


### PR DESCRIPTION
## What

Adds `prime-issues` — an autonomous (AFK) batch pass that pre-triages open GitHub issues to seed future grilling sessions.

For each open issue lacking the primed label, a background investigator analyzes it against current repo state and docs, then writes an honest, adversarial analysis to a temp file. The main thread posts each as an issue comment and applies the `grill-primed` label.

## Comment structure

Fixed sections: evidence (cited), ambiguities, honest doubts on impact & real value, ≥3 genuinely-distinct alternatives, gotchas, points to clarify, other analytical lenses, and a prioritized **grilling agenda**.

## Design

- **Separate from `triage`** — enriches only; never decides disposition or touches state/category roles.
- **Agnostic** to any GitHub repo via the `gh` CLI; no domain-specific references.
- **Anti context-rot** — investigators return tiny pointers, not analyses; markdown stays in `.prime-issues/issue-<N>.md` until posted.
- **Workflow fan-out skeleton** encodes flat-schema + `safeAgent` + no-completion-protocol lessons.
- **AFK guardrails** — scope echo, `--dry-run`, dedup gate (label or disclaimer marker), idempotent label creation, per-issue failure isolation.

## Files

`.claude/skills/prime-issues/`: `SKILL.md`, `COMMENT-TEMPLATE.md`, `INVESTIGATOR-PROMPT.md`, `DOC-DISCOVERY.md`, `AFK-GUARDRAILS.md`, `ORCHESTRATION.md`. Plus `.gitignore` entry for the run temp dir.

## Provenance

Design resolved through a `/grill-me` session (9 decisions) + advisor review (3 refinements). Built via `write-a-skill`; companion files use the flat layout of sibling skills (`triage`, `grill-with-docs`).

## Verification status

Artifact created and self-checked (file set, no domain leakage, links resolve). End-to-end runtime behavior **not yet verified** — pending a `/prime-issues --dry-run`.