### PR TITLE
docs(wiki): ingest 5 Claude Code vendor docs and reconcile lint findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ next-steps.md
 sandcastle-ref
 
 .orchestrate
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ next-steps.md
 .wiki-run/
 
 sandcastle-ref
+
+.orchestrate

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ next-steps.md
 
 # prime-issues skill: per-run temp analyses (written by investigators, deleted after posting)
 .prime-issues/
+
+# wiki-lint / wiki-ingest workflow runs: per-run scaffolding (corpus map, proposals, scratch)
+.wiki-run/
+
+sandcastle-ref

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.orchestrate/commands.json
+++ b/.orchestrate/commands.json
@@ -1,6 +1,0 @@
-{
-  "tests": ["npm", "--prefix", "plugins/orchestrate/orchestrate-mcp", "run", "test"],
-  "typecheck": ["npm", "--prefix", "plugins/orchestrate/orchestrate-mcp", "run", "typecheck"],
-  "build": ["npm", "--prefix", "plugins/orchestrate/orchestrate-mcp", "run", "build"],
-  "install": ["npm", "--prefix", "plugins/orchestrate/orchestrate-mcp", "ci"]
-}

--- a/docs/analysis/orchestrate-plugin-run-findings.md
+++ b/docs/analysis/orchestrate-plugin-run-findings.md
@@ -1,0 +1,507 @@
+# Orchestrate Plugin — Run Findings Log
+
+**Purpose.** This document records every error, defect, friction point, and
+improvement opportunity observed while running the `orchestrate` plugin
+end to end. It is an incremental log: new findings are appended as the run
+progresses. It exists to feed a later improvement plan for the orchestrate
+plugin — so each entry captures the *symptom*, the *root cause*, the
+*mitigation applied to keep the run going*, and a *concrete recommendation*.
+
+## Run context
+
+| Field | Value |
+|-------|-------|
+| Plugin | `orchestrate` v1.0.1 (`~/.claude/plugins/cache/agent-engineering-toolkit/orchestrate/1.0.1`) |
+| Invoked | `/orchestrate:orchestrate` (no arguments) |
+| Repository | `agent-engineering-toolkit` (multi-plugin marketplace of Markdown skills) |
+| Run id | `20260521-201015` |
+| Date | 2026-05-21 |
+| Backlog | PRD #143 decomposed into 9 slices (#144–#152) |
+| Umbrella branch | `orchestrate/umbrella-20260521-201015` |
+| Orchestrator model | Opus 4.7 (1M context) |
+| Waves | 7 — `[[144],[145,146],[147],[148,149],[150],[151],[152]]` |
+
+## Severity legend
+
+- **High** — would corrupt the run or its output if not caught (wrong work
+  produced, data loss, unrecoverable state).
+- **Medium** — blocks or degrades the run until a workaround is applied;
+  recoverable but costs time and requires operator judgement.
+- **Low** — quality or ergonomics issue; run proceeds, but the result or the
+  operator experience is worse than it should be.
+
+Each finding also notes whether it is a **plugin defect** (bug in code or
+shipped templates), a **skill-instruction defect** (the `SKILL.md` text is
+wrong or incomplete), or a **design gap** (the plugin behaves as written, but
+the design leaves a sharp edge).
+
+---
+
+## F-001 — Orchestrate config files absent; plugin offers no bootstrap
+
+- **Severity:** Medium
+- **Type:** Design gap
+- **Phase:** Section 1 — prerequisites / fresh-run setup
+
+**Symptom.** The target repository had no `.orchestrate/` directory at all —
+no `commands.json`, no `routing.json`, no `handoff.json`. The skill's
+prerequisites state the project "should have committed" `commands.json` and
+`routing.json` (from the plugin's `templates/`), but the skill provides no
+mechanism to get them there.
+
+**Cause.** The orchestrate plugin ships the three templates under its own
+`templates/` directory but has no install/bootstrap step: no setup
+subcommand, no first-run detection, and the skill does not offer to copy
+them. Any first-ever run on a repo hits this. The skill *tolerates* missing
+config (documented fallbacks) but tolerating is not the same as bootstrapping.
+
+**Mitigation.** Manually created `.orchestrate/`, copied `routing.json`
+verbatim from the template, copied `handoff.json` with one edit (see F-002),
+and deliberately omitted `commands.json` (see F-003).
+
+**Recommendation.** Add a real bootstrap path: either a `/orchestrate-init`
+subcommand, or have the skill detect the missing `.orchestrate/` directory on
+a fresh run and offer to copy the templates (project-type-aware — see F-003).
+Document the templates' filesystem location and an exact copy command in the
+skill prerequisites.
+
+---
+
+## F-002 — `handoff.json` template hardcodes a 200k context window
+
+- **Severity:** Medium
+- **Type:** Plugin defect (shipped template) / design gap (watchdog)
+- **Phase:** Section 1 — config setup
+
+**Symptom.** The `handoff.json` template sets
+`watchdog.contextWindowTokens: 200000`. The orchestrator session runs on
+Opus 4.7 with a 1M-token context window. With `thresholdPercent: 40`, the
+context-watchdog would write the handoff flag at roughly 80k tokens — under
+10% of the real window — forcing a successor session every one or two slices
+and shredding the run into many short-lived sessions.
+
+**Cause.** The template assumes a fixed 200k-token model. The value is a
+static config constant, not derived from the actual running model's context
+window.
+
+**Mitigation.** Edited `contextWindowTokens` to `1000000` before installing,
+so the watchdog trips near a realistic ~400k tokens.
+
+**Recommendation.** The context-watchdog should read the actual model context
+window at runtime instead of trusting a static config value; failing that,
+the skill should set `contextWindowTokens` from the detected model during
+bootstrap. At minimum, document loudly that this value must match the
+operator's model or handoffs will fire far too early.
+
+---
+
+## F-003 — `commands.json` template is npm-only; breaks non-JS repos
+
+- **Severity:** Medium
+- **Type:** Plugin defect (shipped template)
+- **Phase:** Section 1 — config setup
+
+**Symptom.** The `commands.json` template hardcodes `npm test`,
+`npm run typecheck`, `npm run build`, `npm run lint`. The target repository is
+a Markdown skill marketplace with no `package.json` anywhere in the tree.
+Installing the template verbatim would make every capability tool
+(`run_tests`, `run_typecheck`, `run_build`, `run_lint`) spawn a failing `npm`
+process on every slice.
+
+**Cause.** The template is hardwired to the JavaScript/npm ecosystem with no
+project-type detection. The plugin assumes its target is an npm project.
+
+**Mitigation.** Deliberately did NOT install `commands.json`. With the file
+absent, the capability tools return `not-configured`, which the skill
+explicitly tolerates as a clean degradation. Real per-slice verification on
+this repo comes from each meta-skill's own fixture-corpus validation loop, not
+the generic capability tools — so nothing of value was lost.
+
+**Recommendation.** Make the template project-type-aware: detect
+`package.json` / `Cargo.toml` / `pyproject.toml` / `Makefile` / none, and emit
+the matching commands (or an empty object). Ship `commands.json` empty or
+fully commented by default. Key principle: a `not-configured` capability is
+safe; a capability wired to a command that always errors is worse than none.
+
+---
+
+## F-004 — Backlog query does not exclude the parent PRD
+
+- **Severity:** High
+- **Type:** Skill-instruction defect / design gap
+- **Phase:** Section 1, steps 2–3 — read the backlog
+
+**Symptom.** `gh issue list --label ready-for-agent --state open` returned
+**10** issues: the 9 implementable slices (#144–#152) **plus #143, the parent
+PRD itself**, which also carries the `ready-for-agent` label. The skill's
+backlog definition is "every open issue with the `ready-for-agent` label",
+which would enrol #143 as a tenth slice.
+
+**Cause.** The skill identifies the parent PRD from each slice's `Parent:`
+section in order to set `parentIssue`, but it never excludes an issue that is
+*itself* named as that parent. A PRD that is labelled `ready-for-agent` and
+has been decomposed into child slices is, to the query, indistinguishable
+from a slice.
+
+**Impact if unmitigated.** An implementer subagent would receive the entire
+PRD #143 body and attempt to build all nine workstreams inside one worktree —
+duplicating every slice's work and guaranteeing umbrella-merge conflicts. This
+is the most dangerous finding so far: it silently produces wrong, conflicting
+work rather than failing loudly.
+
+**Mitigation.** Excluded #143 from the `slices` set; recorded it only as
+`parentIssue: 143`. It still receives per-wave progress comments. Flagged for
+manual re-triage at run end (the orchestrator must not relabel issues outside
+its documented tracker protocol).
+
+**Recommendation.** Add an explicit backlog-filtering step: any issue that is
+named in another backlog issue's `Parent:` section is a PRD, not a slice —
+exclude it from `slices` and use it as `parentIssue`. Optionally also exclude
+issues whose title begins with `PRD:` as a secondary heuristic.
+
+---
+
+## F-005 — `create_worktree` internal `git fetch` fails with an empty command
+
+- **Severity:** Medium
+- **Type:** Plugin defect (MCP server)
+- **Phase:** Section 3, step 1 — create worktree (slice #144)
+
+**Symptom.** `create_worktree` returned `status: "ok"` but
+`fetchStatus: "failed"` with
+`fetchError: "error: cannot run : No such file or directory"`. The error
+string has an empty token between `run` and `:` — the fetch subprocess was
+spawned with an empty/unresolved git executable path.
+
+**Cause.** Inside the MCP server process, the `git fetch` attempted before
+branching resolves the git binary to an empty string — most likely a PATH
+inheritance or git-path resolution bug in the MCP server's environment. The
+worktree creation itself still succeeded because the `baseRef`
+(`orchestrate/umbrella-20260521-201015`) was a local branch that needed no
+fetch.
+
+**Impact if unmitigated.** For a worktree whose `baseRef` is a remote-tracking
+branch that genuinely needs a fresh fetch, the stale local ref would be used
+silently. `fetchStatus: "failed"` is surfaced in the response, but it is easy
+for an orchestrator to overlook a non-`error` status field.
+
+**Mitigation.** None required this run: the orchestrator runs `git fetch
+origin` itself at section 1 startup, and the umbrella branch was created and
+pushed seconds before the worktree call. Documented for plugin follow-up.
+
+**Recommendation.** Fix git-binary resolution in the MCP server's
+`create_worktree` fetch path — use an absolute git path or ensure PATH is
+inherited correctly by the spawned process. Add a regression test asserting
+`fetchStatus: "ok"` in a normal environment.
+
+---
+
+## F-006 — Subagent type names require the `orchestrate:` plugin namespace
+
+- **Severity:** Medium
+- **Type:** Skill-instruction defect
+- **Phase:** Section 3, step 3 — spawn investigator (slice #144)
+
+**Symptom.** The skill says "spawn the `investigator-<effort>` subagent".
+Spawning with `subagent_type: "investigator-deep"` failed:
+`Agent type 'investigator-deep' not found`. The registered agent types are
+plugin-namespaced: `orchestrate:investigator-deep`,
+`orchestrate:implementer-deep`, `orchestrate:reviewer-deep`,
+`orchestrate:conflict-resolver-deep` (and the `-standard` variants).
+
+**Cause.** The skill instructions use the bare agent name throughout the Roles
+section and sections 2–3. When orchestrate is installed as a plugin, its
+bundled subagents register under the `orchestrate:` namespace. The skill text
+was written as though the agents were un-namespaced.
+
+**Impact if unmitigated.** The first spawn of every role fails. An
+orchestrator that does not realise the names are namespaced would treat this
+as an unrecoverable error and stop the run.
+
+**Mitigation.** Retried every subagent spawn with the `orchestrate:` prefix.
+All subsequent spawns use the namespaced form.
+
+**Recommendation.** Update the skill — Roles section and sections 2–3 — to
+spell the subagent types as `orchestrate:investigator-<effort>` etc., or add
+an explicit note that the plugin namespace prefix must be prepended when
+orchestrate runs as an installed plugin.
+
+---
+
+## F-007 — Investigator subagent pulled sibling-slice scope into its brief
+
+- **Severity:** Medium
+- **Type:** Design gap (subagent prompt / orchestrator contract)
+- **Phase:** Section 3, steps 3→4 — investigate then implement (slice #144)
+
+**Symptom.** The `investigator-deep` brief for slice #144 (the tracer slice)
+listed a "version cascade" step — bump `plugin.json` and the root marketplace
+manifest — in both its `relevantFiles` and its suggested `approach`. Version
+cascade is the exclusive scope of slice #152 ("Marketplace version cascade —
+final atomic commit"), a separate slice blocked by all eight predecessors.
+Issue #144's acceptance criteria contain no version-bump requirement.
+
+**Cause.** The investigator read the binding spec (ADR-0007, CONTEXT.md),
+which describe the *whole* PRD including the version cascade, and folded a
+downstream slice's work into the tracer slice. The investigator prompt handed
+it issue #144's body but did not give it the boundaries of the sibling slices,
+so it had no signal that version bumping belonged elsewhere.
+
+**Impact if unmitigated.** The implementer would bump versions inside slice
+#144, creating a merge conflict with slice #152 and violating the
+repository's atomic-commit-by-concern rule.
+
+**Mitigation.** The orchestrator cross-checked the investigator brief against
+#144's actual acceptance criteria, caught the over-scope, and added an
+explicit "CRITICAL SCOPE CORRECTION" block to the implementer prompt telling
+it to ignore the version-cascade step and touch no version/marketplace files.
+The implementer confirmed it touched none.
+
+**Recommendation.** Two complementary fixes: (a) the skill should instruct the
+orchestrator to pass each slice's own acceptance criteria to the investigator
+as the hard scope boundary; (b) the investigator subagent prompt should carry
+a standing guard — "this issue's acceptance criteria are the complete scope;
+do not pull in work from sibling or downstream slices". As a general rule, the
+orchestrator must diff every subagent brief against the issue's ACs before
+forwarding it downstream.
+
+---
+
+## F-008 — Local umbrella ref goes stale; next wave's worktrees miss prior slices
+
+- **Severity:** High
+- **Type:** Plugin defect / design gap (compounds F-005)
+- **Phase:** Section 2 wave loop → Section 3 step 1 — create Wave 1 worktrees (#145, #146)
+
+**Symptom.** After slice #144's PR squash-merged into the **remote** umbrella
+branch, the orchestrator created the Wave 1 worktrees (#145, #146) with
+`create_worktree` and `baseRef: "orchestrate/umbrella-20260521-201015"`.
+Because `create_worktree`'s internal `git fetch` fails (F-005), it branched
+from the **local** umbrella ref — still at the pre-#144 commit `081b4b8` (the
+original `development` tip). The remote umbrella was at `2bf4bd2` (post-#144).
+The Wave 1 worktrees were missing slice #144's entire merged contribution.
+
+**Cause.** Two compounding issues. (1) F-005 — `create_worktree`'s internal
+fetch is broken, so it never refreshes the umbrella. (2) The skill's section 3
+step 1 says branch from `orchestrate/umbrella-<runId>` (the local branch name)
+and implicitly assumes `create_worktree`'s fetch keeps it current. Nothing in
+the orchestrator loop fast-forwards the local umbrella ref after a slice
+merges into the *remote* umbrella. So every wave after wave 0 cuts its
+worktrees from a stale base.
+
+**Impact if unmitigated.** High. Each wave's slices would be implemented
+against a base missing every prior wave's work. Dependent slices — #145 and
+#146 are both `blocked-by #144` — would be built without the very work they
+depend on. On merge into the umbrella, the result is either silent loss of
+the prior slice's changes in overlapping regions, or spurious conflicts. The
+dependency graph would be structurally violated even though the wave ordering
+itself is correct. This is the kind of defect that produces a plausible-looking
+but wrong final result.
+
+**Mitigation.** Detected by noticing `fetchStatus: "failed"` and reasoning
+that the remote umbrella had advanced past the local ref after the #144 merge.
+Fixed by: `git fetch origin`, then
+`git branch -f orchestrate/umbrella-<runId> origin/orchestrate/umbrella-<runId>`
+to fast-forward the local ref; then removing the two stale worktrees, deleting
+their slice branches, and recreating them from the now-fresh local umbrella.
+Verified each new worktree's HEAD equals the post-#144 squash-merge commit
+`2bf4bd2`. Going forward, the orchestrator runs
+`git fetch origin && git branch -f orchestrate/umbrella-<runId> origin/orchestrate/umbrella-<runId>`
+at the start of every wave, before creating that wave's worktrees.
+
+**Recommendation.** (1) Fix F-005 so `create_worktree`'s internal fetch works.
+(2) Independently of F-005, the skill MUST add an explicit step at the start
+of every wave (section 2): fetch and fast-forward the local umbrella ref to
+the remote before creating the wave's worktrees — correctness must not depend
+on `create_worktree`'s internal fetch. (3) Alternatively, the skill should
+pass the remote-tracking ref (`origin/orchestrate/umbrella-<runId>`) as
+`baseRef` after an orchestrator-level fetch. As shipped, the design has a
+silent-data-loss failure mode that only an observant orchestrator caught.
+
+---
+
+## F-009 — Implementer subagent returned without its contracted structured report
+
+- **Severity:** Medium
+- **Type:** Design gap (subagent output contract / orchestrator robustness)
+- **Phase:** Section 3 step 4 — implementer for slice #149 (Wave 3)
+
+**Symptom.** `implementer-149` (`orchestrate:implementer-standard`) performed all
+its work — 21 files created/modified in the worktree — but its returned message
+ended mid-sentence ("Verificação final da `standalone-skills.md` para confirmar
+o conteúdo:") with no `status` / `filesChanged` / `notes` structured report.
+The orchestrate skill's section 3 step 4 depends on the implementer returning
+`status` (to detect `blocked`) and `filesChanged` (to know what to stage).
+
+**Cause.** The subagent's final turn was truncated — it narrated a verification
+step and the response ended before it emitted the structured report. The
+orchestrate implementer subagent has no enforced output schema; "return
+status/filesChanged/notes" is a prompt instruction, not a structural guarantee,
+so a truncated or prematurely-ended turn silently drops the contract.
+
+**Impact if unmitigated.** The orchestrator cannot determine whether the slice
+succeeded or which files to stage. A naive orchestrator might mark the slice
+`failed` (losing completed work) or stall waiting for a report that never comes.
+
+**Mitigation.** Two-pronged. (1) Inspected the worktree directly with
+`git status --short` to recover the actual changeset independent of the agent's
+report. (2) Resumed the agent via `SendMessage` (still resumable by agent ID)
+asking only for the structured report; it returned the full `status: completed`
++ 21-file `filesChanged` + `notes` on resume. Note: `SendMessage` by agent
+*name* failed — `No agent named 'implementer-149' is currently addressable` —
+only the agent *ID* worked, even though the SendMessage tool documentation says
+to address teammates by name and never by UUID. That name/ID inconsistency is a
+secondary friction worth fixing.
+
+**Recommendation.** (1) The orchestrate subagents (implementer, reviewer,
+investigator) should return a machine-checkable structured result — a fenced
+JSON block or a tool-call-shaped return — so truncation is detectable and the
+orchestrator never parses prose. (2) The skill should instruct the orchestrator
+to fall back to `git status` in the worktree when a subagent's report is missing
+`filesChanged`, treating the worktree as the source of truth. (3) Resolve the
+`SendMessage` name-vs-ID inconsistency so a completed-but-resumable agent is
+addressable by the name the orchestrator assigned it.
+
+---
+
+## F-010 — Implementer subagents call advisor() despite explicit instruction not to
+
+- **Severity:** Low
+- **Type:** Design gap (subagent instruction adherence)
+- **Phase:** Section 3 step 4 — implementers for #145, #146, #149
+
+**Symptom.** The implementer prompts explicitly said "Do NOT call advisor() —
+that is orchestration-level." The `implementer-standard` subagents for #145,
+#146, and #149 each called `advisor()` anyway (their notes cite advisor
+guidance). The `implementer-deep` for #144 honored the instruction.
+
+**Cause.** Either the implementer subagent's own definition instructs an advisor
+pass, or the standard-effort (sonnet) variant adheres less strictly to negative
+prompt instructions than the deep (opus) variant. An orchestrator-supplied
+prompt cannot reliably suppress the behavior.
+
+**Impact.** Low — the advisor calls were harmless and in one case (#145 HTML
+colors) improved the result. But each extra advisor call adds latency and token
+cost; across a large backlog this compounds, and it blurs the
+orchestration-level / implementer-level separation the skill intends.
+
+**Mitigation.** None needed — outcomes were fine. Documented only.
+
+**Recommendation.** Decide deliberately whether implementer subagents SHOULD
+consult the advisor. If yes, bake it into their definition and stop telling them
+not to. If no, move the prohibition into the subagent definition itself (more
+authoritative than an orchestrator-supplied prompt). Either way, make the
+`-standard` and `-deep` variants behave consistently.
+
+---
+
+## F-011 — implementer-standard maxTurns (50) too low; silent mid-work truncation
+
+- **Severity:** High
+- **Type:** Plugin defect (subagent config) — concrete root cause behind F-009
+- **Phase:** Section 3 step 4 — implementer for slice #151 (Wave 5)
+
+**Symptom.** `implementer-151` (`orchestrate:implementer-standard`) was
+force-stopped after 63 tool-uses **mid-work** — it had completed only 1 of the
+4 quality-gate skills the slice requires (`agent-customizer-quality-gate`) and
+had just started the second gate's fixtures. It ended its message mid-sentence
+("Agora vou criar os fixtures para `cursor-customizer-quality-gate`…") with no
+structured report and no `blocked` signal. The slice was left roughly 30 %
+implemented.
+
+**Cause.** `implementer-standard.md` pins `maxTurns: 50`. Slice #151 touches
+four separate quality-gate skills, each needing a SKILL.md content edit, a
+criteria-reference edit, and a fixture corpus — far more editing than 50 turns
+allows. The agent was silently truncated at the turn ceiling. Unlike a
+`blocked` return, a maxTurns cutoff produces **no status signal** — the
+orchestrator cannot distinguish "agent finished" from "agent ran out of turns"
+without inspecting the worktree itself.
+
+**Relationship to F-009.** This is the concrete root cause behind the F-009
+class of symptom. F-009 (slice #149) was the same `-standard` variant ending
+without its structured report — there the work happened to be complete; here
+the work itself was truncated. Same defect, worse outcome.
+
+**Impact if unmitigated.** A standard-tier slice that happens to touch many
+files or targets is silently half-implemented. An orchestrator that trusted the
+(absent) report, or did not inspect the worktree, would either commit a partial
+slice or fail it — losing the partial work and shipping a broken convention
+gate.
+
+**Mitigation.** Inspected the worktree with `git status` — found only 1 of 4
+gates done (2 files modified + 2 `assets/` dirs partially created). Resumed the
+agent via `SendMessage` (a resume grants a fresh 50-turn budget) with an
+explicit efficiency instruction: use ONE shared golden fixture corpus across
+all four gates instead of per-gate duplicate copies — shrinking the remaining
+work enough to fit a second budget.
+
+**Recommendation.** (1) Raise `implementer-standard`'s `maxTurns`, or make it
+scope-aware — a slice touching N targets needs a budget proportional to N.
+(2) A maxTurns cutoff MUST surface as an explicit `status: incomplete` (or
+`blocked`) result, never a silent mid-sentence stop — the orchestrator needs to
+detect truncation without worktree forensics. (3) The orchestrator should, as a
+standing rule, run `git status` on every worktree after the implementer returns
+and compare the changeset against the issue's expected scope before trusting
+completion. (4) Tier assessment should account for turn budget, not just
+conceptual difficulty: a slice that fans out across many independent targets
+(like #151's four gates) may warrant the `complex` tier purely to get the
+larger turn budget and an investigator pass, even when each individual edit is
+simple.
+
+---
+
+## Non-plugin observations (surfaced during the run, not orchestrate defects)
+
+These were discovered while running orchestrate but are defects in the
+*target repository's content*, not in the orchestrate plugin. They are logged
+here only so the context is not lost; they belong in a PRD-content follow-up,
+not the plugin improvement plan.
+
+### O-001 — Wiki worked example uses attributes outside its own closed set
+
+The implementer for #144 flagged that
+`wiki/knowledge/skill-body-convention.md`'s worked example uses
+`<REFERENCES load="on-demand">` and `<VALIDATION loop="max-iterations:3">`,
+but `load=` and `loop=` are not in the closed attribute set documented on the
+same page. This internal inconsistency in the PRD #143 source material
+produces warn-tier (non-blocking) validation findings. It should be reconciled
+by a content follow-up to the wiki page.
+
+---
+
+## Run outcome
+
+The run completed successfully — all 9 slices passed, 0 failed, 0 skipped, final
+integration PR #180 opened. Every finding below was either worked around by the
+orchestrator or was non-blocking. **No finding stopped the run**, but several
+(F-004, F-008, F-011) would have produced wrong or incomplete output if the
+orchestrator had not actively detected and corrected them — they are silent
+failure modes, dangerous precisely because the run still *looks* successful.
+
+### Findings summary
+
+| ID | Severity | Type | One-line |
+|----|----------|------|----------|
+| F-001 | Medium | Design gap | No bootstrap for `.orchestrate/` config files |
+| F-002 | Medium | Plugin defect | `handoff.json` hardcodes a 200k context window |
+| F-003 | Medium | Plugin defect | `commands.json` template is npm-only |
+| F-004 | High | Skill defect | Backlog query does not exclude the parent PRD |
+| F-005 | Medium | Plugin defect | `create_worktree` internal `git fetch` fails (empty command) |
+| F-006 | Medium | Skill defect | Subagent types need the `orchestrate:` namespace prefix |
+| F-007 | Medium | Design gap | Investigator pulled sibling-slice scope into its brief |
+| F-008 | High | Plugin defect | Local umbrella ref goes stale; wave worktrees miss prior slices |
+| F-009 | Medium | Design gap | Implementer returned without its structured report |
+| F-010 | Low | Design gap | Implementers call `advisor()` despite instruction not to |
+| F-011 | High | Plugin defect | `implementer-standard` maxTurns (50) too low; silent truncation |
+
+Three findings are **High severity** and should anchor the improvement plan:
+F-004 (parent PRD pollutes the backlog), F-008 (stale umbrella ref — silent
+data loss across waves), and F-011 (turn-limit truncation — silent incomplete
+work). All three share a theme: **the plugin's failure modes are silent** — the
+run continues and reports success while producing wrong or partial output. The
+highest-leverage improvement is making each of these fail loudly instead.
+
+F-005 is the lowest-effort high-value fix (one git-path resolution bug) and it
+is the root cause that makes F-008 dangerous — fixing F-005 de-risks F-008.
+
+*Log status: CLOSED — run `20260521-201015` complete.*

--- a/docs/analysis/orchestrate-prd-v2-body.md
+++ b/docs/analysis/orchestrate-prd-v2-body.md
@@ -1,0 +1,274 @@
+## Problem Statement
+
+Operators run the `orchestrate` plugin for long, autonomous, multi-wave runs that
+implement a backlog of `ready-for-agent` issues end to end. Real runs
+(`prd19-20260530-035027`, `prd24-20260602-145053`) surfaced a cluster of defects
+and gaps that, together, undermine the plugin's core promises — "an interrupted
+run resumes", "no slice merges on unverified state", "concurrent runs stay
+isolated", and "merged work is reflected on the tracker":
+
+- **Self-breaking bugs.** Fresh slice worktrees lack `.orchestrate/commands.json`,
+  so the capability tools silently no-op (`not-configured`) and the verification
+  loop — the safety boundary — does nothing. The `slices` run-state shape is
+  documented ambiguously and fails maximally late (after all expensive subagents
+  run). `verify_changeset` mis-flags a correct changeset as `mismatch` when files
+  land in a new directory. The context-handoff successor resumes the wrong
+  partition because `resumePrompt` is a static literal.
+- **Shallow verification.** Merge readiness trusts subagent self-report; there is
+  no integration-test tier; clean-but-semantically-broken cross-slice merges are
+  never re-verified on the umbrella; a known pre-existing red test forces per-slice
+  re-judgement.
+- **Fragile resilience.** Network operations have no retry and a push can report
+  success without landing; slice integration is not sub-step checkpointed, so a
+  resume discards expensive completed work; a large issue maps to a single
+  implementer turn and tends to FAIL `incomplete`.
+- **Lifecycle and hygiene gaps.** Merged issues are never closed on the tracker;
+  failed-slice worktrees have no surfaced, reclaimable handle; slice branches
+  accumulate until the whole-run sweep; a confident-but-wrong root-cause diagnosis
+  propagates as established fact.
+- **Cross-run isolation is convention, not guarantee.** A new or concurrent
+  `/orchestrate` invocation must never delete or mutate another in-progress run's
+  data, with a deterministic mechanism rather than prose the orchestrator LLM
+  follows.
+
+## Solution
+
+A hardening pass — "orchestrate hardening v2" — applied in dependency order:
+bugs-first as a manual pre-wave, then enhancements by the dependency DAG.
+
+The keystone is making `.orchestrate/commands.json` resolve inside slice worktrees:
+until that holds, the orchestrator-side capability gate, the known-failure
+allowlist, and any self-verification are all silent no-ops. Resolution is done by
+reading `commands.json` from the **main repository root** (via the worktree's
+shared git common dir) while still **executing** capability commands in the
+worktree — decoupling "where config is read" from "where the command runs".
+
+On that foundation: the orchestrator runs the capability tools itself as an
+independent pre-merge gate; a known-failure allowlist annotates baseline failures
+so they are not re-judged each slice; a new integration tier and a tiered
+post-merge umbrella re-verification catch cross-slice breakage early; a
+`push_and_verify` tool plus bounded gh-retry survive transient outages; sub-step
+checkpointing lets a resume continue from where it stopped instead of redoing
+expensive work; an `incomplete` implementer is continued in place rather than
+failed; issues are closed when their code actually lands in `development`; failed
+worktrees and slice branches get deliberate reclamation; root-cause prose carries
+a verified-vs-hypothesis label; and cross-run isolation becomes a deterministic,
+tested invariant.
+
+## User Stories
+
+1. As an operator, I want a slice worktree's capability tools to find the
+   project's `commands.json`, so that build/test verification actually runs
+   instead of silently no-opping.
+2. As an operator, I want capability commands to execute against the slice's own
+   code while reading config from the project root, so that tests reflect the
+   slice but configuration stays single-sourced.
+3. As an operator, I want a changeset that adds files in a brand-new directory to
+   verify as `matched`, so that a correct implementer result is not mis-flagged as
+   `mismatch`.
+4. As an operator, I want a context-handoff successor to resume the same PRD
+   partition the interrupted run owned, so that automatic handoff never widens or
+   mis-targets scope.
+5. As an operator, I want a malformed `run-state.json` shape to fail within
+   seconds of the first write, so that I do not discover it only after every
+   expensive subagent has run.
+6. As an operator, I want the orchestrator to independently run build and tests on
+   each slice worktree before merging, so that a merge never depends solely on a
+   subagent's self-report.
+7. As an operator, I want a known pre-existing failing test declared once, so that
+   each slice's gate does not force me (or the orchestrator) to re-judge "baseline
+   or regression?".
+8. As an operator, I want an integration-test tier I can configure, so that
+   acceptance criteria that depend on integration tests are actually verifiable.
+9. As an operator, I want the umbrella re-verified after slices land, so that a
+   textually-clean but semantically-broken cross-slice merge is caught early
+   rather than after the whole wave piled on top of it.
+10. As an operator, I want network operations retried with bounded backoff, so
+    that a transient API outage does not strand a long run.
+11. As an operator, I want a push confirmed to have landed on the remote before a
+    PR is opened, so that a silent push failure does not surface as a confusing
+    "Head ref must be a branch" error later.
+12. As an operator, I want an interrupted slice to resume from its last completed
+    sub-step, so that a ~170k-token implementer turn and a deep review are not
+    discarded to redo already-verified work.
+13. As an operator, I want a large, well-specified issue to be continued across
+    additional implementer turns in place, so that it is not systematically biased
+    toward an `incomplete` FAIL.
+14. As an operator, I want each issue closed when its code actually merges into
+    `development`, so that the tracker reflects the real state without manual
+    closing — and is never closed prematurely.
+15. As an operator, I want a failed slice's preserved worktree discoverable from
+    the tracker and reclaimable by a deliberate command, so that it is neither
+    lost nor left lingering forever.
+16. As an operator, I want a merged slice's branch reclaimed immediately after it
+    integrates into the umbrella, so that dead branches do not accumulate until
+    the whole-run sweep.
+17. As an operator, I want a root-cause diagnosis labeled verified vs hypothesis,
+    so that a confident-but-wrong environmental claim does not propagate as fact
+    and cost the next session re-investigation.
+18. As an operator, I want a second `/orchestrate` invocation to be unable to
+    delete or mutate another in-progress run's data, guaranteed by a status check
+    in the tools, so that concurrent runs are safely isolated.
+19. As an operator, I want IDE/language-server diagnostics about worktree paths
+    treated as non-authoritative, so that the orchestrator does not waste
+    reasoning refuting false-positive diagnostics.
+20. As an operator, I want `mergeStateStatus: UNSTABLE` documented as non-blocking,
+    so that a mergeable PR is not subjected to needless per-slice deliberation.
+21. As a developer reviewing the run, I want the final integration pull request to
+    carry closing keywords for every passed slice, so that merging it into the
+    default branch closes those issues natively.
+22. As a maintainer, I want every resolved design decision recorded with its
+    rejected alternatives, so that a future reader understands why each path was
+    chosen.
+
+## Implementation Decisions
+
+Grouped by the dependency tier established during the grilling session. The full
+rationale, rejected alternatives, and per-decision implementation surface live in
+the decision ledger (`docs/analysis/orchestrate-grill-decisions.md`).
+
+**Sequencing.** Bugs-first manual pre-wave, then enhancements by the DAG. `#237`
+is the keystone — until `commands.json` resolves in worktrees, the capability gate
+(#230-P1.3), known-failures (#231-P2.5) and any self-verification are silent
+no-ops. `#230-P1.2` (sub-step checkpoint) unblocks `#232-A.1` (incremental
+reclamation).
+
+**Tier 0 — self-breaking bugs.**
+- #237 — capability tools resolve `commands.json` from the main repository root
+  (via the worktree's shared git common dir), **decoupled** from the execution
+  cwd (still the worktree). Single source of truth; no commit footgun; no
+  staleness.
+- #236 — `verify_changeset` and `recover_changed_files` enumerate untracked files
+  individually (`--untracked-files=all`) so a new untracked directory is not
+  collapsed into a single entry.
+- #233 — the orchestrator derives the resume invocation from its own `runId`
+  prefix (`prd<N>-` → `/orchestrate <N>`; `backlog-` → `/orchestrate`) and passes
+  it to `spawn_successor` as an optional input; the static `handoff.json` value is
+  a fallback only.
+- #238 — `SKILL.md` states `slices` is a MAP keyed by issue-id string (with an
+  inline example), plus a thin run-state shape validator the orchestrator calls
+  right after the first write (reusing the render tools' existing schema) so a
+  mis-shape fails fast.
+
+**Tier 1 — capability-gated (depend on #237).**
+- #230-P1.3 — the orchestrator runs the capability tools itself on each slice
+  worktree as a pre-merge gate, independent of any subagent envelope.
+- #231-P2.5 — an optional `knownFailures` pattern list in `commands.json`; the
+  gate annotates which known patterns matched a failing command's output (L1,
+  best-effort, framework-agnostic; not a structured "0 new" guarantee).
+- #235 — a new optional `integration` capability verb run once per wave, plus a
+  tiered post-merge umbrella re-verification: unit/build re-verified per slice
+  merge (early, precise attribution), integration per wave (bounded cost).
+
+**Tier 2 — resilience/state.**
+- #230-P1.1 — a new `push_and_verify` MCP tool (git push + `git ls-remote` landing
+  check + bounded exponential backoff, git-only to respect the no-gh-in-MCP
+  invariant); `gh` op retry stays orchestrator prose.
+- #230-P1.2 — each slice gains a `subState`
+  (`implemented|verified|reviewed|pushed|pr-open|merged`); resume continues from
+  the recorded sub-step, reconstructing the changed-file set from the preserved
+  worktree via `recover_changed_files` and re-validating the resume point, instead
+  of discarding the in-progress slice.
+- #232-A.1 — a slice branch is reclaimed (remote via `--delete-branch`, local
+  after worktree removal) as soon as it reaches `subState: merged`.
+
+**Tier 3 — DX/epistemic.**
+- #228 — issues close on merge→`development`: closing keywords in the final
+  umbrella PR body (immediate native close when the integration base is the
+  default branch) plus an orchestrator backstop that `gh issue close`s passed
+  slices when the cleanup sweep confirms the final PR merged.
+- #234 — `incomplete` becomes continue-then-fail: the envelope carries a
+  `remainingWork` handoff; the orchestrator re-spawns the implementer in the same
+  preserved worktree until `completed` or a configurable continuation budget is
+  exhausted, with a no-progress guard.
+- #239 — the envelope gains a `rootCause` object with a
+  `status: verified | hypothesis` tag (and evidence when verified) so root-cause
+  prose carries its epistemic standing through every downstream hop.
+- #231-P2.1 — `SKILL.md` declares worktree IDE/language-server diagnostics
+  non-authoritative; the capability tools are the only build/test source of truth.
+- #231-P2.4 — `SKILL.md` documents `mergeStateStatus: UNSTABLE` as non-blocking;
+  the gate is the `mergeable` field.
+
+**New — #240 (cross-run isolation).** The deterministic in-progress protection in
+`clean_runs` (re-read the run's own `run-state.json`; refuse unless
+`status: completed`) is elevated to an ADR-recorded, test-covered invariant,
+extended to any cross-run-mutating tool, tightened to also require a non-null
+`finalPullRequest`, and complemented by an assertion that no tool writes outside
+its own run directory.
+
+**Still pending (deferred to a follow-up grill; tracked in this PRD).**
+- #231-P2.2 — `detect-project` sets a language-aware `install`; an implementer
+  envelope `needs-dependency` signal for orchestrator fetch-and-retry of new deps.
+- #231-P2.3 — an `intraWaveConcurrency: parallel | sequential` knob.
+- #232-A.2 — surfaced failed-worktree pointer + an `/orchestrate clean --failed
+  <runId>` reclaim mode.
+
+## Testing Decisions
+
+A good test exercises external behavior through a module's public interface, not
+its internals; it survives a refactor that preserves behavior. Test creation
+follows the project's red-green-refactor loop (`/tdd`).
+
+The deep, isolation-testable modules introduced or modified here:
+
+- **Config-resolution root** (capability command loading) — given a worktree path,
+  resolves `commands.json` from the main working tree while executing in the
+  worktree; covered with a real worktree fixture, asserting both the resolved
+  config and the execution cwd.
+- **`push_and_verify`** — push, landing check, and bounded-backoff retry as a
+  structured result that never throws; transient-vs-permanent classification.
+- **Run-state shape validator** — accepts a map-shaped `slices`, rejects an
+  array-shaped one with a clear, early error (reusing the render schema).
+- **Untracked-file enumeration** — files added in a new untracked directory are
+  enumerated individually, so `verify_changeset` returns `matched` not `mismatch`
+  (and the same for `recover_changed_files`).
+- **`spawn_successor` resume override** — pure command construction: an explicit
+  `resumePrompt` input wins over the static config value.
+- **Known-failure annotation** — a failing command's output is annotated with the
+  matched known patterns; an unmatched failure indicator is surfaced.
+- **`rootCause` envelope schema** — the validator accepts and classifies a
+  verified-vs-hypothesis root cause; a missing status is surfaced.
+- **`subState` run-state schema** and the **`integration` verb** schema extension.
+- **`clean_runs` isolation gate** — an `in-progress` run is never cleaned whatever
+  the verdict says; a `completed`-but-`finalPullRequest`-null run is skipped.
+
+Prior art: the existing MCP tool tests under `orchestrate-mcp` (the tools are
+validated against their Zod schemas; `verify_changeset`/`recover_changed_files`
+already share `parsePorcelainZ`; pure command-construction is already unit-tested
+for `spawn_successor`). `orchestrate-mcp/dist/` is committed — rebuild after any
+`src/` change.
+
+## Out of Scope
+
+- The three pending sub-parts (#231-P2.2, #231-P2.3, #232-A.2) are part of this
+  PRD's umbrella but their design is NOT finalized — they are deferred to a
+  follow-up grilling session and must not be implemented from leaning
+  recommendations alone.
+- Structured per-framework test-result parsing (L3 for known failures) — explicitly
+  rejected for v1 in favor of the L1 pattern annotation.
+- Upfront intra-issue decomposition (an ordered sub-task checklist) — deferred; v1
+  uses continue-in-place. Revisit only if continue-in-place proves insufficient.
+- Auto-detection of shared-file contention for the intra-wave concurrency knob.
+- A per-run lock/heartbeat mechanism for isolation — rejected in favor of the
+  self-cleaning status gate.
+- Per-PRD configuration override layers — the config files stay shared and
+  read-only during a run; the only genuinely per-run value (resumePrompt) is
+  derived, not stored.
+- Auto-merging the final integration PR — the human review gate stays.
+
+## Further Notes
+
+- Dependency DAG (prose, not encoded as `Blocked by` edges because the issues
+  bundle independent sub-parts so issue-level edges would be approximate): #237 is
+  the keystone for all capability-gated work; #230-P1.2 unblocks #232-A.1. When the
+  work is sliced finer at orchestration time, precise `Blocked by` edges are added
+  then.
+- The child issues are the existing #228, #230–#240; each is linked to this PRD via
+  its `Parent` field. #231 and #232 are partially locked — their per-sub-part status
+  is recorded in their issue comments.
+- ADR-worthy decisions to record from this work: the config-resolution-root
+  decoupling (#237) and the cross-run isolation invariant (#240).
+- Glossary impact: the CONTEXT.md **Implementer `incomplete` status** entry must be
+  updated — `incomplete` is now bounded-continue-then-FAIL, not immediate FAIL.
+- Respects ADR-0008 (concurrent run management) and ADR-0009 (subagent advisor
+  policy); the no-gh-in-MCP invariant is preserved throughout.

--- a/docs/claude-code/agent-teams/agent-teams.md
+++ b/docs/claude-code/agent-teams/agent-teams.md
@@ -1,0 +1,426 @@
+> ## Documentation Index
+> Fetch the complete documentation index at: https://code.claude.com/docs/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Orchestrate teams of Claude Code sessions
+
+> Coordinate multiple Claude Code instances working together as a team, with shared tasks, inter-agent messaging, and centralized management.
+
+<Warning>
+  Agent teams are experimental and disabled by default. Enable them by adding `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` to your [settings.json](/en/settings) or environment. Agent teams have [known limitations](#limitations) around session resumption, task coordination, and shutdown behavior.
+</Warning>
+
+Agent teams let you coordinate multiple Claude Code instances working together. One session acts as the team lead, coordinating work, assigning tasks, and synthesizing results. Teammates work independently, each in its own context window, and communicate directly with each other.
+
+Unlike [subagents](/en/sub-agents), which run within a single session and can only report back to the main agent, you can also interact with individual teammates directly without going through the lead.
+
+<Note>
+  Agent teams require Claude Code v2.1.32 or later. Check your version with `claude --version`.
+</Note>
+
+This page covers:
+
+* [When to use agent teams](#when-to-use-agent-teams), including best use cases and how they compare with subagents
+* [Starting a team](#start-your-first-agent-team)
+* [Controlling teammates](#control-your-agent-team), including display modes, task assignment, and delegation
+* [Best practices for parallel work](#best-practices)
+
+## When to use agent teams
+
+Agent teams are most effective for tasks where parallel exploration adds real value. See [use case examples](#use-case-examples) for full scenarios. The strongest use cases are:
+
+* **Research and review**: multiple teammates can investigate different aspects of a problem simultaneously, then share and challenge each other's findings
+* **New modules or features**: teammates can each own a separate piece without stepping on each other
+* **Debugging with competing hypotheses**: teammates test different theories in parallel and converge on the answer faster
+* **Cross-layer coordination**: changes that span frontend, backend, and tests, each owned by a different teammate
+
+Agent teams add coordination overhead and use significantly more tokens than a single session. They work best when teammates can operate independently. For sequential tasks, same-file edits, or work with many dependencies, a single session or [subagents](/en/sub-agents) are more effective.
+
+### Compare with subagents
+
+Both agent teams and [subagents](/en/sub-agents) let you parallelize work, but they operate differently. Choose based on whether your workers need to communicate with each other:
+
+<Frame caption="Subagents only report results back to the main agent and never talk to each other. In agent teams, teammates share a task list, claim work, and communicate directly with each other.">
+  <img src="https://mintcdn.com/claude-code/nsvRFSDNfpSU5nT7/images/subagents-vs-agent-teams-light.png?fit=max&auto=format&n=nsvRFSDNfpSU5nT7&q=85&s=2f8db9b4f3705dd3ab931fbe2d96e42a" className="dark:hidden" alt="Diagram comparing subagent and agent team architectures. Subagents are spawned by the main agent, do work, and report results back. Agent teams coordinate through a shared task list, with teammates communicating directly with each other." width="4245" height="1615" data-path="images/subagents-vs-agent-teams-light.png" />
+
+  <img src="https://mintcdn.com/claude-code/nsvRFSDNfpSU5nT7/images/subagents-vs-agent-teams-dark.png?fit=max&auto=format&n=nsvRFSDNfpSU5nT7&q=85&s=d573a037540f2ada6a9ae7d8285b46fd" className="hidden dark:block" alt="Diagram comparing subagent and agent team architectures. Subagents are spawned by the main agent, do work, and report results back. Agent teams coordinate through a shared task list, with teammates communicating directly with each other." width="4245" height="1615" data-path="images/subagents-vs-agent-teams-dark.png" />
+</Frame>
+
+|                   | Subagents                                        | Agent teams                                         |
+| :---------------- | :----------------------------------------------- | :-------------------------------------------------- |
+| **Context**       | Own context window; results return to the caller | Own context window; fully independent               |
+| **Communication** | Report results back to the main agent only       | Teammates message each other directly               |
+| **Coordination**  | Main agent manages all work                      | Shared task list with self-coordination             |
+| **Best for**      | Focused tasks where only the result matters      | Complex work requiring discussion and collaboration |
+| **Token cost**    | Lower: results summarized back to main context   | Higher: each teammate is a separate Claude instance |
+
+Use subagents when you need quick, focused workers that report back. Use agent teams when teammates need to share findings, challenge each other, and coordinate on their own.
+
+## Enable agent teams
+
+Agent teams are disabled by default. Enable them by setting the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable to `1`, either in your shell environment or through [settings.json](/en/settings):
+
+```json settings.json theme={null}
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+## Start your first agent team
+
+After enabling agent teams, tell Claude to create an agent team and describe the task and the team structure you want in natural language. Claude creates the team, spawns teammates, and coordinates work based on your prompt.
+
+This example works well because the three roles are independent and can explore the problem without waiting on each other:
+
+```text theme={null}
+I'm designing a CLI tool that helps developers track TODO comments across
+their codebase. Create an agent team to explore this from different angles: one
+teammate on UX, one on technical architecture, one playing devil's advocate.
+```
+
+From there, Claude creates a team with a [shared task list](/en/interactive-mode#task-list), spawns teammates for each perspective, has them explore the problem, synthesizes findings, and attempts to [clean up the team](#clean-up-the-team) when finished.
+
+The lead's terminal lists all teammates and what they're working on. Use Shift+Down to cycle through teammates and message them directly. After the last teammate, Shift+Down wraps back to the lead.
+
+If you want each teammate in its own split pane, see [Choose a display mode](#choose-a-display-mode).
+
+## Control your agent team
+
+Tell the lead what you want in natural language. It handles team coordination, task assignment, and delegation based on your instructions.
+
+### Choose a display mode
+
+Agent teams support two display modes:
+
+* **In-process**: all teammates run inside your main terminal. Use Shift+Down to cycle through teammates and type to message them directly. Works in any terminal, no extra setup required.
+* **Split panes**: each teammate gets its own pane. You can see everyone's output at once and click into a pane to interact directly. Requires tmux, or iTerm2.
+
+<Note>
+  `tmux` has known limitations on certain operating systems and traditionally works best on macOS. Using `tmux -CC` in iTerm2 is the suggested entrypoint into `tmux`.
+</Note>
+
+The default is `"auto"`, which uses split panes if you're already running inside a tmux session, and in-process otherwise. The `"tmux"` setting enables split-pane mode and auto-detects whether to use tmux or iTerm2 based on your terminal. To override, set [`teammateMode`](/en/settings#available-settings) in `~/.claude/settings.json`:
+
+```json theme={null}
+{
+  "teammateMode": "in-process"
+}
+```
+
+To force in-process mode for a single session, pass it as a flag:
+
+```bash theme={null}
+claude --teammate-mode in-process
+```
+
+Split-pane mode requires either [tmux](https://github.com/tmux/tmux/wiki) or iTerm2 with the [`it2` CLI](https://github.com/mkusaka/it2). To install manually:
+
+* **tmux**: install through your system's package manager. See the [tmux wiki](https://github.com/tmux/tmux/wiki/Installing) for platform-specific instructions.
+* **iTerm2**: install the [`it2` CLI](https://github.com/mkusaka/it2), then enable the Python API in **iTerm2 → Settings → General → Magic → Enable Python API**.
+
+### Specify teammates and models
+
+Claude decides the number of teammates to spawn based on your task, or you can specify exactly what you want:
+
+```text theme={null}
+Create a team with 4 teammates to refactor these modules in parallel.
+Use Sonnet for each teammate.
+```
+
+Teammates don't inherit the lead's `/model` selection by default. To change the model used when the prompt doesn't specify one, set **Default teammate model** in `/config`. Pick **Default (leader's model)** to have teammates follow the lead's current model.
+
+### Require plan approval for teammates
+
+For complex or risky tasks, you can require teammates to plan before implementing. The teammate works in read-only plan mode until the lead approves their approach:
+
+```text theme={null}
+Spawn an architect teammate to refactor the authentication module.
+Require plan approval before they make any changes.
+```
+
+When a teammate finishes planning, it sends a plan approval request to the lead. The lead reviews the plan and either approves it or rejects it with feedback. If rejected, the teammate stays in plan mode, revises based on the feedback, and resubmits. Once approved, the teammate exits plan mode and begins implementation.
+
+The lead makes approval decisions autonomously. To influence the lead's judgment, give it criteria in your prompt, such as "only approve plans that include test coverage" or "reject plans that modify the database schema."
+
+### Talk to teammates directly
+
+Each teammate is a full, independent Claude Code session. You can message any teammate directly to give additional instructions, ask follow-up questions, or redirect their approach.
+
+* **In-process mode**: use Shift+Down to cycle through teammates, then type to send them a message. Press Enter to view a teammate's session, then Escape to interrupt their current turn. Press Ctrl+T to toggle the task list.
+* **Split-pane mode**: click into a teammate's pane to interact with their session directly. Each teammate has a full view of their own terminal.
+
+### Assign and claim tasks
+
+The shared task list coordinates work across the team. The lead creates tasks and teammates work through them. Tasks have three states: pending, in progress, and completed. Tasks can also depend on other tasks: a pending task with unresolved dependencies cannot be claimed until those dependencies are completed.
+
+The lead can assign tasks explicitly, or teammates can self-claim:
+
+* **Lead assigns**: tell the lead which task to give to which teammate
+* **Self-claim**: after finishing a task, a teammate picks up the next unassigned, unblocked task on its own
+
+Task claiming uses file locking to prevent race conditions when multiple teammates try to claim the same task simultaneously.
+
+### Shut down teammates
+
+To gracefully end a teammate's session:
+
+```text theme={null}
+Ask the researcher teammate to shut down
+```
+
+The lead sends a shutdown request. The teammate can approve, exiting gracefully, or reject with an explanation.
+
+### Clean up the team
+
+When you're done, ask the lead to clean up:
+
+```text theme={null}
+Clean up the team
+```
+
+This removes the shared team resources. When the lead runs cleanup, it checks for active teammates and fails if any are still running, so shut them down first.
+
+<Warning>
+  Always use the lead to clean up. Teammates should not run cleanup because their team context may not resolve correctly, potentially leaving resources in an inconsistent state.
+</Warning>
+
+### Enforce quality gates with hooks
+
+Use [hooks](/en/hooks) to enforce rules when teammates finish work or tasks are created or completed:
+
+* [`TeammateIdle`](/en/hooks#teammateidle): runs when a teammate is about to go idle. Exit with code 2 to send feedback and keep the teammate working.
+* [`TaskCreated`](/en/hooks#taskcreated): runs when a task is being created. Exit with code 2 to prevent creation and send feedback.
+* [`TaskCompleted`](/en/hooks#taskcompleted): runs when a task is being marked complete. Exit with code 2 to prevent completion and send feedback.
+
+## How agent teams work
+
+This section covers the architecture and mechanics behind agent teams. If you want to start using them, see [Control your agent team](#control-your-agent-team) above.
+
+### How Claude starts agent teams
+
+There are two ways agent teams get started:
+
+* **You request a team**: give Claude a task that benefits from parallel work and explicitly ask for an agent team. Claude creates one based on your instructions.
+* **Claude proposes a team**: if Claude determines your task would benefit from parallel work, it may suggest creating a team. You confirm before it proceeds.
+
+In both cases, you stay in control. Claude won't create a team without your approval.
+
+### Architecture
+
+An agent team consists of:
+
+| Component     | Role                                                                                       |
+| :------------ | :----------------------------------------------------------------------------------------- |
+| **Team lead** | The main Claude Code session that creates the team, spawns teammates, and coordinates work |
+| **Teammates** | Separate Claude Code instances that each work on assigned tasks                            |
+| **Task list** | Shared list of work items that teammates claim and complete                                |
+| **Mailbox**   | Messaging system for communication between agents                                          |
+
+See [Choose a display mode](#choose-a-display-mode) for display configuration options. Teammate messages arrive at the lead automatically.
+
+The system manages task dependencies automatically. When a teammate completes a task that other tasks depend on, blocked tasks unblock without manual intervention.
+
+Teams and tasks are stored locally:
+
+* **Team config**: `~/.claude/teams/{team-name}/config.json`
+* **Task list**: `~/.claude/tasks/{team-name}/`
+
+Claude Code generates both of these automatically when you create a team and updates them as teammates join, go idle, or leave. The team config holds runtime state such as session IDs and tmux pane IDs, so don't edit it by hand or pre-author it: your changes are overwritten on the next state update.
+
+To define reusable teammate roles, use [subagent definitions](#use-subagent-definitions-for-teammates) instead.
+
+The team config contains a `members` array with each teammate's name, agent ID, and agent type. Teammates can read this file to discover other team members.
+
+There is no project-level equivalent of the team config. A file like `.claude/teams/teams.json` in your project directory is not recognized as configuration; Claude treats it as an ordinary file.
+
+### Use subagent definitions for teammates
+
+When spawning a teammate, you can reference a [subagent](/en/sub-agents) type from any [subagent scope](/en/sub-agents#choose-the-subagent-scope): project, user, plugin, or CLI-defined. This lets you define a role once, such as a security-reviewer or test-runner, and reuse it both as a delegated subagent and as an agent team teammate.
+
+To use a subagent definition, mention it by name when asking Claude to spawn the teammate:
+
+```text theme={null}
+Spawn a teammate using the security-reviewer agent type to audit the auth module.
+```
+
+The teammate honors that definition's `tools` allowlist and `model`, and the definition's body is appended to the teammate's system prompt as additional instructions rather than replacing it. Team coordination tools such as `SendMessage` and the task management tools are always available to a teammate even when `tools` restricts other tools.
+
+<Note>
+  The `skills` and `mcpServers` frontmatter fields in a subagent definition are not applied when that definition runs as a teammate. Teammates load skills and MCP servers from your project and user settings, the same as a regular session.
+</Note>
+
+### Permissions
+
+Teammates start with the lead's permission settings. If the lead runs with `--dangerously-skip-permissions`, all teammates do too. After spawning, you can change individual teammate modes, but you can't set per-teammate modes at spawn time.
+
+### Context and communication
+
+Each teammate has its own context window. When spawned, a teammate loads the same project context as a regular session: CLAUDE.md, MCP servers, and skills. It also receives the spawn prompt from the lead. The lead's conversation history does not carry over.
+
+**How teammates share information:**
+
+* **Automatic message delivery**: when teammates send messages, they're delivered automatically to recipients. The lead doesn't need to poll for updates.
+* **Idle notifications**: when a teammate finishes and stops, they automatically notify the lead.
+* **Shared task list**: all agents can see task status and claim available work.
+* **Teammate messaging**: send a message to one specific teammate by name. To reach everyone, send one message per recipient.
+
+The lead assigns every teammate a name when it spawns them, and any teammate can message any other by that name. To get predictable names you can reference in later prompts, tell the lead what to call each teammate in your spawn instruction.
+
+### Token usage
+
+Agent teams use significantly more tokens than a single session. Each teammate has its own context window, and token usage scales with the number of active teammates. For research, review, and new feature work, the extra tokens are usually worthwhile. For routine tasks, a single session is more cost-effective. See [agent team token costs](/en/costs#agent-team-token-costs) for usage guidance.
+
+## Use case examples
+
+These examples show how agent teams handle tasks where parallel exploration adds value.
+
+### Run a parallel code review
+
+A single reviewer tends to gravitate toward one type of issue at a time. Splitting review criteria into independent domains means security, performance, and test coverage all get thorough attention simultaneously. The prompt assigns each teammate a distinct lens so they don't overlap:
+
+```text theme={null}
+Create an agent team to review PR #142. Spawn three reviewers:
+- One focused on security implications
+- One checking performance impact
+- One validating test coverage
+Have them each review and report findings.
+```
+
+Each reviewer works from the same PR but applies a different filter. The lead synthesizes findings across all three after they finish.
+
+### Investigate with competing hypotheses
+
+When the root cause is unclear, a single agent tends to find one plausible explanation and stop looking. The prompt fights this by making teammates explicitly adversarial: each one's job is not only to investigate its own theory but to challenge the others'.
+
+```text theme={null}
+Users report the app exits after one message instead of staying connected.
+Spawn 5 agent teammates to investigate different hypotheses. Have them talk to
+each other to try to disprove each other's theories, like a scientific
+debate. Update the findings doc with whatever consensus emerges.
+```
+
+The debate structure is the key mechanism here. Sequential investigation suffers from anchoring: once one theory is explored, subsequent investigation is biased toward it.
+
+With multiple independent investigators actively trying to disprove each other, the theory that survives is much more likely to be the actual root cause.
+
+## Best practices
+
+### Give teammates enough context
+
+Teammates load project context automatically, including CLAUDE.md, MCP servers, and skills, but they don't inherit the lead's conversation history. See [Context and communication](#context-and-communication) for details. Include task-specific details in the spawn prompt:
+
+```text theme={null}
+Spawn a security reviewer teammate with the prompt: "Review the authentication module
+at src/auth/ for security vulnerabilities. Focus on token handling, session
+management, and input validation. The app uses JWT tokens stored in
+httpOnly cookies. Report any issues with severity ratings."
+```
+
+### Choose an appropriate team size
+
+There's no hard limit on the number of teammates, but practical constraints apply:
+
+* **Token costs scale linearly**: each teammate has its own context window and consumes tokens independently. See [agent team token costs](/en/costs#agent-team-token-costs) for details.
+* **Coordination overhead increases**: more teammates means more communication, task coordination, and potential for conflicts
+* **Diminishing returns**: beyond a certain point, additional teammates don't speed up work proportionally
+
+Start with 3-5 teammates for most workflows. This balances parallel work with manageable coordination. The examples in this guide use 3-5 teammates because that range works well across different task types.
+
+Having 5-6 [tasks](/en/agent-teams#architecture) per teammate keeps everyone productive without excessive context switching. If you have 15 independent tasks, 3 teammates is a good starting point.
+
+Scale up only when the work genuinely benefits from having teammates work simultaneously. Three focused teammates often outperform five scattered ones.
+
+### Size tasks appropriately
+
+* **Too small**: coordination overhead exceeds the benefit
+* **Too large**: teammates work too long without check-ins, increasing risk of wasted effort
+* **Just right**: self-contained units that produce a clear deliverable, such as a function, a test file, or a review
+
+<Tip>
+  The lead breaks work into tasks and assigns them to teammates automatically. If it isn't creating enough tasks, ask it to split the work into smaller pieces. Having 5-6 tasks per teammate keeps everyone productive and lets the lead reassign work if someone gets stuck.
+</Tip>
+
+### Wait for teammates to finish
+
+Sometimes the lead starts implementing tasks itself instead of waiting for teammates. If you notice this:
+
+```text theme={null}
+Wait for your teammates to complete their tasks before proceeding
+```
+
+### Start with research and review
+
+If you're new to agent teams, start with tasks that have clear boundaries and don't require writing code: reviewing a PR, researching a library, or investigating a bug. These tasks show the value of parallel exploration without the coordination challenges that come with parallel implementation.
+
+### Avoid file conflicts
+
+Two teammates editing the same file leads to overwrites. Break the work so each teammate owns a different set of files.
+
+### Monitor and steer
+
+Check in on teammates' progress, redirect approaches that aren't working, and synthesize findings as they come in. Letting a team run unattended for too long increases the risk of wasted effort.
+
+## Troubleshooting
+
+### Teammates not appearing
+
+If teammates aren't appearing after you ask Claude to create a team:
+
+* In in-process mode, teammates may already be running but not visible. Press Shift+Down to cycle through active teammates.
+* Check that the task you gave Claude was complex enough to warrant a team. Claude decides whether to spawn teammates based on the task.
+* If you explicitly requested split panes, ensure tmux is installed and available in your PATH:
+  ```bash theme={null}
+  which tmux
+  ```
+* For iTerm2, verify the `it2` CLI is installed and the Python API is enabled in iTerm2 preferences.
+
+### Too many permission prompts
+
+Teammate permission requests bubble up to the lead, which can create friction. Pre-approve common operations in your [permission settings](/en/permissions) before spawning teammates to reduce interruptions.
+
+### Teammates stopping on errors
+
+Teammates may stop after encountering errors instead of recovering. Check their output using Shift+Down in in-process mode or by clicking the pane in split mode, then either:
+
+* Give them additional instructions directly
+* Spawn a replacement teammate to continue the work
+
+### Lead shuts down before work is done
+
+The lead may decide the team is finished before all tasks are actually complete. If this happens, tell it to keep going. You can also tell the lead to wait for teammates to finish before proceeding if it starts doing work instead of delegating.
+
+### Orphaned tmux sessions
+
+If a tmux session persists after the team ends, it may not have been fully cleaned up. List sessions and kill the one created by the team:
+
+```bash theme={null}
+tmux ls
+tmux kill-session -t <session-name>
+```
+
+## Limitations
+
+Agent teams are experimental. Current limitations to be aware of:
+
+* **No session resumption with in-process teammates**: `/resume` and `/rewind` do not restore in-process teammates. After resuming a session, the lead may attempt to message teammates that no longer exist. If this happens, tell the lead to spawn new teammates.
+* **Task status can lag**: teammates sometimes fail to mark tasks as completed, which blocks dependent tasks. If a task appears stuck, check whether the work is actually done and update the task status manually or tell the lead to nudge the teammate.
+* **Shutdown can be slow**: teammates finish their current request or tool call before shutting down, which can take time.
+* **One team at a time**: a lead can only manage one team. Clean up the current team before creating a new one.
+* **No nested teams**: teammates cannot spawn their own teams or teammates. Only the lead can manage the team.
+* **Lead is fixed**: the session that creates the team is the lead for its lifetime. You can't promote a teammate to lead or transfer leadership.
+* **Permissions set at spawn**: all teammates start with the lead's permission mode. You can change individual teammate modes after spawning, but you can't set per-teammate modes at spawn time.
+* **Split panes require tmux or iTerm2**: the default in-process mode works in any terminal. Split-pane mode isn't supported in VS Code's integrated terminal, Windows Terminal, or Ghostty.
+
+<Tip>
+  **`CLAUDE.md` works normally**: teammates read `CLAUDE.md` files from their working directory. Use this to provide project-specific guidance to all teammates.
+</Tip>
+
+## Next steps
+
+Explore related approaches for parallel work and delegation:
+
+* **Lightweight delegation**: [subagents](/en/sub-agents) spawn helper agents for research or verification within your session, better for tasks that don't need inter-agent coordination
+* **Manual parallel sessions**: [Git worktrees](/en/worktrees) let you run multiple Claude Code sessions yourself without automated team coordination
+* **Compare approaches**: see the [subagent vs agent team](/en/features-overview#compare-similar-features) comparison for a side-by-side breakdown

--- a/docs/claude-code/dynamic-workflows/dynamic-workflows.md
+++ b/docs/claude-code/dynamic-workflows/dynamic-workflows.md
@@ -1,0 +1,239 @@
+> ## Documentation Index
+> Fetch the complete documentation index at: https://code.claude.com/docs/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Orchestrate subagents at scale with dynamic workflows
+
+> Dynamic workflows orchestrate many subagents from a script Claude writes and you can rerun. Use them for codebase audits, large migrations, and cross-checked research.
+
+{/* plan-availability: feature=workflows plans=pro,max,team,enterprise providers=all */}
+
+<Note>
+  Dynamic workflows are in research preview. They require Claude Code v2.1.154 or later and are available on all paid plans, with Anthropic API access, and on Amazon Bedrock, Google Cloud Vertex AI, and Microsoft Foundry. On Pro, turn them on from the Dynamic workflows row in `/config`.
+</Note>
+
+A dynamic workflow is a JavaScript script that orchestrates [subagents](/en/sub-agents) at scale. Claude writes the script for the task you describe, and a runtime executes it in the background while your session stays responsive.
+
+Reach for a workflow when a task needs more agents than one conversation can coordinate, or when you want the orchestration codified as a script you can read and rerun. Examples include a codebase-wide bug sweep, a 500-file migration, a research question that needs sources cross-checked against each other, and a hard plan worth drafting from several independent angles before you commit to one.
+
+This page covers how to:
+
+* Decide [when to use a workflow](#when-to-use-a-workflow) instead of subagents or skills
+* [Run a bundled workflow](#run-a-bundled-workflow) with `/deep-research`
+* [Have Claude write a workflow](#have-claude-write-a-workflow) for your task and save it
+* Understand [how a workflow runs](#how-a-workflow-runs) and [manage runs](#manage-runs)
+
+## When to use a workflow
+
+[Subagents](/en/sub-agents), [skills](/en/skills), and workflows can all run a multi-step task. The difference is who holds the plan:
+
+|                                 | Subagents                      | Skills                       | Workflows                            |
+| :------------------------------ | :----------------------------- | :--------------------------- | :----------------------------------- |
+| What it is                      | A worker Claude spawns         | Instructions Claude follows  | A script the runtime executes        |
+| Who decides what runs next      | Claude, turn by turn           | Claude, following the prompt | The script                           |
+| Where intermediate results live | Claude's context window        | Claude's context window      | Script variables                     |
+| What's repeatable               | The worker definition          | The instructions             | The orchestration itself             |
+| Scale                           | A few delegated tasks per turn | Same as subagents            | Dozens to hundreds of agents per run |
+| Interruption                    | Restarts the turn              | Restarts the turn            | Resumable in the same session        |
+
+A workflow moves the plan into code. With subagents and skills, Claude is the orchestrator: it decides turn by turn what to spawn next, and every result lands in Claude's context. A workflow script holds the loop, the branching, and the intermediate results itself, so Claude's context holds only the final answer.
+
+Moving the plan into code also lets a workflow apply a repeatable quality pattern, not just run more agents: it can have independent agents adversarially review each other's findings before they're reported, or draft a plan from several angles and weigh them against each other, so you get a more trustworthy result than a single pass.
+
+## Run a bundled workflow
+
+The quickest way to see a workflow in action is to run `/deep-research`, the [built-in workflow](#bundled-workflows) Claude Code includes for investigating a question across many sources. You'll see agents work through a set of phases in the background while your session stays free, and get one report at the end instead of a turn-by-turn transcript.
+
+<Steps>
+  <Step title="Run the workflow">
+    Run `/deep-research` with a question you want investigated. It fans out web searches across several angles, fetches and cross-checks the sources it finds, and synthesizes a cited report.
+
+    ```text theme={null}
+    /deep-research What changed in the Node.js permission model between v20 and v22?
+    ```
+  </Step>
+
+  <Step title="Allow workflows">
+    Claude Code asks whether to allow the workflow. Select **Yes** to continue. The exact prompt depends on your permission mode. See [Approve the plan before it runs](#approve-the-plan-before-it-runs) for the per-mode options.
+  </Step>
+
+  <Step title="Watch progress">
+    The run starts in the background. Run `/workflows`, use the arrow keys to select the run, and press Enter to open its progress view:
+
+    ```text theme={null}
+    /workflows
+    ```
+
+    The view shows each phase with its agent count, token total, and elapsed time. Drill into any phase to see its agents and what each one found. See [Watch the run](#watch-the-run) for the full set of controls.
+
+    You can also watch from the task panel below the input box: a one-line progress summary appears there while the run is going. Press the down arrow to focus it, then Enter to expand.
+  </Step>
+
+  <Step title="Read the report">
+    When the run finishes, the report lands in your session. It cites the sources each claim came from, with claims that didn't survive cross-checking already filtered out.
+  </Step>
+</Steps>
+
+To run a workflow for your own task, [have Claude write one](#have-claude-write-a-workflow), and once a run does what you wanted you can [save it](#save-the-workflow-for-reuse) as a command of your own.
+
+### Bundled workflows
+
+Claude Code includes `/deep-research` as a built-in workflow:
+
+| Command                     | What it does                                                                                                                                                                                                                                                                                                      |
+| :-------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/deep-research <question>` | Fans out web searches on a question across several angles, fetches and cross-checks the sources it finds, votes on each claim, and returns a cited report with claims that didn't survive cross-checking filtered out. Requires the [WebSearch tool](/en/tools-reference#websearch-tool-behavior) to be available |
+
+[Workflows you save](#save-the-workflow-for-reuse) yourself become commands the same way and appear in `/` autocomplete alongside the bundled ones.
+
+### Watch the run
+
+Workflows run in the background, so the session stays responsive while agents work. Run `/workflows` at any time to list running and completed workflows, then select one to open its progress view.
+
+```text theme={null}
+/workflows
+```
+
+The progress view shows each phase with its agent counts, token totals, and elapsed time. The footer lists the key for each action:
+
+| Key            | Action                                                                                              |
+| :------------- | :-------------------------------------------------------------------------------------------------- |
+| `↑` / `↓`      | Select a phase or agent                                                                             |
+| `Enter` or `→` | Drill into the selected phase, then into an agent to read its prompt, recent tool calls, and result |
+| `Esc`          | Back out one level                                                                                  |
+| `j` / `k`      | Scroll within the agent detail when it overflows                                                    |
+| `p`            | Pause or resume the run                                                                             |
+| `x`            | Stop the selected agent, or stop the whole workflow when focus is on the run                        |
+| `r`            | Restart the selected running agent                                                                  |
+| `s`            | [Save](#save-the-workflow-for-reuse) the run's script as a command                                  |
+
+## Have Claude write a workflow
+
+You can have Claude write a workflow for your task in two ways:
+
+* [Ask for a workflow](#ask-for-a-workflow-in-your-prompt) in your prompt with the word `workflow`, and Claude writes one for the task.
+* [Let Claude decide with ultracode](#let-claude-decide-with-ultracode): set `/effort ultracode` and Claude plans a workflow for every substantive task in the session.
+
+You can also run a workflow command that already exists: a [bundled workflow](#bundled-workflows) like `/deep-research`, or one you've [saved](#save-the-workflow-for-reuse).
+
+### Ask for a workflow in your prompt
+
+To run a single task as a workflow without changing the session's effort level, include the word `workflow` anywhere in your prompt.
+
+```text theme={null}
+Run a workflow to audit every API endpoint under src/routes/ for missing auth checks
+```
+
+Claude Code highlights the word in your input and Claude writes a workflow script for the task instead of working through it turn by turn.
+
+If the run does what you wanted, you can [save it as a command](#save-the-workflow-for-reuse) afterward.
+
+If Claude Code highlights the word when you didn't mean to trigger one, press `alt+w` to ignore it for this prompt, or press backspace while the cursor is right after the highlighted word. To stop the word from triggering at all, turn off Workflow keyword trigger in `/config`.
+
+### Let Claude decide with ultracode
+
+Ultracode is a Claude Code setting that combines `xhigh` [reasoning effort](/en/model-config#adjust-effort-level) with automatic workflow orchestration. With it on, Claude plans a workflow for each substantive task instead of waiting for you to ask.
+
+```text theme={null}
+/effort ultracode
+```
+
+With ultracode on, Claude decides when a task warrants a workflow. A single request can turn into several workflows in a row: one to understand the code, one to make the change, and one to verify it. This applies to every task in the session, so each request uses more tokens and takes longer than at lower effort levels.
+
+Ultracode lasts for the current session and resets when you start a new one. Drop back with `/effort high` when you return to routine work. It's available on models that support `xhigh` [effort](/en/model-config#adjust-effort-level); on other models the `/effort` menu doesn't offer it.
+
+### Approve the plan before it runs
+
+In the CLI, the per-run prompt shows the planned phases and these options:
+
+* **Yes, run it**: start the run
+* **Yes, and don't ask again for `<name>` in `<path>`**: start, and skip this prompt for this workflow in this project from now on
+* **View raw script**: read the script before deciding
+* **No**: cancel
+
+`Ctrl+G` opens the script in your editor. `Tab` lets you adjust the prompt before the run starts.
+
+Whether you see this prompt depends on your [permission mode](/en/permission-modes):
+
+| Permission mode                            | When you're prompted                                                                                                                                    |
+| :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Default, accept edits                      | Every run, unless you've selected **Yes, and don't ask again** for that workflow in this project                                                        |
+| Auto                                       | First launch only. Any **Yes** records consent in your user settings, and later launches start without prompting. Skipped entirely when ultracode is on |
+| Bypass permissions, `claude -p`, Agent SDK | Never. The run starts immediately                                                                                                                       |
+
+In the Desktop app, an approval card shows the workflow name, the phase list, and a token-usage caution, with **Once**, **Always**, and **Deny** actions. The progress view appears in the Background tasks side pane.
+
+Your permission mode controls only the launch prompt above. The subagents the workflow spawns always run in `acceptEdits` mode and inherit your [tool allowlist](/en/settings#permission-settings), regardless of your session's mode. File edits are auto-approved.
+
+Shell commands, web fetches, and MCP tools that aren't in your allowlist can still prompt you mid-run. To avoid this on a long run, add the commands the agents need to your allowlist before starting.
+
+In `claude -p` and the Agent SDK there is no one to prompt, so tool calls follow your configured permission rules without interactive confirmation.
+
+### Save the workflow for reuse
+
+When Claude writes a workflow for a task you'll repeat, you can save that run's script as a command. A process like a review you run on every branch then runs the same orchestration each time.
+
+Run `/workflows`, select the run you want to keep, and press `s`. In the save dialog, Tab toggles between the two save locations:
+
+* `.claude/workflows/` in your project: shared with everyone who clones the repo
+* `~/.claude/workflows/` in your home directory: available in every project, visible only to you
+
+Press Enter to save. The workflow runs as `/<name>` in future sessions from either location.
+
+If a project workflow and a personal workflow share a name, the project one runs.
+
+## How a workflow runs
+
+The workflow runtime executes the script in an isolated environment, separate from your conversation. Intermediate results stay in script variables instead of landing in Claude's context.
+
+The runtime tracks each agent's result as the run progresses, which is what makes a run [resumable](#resume-after-a-pause) within the same session.
+
+### Behavior and limits
+
+The runtime applies the following constraints:
+
+| Constraint                                                           | Why                                                                                                            |
+| :------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
+| No mid-run user input                                                | Only agent permission prompts can pause a run. For sign-off between stages, run each stage as its own workflow |
+| No direct filesystem or shell access from the workflow itself        | Agents read, write, and run commands. The script coordinates the agents                                        |
+| Up to 16 concurrent agents, fewer on machines with limited CPU cores | Bounds local resource use                                                                                      |
+| 1,000 agents total per run                                           | Prevents runaway loops                                                                                         |
+
+## Manage runs
+
+Once a run starts, you manage it from the `/workflows` view, or by expanding its progress line in the task panel below the input box.
+
+### Resume after a pause
+
+If you stop a run, you can resume it: agents that already completed return their cached results, and the rest run live. Resume a paused run from `/workflows` by selecting it and pressing `p`, or ask Claude to relaunch the workflow with the same script.
+
+Resume works within the same Claude Code session. If you exit Claude Code while a workflow is running, the next session starts the workflow fresh.
+
+### Cost
+
+A workflow spawns many agents, so a single run can use meaningfully more tokens than working through the same task in conversation. Runs count toward your plan's usage and rate limits like any other session. You can stop a running workflow from `/workflows` at any time without losing completed work.
+
+Every agent in a workflow uses your session's model unless the script routes a stage to a different one. To control the model cost:
+
+* Check `/model` before a large run if you usually switch to a smaller model for routine work
+* Ask Claude to use a smaller model for stages that don't need the strongest one when you describe the task
+
+### Turn workflows off
+
+Workflows are available in the CLI, the Desktop app, the IDE extensions, [non-interactive mode](/en/headless) with `claude -p`, and the [Agent SDK](/en/agent-sdk/overview). The same disable settings apply on every surface.
+
+To turn workflows off for yourself:
+
+* Toggle Dynamic workflows off in `/config`. Persists across sessions.
+* Set `"disableWorkflows": true` in `~/.claude/settings.json`. Persists across sessions.
+* Set `CLAUDE_CODE_DISABLE_WORKFLOWS=1`. Read at startup, so it applies wherever you set it.
+
+To turn workflows off for your whole organization, set `"disableWorkflows": true` in [managed settings](/en/server-managed-settings), or use the toggle on the [Claude Code admin settings](https://claude.ai/admin-settings/claude-code) page.
+
+When workflows are disabled, the bundled workflow commands are unavailable, the `workflow` keyword no longer triggers a run, and `ultracode` is removed from the `/effort` menu.
+
+## Related resources
+
+* [Run agents in parallel](/en/agents): compare subagents, agent view, agent teams, and workflows
+* [Create custom subagents](/en/sub-agents): the worker primitive workflows orchestrate
+* [Manage costs](/en/costs): how multi-agent runs count toward usage limits

--- a/docs/claude-code/goals.md
+++ b/docs/claude-code/goals.md
@@ -1,0 +1,142 @@
+> ## Documentation Index
+> Fetch the complete documentation index at: https://code.claude.com/docs/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Keep Claude working toward a goal
+
+> Set a completion condition with /goal and Claude keeps working across turns until the condition is met.
+
+<Note>
+  `/goal` requires Claude Code v2.1.139 or later.
+</Note>
+
+The `/goal` command sets a completion condition and Claude keeps working toward it without you prompting each step. After each turn, a small fast model checks whether the condition holds. If not, Claude starts another turn instead of returning control to you. The goal clears automatically once the condition is met.
+
+Use a goal for substantial work with a verifiable end state:
+
+* Migrating a module to a new API until every call site compiles and tests pass
+* Implementing a design doc until all acceptance criteria hold
+* Splitting a large file into focused modules until each is under a size budget
+* Working through a labeled issue backlog until the queue is empty
+
+This page covers how to:
+
+* [Compare autonomous workflow approaches](#compare-to-other-autonomous-workflows): `/loop`, Stop hooks, and auto mode
+* [Set a goal](#set-a-goal) and [write an effective condition](#write-an-effective-condition)
+* [Check status](#check-status), [clear early](#clear-a-goal), and [run non-interactively](#run-non-interactively)
+* See [how evaluation works](#how-evaluation-works) and [requirements](#requirements)
+
+## Compare to other autonomous workflows
+
+Three approaches keep the current session running between prompts. Pick based on what should start the next turn:
+
+| Approach                                                            | Next turn starts when      | Stops when                                      |
+| :------------------------------------------------------------------ | :------------------------- | :---------------------------------------------- |
+| `/goal`                                                             | The previous turn finishes | A model confirms the condition is met           |
+| [`/loop`](/en/scheduled-tasks#run-a-prompt-repeatedly-with-%2Floop) | A time interval elapses    | You stop it, or Claude decides the work is done |
+| [Stop hook](/en/hooks-guide#prompt-based-hooks)                     | The previous turn finishes | Your own script or prompt decides               |
+
+`/goal` and a Stop hook both fire after every turn. `/goal` is a session-scoped shortcut: you type a condition and it's active for the current session only. A Stop hook lives in your settings file, applies to every session in its scope, and can run a script for deterministic checks or a prompt for model-evaluated ones.
+
+[Auto mode](/en/auto-mode-config) on its own approves tool calls within a single turn but doesn't start a new one. Claude stops when it judges the work done. `/goal` adds a separate evaluator that checks your condition after every turn, so completion is decided by a fresh model rather than the one doing the work. The two are complementary: auto mode removes per-tool prompts, and `/goal` removes per-turn prompts.
+
+<Tip>
+  The approaches above keep the current session running. You can also schedule work that runs independent of any open session, such as nightly tests or morning triage. See [scheduling options](/en/scheduled-tasks#compare-scheduling-options) for cloud routines and desktop scheduled tasks.
+</Tip>
+
+## Use `/goal`
+
+One goal can be active per session. The same command sets, checks, and clears it depending on the argument.
+
+### Set a goal
+
+Run `/goal` followed by the condition you want satisfied. If a goal is already active, the new one replaces it.
+
+```text theme={null}
+/goal all tests in test/auth pass and the lint step is clean
+```
+
+Setting a goal starts a turn immediately, with the condition itself as the directive. You don't need to send a separate prompt. While the goal is active, a `◎ /goal active` indicator shows how long the goal has been running.
+
+After each turn, the evaluator returns a short reason explaining why the condition is or isn't met. The most recent reason appears in the status view and in the transcript so you can see what Claude is working toward next.
+
+<Note>
+  A goal keeps running until the condition is met or you run `/goal clear`. Run `/goal` with no argument to see turns and tokens spent so far.
+</Note>
+
+### Write an effective condition
+
+The [evaluator](#how-evaluation-works) judges your condition against what Claude has surfaced in the conversation. It doesn't run commands or read files independently, so write the condition as something Claude's own output can demonstrate. "All tests in `test/auth` pass" works because Claude runs the tests and the result lands in the transcript for the evaluator to read.
+
+A condition that holds up across many turns usually has:
+
+* **One measurable end state**: a test result, a build exit code, a file count, an empty queue
+* **A stated check**: how Claude should prove it, such as "`npm test` exits 0" or "`git status` is clean"
+* **Constraints that matter**: anything that must not change on the way there, such as "no other test file is modified"
+
+The condition can be up to 4,000 characters.
+
+To bound how long a goal runs, include a turn or time clause in the condition, such as `or stop after 20 turns`. Claude reports progress against that clause each turn and the evaluator judges it from the conversation.
+
+### Check status
+
+Run `/goal` with no arguments to see the current state.
+
+```text theme={null}
+/goal
+```
+
+If a goal is active, the status shows:
+
+* The condition
+* How long it has been running
+* How many turns have been evaluated
+* The current token spend
+* The evaluator's most recent reason
+
+If no goal is active but one was achieved earlier in the session, the status shows the achieved condition along with its duration, turn count, and token spend.
+
+### Clear a goal
+
+Run `/goal clear` to remove an active goal before its condition is met.
+
+```text theme={null}
+/goal clear
+```
+
+`stop`, `off`, `reset`, `none`, and `cancel` are accepted as aliases for `clear`. Running `/clear` to start a new conversation also removes any active goal.
+
+### Resume with an active goal
+
+A goal that was still active when a session ended is restored when you resume that session with `--resume` or `--continue`. The condition carries over, but the turn count, timer, and token-spend baseline all reset on resume. A goal that was already achieved or cleared is not restored.
+
+### Run non-interactively
+
+`/goal` works in [non-interactive mode](/en/headless), in the [desktop app](/en/desktop), and through [Remote Control](/en/remote-control). Setting a goal with `-p` runs the loop to completion in a single invocation:
+
+```bash theme={null}
+claude -p "/goal CHANGELOG.md has an entry for every PR merged this week"
+```
+
+Interrupt the process with Ctrl+C to stop a non-interactive goal before the condition is met.
+
+## How evaluation works
+
+`/goal` is a wrapper around a session-scoped [prompt-based Stop hook](/en/hooks#prompt-based-hooks). Each time Claude finishes a turn, the condition and the conversation so far are sent to your configured [small fast model](/en/model-config), which defaults to Haiku. The model returns a yes-or-no decision and a short reason. A "no" tells Claude to keep working and includes the reason as guidance for the next turn. A "yes" clears the goal and records an achieved entry in the transcript.
+
+The evaluator runs on whichever provider your session is configured for. It does not call tools, so it can only judge what Claude has already surfaced in the conversation.
+
+<Note>
+  Evaluation tokens are billed on the small fast model configured for your provider and are typically negligible compared to main-turn spend.
+</Note>
+
+## Requirements
+
+`/goal` runs only in workspaces where you have accepted the trust dialog, because the evaluator is part of the hooks system. `/goal` is also unavailable when [`disableAllHooks`](/en/hooks#disable-or-remove-hooks) is set at any settings level or when [`allowManagedHooksOnly`](/en/settings#hook-configuration) is set in managed settings. In each case, the command tells you why instead of silently doing nothing.
+
+## See also
+
+* [Run a prompt repeatedly with `/loop`](/en/scheduled-tasks#run-a-prompt-repeatedly-with-%2Floop): re-run on a time interval instead of until a condition holds
+* [Prompt-based hooks](/en/hooks-guide#prompt-based-hooks): write your own Stop hook when you need custom evaluation logic
+* [Auto mode](/en/auto-mode-config): approve tool calls automatically so each goal turn runs unattended
+* [Scheduling comparison](/en/scheduled-tasks#compare-scheduling-options): run work on a schedule independent of any open session

--- a/docs/claude-code/monorepos-and-large-repos.md
+++ b/docs/claude-code/monorepos-and-large-repos.md
@@ -1,0 +1,471 @@
+> ## Documentation Index
+> Fetch the complete documentation index at: https://code.claude.com/docs/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Set up Claude Code in a monorepo or large codebase
+
+> Configure Claude Code for monorepos and large single-tree codebases with nested CLAUDE.md files, sparse worktrees, code intelligence, and per-package skills so Claude stays focused on the code you're working in.
+
+A large codebase can be one repository with millions of lines or a monorepo with many packages. Claude Code works at any size, but as the codebase grows, the defaults tuned for smaller projects can fill the context window with instructions and file reads unrelated to the task, costing tokens and degrading Claude's performance.
+
+This guide shows individual developers and engineering teams how to scope Claude to the part of the codebase a task touches. Each section notes whether a setting is personal to your machine or committed to the repository.
+
+## What this guide covers
+
+The [table below](#settings-on-this-page) lists each setting and what it accomplishes. The [file tree after it](#the-example-monorepo) is the example monorepo every code sample on this page refers to.
+
+### Settings on this page
+
+Each setting below is independent. They layer rather than replace each other, so apply whichever fit your repository. [Choose where to start Claude](#choose-where-to-start-claude) determines where your settings files live, so read it first. [Put it together](#put-it-together) shows all of them combined.
+
+| I want to                                                                                           | Use                                                                                        |
+| :-------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------- |
+| Load only the conventions for the code you touch, instead of one root file covering every subsystem | Per-directory [CLAUDE.md files](#layer-claude-md-files-by-directory)                       |
+| Exclude CLAUDE.md files for packages you never work in                                              | [`claudeMdExcludes`](#exclude-irrelevant-claude-md-files)                                  |
+| Block Claude from opening build output, generated code, and vendored dependencies                   | [`Read` deny rules](#block-reads-of-generated-and-vendored-code) in `permissions.deny`     |
+| Find a symbol's definition or callers through the language server instead of scanning files         | A [code intelligence plugin](#reduce-file-reads-with-code-intelligence)                    |
+| Check out only the directories a task needs when Claude creates a worktree                          | [`worktree.sparsePaths`](#check-out-only-the-directories-you-need)                         |
+| Read and edit a sibling package or another repository from the same session                         | [`--add-dir`](#grant-access-across-packages-or-repositories) or `additionalDirectories`    |
+| Give Claude procedures specific to one area that load only when relevant                            | Per-directory [skills](#add-per-directory-skills)                                          |
+| Replace many per-directory CLAUDE.md files with one set of conventions everyone installs            | A [plugin](#centralize-conventions-when-layering-stops-scaling) in an internal marketplace |
+
+<Tip>
+  For workflow techniques that keep context small in any repository, such as [running exploration in a subagent](/en/best-practices#use-subagents-for-investigation) so file reads stay out of the main conversation, see [Best practices for Claude Code](/en/best-practices). To roll out a baseline configuration to every developer in your organization, see [Set up Claude Code for your organization](/en/admin-setup).
+</Tip>
+
+### The example monorepo
+
+The examples throughout this page refer to a monorepo with three packages. The same patterns work in a large single-tree codebase: where an example uses `packages/api/`, substitute your own subsystem directory such as `src/backend/` or `lib/core/`.
+
+```text theme={null}
+monorepo/
+  CLAUDE.md                     # root instructions
+  packages/
+    api/
+      CLAUDE.md                 # API-specific instructions
+      .claude/skills/
+      src/
+    web/
+      CLAUDE.md                 # frontend-specific instructions
+      .claude/skills/
+      src/
+    shared/
+      CLAUDE.md                 # shared library instructions
+      src/
+```
+
+## Choose where to start Claude
+
+Where you launch `claude` determines which files Claude can read and edit without an additional permission grant, which CLAUDE.md files load into context at startup, and which project settings apply.
+
+| Start from      | File access                             | CLAUDE.md loaded at launch                                           | Use when                                   |
+| :-------------- | :-------------------------------------- | :------------------------------------------------------------------- | :----------------------------------------- |
+| Repository root | Every file                              | Root only; subdirectory files load on demand when Claude reads there | Tasks span multiple packages or subsystems |
+| A subdirectory  | That subtree only, until you grant more | That directory's plus every ancestor's                               | Work is scoped to one package or subsystem |
+
+Project settings in `.claude/settings.json` load only from your starting directory and are not inherited from parent directories the way CLAUDE.md files are: a `.claude/settings.json` at the repository root applies only when you start from the root.
+
+Each section below states whether its settings file belongs at the repository root or in the subdirectory you start from, and whether it is committed or kept local.
+
+## Layer CLAUDE.md files by directory
+
+In a large codebase, a single CLAUDE.md at the repository root tends to either grow to cover every subsystem's conventions, costing context on instructions unrelated to the current task, or stay too generic to be useful. Splitting instructions across per-directory files means Claude loads repository-wide rules plus only the conventions for the code you're working in.
+
+Claude Code loads every [CLAUDE.md](/en/memory) file from your working directory and every parent directory at launch, then loads each subdirectory's file on demand when it reads files there. A root file sets repository-wide rules and each subdirectory adds its own.
+
+A common split is two levels:
+
+* **Root `CLAUDE.md`**: instructions that apply everywhere, such as coding standards, commit conventions, and repository layout
+* **Per-subdirectory `CLAUDE.md`**: conventions specific to that area's stack. In a monorepo that's one per package. In a large single tree it's one per subsystem such as `src/db/` or `src/api/`
+
+Commit these files to the repository so teammates inherit them. Each directory's owner typically maintains its file.
+
+The root `CLAUDE.md` orients Claude to the repository structure:
+
+```markdown CLAUDE.md theme={null}
+This is a monorepo with three packages under packages/:
+
+- packages/api: Node.js REST API with Express, TypeScript, and PostgreSQL
+- packages/web: React frontend with Vite, TypeScript, and TailwindCSS
+- packages/shared: shared TypeScript utilities used by both api and web
+
+Run commands from the package directory, not the monorepo root.
+Each package has its own tsconfig.json, package.json, and test suite.
+```
+
+Each subdirectory's `CLAUDE.md`, here `packages/api/CLAUDE.md`, adds context specific to that area's stack:
+
+```markdown packages/api/CLAUDE.md theme={null}
+This package is the REST API server.
+
+- Run tests: `npm test` (uses Vitest)
+- Run dev server: `npm run dev` (port 3001)
+- Database migrations: `npm run migrate`
+- Environment variables: copy `.env.example` to `.env`
+
+API routes are in src/routes/. Each route file exports an Express router.
+Database queries use Knex in src/db/. Never write raw SQL strings in route handlers.
+```
+
+When you start Claude from `packages/api/`, it loads both `packages/api/CLAUDE.md` and the root `CLAUDE.md`. Claude sees the local instructions alongside the repository-wide rules, with no instructions from `packages/web/` in context. The same holds for any subdirectory in a non-monorepo tree.
+
+A few ways to keep the files current as the codebase and models change:
+
+* **Review in pull requests**: treat CLAUDE.md edits like any other documentation change so conventions track the code
+* **Revisit after major model releases**: instructions that worked around an older model's limitation may become overhead once a newer model handles the case on its own. For example, a rule that forces single-file refactors can be deleted once the limitation is gone
+* **Add a Stop hook that proposes updates**: a [`Stop` hook](/en/hooks#stop) receives the path to the session transcript when Claude finishes responding, so a script can review the session and propose CLAUDE.md updates while the gap it exposed is fresh
+
+For more on how CLAUDE.md files load and interact, see [Memory and project instructions](/en/memory).
+
+### Choose between per-directory CLAUDE.md and path-scoped rules
+
+Per-directory `CLAUDE.md` files and [path-scoped rules](/en/memory#path-specific-rules) under `.claude/rules/` both let you target instructions to part of the tree. They differ in where the file lives and when it loads.
+
+| Approach                             | File location                            | Loads when                                                                              | Use when                                                                                  |
+| :----------------------------------- | :--------------------------------------- | :-------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------- |
+| Per-directory `CLAUDE.md`            | Inside the directory, alongside its code | At launch when started from that directory, or on demand when Claude reads a file there | Directory owners maintain their own conventions; instructions are versioned with the code |
+| Path-scoped rule in `.claude/rules/` | Central `.claude/` at the repo root      | When Claude works with a file matching the rule's `paths:` glob                         | You want all conventions in one place, or the same rule applies to many scattered paths   |
+
+For a comparison that also covers skills, see [Compare similar features](/en/features-overview#compare-similar-features).
+
+### Exclude irrelevant CLAUDE.md files
+
+When you start Claude from the repository root, each subdirectory's CLAUDE.md loads as soon as Claude reads a file in that directory. The `claudeMdExcludes` setting skips specific files by path or glob pattern so they never load.
+
+Use this for directories you never work in, such as other teams' packages, legacy code, or vendored subtrees. The exclusion list is static, not a per-task switch. To focus on one package today and another tomorrow, [start Claude from that package's directory](#choose-where-to-start-claude) instead of editing exclusions.
+
+If you only want these exclusions for yourself, put the setting in `.claude/settings.local.json`, which is gitignored and not committed. Patterns use glob syntax matched against absolute file paths, so start relative-style patterns with `**/` to match anywhere in the tree. The example below excludes packages owned by other teams:
+
+```json .claude/settings.local.json theme={null}
+{
+  "claudeMdExcludes": [
+    "**/packages/admin-dashboard/**",
+    "**/packages/legacy-*/**"
+  ]
+}
+```
+
+This skips every CLAUDE.md and rules file under those packages. The root CLAUDE.md and the packages you do work in still load normally.
+
+These patterns cover other common cases:
+
+* `"**/packages/*/CLAUDE.md"`: excludes every package's CLAUDE.md while keeping the root
+* `"**/packages/web/**"`: excludes everything under the web package, including rules
+* `"/home/user/monorepo/legacy/CLAUDE.md"`: excludes one specific file by absolute path
+
+Managed policy CLAUDE.md files cannot be excluded, so organization-wide instructions always apply. You can set `claudeMdExcludes` at any [settings scope](/en/settings#configuration-scopes): user, project, local, or managed. Arrays merge across scopes, so a team can set project-level defaults while individuals add local overrides.
+
+For the full exclusion documentation, see [Exclude specific CLAUDE.md files](/en/memory#exclude-specific-claude-md-files).
+
+## Reduce what Claude reads
+
+Instructions are only part of what ends up in Claude's context. File reads are another cost that grows with the codebase. The settings below block reads of irrelevant paths and replace exhaustive file scans with language-server lookups.
+
+### Block reads of generated and vendored code
+
+Claude's content searches respect `.gitignore` by default, so paths already listed there, such as `node_modules/`, `dist/`, and `build/`, stay out of search results without additional configuration.
+
+For paths that are checked in, such as a vendored SDK or committed generated code, add `Read` deny rules in `permissions.deny` to block Claude from opening those files even when a search lists them.
+
+To apply these exclusions for everyone working in the repository, commit them to `.claude/settings.json`. To keep them personal, use `.claude/settings.local.json` instead. Like other project settings on this page, these files load only from your starting directory. Place them at the repository root if you start Claude there, or in each package's `.claude/` if you start from subdirectories. To enforce the same deny rules in every session regardless of starting directory, set them in [managed settings](/en/settings#settings-files), which user and project settings cannot override.
+
+The example below blocks build artifacts and a vendored SDK:
+
+```json .claude/settings.json theme={null}
+{
+  "permissions": {
+    "deny": [
+      "Read(./**/dist/**)",
+      "Read(./**/build/**)",
+      "Read(./**/*.generated.*)",
+      "Read(./vendor/**)"
+    ]
+  }
+}
+```
+
+Deny rules cover Claude's built-in file tools and recognized Bash file commands, including `cat`, `head`, `grep`, and `find`, when a denied path is passed as an argument. They do not filter denied paths out of a recursive search's output, and they do not cover arbitrary subprocesses that open files themselves. For the full pattern syntax, see [Read and Edit permission rules](/en/permissions#read-and-edit).
+
+### Reduce file reads with code intelligence
+
+In a large codebase, finding where a symbol is defined or used can cost many file reads and grep calls. [Code intelligence plugins](/en/discover-plugins#code-intelligence) connect Claude to a language server so it can jump to definitions, find references, and surface type errors directly instead of scanning the tree.
+
+The official marketplace has plugins for TypeScript, Python, Go, Rust, and other common languages. The example below installs the TypeScript plugin:
+
+```shell theme={null}
+/plugin install typescript-lsp@claude-plugins-official
+```
+
+To enable a plugin for everyone in the repository rather than installing it yourself, add it to the [`enabledPlugins` project setting](/en/settings#plugin-settings).
+
+Code intelligence plugins require the language's language server binary on each developer's machine. See [which binary each language requires](/en/discover-plugins#code-intelligence). Installing from the official marketplace requires network access to GitHub, where the marketplace is hosted. On a restricted network, [add the marketplace from an internal Git host or local path](/en/discover-plugins#add-from-other-git-hosts) instead.
+
+This pairs well with `claudeMdExcludes` and the `Read` deny rules above. Those keep irrelevant content out of context, and code intelligence keeps Claude from reading through what remains to locate a definition.
+
+## Scope worktrees and file access
+
+These settings control what's on disk in worktrees and which directories Claude can read and write beyond your starting point.
+
+### Check out only the directories you need
+
+The `--worktree` flag starts a session in a new git worktree so changes stay isolated from your main checkout. By default it checks out the entire repository. In a large repository, the `worktree.sparsePaths` setting uses git sparse-checkout to write only the listed directories plus root-level files to disk, so worktrees start faster and use less space.
+
+If everyone working in this directory needs the same paths, commit the setting to `.claude/settings.json`. To add paths for yourself, use `.claude/settings.local.json`: the lists merge across scopes, so a local file can add paths to the committed list but not remove them. The example below shows the committed file:
+
+```json .claude/settings.json theme={null}
+{
+  "worktree": {
+    "sparsePaths": [
+      ".claude",
+      "packages/api",
+      "packages/shared"
+    ]
+  }
+}
+```
+
+When Claude creates a worktree, it checks out only `.claude/`, `packages/api/`, and `packages/shared/` instead of the full tree. Paths in `sparsePaths` are relative to the repository root, regardless of which subdirectory you start Claude from. Any directory paths work here, not only package roots.
+
+This is particularly useful for [subagent worktree isolation](/en/worktrees#isolate-subagents-with-worktrees). Subagents are parallel Claude instances spawned for subtasks, and each one that runs in a worktree gets a lightweight checkout instead of the full tree. All worktrees in a session share the same `sparsePaths`, so if one subagent needs `packages/api/` and another needs `packages/web/`, list both.
+
+List directories in `sparsePaths`, not individual files. Root-level files like `package.json`, `tsconfig.base.json`, and lock files are always checked out alongside the directories you list. Root-level directories are not, so include `.claude` in the list if you want the repository root's `.claude/settings.json`, `.claude/rules/`, or `.claude/skills/` available inside the worktree.
+
+To avoid duplicating large directories like `node_modules` across worktrees, pair `sparsePaths` with `symlinkDirectories` in the same `.claude/settings.json`:
+
+```json .claude/settings.json theme={null}
+{
+  "worktree": {
+    "sparsePaths": [
+      ".claude",
+      "packages/api",
+      "packages/shared"
+    ],
+    "symlinkDirectories": [
+      "node_modules"
+    ]
+  }
+}
+```
+
+This creates a symlink from each worktree's `node_modules/` back to the main repository's copy rather than duplicating it on disk.
+
+<Note>
+  The `sparsePaths` and `symlinkDirectories` settings are read from your starting directory before the worktree is created. After creation, the session's working directory is the worktree root, not the subdirectory you launched from. Project settings inside the worktree therefore load from the worktree root's `.claude/settings.json`, the checked-out copy of the repository root's file. Put any other settings you need inside worktrees, such as permission rules or hooks, in the repository root's `.claude/settings.json`.
+</Note>
+
+For the full worktree settings reference, see [Worktree settings](/en/settings#worktree-settings).
+
+### Grant access across packages or repositories
+
+This section applies when you start Claude from a subdirectory, or when a task spans multiple checkouts. If you start from the repository root in a single large tree, Claude already has access to every file and you can skip this.
+
+When you start Claude from `packages/api/`, it can read and write files within that directory. If a task requires changes across packages, such as updating a shared type that both `api` and `web` import, you need to grant access to the sibling directory. The same mechanism grants access to a separately-checked-out repository.
+
+The `additionalDirectories` setting in `.claude/settings.json` gives Claude access to directories outside the working directory. The example below grants access to two sibling packages:
+
+```json .claude/settings.json theme={null}
+{
+  "permissions": {
+    "additionalDirectories": [
+      "../shared",
+      "../web"
+    ]
+  }
+}
+```
+
+Relative paths resolve against the directory you start Claude from. With this configuration, Claude can read and edit files in `packages/shared/` and `packages/web/` while working from `packages/api/`.
+
+You can also grant access at runtime without editing settings by passing `--add-dir` when you start Claude:
+
+```bash theme={null}
+claude --add-dir ../shared
+```
+
+However you add a directory, Claude can read and edit files in it. Whether the directory's CLAUDE.md, `.claude/rules/` files, and skills also load depends on how you added it:
+
+| Added with                             | Loads CLAUDE.md and rules                | Loads skills |
+| :------------------------------------- | :--------------------------------------- | :----------- |
+| `additionalDirectories` setting        | Never                                    | Never        |
+| `--add-dir` flag or `/add-dir` command | Only with the environment variable below | Yes          |
+
+To load CLAUDE.md and rules files from a directory added with `--add-dir` or `/add-dir`, set the `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD` environment variable:
+
+```bash theme={null}
+CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 claude --add-dir ../shared
+```
+
+The environment variable has no effect on directories listed in the `additionalDirectories` setting. See [Load from additional directories](/en/memory#load-from-additional-directories) for details.
+
+For sibling directories that everyone in this area needs, commit `additionalDirectories` to `.claude/settings.json`. For a personal selection or one-off access, use `.claude/settings.local.json` or pass `--add-dir` at launch.
+
+## Add per-directory skills
+
+Any subdirectory can define [skills](/en/skills) scoped to its own stack. A skill loads on demand when Claude determines it's relevant, so API-specific tooling doesn't consume context during frontend work.
+
+Skills live under `.claude/skills/` inside the directory. Commit them alongside that area's code so anyone who clones the repository gets them. In a monorepo this can be one set of skills per package. In a large single-tree codebase it's one set per subsystem such as `src/db/.claude/skills/`.
+
+Create a skill directory inside the subdirectory:
+
+```bash theme={null}
+mkdir -p packages/api/.claude/skills/api-testing
+```
+
+Then write `SKILL.md` inside that directory, here `packages/api/.claude/skills/api-testing/SKILL.md`. This example teaches Claude the API package's testing patterns:
+
+```markdown packages/api/.claude/skills/api-testing/SKILL.md theme={null}
+---
+name: api-testing
+description: Testing patterns for the API package. Use when writing or modifying tests in packages/api/.
+---
+
+## Test structure
+
+Tests are in `src/__tests__/` mirroring the `src/` directory structure.
+Each route file has a corresponding `.test.ts` file.
+
+## Running tests
+
+- All tests: `npm test`
+- Single file: `npm test -- src/__tests__/routes/users.test.ts`
+- Watch mode: `npm test -- --watch`
+
+## Test utilities
+
+- `src/__tests__/helpers/db.ts`: provides `setupTestDb()` and `teardownTestDb()` for database tests
+- `src/__tests__/helpers/auth.ts`: provides `createTestUser()` and `getAuthToken()` for authenticated endpoints
+
+## Patterns
+
+- Use `supertest` for HTTP assertions, not raw fetch
+- Always wrap database tests in a transaction that rolls back
+- Mock external services in `src/__tests__/mocks/`
+```
+
+A different subdirectory holds different skills the same way: `packages/web/.claude/skills/component-patterns/` describes the frontend's component conventions instead of testing. When Claude works on a file in `packages/api/`, it loads the api-testing skill. When it works in `packages/web/`, it loads component-patterns instead. Neither directory's skills load during the other's tasks.
+
+You can also scope a skill by file pattern instead of by placement. The [`paths` frontmatter field](/en/skills#frontmatter-reference) takes glob patterns, and Claude loads the skill automatically only when it works with matching files. Use this for a skill that lives in the repository root's `.claude/skills/` but applies only to certain files wherever they appear, such as a database-migration skill scoped to `**/migrations/**`.
+
+For more on creating and organizing skills, see [Skills](/en/skills).
+
+### Keep skills discoverable
+
+With skills spread across many directories, the list Claude chooses from can grow large. Claude picks a skill by reading every discovered skill's name and description, and only the chosen skill's full content loads into context. This section covers how to keep that list small and write descriptions that survive shortening.
+
+Which skills are in scope depends on where you start Claude:
+
+* **From a subdirectory such as `packages/api/`**: skills from that directory, every parent up to the repository root, and the user and enterprise levels
+* **From the repository root**: skills from every subdirectory Claude touches during the session, which can accumulate into the hundreds
+* **After adding a sibling with [`--add-dir`](#grant-access-across-packages-or-repositories)**: that sibling's skills load too. The `additionalDirectories` setting grants file access only and does not load skills
+
+Names always load, but [descriptions are shortened when there are many](/en/skills#skill-descriptions-are-cut-short), which can strip the keywords Claude uses to decide whether a skill applies. Keep descriptions short and lead with words a request would contain, like "writing or modifying tests in `packages/api/`".
+
+For skills that many directories share, such as PR conventions or a deploy checklist, place them in the repository root's `.claude/skills/` so they load from any starting directory. When shared skills need their own version history or must work across repositories, package them as a [plugin](/en/plugins) instead. Plugin skills use a `plugin-name:skill-name` namespace, so they never collide with per-directory skills. A platform team can version and update them in one place.
+
+To find which skills go unused, enable the OpenTelemetry [logs exporter](/en/monitoring-usage) and set `OTEL_LOG_TOOL_DETAILS=1` so skill names are recorded verbatim instead of redacted. The [`skill_activated` event](/en/monitoring-usage#skill-activated-event) records every invocation in its `skill.name` attribute, and `invocation_trigger` records whether a command, Claude, or a nested skill invoked it, which tells you what to consolidate or retire.
+
+## Centralize conventions when layering stops scaling
+
+Per-directory CLAUDE.md files can become hard to govern as the codebase grows. Conventions drift, files go stale, and no one owns the root. Solving that typically falls to the team that maintains the repository's Claude Code setup rather than to each developer working in their own area.
+
+Move conventions and reference content out of always-loaded CLAUDE.md and into mechanisms that load on demand:
+
+* [Skills](/en/skills): reference material Claude loads only when relevant to the task
+* [Plugins](/en/plugins): versioned bundles of skills, hooks, and commands that a platform team owns centrally
+* [MCP servers](/en/mcp): if your organization already runs a code search or RAG index over the repository, expose it as an MCP tool so Claude queries it instead of reading files directly
+
+See [server-managed or endpoint-managed settings](/en/server-managed-settings#choose-between-server-managed-and-endpoint-managed-settings) for how platform teams can enforce these centrally.
+
+### Recommend the right plugin at session start
+
+Once conventions live in plugins, a teammate starting Claude in an unfamiliar part of the tree has no signal about which plugin that area's owners maintain. A [`SessionStart` hook](/en/hooks#sessionstart) can close that gap, since anything the hook prints to stdout is added to Claude's context before the first prompt.
+
+For example, you can write a script that reads the launch directory from the [hook input](/en/hooks#common-input-fields), looks it up in a path-to-plugin map committed to the repository, and prints the recommendation for Claude to relay in its first reply. See [Automate workflows with hooks](/en/hooks-guide) to write and register the hook.
+
+## Put it together
+
+The combined configuration below uses the monorepo layout. The same files work for any subdirectory in a large single tree. Project settings load only from the directory you start Claude in, so each subdirectory's `.claude/settings.json` must be self-contained rather than layered on a root file.
+
+The example commits `worktree`, `additionalDirectories`, and the `Read` deny rules in `.claude/settings.json` so every developer in `packages/api/` gets the same sibling access, sparse paths, and exclusions. The file below is the committed per-area settings for `packages/api/`:
+
+```json packages/api/.claude/settings.json theme={null}
+{
+  "worktree": {
+    "sparsePaths": [
+      ".claude",
+      "packages/api",
+      "packages/shared"
+    ],
+    "symlinkDirectories": [
+      "node_modules"
+    ]
+  },
+  "permissions": {
+    "additionalDirectories": [
+      "../shared"
+    ],
+    "deny": [
+      "Read(./**/dist/**)",
+      "Read(./**/build/**)"
+    ]
+  }
+}
+```
+
+Because this session starts from `packages/api/`, sibling packages' CLAUDE.md files are already out of scope, so `claudeMdExcludes` is not needed here. Add it to the repository root's `.claude/settings.local.json` instead if you also start sessions from the root.
+
+The `additionalDirectories` entry applies when you start Claude from `packages/api/` directly. Inside a worktree created from this session, the working directory is the worktree root, so this settings file does not load. The sibling packages are already reachable inside the worktree without it, but the deny rules need a second copy in the repository root's `.claude/settings.json` so worktree sessions pick them up, as the [worktree settings note](#check-out-only-the-directories-you-need) describes:
+
+```json .claude/settings.json theme={null}
+{
+  "permissions": {
+    "deny": [
+      "Read(./**/dist/**)",
+      "Read(./**/build/**)"
+    ]
+  }
+}
+```
+
+After setup, the repository has this layout:
+
+```text theme={null}
+monorepo/
+  CLAUDE.md
+  .claude/settings.json                           # deny rules for worktree sessions
+  packages/
+    api/
+      CLAUDE.md
+      .claude/settings.json                       # worktree, additionalDirectories, deny rules
+      .claude/skills/api-testing/SKILL.md
+    web/
+      CLAUDE.md
+      .claude/skills/component-patterns/SKILL.md
+    shared/
+      CLAUDE.md
+```
+
+With this setup, starting Claude from `packages/api/`:
+
+* Loads the root CLAUDE.md and `packages/api/CLAUDE.md`, skips `packages/web/CLAUDE.md`
+* Can read and edit files in `packages/api/` and `packages/shared/`
+* Skips reads of build output under `dist/` and `build/` in `packages/api/`
+* Has the api-testing skill available on demand
+* Creates worktrees containing `.claude/`, `packages/api/`, `packages/shared/`, and root-level files, with the deny rules applied across the worktree from the root settings file
+
+## Scope and plan changes that span packages
+
+The configuration above controls what Claude sees. When a single change touches several packages, such as updating a shared type along with every call site that uses it, how you scope and sequence the task also affects the result.
+
+Two techniques help keep a cross-package change consistent:
+
+* **Give Claude the whole change in one session**: handing over the shared edit and its call sites together keeps the decisions behind each edit consistent, rather than re-deriving them per package
+* **Save the plan to a file before editing**: [plan first](/en/best-practices#explore-first-then-plan-then-code) and ask Claude to write the plan to a markdown file in the repository. A long cross-package session [compacts its context](/en/context-window#what-survives-compaction) along the way, and the saved plan survives where conversation history may not
+
+## Next steps
+
+Once this configuration is in place, you can refine it:
+
+* Use [hooks](/en/hooks-guide) to run per-directory linters or type-checkers after Claude edits files
+* Review [Manage costs effectively](/en/costs) to understand how codebase size affects token usage and how to set spend limits before a wider rollout
+* Read [How Claude Code works in large codebases](https://claude.com/blog/how-claude-code-works-in-large-codebases-best-practices-and-where-to-start) on the Claude blog for organizational rollout patterns and ownership models that sit above the per-repository configuration on this page

--- a/docs/claude-code/worktrees/parallel-sessions-worktrees.md
+++ b/docs/claude-code/worktrees/parallel-sessions-worktrees.md
@@ -1,0 +1,163 @@
+> ## Documentation Index
+> Fetch the complete documentation index at: https://code.claude.com/docs/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Run parallel sessions with worktrees
+
+> Isolate parallel Claude Code sessions in separate git worktrees so changes don't collide. Covers the `--worktree` flag, subagent isolation, `.worktreeinclude`, cleanup, and non-git VCS hooks.
+
+A [git worktree](https://git-scm.com/docs/git-worktree) is a separate working directory with its own files and branch, sharing the same repository history and remote as your main checkout. Running each Claude Code session in its own worktree means edits in one session never touch files in another, so you can have Claude building a feature in one terminal while fixing a bug in a second.
+
+This page covers worktree isolation in the CLI. Everything below assumes a git repository. For other version control systems, see [Non-git version control](#non-git-version-control). The [desktop app](/en/desktop#work-in-parallel-with-sessions) creates a worktree for every new session automatically.
+
+Worktrees are one of several ways to run Claude in parallel. They isolate file edits, while [subagents](/en/sub-agents) and [agent teams](/en/agent-teams) coordinate the work itself. See [Run agents in parallel](/en/agents) to compare the approaches, or skip ahead to [Isolate subagents with worktrees](#isolate-subagents-with-worktrees) to use worktrees and subagents together.
+
+## Start Claude in a worktree
+
+Pass `--worktree` or `-w` to create an isolated worktree and start Claude in it. By default, the worktree is created under `.claude/worktrees/<value>/` at your repository root, on a new branch named `worktree-<value>`:
+
+```bash theme={null}
+claude --worktree feature-auth
+```
+
+To put worktrees somewhere else, configure a [`WorktreeCreate` hook](#non-git-version-control). Run the command again with a different name in another terminal to start a second isolated session:
+
+```bash theme={null}
+claude --worktree bugfix-123
+```
+
+If you omit the name, Claude generates one such as `bright-running-fox`:
+
+```bash theme={null}
+claude --worktree
+```
+
+You can also ask Claude to "work in a worktree" during a session, and it will create one with the [`EnterWorktree`](/en/tools-reference) tool. Once in a worktree, Claude can switch directly to another one under `.claude/worktrees/` by calling `EnterWorktree` with the target path. The previous worktree stays on disk untouched.
+
+Before using `--worktree` in a directory for the first time, accept the workspace trust dialog by running `claude` once in that directory. If trust has not yet been accepted, `--worktree` exits with an error and prompts you to run `claude` in the directory first, including when combined with `-p`.
+
+<Tip>
+  Add `.claude/worktrees/` to your `.gitignore` so worktree contents don't appear as untracked files in your main checkout.
+</Tip>
+
+### Choose the base branch
+
+Worktrees branch from your repository's default branch, `origin/HEAD`, so they start from a clean tree matching the remote. If no remote is configured or the fetch fails, the worktree falls back to your current local `HEAD`. To always branch from local `HEAD` instead, set `worktree.baseRef` to `"head"` in [settings](/en/settings#worktree-settings). Setting `baseRef` to `"head"` makes new worktrees carry your unpushed commits and feature-branch state, which is useful when isolating subagents that need to operate on in-progress work. The setting accepts only `"fresh"` or `"head"`, not arbitrary git refs:
+
+```json theme={null}
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}
+```
+
+To branch from a specific pull request, pass the PR number prefixed with `#`, or a full GitHub pull request URL. Claude Code fetches `pull/<number>/head` from `origin` and creates the worktree at `.claude/worktrees/pr-<number>`:
+
+```bash theme={null}
+claude --worktree "#1234"
+```
+
+For full control over how worktrees are created, configure a [`WorktreeCreate` hook](/en/hooks#worktreecreate), which replaces the default `git worktree` logic entirely.
+
+## Copy gitignored files into worktrees
+
+A worktree is a fresh checkout, so untracked files like `.env` or `.env.local` from your main repository are not present. To copy them automatically when Claude creates a worktree, add a `.worktreeinclude` file to your project root.
+
+The file uses `.gitignore` syntax. Only files that match a pattern and are also gitignored are copied, so tracked files are never duplicated.
+
+This `.worktreeinclude` copies two env files and a secrets config into each new worktree:
+
+```text .worktreeinclude theme={null}
+.env
+.env.local
+config/secrets.json
+```
+
+This applies to worktrees created with `--worktree`, [subagent worktrees](#isolate-subagents-with-worktrees), and parallel sessions in the [desktop app](/en/desktop#work-in-parallel-with-sessions).
+
+## Isolate subagents with worktrees
+
+Subagents can run in their own worktrees so parallel edits don't conflict. Ask Claude to "use worktrees for your agents", or set it permanently on a [custom subagent](/en/sub-agents#supported-frontmatter-fields) by adding `isolation: worktree` to the frontmatter. Each subagent gets a temporary worktree that is removed automatically when the subagent finishes without changes.
+
+Subagent worktrees use the same [base branch](#choose-the-base-branch) as `--worktree`, so they branch from your repository's default branch unless `worktree.baseRef` is set to `"head"`.
+
+## Clean up worktrees
+
+When you exit a worktree session, cleanup depends on whether you made changes:
+
+* **No uncommitted changes, no untracked files, and no new commits**: the worktree and its branch are removed automatically. If the session has a [name](/en/sessions#name-your-sessions), Claude prompts instead so you can keep the worktree for later
+* **Uncommitted changes, untracked files, or new commits exist**: Claude prompts you to keep or remove the worktree. Keeping preserves the directory and branch so you can return later. Removing deletes the worktree directory and its branch, discarding any uncommitted changes, untracked files, and commits
+* **Non-interactive runs**: worktrees created with `--worktree` alongside `-p` are not cleaned up automatically since there is no exit prompt. Remove them with `git worktree remove`
+
+Worktrees that Claude created for subagents and [background sessions](/en/agent-view#how-file-edits-are-isolated) are removed automatically once they are older than your [`cleanupPeriodDays`](/en/settings#available-settings) setting, provided they have no uncommitted changes, no untracked files, and no unpushed commits. Worktrees you create with `--worktree` are never removed by this sweep.
+
+## Manage worktrees manually
+
+For full control over worktree location and branch configuration, create worktrees with Git directly. This is useful when you need to check out a specific existing branch or place the worktree outside the repository.
+
+Create a worktree on a new branch:
+
+```bash theme={null}
+git worktree add ../project-feature-a -b feature-a
+```
+
+Create a worktree from an existing branch:
+
+```bash theme={null}
+git worktree add ../project-bugfix bugfix-123
+```
+
+Start Claude in the worktree:
+
+```bash theme={null}
+cd ../project-feature-a && claude
+```
+
+List your worktrees:
+
+```bash theme={null}
+git worktree list
+```
+
+Remove one when you're done with it:
+
+```bash theme={null}
+git worktree remove ../project-feature-a
+```
+
+See the [Git worktree documentation](https://git-scm.com/docs/git-worktree) for the full command reference. Remember to initialize your development environment in each new worktree: install dependencies, set up virtual environments, or run whatever your project's setup requires.
+
+## Non-git version control
+
+Worktree isolation uses git by default. For SVN, Perforce, Mercurial, or other systems, configure [`WorktreeCreate` and `WorktreeRemove` hooks](/en/hooks#worktreecreate) to provide custom creation and cleanup logic. Because the hook replaces the default git behavior, [`.worktreeinclude`](#copy-gitignored-files-into-worktrees) is not processed when you use `--worktree`. Copy any local configuration files inside your hook script instead.
+
+This `WorktreeCreate` hook reads the worktree name from stdin, checks out a fresh SVN working copy, and prints the directory path so Claude Code can use it as the session's working directory:
+
+```json theme={null}
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'NAME=$(jq -r .name); DIR=\"$HOME/.claude/worktrees/$NAME\"; svn checkout https://svn.example.com/repo/trunk \"$DIR\" >&2 && echo \"$DIR\"'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Pair it with a `WorktreeRemove` hook to clean up when the session ends. See the [hooks reference](/en/hooks#worktreecreate) for the input schema and a removal example.
+
+## See also
+
+Worktrees handle file isolation. The related pages below cover delegating work into those isolated checkouts and switching between the sessions you create:
+
+* [Subagents](/en/sub-agents): delegate work to isolated agents within a session
+* [Agent teams](/en/agent-teams): coordinate multiple Claude sessions automatically
+* [Manage sessions](/en/sessions): name, resume, and switch between conversations
+* [Desktop parallel sessions](/en/desktop#work-in-parallel-with-sessions): worktree-backed sessions in the desktop app

--- a/wiki/knowledge/agent-configuration-files.md
+++ b/wiki/knowledge/agent-configuration-files.md
@@ -1,8 +1,8 @@
 # Agent Configuration Files
 
 **Summary**: Repository-level context files (AGENTS.md, CLAUDE.md, .cursorrules) that provide persistent project-specific instructions to coding agents — the primary interface between developers and AI tools, governed by the principle that less is more.
-**Sources**: a-guide-to-agents.md, how-claude-remembers-a-project.md, rules.md, Evaluating-AGENTS-paper.md, analysis-a-guide-to-agents.md, analysis-how-claude-remembers-a-project.md
-**Last updated**: 2026-04-18
+**Sources**: a-guide-to-agents.md, how-claude-remembers-a-project.md, rules.md, Evaluating-AGENTS-paper.md, analysis-a-guide-to-agents.md, analysis-how-claude-remembers-a-project.md, monorepos-and-large-repos.md
+**Last updated**: 2026-06-04
 
 ---
 
@@ -72,6 +72,15 @@ Four activation modes for `.cursor/rules/*.mdc` files:
 - Personal preferences in project files
 - Conflicting rules (model picks one arbitrarily)
 
+## Per-directory CLAUDE.md vs path-scoped rules
+
+When a convention belongs to one part of a large repo, choose between two placement mechanisms:
+
+- **Per-directory `CLAUDE.md`** — lives with the code it governs, versioned by that directory's owners, and loads either at launch (when you start Claude from that directory) or on demand (when Claude reads files there) (source: monorepos-and-large-repos.md).
+- **Path-scoped `.claude/rules/`** — centralized at the repo root and loads only when files matching its `paths:` glob are touched (source: monorepos-and-large-repos.md).
+
+Prefer path-scoped rules when one convention applies to many scattered paths, or when you want all conventions collected in one place rather than spread across directory-local files (source: monorepos-and-large-repos.md). See [[monorepo-large-codebase-setup]] for scoping Claude Code to part of a monorepo.
+
 ## Related pages
 
 - [[progressive-disclosure]]
@@ -79,3 +88,4 @@ Four activation modes for `.cursor/rules/*.mdc` files:
 - [[claude-code-memory]]
 - [[cursor-rules]]
 - [[context-engineering]]
+- [[monorepo-large-codebase-setup]]

--- a/wiki/knowledge/agent-workflows.md
+++ b/wiki/knowledge/agent-workflows.md
@@ -1,8 +1,8 @@
 # Agent Workflows
 
 **Summary**: Proven patterns for structuring LLM agent work — from the fundamental Explore → Plan → Code → Verify loop to multi-agent architectures and progressive context strategies that prevent one-shotting complex projects.
-**Sources**: research-agent-workflows-and-patterns.md, a-guide-to-agents.md, analysis-a-guide-to-agents.md
-**Last updated**: 2026-04-18
+**Sources**: research-agent-workflows-and-patterns.md, a-guide-to-agents.md, analysis-a-guide-to-agents.md, dynamic-workflows.md, goals.md, parallel-sessions-worktrees.md
+**Last updated**: 2026-06-04
 
 ---
 
@@ -52,6 +52,19 @@ Team lead coordinates multiple agents working in parallel:
 - Direct communication between teammates
 - Available in Claude Code via Agent Teams (experimental)
 
+Claude Code now also provides a *codified* orchestrator primitive — dynamic workflows — where the plan lives in a rerunnable script rather than in Claude's turn-by-turn decisions (source: dynamic-workflows.md). See [[claude-code-workflows]]. Worktrees are the file-isolation substrate underneath these parallel/orchestrator patterns (source: parallel-sessions-worktrees.md); see [[claude-code-worktrees]].
+
+## Session-Continuing Autonomous Approaches
+
+Several Claude Code mechanisms keep a session working autonomously; they differ by *what starts the next turn* (source: goals.md):
+
+- **`/goal`** — the next turn starts when the previous one finishes, and the run stops when a fresh small model confirms the condition is met (source: goals.md)
+- **`/loop`** — the next turn starts on a time interval (source: goals.md)
+- **Stop hook** — fires after every turn (source: goals.md)
+- **auto mode** — does *not* start a new turn; it only auto-approves tool calls within one (source: goals.md)
+
+`/goal` and auto mode are complementary: auto mode removes per-tool prompts while `/goal` removes per-turn prompts (source: goals.md).
+
 ## Context Management During Workflows
 
 | Strategy                        | Complexity | Effectiveness                      |
@@ -78,3 +91,6 @@ Boris Cherny's principle applies: prefer simple, straightforward solutions over 
 - [[context-engineering]]
 - [[claude-code-subagents]]
 - [[cursor-subagents]]
+- [[claude-code-workflows]]
+- [[claude-code-agent-teams]]
+- [[claude-code-worktrees]]

--- a/wiki/knowledge/claude-code-agent-teams.md
+++ b/wiki/knowledge/claude-code-agent-teams.md
@@ -1,0 +1,87 @@
+# Claude Code Agent Teams
+
+**Summary**: Experimental multi-session orchestration: a team lead spawns independent Claude Code teammates that share a file-locked task list, message each other point-to-point, and are governed by three team hooks.
+**Sources**: agent-teams.md
+**Last updated**: 2026-06-04
+---
+
+Agent teams let one Claude Code session coordinate several others working together (source: agent-teams.md). One session acts as the **team lead** — it creates the team, spawns teammates, assigns work, and synthesizes results — while each teammate runs independently in its own context window and communicates directly with the others (source: agent-teams.md). The feature is experimental and disabled by default; enable it by setting the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable to `1`, in your shell or in `settings.json` (source: agent-teams.md). It requires Claude Code v2.1.32 or later (source: agent-teams.md).
+
+## When to use teams instead of subagents
+
+Both agent teams and [[subagents]] parallelize work, but they differ on one decisive axis: communication (source: agent-teams.md). A [[claude-code-subagents]] worker runs in its own context and reports results only back to the caller — subagents never talk to each other, and the main agent manages all of their work (source: agent-teams.md). Agent teammates, by contrast, are fully independent Claude Code sessions that message each other directly and self-coordinate through a shared task list (source: agent-teams.md).
+
+Use subagents when you need quick, focused workers whose result is all that matters; use agent teams when the workers need to share findings, challenge each other, and coordinate on their own (source: agent-teams.md). Teams are most effective for parallel research and review, building separate new modules or features, debugging with competing hypotheses, and cross-layer changes where each layer has a distinct owner (source: agent-teams.md). They add coordination overhead and use significantly more tokens than a single session, so for sequential tasks, same-file edits, or work with many dependencies, a single session or subagents are the better fit (source: agent-teams.md). This makes teams the concrete Claude Code realization of an orchestrator-style [[agent-workflows]] pattern, with self-coordination replacing a single managing agent.
+
+## Architecture
+
+An agent team has four components (source: agent-teams.md):
+
+- **Team lead** — the main session that creates the team, spawns teammates, and coordinates work (source: agent-teams.md).
+- **Teammates** — separate Claude Code instances that each work on assigned tasks (source: agent-teams.md).
+- **Task list** — a shared list of work items that teammates claim and complete (source: agent-teams.md).
+- **Mailbox** — the messaging system for communication between agents (source: agent-teams.md).
+
+Claude starts a team either because you explicitly ask for one or because it proposes one for a task that benefits from parallel work and you confirm; it will not create a team without your approval (source: agent-teams.md).
+
+## The shared task list and file-locked claiming
+
+The shared task list coordinates work across the team: the lead creates tasks and teammates work through them (source: agent-teams.md). Each task is in one of three states — pending, in progress, or completed — and tasks can depend on other tasks, so a pending task with unresolved dependencies cannot be claimed until those dependencies complete (source: agent-teams.md). The system manages dependencies automatically: when a teammate finishes a task that others depend on, the blocked tasks unblock without manual intervention (source: agent-teams.md).
+
+The lead can assign a task explicitly, or a teammate can self-claim the next unassigned, unblocked task after finishing its current one (source: agent-teams.md). Task claiming uses **file locking** to prevent race conditions when multiple teammates try to claim the same task simultaneously (source: agent-teams.md).
+
+## Context and communication
+
+Each teammate has its own context window (source: agent-teams.md). When spawned, a teammate loads the same project context as a regular session — CLAUDE.md, MCP servers, and skills — plus the spawn prompt from the lead, but the lead's conversation history does not carry over (source: agent-teams.md). Because teammates read CLAUDE.md from their working directory like any other session, [[claude-code-memory]] is the way to give project-specific guidance to every teammate at once (source: agent-teams.md).
+
+Messaging is **point-to-point**: you send a message to one specific teammate by name, and to reach everyone you send one message per recipient — there is no broadcast primitive (source: agent-teams.md). Addressing is per-recipient, but **delivery is automatic**: when a teammate sends a message it is delivered to the recipient without the lead having to poll for updates (source: agent-teams.md). The lead assigns every teammate a name when spawning it, and any teammate can message any other by that name; tell the lead what to call each teammate to get predictable names you can reference in later prompts (source: agent-teams.md). When a teammate finishes and stops, it automatically notifies the lead, and all agents can see task status and claim available work through the shared list (source: agent-teams.md).
+
+## Quality-gate hooks
+
+Three [[claude-code-hooks]] events fire over a team's lifecycle, and each one **blocks by exiting with code 2** (source: agent-teams.md):
+
+- **`TeammateIdle`** — runs when a teammate is about to go idle; exit code 2 sends feedback and keeps the teammate working (source: agent-teams.md).
+- **`TaskCreated`** — runs when a task is being created; exit code 2 prevents creation and sends feedback (source: agent-teams.md).
+- **`TaskCompleted`** — runs when a task is being marked complete; exit code 2 prevents completion and sends feedback (source: agent-teams.md).
+
+## Reusing subagent definitions as teammate roles
+
+When spawning a teammate, you can reference a subagent type from any scope — project, user, plugin, or CLI-defined — so a role like a security reviewer can be defined once and reused both as a delegated [[claude-code-subagents]] worker and as a teammate (source: agent-teams.md). The teammate honors that definition's `tools` allowlist and `model`, and the definition's body is appended to the teammate's system prompt as additional instructions rather than replacing it (source: agent-teams.md). Two caveats matter: the `skills` and `mcpServers` frontmatter fields are **not** applied when a definition runs as a teammate — teammates load [[claude-code-skills]] and MCP servers from your project and user settings like a regular session — and the team coordination tools, `SendMessage` and the task-management tools, are always available to a teammate even when `tools` restricts everything else (source: agent-teams.md).
+
+## Plan approval for risky work
+
+For complex or risky tasks, you can require a teammate to plan before implementing: it works in read-only plan mode until the lead approves its approach (source: agent-teams.md). When the teammate finishes planning it sends a plan-approval request to the lead, which either approves it or rejects it with feedback; on rejection the teammate stays in plan mode, revises, and resubmits, and once approved it exits plan mode and begins implementation (source: agent-teams.md). The lead makes approval decisions autonomously, so you steer its judgment by giving it criteria in your prompt, such as only approving plans that include test coverage (source: agent-teams.md).
+
+## Permissions and display modes
+
+Teammates start with the lead's permission settings — if the lead runs with `--dangerously-skip-permissions`, so do all teammates; you can change individual teammate modes after spawning but cannot set per-teammate modes at spawn time (source: agent-teams.md). Teams support two display modes: **in-process**, where all teammates run inside the main terminal and you cycle through them with Shift+Down to message them, and **split panes**, where each teammate gets its own pane (requiring tmux or iTerm2) (source: agent-teams.md). The default `"auto"` uses split panes inside an existing tmux session and in-process otherwise, overridable via `teammateMode` in settings or the `--teammate-mode` flag (source: agent-teams.md).
+
+## Storage layout
+
+Team and task state is stored locally and is machine-generated (source: agent-teams.md):
+
+- **Team config**: `~/.claude/teams/{team-name}/config.json` (source: agent-teams.md).
+- **Task list**: `~/.claude/tasks/{team-name}/` (source: agent-teams.md).
+
+The team config holds runtime state such as session IDs and tmux pane IDs, plus a `members` array of each teammate's name, agent ID, and agent type that teammates can read to discover other members (source: agent-teams.md). Claude Code rewrites these files on every state update, so they must not be hand-edited or pre-authored — changes are overwritten (source: agent-teams.md). There is no project-level equivalent: a file like `.claude/teams/teams.json` in the project directory is not recognized as configuration and is treated as an ordinary file (source: agent-teams.md).
+
+## Shutting down and cleaning up
+
+To end a teammate gracefully, the lead sends it a shutdown request, which the teammate can approve (exiting gracefully) or reject with an explanation (source: agent-teams.md). When you are done, ask the lead to clean up, which removes the shared team resources; cleanup checks for active teammates and fails if any are still running, so shut them down first (source: agent-teams.md). Always run cleanup through the lead — teammates should not, because their team context may not resolve correctly and could leave resources in an inconsistent state (source: agent-teams.md).
+
+## Sizing and best practices
+
+Start with 3-5 teammates for most workflows to balance parallel work with manageable coordination, and aim for roughly 5-6 tasks per teammate to keep everyone productive without excessive context switching (source: agent-teams.md). Token cost scales linearly with the number of active teammates and coordination overhead grows as you add more, so three focused teammates often outperform five scattered ones (source: agent-teams.md). Give teammates enough task-specific context in the spawn prompt since they don't inherit the lead's conversation history, size tasks as self-contained units with a clear deliverable, and break work so each teammate owns a different set of files to avoid overwrite conflicts (source: agent-teams.md). If you are new to teams, start with research and review tasks that have clear boundaries and don't require writing code before attempting parallel implementation (source: agent-teams.md).
+
+## Limitations
+
+Agent teams are experimental, with several known limitations (source: agent-teams.md): `/resume` and `/rewind` do not restore in-process teammates, so after resuming a session the lead may try to message teammates that no longer exist; task status can lag when teammates fail to mark tasks complete, blocking dependent tasks; shutdown can be slow because teammates finish their current request before stopping; a lead can manage only one team at a time and must clean up the current one before creating another; teammates cannot spawn their own teams or teammates; and the lead is fixed for the team's lifetime — you cannot promote a teammate to lead or transfer leadership (source: agent-teams.md).
+
+## Related pages
+- [[claude-code-subagents]]
+- [[subagents]]
+- [[agent-workflows]]
+- [[claude-code-hooks]]
+- [[claude-code-memory]]
+- [[claude-code-skills]]
+- [[monorepo-large-codebase-setup]]

--- a/wiki/knowledge/claude-code-hooks.md
+++ b/wiki/knowledge/claude-code-hooks.md
@@ -1,8 +1,8 @@
 # Claude Code Hooks
 
 **Summary**: Deterministic automation points in the Claude Code lifecycle that execute shell commands, HTTP requests, MCP tool calls, LLM prompts, or agent-based verification at specific events — enabling formatting, validation, auditing, and control flow without relying on the model's judgment.
-**Sources**: automate-workflow-with-hooks.md, claude-hook-reference-doc.md, analysis-automate-workflow-with-hooks.md, analysis-claude-hook-reference-doc.md
-**Last updated**: 2026-05-22
+**Sources**: automate-workflow-with-hooks.md, claude-hook-reference-doc.md, analysis-automate-workflow-with-hooks.md, analysis-claude-hook-reference-doc.md, agent-teams.md, goals.md, monorepos-and-large-repos.md, parallel-sessions-worktrees.md
+**Last updated**: 2026-06-04
 
 ---
 
@@ -95,6 +95,8 @@ Tool events support an optional per-handler `if` field that uses permission-rule
 | ---------------- | ------------------------------------------------------------ | ------------------ | ---------------------------------- |
 | `WorktreeCreate` | Worktree created via `--worktree` or `isolation: "worktree"` | No matcher support | Yes — non-zero exit fails creation |
 | `WorktreeRemove` | Worktree removed at session exit or subagent finish          | No matcher support | No                                 |
+
+Because a `WorktreeCreate` hook **replaces the default git logic entirely**, `.worktreeinclude` is **not** processed when using `--worktree` — local config files (e.g. `.env`) must be copied inside the hook script instead (source: parallel-sessions-worktrees.md). See [[claude-code-worktrees]].
 
 ### MCP Elicitation Events
 
@@ -194,6 +196,10 @@ For structured control, return JSON on exit 0: `{hookSpecificOutput: {hookEventN
 
 Multiple events support injecting text into Claude's context via the `additionalContext` field in JSON output: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `Notification`, and `SubagentStart`. Multiple hooks' values are concatenated. For `SessionStart`, `CLAUDE_ENV_FILE` enables persisting environment variables for all subsequent Bash commands in the session.
 
+### Monorepo Onboarding Hooks
+
+In a large monorepo, a `SessionStart` hook can print a path-to-plugin recommendation to stdout, which is added to context before the first prompt — so a session started in an unfamiliar subtree learns which plugin owns that area (source: monorepos-and-large-repos.md). Complementarily, a `Stop` hook receives the session-transcript path and can propose `CLAUDE.md` updates while the gap exposed during the session is still fresh (source: monorepos-and-large-repos.md). See [[monorepo-large-codebase-setup]].
+
 ## Async Hooks
 
 Set `"async": true` on command hooks to run them in the background without blocking Claude. Async hooks:
@@ -249,6 +255,10 @@ fi
 
 Use for decisions requiring judgment rather than deterministic rules.
 
+### `/goal` — Productized Session-Scoped Stop Hook
+
+The `/goal` command is a productized wrapper around a session-scoped prompt-based `Stop` hook: it sets a completion condition inline for the current session rather than living in a settings file across all sessions in scope (source: goals.md). After each turn a small fast model (Haiku by default) evaluates the condition and either continues — feeding its reason back as next-turn guidance — or clears the goal once the condition is met (source: goals.md). The evaluator **does not call tools or read files**; it judges only what Claude has already surfaced in the transcript, so an effective condition must be demonstrable in Claude's own output (source: goals.md). `/goal` is unavailable when `disableAllHooks` is set at any level or when `allowManagedHooksOnly` is set in managed settings, and it requires Claude Code v2.1.139+ (source: goals.md). See [[agent-workflows]] for how `/goal` compares with `/loop`, raw Stop hooks, and auto mode as session-continuing autonomous approaches.
+
 ## Agent-Based Hooks
 
 `type: "agent"` hooks spawn a subagent with tool access (Read, Grep, Glob, etc.) to verify conditions against the actual state of the codebase. Same `"ok"`/`"reason"` response format as prompt hooks, but supports up to 50 tool-use turns with a longer default timeout of 60 seconds. Use `$ARGUMENTS` as a placeholder for hook input JSON in the prompt.
@@ -296,5 +306,9 @@ Hooks can be defined directly in [[claude-code-skills]] and [[claude-code-subage
 - [[claude-code-plugins]]
 - [[claude-code-memory]]
 - [[claude-code-subagents]]
+- [[claude-code-agent-teams]]
+- [[claude-code-workflows]]
+- [[claude-code-worktrees]]
+- [[monorepo-large-codebase-setup]]
 - [[cursor-hooks]]
 - [[agent-workflows]]

--- a/wiki/knowledge/claude-code-memory.md
+++ b/wiki/knowledge/claude-code-memory.md
@@ -1,8 +1,8 @@
 # Claude Code Memory
 
 **Summary**: The multi-layered system by which Claude Code maintains persistent project context across sessions — comprising CLAUDE.md and CLAUDE.local.md file hierarchies, path-scoped rules in `.claude/rules/`, auto memory from corrections, and import-based composition.
-**Sources**: how-claude-remembers-a-project.md, analysis-how-claude-remembers-a-project.md
-**Last updated**: 2026-05-22
+**Sources**: how-claude-remembers-a-project.md, analysis-how-claude-remembers-a-project.md, monorepos-and-large-repos.md
+**Last updated**: 2026-06-04
 
 ---
 
@@ -38,13 +38,17 @@ CLAUDE.md files live in several locations, listed below in **load order** — br
 | Project instructions | `./CLAUDE.md` or `./.claude/CLAUDE.md`                                                                                                | Team-shared, via source control        |
 | Local instructions   | `./CLAUDE.local.md`                                                                                                                   | Personal per-project, add to `.gitignore` |
 
-Within the directory tree, content is ordered from filesystem root down to the working directory; within each directory `CLAUDE.local.md` is appended after `CLAUDE.md`. Subdirectory `CLAUDE.md`/`CLAUDE.local.md` files (e.g. `./src/CLAUDE.md`) are not loaded at launch — they load on demand when Claude reads files in that directory.
+Within the directory tree, content is ordered from filesystem root down to the working directory; within each directory `CLAUDE.local.md` is appended after `CLAUDE.md`. Subdirectory `CLAUDE.md`/`CLAUDE.local.md` files (e.g. `./src/CLAUDE.md`) are not loaded at launch — they load on demand when Claude reads files in that directory. This on-demand rule holds only when you start Claude from the repository root or an ancestor of the subdirectory; when you **start Claude from a subdirectory**, it loads that directory's `CLAUDE.md` plus every ancestor's at launch (source: monorepos-and-large-repos.md).
+
+Project `.claude/settings.json` loads only from the starting directory and is **not** inherited from parent directories the way `CLAUDE.md` is, so each subdirectory's settings file must be self-contained (source: monorepos-and-large-repos.md).
 
 ### CLAUDE.local.md
 
 `CLAUDE.local.md` at the project root holds private per-project preferences (sandbox URLs, preferred test data) that should not be checked in (source: how-claude-remembers-a-project.md). It loads alongside `CLAUDE.md` and is treated the same way. Add it to `.gitignore` — running `/init` with the personal option does this for you. Because a gitignored `CLAUDE.local.md` only exists in the worktree where it was created, share personal instructions across worktrees by importing a home-directory file (`@~/.claude/my-project-instructions.md`) instead.
 
 The managed-policy layer can also be supplied as a `claudeMd` key inside `managed-settings.json` rather than a separate file; `claudeMd` set in user, project, or local settings has no effect.
+
+`claudeMdExcludes` is a static path/glob exclusion that skips matching `CLAUDE.md`/rules files — it is a settings-level list, not a per-task switch. Globs are matched against **absolute** paths, so prefix patterns with `**/` to match by basename or relative location. The arrays merge across user, project, local, and managed scopes, and the exclusion cannot remove a managed-policy `CLAUDE.md`. To focus on one part of the tree per task, start Claude from the relevant directory instead of editing exclusions (source: monorepos-and-large-repos.md).
 
 ## Path-Scoped Rules
 
@@ -113,3 +117,4 @@ Claude accumulates learnings across sessions without you writing anything — bu
 - [[context-engineering]]
 - [[claude-code-hooks]]
 - [[cursor-rules]]
+- [[monorepo-large-codebase-setup]]

--- a/wiki/knowledge/claude-code-plugins.md
+++ b/wiki/knowledge/claude-code-plugins.md
@@ -1,8 +1,8 @@
 # Claude Code Plugins
 
 **Summary**: Distributable packages that bundle skills, agents, hooks, MCP/LSP servers, commands, and background monitors into a single installable unit with namespace isolation — the primary mechanism for sharing Claude Code extensions across teams and the community.
-**Sources**: claude-create-plugin-doc.md, analysis-claude-create-plugin-doc.md, research-claude-code-skills-format.md
-**Last updated**: 2026-05-22
+**Sources**: claude-create-plugin-doc.md, analysis-claude-create-plugin-doc.md, research-claude-code-skills-format.md, monorepos-and-large-repos.md
+**Last updated**: 2026-06-04
 
 ---
 
@@ -82,6 +82,12 @@ Monitor entries also support a `when` trigger and variable substitution (see the
 ## Default Settings
 
 A plugin can ship a `settings.json` at its root to apply default configuration when enabled. Only the `agent` and `subagentStatusLine` keys are honored. Setting `agent` activates one of the plugin's custom agents as the main thread — applying its system prompt, tool restrictions, and model — letting a plugin change how Claude Code behaves by default. `settings.json` takes priority over `settings` declared in `plugin.json`; unknown keys are silently ignored.
+
+## Code-Intelligence and LSP Plugins
+
+Code-intelligence plugins that ship an LSP server (e.g. `typescript-lsp@claude-plugins-official`) let Claude replace brute-force file scans with language-server lookups — go-to-definition, find-references, and symbol search instead of reading whole trees (source: monorepos-and-large-repos.md). Enable them repo-wide via `enabledPlugins` so every contributor gets the same code intelligence (source: monorepos-and-large-repos.md). They require the language-server binary installed on each machine plus network access to the plugin host — GitHub by default, or an internal Git host on restricted networks (source: monorepos-and-large-repos.md).
+
+Plugins (and MCP code-search/RAG servers) also centralize project conventions when per-directory `CLAUDE.md` layering stops scaling — when files drift, go stale, or have no root owner — by moving conventions into on-demand mechanisms rather than always-loaded memory (source: monorepos-and-large-repos.md). Plugin skills use the `plugin-name:skill-name` namespace, so conventions packaged this way never collide across installed plugins (source: monorepos-and-large-repos.md). See [[monorepo-large-codebase-setup]] for scoping Claude to the part of a large tree a task touches.
 
 ## Distribution
 
@@ -164,3 +170,4 @@ A local plugin (loaded via `--plugin-dir`) overrides a marketplace plugin with t
 - [[claude-code-subagents]]
 - [[cursor-plugins]]
 - [[agent-skills-standard]]
+- [[monorepo-large-codebase-setup]]

--- a/wiki/knowledge/claude-code-skills.md
+++ b/wiki/knowledge/claude-code-skills.md
@@ -1,8 +1,8 @@
 # Claude Code Skills
 
 **Summary**: Custom instruction packages that extend Claude Code's capabilities through SKILL.md files with YAML frontmatter — following the Agent Skills open standard with Claude-specific extensions for model selection, tool restriction, and context forking.
-**Sources**: extend-claude-with-skills.md, research-claude-code-skills-format.md, analysis-extend-claude-with-skills.md, analysis-research-claude-code-skills-format.md
-**Last updated**: 2026-05-22
+**Sources**: extend-claude-with-skills.md, research-claude-code-skills-format.md, analysis-extend-claude-with-skills.md, analysis-research-claude-code-skills-format.md, monorepos-and-large-repos.md
+**Last updated**: 2026-06-04
 
 ---
 
@@ -55,6 +55,10 @@ All fields are optional; only `description` is recommended (source: extend-claud
 2. **Project skills** — `.claude/skills/`
 3. **Personal skills** — `~/.claude/skills/`
 
+### Per-directory placement in large repos
+
+In a monorepo or large single-tree codebase, skills can also live under `<subdir>/.claude/skills/`, loading on demand by directory scope or by their `paths:` frontmatter glob (source: monorepos-and-large-repos.md). Which skills are in scope depends on the start directory: starting from the repository root, every touched subdirectory's skills accumulate as Claude reads files across the tree (source: monorepos-and-large-repos.md). When many skills exist, their descriptions are shortened in the listing, so lead each description with the request keywords most likely to trigger it (source: monorepos-and-large-repos.md). To find unused skills to retire, watch the OpenTelemetry `skill_activated` event (set `OTEL_LOG_TOOL_DETAILS=1`) and inspect its `invocation_trigger` attribute (source: monorepos-and-large-repos.md). See [[monorepo-large-codebase-setup]] for the full scoping setup.
+
 ## Progressive Disclosure
 
 | Tier                             | Loaded When       | Budget        |
@@ -100,3 +104,4 @@ Three additional bundled skills (Claude Code v2.1.145+) launch your app and conf
 - [[claude-code-plugins]]
 - [[cursor-skills]]
 - [[progressive-disclosure]]
+- [[monorepo-large-codebase-setup]]

--- a/wiki/knowledge/claude-code-subagents.md
+++ b/wiki/knowledge/claude-code-subagents.md
@@ -1,8 +1,8 @@
 # Claude Code Subagents
 
 **Summary**: Task-specific assistants defined as Markdown files with YAML frontmatter that run in isolated context windows within Claude Code sessions — supporting tool restriction, model selection, permission modes, persistent memory, and worktree isolation.
-**Sources**: creating-custom-subagents.md, claude-orchestrate-of-claude-code-sessions.md, analysis-creating-custom-subagents.md, research-subagent-best-practices.md
-**Last updated**: 2026-05-21
+**Sources**: creating-custom-subagents.md, claude-orchestrate-of-claude-code-sessions.md, analysis-creating-custom-subagents.md, research-subagent-best-practices.md, agent-teams.md, dynamic-workflows.md, parallel-sessions-worktrees.md
+**Last updated**: 2026-06-04
 
 ---
 
@@ -116,67 +116,7 @@ All hook events are supported. Key behaviors:
 
 ## Agent Teams (Experimental)
 
-Multiple Claude Code instances coordinating as a team. Enable with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`. Requires Claude Code v2.1.32+.
-
-### Architecture
-
-| Component     | Role                                                                            |
-| ------------- | ------------------------------------------------------------------------------- |
-| **Team lead** | Creates team, breaks work into tasks, coordinates progress, synthesizes results |
-| **Teammates** | Independent Claude Code instances, each with own context window                 |
-| **Task list** | Shared state — teammates claim tasks, mark complete                             |
-| **Mailbox**   | Direct messaging between lead and teammates, or between teammates               |
-
-### Task Workflow
-
-Tasks flow through states: **pending** → **in progress** → **completed**. Task dependencies are supported — a task won't become available until its dependencies are complete. File locking prevents race conditions when teammates access shared resources.
-
-### Communication
-
-- **Lead ↔ Teammate**: Direct messages via task list updates and mailbox
-- **Teammate ↔ Teammate**: Broadcast messages for coordination
-- Display modes: **in-process** (cycle with `Shift+Down`) or **split-panes** (tmux/iTerm2)
-
-### Team-Specific Hooks
-
-Two hook events exist specifically for agent teams:
-
-- `TeammateIdle` — fires when a teammate is about to go idle; block to keep it working
-- `TaskCompleted` — fires when a task is marked complete; block to prevent completion
-
-### Sizing Guidelines
-
-| Guideline          | Recommendation                                                                  |
-| ------------------ | ------------------------------------------------------------------------------- |
-| Team size          | **3–5 teammates** for most workflows                                            |
-| Tasks per teammate | **5–6 tasks** each keeps everyone productive                                    |
-| Scaling rule       | Add teammates only when work genuinely benefits from parallelism                |
-| Task granularity   | Self-contained units producing clear deliverables (function, test file, review) |
-
-Three focused teammates often outperform five scattered ones. Token costs scale linearly with teammate count, and coordination overhead increases with team size.
-
-### Team Use Cases
-
-- Parallel research from different angles
-- Cross-layer coordination (frontend, backend, tests simultaneously)
-- Model comparison on same task
-- Large PR reviews split by concern area
-
-### Team Anti-Patterns
-
-- Sequential, tightly-coupled tasks (use single session)
-- Same-file edits across teammates (causes overwrites)
-- Simple tasks that don't justify coordination overhead (higher token cost)
-- Running unattended too long (increases risk of wasted effort)
-
-### Current Limitations
-
-- No session resumption with in-process teammates (`/resume` and `/rewind` don't restore them)
-- Task status can lag — teammates sometimes fail to mark tasks complete
-- One team per session; no nested teams
-- Lead is fixed for the session lifetime
-- All teammates start with the lead's permission mode
-- Split panes require tmux or iTerm2 (not supported in VS Code terminal, Windows Terminal, or Ghostty)
+A fixed team lead spawns independent Claude Code teammate instances — each with its own context window — that share a file-locked task list and message each other point-to-point through a mailbox, governed by three team-specific hooks (source: agent-teams.md). This is distinct from single-session subagents (which report only to their caller and never talk to each other). See the canonical page [[claude-code-agent-teams]] for architecture, communication, team hooks, sizing, and limitations.
 
 ## Fork Mode (Experimental)
 
@@ -192,6 +132,11 @@ Enabling fork mode changes three things (source: creating-custom-subagents.md):
 
 You can start a fork yourself with `/fork` followed by a directive (e.g. `/fork draft unit tests for the parser changes so far`); Claude Code names the fork from the first words of the directive (source: creating-custom-subagents.md). Because a fork's system prompt and tool definitions are identical to the parent, its first request reuses the parent's prompt cache, making forking cheaper than spawning a fresh subagent for tasks that need the same context (source: creating-custom-subagents.md). A fork cannot spawn further forks (source: creating-custom-subagents.md).
 
+## Claude-Code-Specific Subagent Behavior
+
+- **Workflow-spawned subagents**: subagents spawned by a [[claude-code-workflows]] dynamic workflow always run in `acceptEdits` mode and inherit the session tool allowlist regardless of the session's permission mode — file edits are auto-approved, though un-allowlisted shell/web/MCP calls can still prompt mid-run (source: dynamic-workflows.md).
+- **Subagent worktrees**: subagent (and background-session) worktrees are auto-removed once older than the `cleanupPeriodDays` setting if they are clean (no uncommitted changes, untracked files, or unpushed commits), whereas `--worktree`-created worktrees are never swept; subagent worktrees inherit the same base branch as `--worktree` (source: parallel-sessions-worktrees.md). See [[claude-code-worktrees]].
+
 ## Key Constraint
 
 **Subagents cannot spawn other subagents** — this prevents infinite nesting. Use the `Agent(worker, researcher)` tool syntax to restrict which named subagents can be spawned from the parent context.
@@ -206,3 +151,7 @@ You can start a fork yourself with `/fork` followed by a directive (e.g. `/fork 
 - [[claude-code-hooks]]
 - [[agent-workflows]]
 - [[cursor-subagents]]
+- [[claude-code-agent-teams]]
+- [[claude-code-workflows]]
+- [[claude-code-worktrees]]
+- [[monorepo-large-codebase-setup]]

--- a/wiki/knowledge/claude-code-workflows.md
+++ b/wiki/knowledge/claude-code-workflows.md
@@ -1,0 +1,70 @@
+# Claude Code Dynamic Workflows
+
+**Summary**: Dynamic workflows — a JavaScript script the runtime executes to orchestrate dozens–hundreds of subagents; the plan lives in code and intermediate results stay in script variables, off the main context.
+**Sources**: dynamic-workflows.md
+**Last updated**: 2026-06-04
+---
+
+A dynamic workflow is a JavaScript script that orchestrates [[claude-code-subagents]] at scale (source: dynamic-workflows.md). Claude writes the script for the task you describe, and a runtime executes it in the background while your session stays responsive (source: dynamic-workflows.md). Dynamic workflows are in research preview and require Claude Code v2.1.154 or later (source: dynamic-workflows.md). They are available on all paid plans, with Anthropic API access, and on Amazon Bedrock, Google Cloud Vertex AI, and Microsoft Foundry (source: dynamic-workflows.md).
+
+Reach for a workflow when a task needs more agents than one conversation can coordinate, or when you want the orchestration codified as a script you can read and rerun (source: dynamic-workflows.md). Example tasks include a codebase-wide bug sweep, a 500-file migration, a research question whose sources need cross-checking against each other, and a hard plan worth drafting from several independent angles before committing to one (source: dynamic-workflows.md).
+
+## The third orchestration primitive: who holds the plan
+
+[[claude-code-subagents]] (subagents), [[claude-code-skills]] (skills), and workflows can all run a multi-step task; the difference is who holds the plan (source: dynamic-workflows.md). A subagent is a worker Claude spawns, and a skill is a set of instructions Claude follows — in both cases Claude decides turn by turn what runs next, and every result lands in Claude's context window (source: dynamic-workflows.md). A workflow is a script the runtime executes, so the script decides what runs next, and intermediate results live in script variables (source: dynamic-workflows.md).
+
+With subagents and skills, Claude is the orchestrator; a workflow moves the plan into code, so the script holds the loop, the branching, and the intermediate results itself, and Claude's context holds only the final answer (source: dynamic-workflows.md). What is repeatable also differs: subagents make the worker definition repeatable and skills make the instructions repeatable, whereas a workflow makes the orchestration itself repeatable (source: dynamic-workflows.md). Subagents and skills handle a few delegated tasks per turn, while a workflow scales to dozens to hundreds of agents per run (source: dynamic-workflows.md). On interruption, subagents and skills restart the turn, while a workflow is resumable within the same session (source: dynamic-workflows.md). This placement of the orchestration loop in code makes dynamic workflows a [[context-engineering]] strategy, not just a scaling feature.
+
+## Quality patterns, not just more agents
+
+Moving the plan into code lets a workflow apply a repeatable quality pattern, not just run more agents (source: dynamic-workflows.md). A workflow can have independent agents adversarially review each other's findings before they are reported, or draft a plan from several angles and weigh them against each other, so the result is more trustworthy than a single pass (source: dynamic-workflows.md). This is the codified, rerunnable counterpart to the orchestration patterns described in [[agent-workflows]] and a concrete instance of [[harness-engineering]].
+
+## Running a bundled workflow
+
+Claude Code includes `/deep-research` as a built-in workflow for investigating a question across many sources (source: dynamic-workflows.md). It fans out web searches on a question across several angles, fetches and cross-checks the sources it finds, votes on each claim, and returns a cited report with claims that didn't survive cross-checking filtered out (source: dynamic-workflows.md). `/deep-research` requires the WebSearch tool to be available (source: dynamic-workflows.md). The cross-check-and-vote step pairs naturally with the verification framing in [[structured-outputs]].
+
+Run `/workflows` at any time to list running and completed workflows, then select one to open its progress view, which shows each phase with its agent counts, token totals, and elapsed time (source: dynamic-workflows.md). You can drill into any phase to read its agents' prompts, recent tool calls, and results, pause or resume the run, stop an individual agent or the whole workflow, restart a running agent, or save the run's script as a command (source: dynamic-workflows.md). A one-line progress summary also appears in the task panel below the input box while a run is going (source: dynamic-workflows.md).
+
+## Having Claude write a workflow
+
+Claude writes a workflow for your task in two ways (source: dynamic-workflows.md). The first is to include the word `workflow` anywhere in your prompt: Claude Code highlights the word and Claude writes a workflow script for the task instead of working through it turn by turn (source: dynamic-workflows.md). If the keyword is highlighted when you didn't mean to trigger a workflow, press `alt+w` to ignore it for the prompt, or turn off the Workflow keyword trigger in `/config` (source: dynamic-workflows.md).
+
+The second is `/effort ultracode`, a setting that combines `xhigh` reasoning effort with automatic workflow orchestration, so Claude plans a workflow for each substantive task instead of waiting for you to ask (source: dynamic-workflows.md). A single request can turn into several workflows in a row — for example one to understand the code, one to make the change, and one to verify it — which uses more tokens and takes longer than lower effort levels (source: dynamic-workflows.md). Ultracode lasts for the current session and resets when you start a new one (source: dynamic-workflows.md).
+
+### Approving the plan before it runs
+
+In the CLI, the per-run prompt shows the planned phases with options to run it, run it and skip the prompt for that workflow in the project from now on, view the raw script, or cancel (source: dynamic-workflows.md). Whether you see this prompt depends on your permission mode: in Default and accept-edits modes you are prompted every run unless you chose "don't ask again" for that workflow; in Auto mode you are prompted on first launch only, and it is skipped entirely when ultracode is on; under Bypass permissions, `claude -p`, and the Agent SDK the run starts immediately with no prompt (source: dynamic-workflows.md).
+
+Your permission mode controls only the launch prompt — the subagents the workflow spawns always run in `acceptEdits` mode and inherit your tool allowlist regardless of the session's mode, and file edits are auto-approved (source: dynamic-workflows.md). Shell commands, web fetches, and MCP tools that aren't in your allowlist can still prompt you mid-run, so adding the commands the agents need to your allowlist before a long run avoids interruptions (source: dynamic-workflows.md). This `acceptEdits`-plus-allowlist behavior is the Claude-Code-specific runtime contract for the worker subagents described in [[claude-code-subagents]].
+
+### Saving a workflow for reuse
+
+When Claude writes a workflow for a task you'll repeat, you can save that run's script as a command by selecting the run in `/workflows` and pressing `s` (source: dynamic-workflows.md). The save dialog offers two locations: `.claude/workflows/` in your project, shared with everyone who clones the repo, or `~/.claude/workflows/` in your home directory, available in every project but visible only to you (source: dynamic-workflows.md). The workflow then runs as `/<name>` in future sessions, and if a project workflow and a personal workflow share a name, the project one runs (source: dynamic-workflows.md).
+
+## How a workflow runs
+
+The workflow runtime executes the script in an isolated environment, separate from your conversation, so intermediate results stay in script variables instead of landing in Claude's context (source: dynamic-workflows.md). The runtime tracks each agent's result as the run progresses, which is what makes a run resumable within the same session (source: dynamic-workflows.md).
+
+### Behavior and limits
+
+The runtime applies several constraints (source: dynamic-workflows.md). A run takes no mid-run user input — only agent permission prompts can pause it — so for sign-off between stages you run each stage as its own workflow (source: dynamic-workflows.md). The workflow script itself has no direct filesystem or shell access; only its spawned agents read, write, and run commands, while the script coordinates them (source: dynamic-workflows.md). A run uses up to 16 concurrent agents, fewer on machines with limited CPU cores, to bound local resource use (source: dynamic-workflows.md). A run is capped at 1,000 agents total to prevent runaway loops (source: dynamic-workflows.md).
+
+### Resuming after a pause
+
+If you stop a run, you can resume it: agents that already completed return their cached results, and the rest run live (source: dynamic-workflows.md). Resume a paused run from `/workflows` by selecting it and pressing `p`, or ask Claude to relaunch the workflow with the same script (source: dynamic-workflows.md). Resume works only within the same Claude Code session — if you exit Claude Code while a workflow is running, the next session starts the workflow fresh (source: dynamic-workflows.md).
+
+### Cost
+
+A workflow spawns many agents, so a single run can use meaningfully more tokens than working through the same task in conversation, and runs count toward your plan's usage and rate limits like any other session (source: dynamic-workflows.md). You can stop a running workflow from `/workflows` at any time without losing completed work (source: dynamic-workflows.md). Every agent in a workflow uses your session's model unless the script routes a stage to a different one, so checking `/model` before a large run and asking Claude to use a smaller model for stages that don't need the strongest one both control cost (source: dynamic-workflows.md).
+
+## Turning workflows off
+
+Workflows are available in the CLI, the Desktop app, the IDE extensions, non-interactive mode with `claude -p`, and the Agent SDK, and the same disable settings apply on every surface (source: dynamic-workflows.md). To turn them off for yourself, toggle Dynamic workflows off in `/config`, set `"disableWorkflows": true` in `~/.claude/settings.json`, or set `CLAUDE_CODE_DISABLE_WORKFLOWS=1` (source: dynamic-workflows.md). To turn them off for a whole organization, set `"disableWorkflows": true` in managed settings or use the toggle on the Claude Code admin settings page (source: dynamic-workflows.md). When workflows are disabled, the bundled workflow commands are unavailable, the `workflow` keyword no longer triggers a run, and `ultracode` is removed from the `/effort` menu (source: dynamic-workflows.md).
+
+## Related pages
+- [[agent-workflows]]
+- [[subagents]]
+- [[claude-code-subagents]]
+- [[context-engineering]]
+- [[harness-engineering]]
+- [[structured-outputs]]

--- a/wiki/knowledge/claude-code-worktrees.md
+++ b/wiki/knowledge/claude-code-worktrees.md
@@ -1,0 +1,110 @@
+# Claude Code Worktrees
+
+**Summary**: CLI-native git-worktree isolation in Claude Code: the --worktree/-w flag, base-branch selection (worktree.baseRef, PR worktrees), .worktreeinclude, subagent worktree isolation, change-aware cleanup, and non-git VCS hooks.
+**Sources**: parallel-sessions-worktrees.md
+**Last updated**: 2026-06-04
+---
+
+A git worktree is a separate working directory with its own files and branch that shares the same repository history and remote as the main checkout (source: parallel-sessions-worktrees.md). Running each Claude Code session in its own worktree means edits in one session never touch files in another, so Claude can build a feature in one terminal while fixing a bug in a second (source: parallel-sessions-worktrees.md). Everything on this page assumes a git repository; for other version control systems, see [Non-git version control](#non-git-version-control) (source: parallel-sessions-worktrees.md).
+
+## File isolation versus work coordination
+
+Worktrees are deliberately distinct from [[claude-code-subagents]] and agent teams: worktrees isolate **file edits**, while subagents and agent teams **coordinate the work itself** (source: parallel-sessions-worktrees.md). The two approaches compose rather than compete — subagents can run inside worktrees — but they solve different problems, so reach for worktrees when the concern is files colliding and for subagents/teams when the concern is who does which task (source: parallel-sessions-worktrees.md). These parallel-execution patterns are the file-isolation substrate underneath the orchestration approaches described in [[agent-workflows]] (source: parallel-sessions-worktrees.md).
+
+## Start Claude in a worktree
+
+Pass `--worktree` or `-w` to create an isolated worktree and start Claude in it (source: parallel-sessions-worktrees.md). By default the worktree is created under `.claude/worktrees/<value>/` at the repository root, on a new branch named `worktree-<value>` (source: parallel-sessions-worktrees.md).
+
+```bash
+claude --worktree feature-auth
+```
+
+Running the command again with a different name in another terminal starts a second isolated session (source: parallel-sessions-worktrees.md). If the name is omitted, Claude generates one such as `bright-running-fox` (source: parallel-sessions-worktrees.md).
+
+```bash
+claude --worktree
+```
+
+During a session you can also ask Claude to "work in a worktree" and it creates one with the `EnterWorktree` tool (source: parallel-sessions-worktrees.md). Once in a worktree, Claude can switch directly to another one under `.claude/worktrees/` by calling `EnterWorktree` with the target path, and the previous worktree stays on disk untouched (source: parallel-sessions-worktrees.md). The `EnterWorktree`/`ExitWorktree` tools are how Claude moves between isolated checkouts during a session (source: parallel-sessions-worktrees.md).
+
+Before using `--worktree` in a directory for the first time, accept the workspace trust dialog by running `claude` once in that directory (source: parallel-sessions-worktrees.md). If trust has not yet been accepted, `--worktree` exits with an error and prompts you to run `claude` in the directory first — including when combined with `-p` (source: parallel-sessions-worktrees.md). Adding `.claude/worktrees/` to `.gitignore` keeps worktree contents from appearing as untracked files in the main checkout (source: parallel-sessions-worktrees.md).
+
+## Choose the base branch
+
+Worktrees branch from the repository's default branch, `origin/HEAD`, so they start from a clean tree matching the remote (source: parallel-sessions-worktrees.md). If no remote is configured or the fetch fails, the worktree falls back to the current local `HEAD` (source: parallel-sessions-worktrees.md).
+
+To always branch from local `HEAD` instead, set `worktree.baseRef` to `"head"` in settings (source: parallel-sessions-worktrees.md). Setting `baseRef` to `"head"` makes new worktrees carry unpushed commits and feature-branch state, which is useful when isolating subagents that need to operate on in-progress work (source: parallel-sessions-worktrees.md). The setting accepts only `"fresh"` or `"head"`, not arbitrary git refs (source: parallel-sessions-worktrees.md).
+
+```json
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}
+```
+
+To branch from a specific pull request, pass the PR number prefixed with `#`, or a full GitHub pull request URL (source: parallel-sessions-worktrees.md). Claude Code fetches `pull/<number>/head` from `origin` and creates the worktree at `.claude/worktrees/pr-<number>` (source: parallel-sessions-worktrees.md).
+
+```bash
+claude --worktree "#1234"
+```
+
+For full control over how worktrees are created, configure a `WorktreeCreate` hook, which replaces the default `git worktree` logic entirely (source: parallel-sessions-worktrees.md). See [[claude-code-hooks]] for the worktree hook events.
+
+## Copy gitignored files into worktrees
+
+A worktree is a fresh checkout, so untracked files like `.env` or `.env.local` from the main repository are not present (source: parallel-sessions-worktrees.md). To copy them automatically when Claude creates a worktree, add a `.worktreeinclude` file to the project root (source: parallel-sessions-worktrees.md).
+
+The file uses `.gitignore` syntax, and only files that match a pattern and are also gitignored are copied, so tracked files are never duplicated (source: parallel-sessions-worktrees.md).
+
+```text
+.env
+.env.local
+config/secrets.json
+```
+
+This applies to worktrees created with `--worktree`, to subagent worktrees, and to parallel sessions in the desktop app (source: parallel-sessions-worktrees.md). Note the important exception: when a `WorktreeCreate` hook replaces the default git logic, `.worktreeinclude` is **not** processed, so local config files must be copied inside the hook script instead (source: parallel-sessions-worktrees.md).
+
+## Isolate subagents with worktrees
+
+Subagents can run in their own worktrees so parallel edits don't conflict (source: parallel-sessions-worktrees.md). Ask Claude to "use worktrees for your agents", or set it permanently on a custom subagent by adding `isolation: worktree` to the frontmatter (source: parallel-sessions-worktrees.md). Each subagent gets a temporary worktree that is removed automatically when the subagent finishes without changes (source: parallel-sessions-worktrees.md). See [[claude-code-subagents]] for the full frontmatter contract.
+
+Subagent worktrees use the same base branch as `--worktree`, so they branch from the repository's default branch unless `worktree.baseRef` is set to `"head"` (source: parallel-sessions-worktrees.md).
+
+## Clean up worktrees
+
+Cleanup on exit depends on whether you made changes (source: parallel-sessions-worktrees.md):
+
+- With **no uncommitted changes, no untracked files, and no new commits**, the worktree and its branch are removed automatically; if the session has a name, Claude prompts instead so you can keep the worktree for later (source: parallel-sessions-worktrees.md).
+- With **uncommitted changes, untracked files, or new commits**, Claude prompts you to keep or remove the worktree — keeping preserves the directory and branch, while removing deletes the directory and branch and discards those uncommitted changes, untracked files, and commits (source: parallel-sessions-worktrees.md).
+- For **non-interactive runs**, worktrees created with `--worktree` alongside `-p` are not cleaned up automatically because there is no exit prompt, so remove them with `git worktree remove` (source: parallel-sessions-worktrees.md).
+
+The asymmetry between automatic and never-automatic cleanup is the load-bearing distinction. Worktrees that Claude created for subagents and background sessions **are** removed automatically once they are older than the `cleanupPeriodDays` setting, provided they have no uncommitted changes, no untracked files, and no unpushed commits (source: parallel-sessions-worktrees.md). Worktrees you create with `--worktree`, by contrast, are **never** removed by that sweep (source: parallel-sessions-worktrees.md).
+
+## Manage worktrees manually
+
+For full control over worktree location and branch configuration, create worktrees with Git directly, which is useful when you need to check out a specific existing branch or place the worktree outside the repository (source: parallel-sessions-worktrees.md).
+
+```bash
+git worktree add ../project-feature-a -b feature-a   # new branch
+git worktree add ../project-bugfix bugfix-123        # existing branch
+cd ../project-feature-a && claude                     # start Claude there
+git worktree list                                     # list worktrees
+git worktree remove ../project-feature-a              # remove when done
+```
+
+Remember to initialize the development environment in each new worktree: install dependencies, set up virtual environments, or run whatever the project's setup requires (source: parallel-sessions-worktrees.md). This per-worktree setup discipline mirrors the guidance for Cursor's worktree feature in [[cursor-tools]], even though the two platforms use different cleanup mechanisms (source: parallel-sessions-worktrees.md).
+
+## Non-git version control
+
+Worktree isolation uses git by default (source: parallel-sessions-worktrees.md). For SVN, Perforce, Mercurial, or other systems, configure `WorktreeCreate` and `WorktreeRemove` hooks to provide custom creation and cleanup logic (source: parallel-sessions-worktrees.md). Because the hook replaces the default git behavior, `.worktreeinclude` is not processed when you use `--worktree`, so you must copy any local configuration files inside your hook script instead (source: parallel-sessions-worktrees.md).
+
+A `WorktreeCreate` hook can read the worktree name from stdin, check out a fresh working copy (for example via `svn checkout`), and print the directory path so Claude Code uses it as the session's working directory (source: parallel-sessions-worktrees.md). Pair it with a `WorktreeRemove` hook to clean up when the session ends (source: parallel-sessions-worktrees.md). See [[claude-code-hooks]] for the input schema and worktree hook event details.
+
+## Related pages
+
+- [[cursor-tools]]
+- [[claude-code-subagents]]
+- [[claude-code-hooks]]
+- [[agent-workflows]]
+- [[claude-code-memory]]

--- a/wiki/knowledge/compliance-routing.md
+++ b/wiki/knowledge/compliance-routing.md
@@ -65,3 +65,9 @@ For a detailed routing guide including entry points, validation paths, and commo
 - [[validation-routing-claude]] — Claude Code plugin validation
 - [[validation-routing-cursor]] — Cursor IDE plugin validation
 - [[validation-routing-standalone]] — Standalone skills validation
+
+## Related pages
+
+- [[validation-routing-claude]]
+- [[validation-routing-cursor]]
+- [[validation-routing-standalone]]

--- a/wiki/knowledge/context-engineering.md
+++ b/wiki/knowledge/context-engineering.md
@@ -1,8 +1,8 @@
 # Context Engineering
 
 **Summary**: The discipline of managing all context fed to an LLM — instructions, examples, retrieved data, tool outputs — to maximize signal density per token and minimize degradation from noise, staleness, and position effects.
-**Sources**: research-context-engineering-comprehensive.md, research-context-rot-and-management.md, a-guide-to-agents.md, research-whitespace-and-formatting.md, advanced-context-engineering-coding-agents-dev.md, agents-md-is-a-liability-paddo.md, context-engineering-commercial-agents-jeremy-daly.md, context-engineering-most-important-skill-dev.md, context-stops-being-scarce-paddo.md, million-token-context-window-syntackle.md, pi-context-zone-github.md, shedding-dead-context-ryan-spletzer.md
-**Last updated**: 2026-05-01
+**Sources**: research-context-engineering-comprehensive.md, research-context-rot-and-management.md, a-guide-to-agents.md, research-whitespace-and-formatting.md, advanced-context-engineering-coding-agents-dev.md, agents-md-is-a-liability-paddo.md, context-engineering-commercial-agents-jeremy-daly.md, context-engineering-most-important-skill-dev.md, context-stops-being-scarce-paddo.md, million-token-context-window-syntackle.md, pi-context-zone-github.md, shedding-dead-context-ryan-spletzer.md, dynamic-workflows.md, monorepos-and-large-repos.md
+**Last updated**: 2026-06-04
 
 ---
 
@@ -37,8 +37,9 @@ Place long documents at the top and queries at the bottom — this exploits the 
 
 1. **[[progressive-disclosure]]** — Load instructions conditionally (skills, path-scoped rules, subagent summaries) instead of dumping everything into the main prompt
 2. **Compaction** — Summarize accumulated context when nearing the window limit. The lightest-touch approach is **tool result clearing** (replacing verbose tool outputs with summaries). For conversations, ask the model to summarize. The simplest approach matches sophisticated alternatives.
-3. **Structured note-taking** — Agent writes notes persisted outside the context window (JSON state files, progress.txt, git commits). The agent can reload specific notes on demand rather than carrying all history in context. This is [[prompt-engineering]]'s state tracking applied to context management.
+3. **Structured note-taking** — Agent writes notes persisted outside the context window (JSON state files, progress.txt, git commits). The agent can reload specific notes on demand rather than carrying all history in context. This is [[prompt-engineering]]'s state tracking applied to context management. In long cross-package sessions, save the plan to a markdown file: a file survives compaction, where conversation history may not (source: monorepos-and-large-repos.md).
 4. **[[subagents]]** — Route complex research to isolated contexts; return only summaries (1,000–2,000 tokens) instead of tens of thousands of exploration tokens. JIT documentation is a variant: let the agent generate docs during planning, then use those docs (not the raw exploration) in execution.
+5. **Dynamic workflows** — Move the orchestration loop into a script the runtime executes, so intermediate agent results live in script variables instead of Claude's context window; the main context then holds only the final answer rather than the full exploration trail (source: dynamic-workflows.md). See [[claude-code-workflows]].
 
 ### Choosing a Strategy
 
@@ -74,6 +75,7 @@ Audit dead context:
 - Remove skills not relevant to current work
 - Test effective budget with a bare context first
 - IFScale benchmark: at 500 instructions, agents follow only ~68% and skip 1 in 3 (source: agents-md-is-a-liability-paddo.md)
+- Move conventions and reference content out of always-loaded CLAUDE.md into on-demand mechanisms — skills, plugins, or an MCP code-search/RAG server — so the convention text only enters context when the relevant area is touched (source: monorepos-and-large-repos.md)
 
 ## Large Context Windows and Their Limits
 
@@ -137,3 +139,5 @@ Well-formatted 1,000-token prompt beats a wall-of-text 900-token prompt. Cut con
 - [[long-context-lost-in-middle]]
 - [[harness-engineering]]
 - [[rpi-workflow]]
+- [[claude-code-workflows]]
+- [[pi-context-zone]]

--- a/wiki/knowledge/cursor-tools.md
+++ b/wiki/knowledge/cursor-tools.md
@@ -92,3 +92,4 @@ In the **Editor Window**, use the Worktree Skills commands instead:
 - [[cursor-plugins]]
 - [[cursor-subagents]]
 - [[agent-workflows]]
+- [[claude-code-worktrees]]

--- a/wiki/knowledge/harness-engineering.md
+++ b/wiki/knowledge/harness-engineering.md
@@ -215,3 +215,4 @@ What works: start simple, add configuration only when the agent actually fails, 
 - [[long-context-lost-in-middle]]
 - [[spec-driven-development]]
 - [[human-layer]]
+- [[pi-context-zone]]

--- a/wiki/knowledge/index.md
+++ b/wiki/knowledge/index.md
@@ -1,6 +1,6 @@
 # Wiki Index
 
-Total pages: **41**
+Total pages: **45**
 
 ---
 
@@ -19,7 +19,7 @@ Total pages: **41**
 | Page                          | Summary                                                                |
 | ----------------------------- | ---------------------------------------------------------------------- |
 | [[evaluating-agents-paper]]   | ETH Zurich 2026 study: minimal configs outperform comprehensive ones   |
-| [[agent-workflows]]           | Fundamental loop, five core patterns, orchestration strategies         |
+| [[agent-workflows]]           | Fundamental loop, five core patterns, orchestration strategies, autonomy modes, dynamic workflows |
 | [[subagents]]                 | Cross-platform subagent comparison, context firewall pattern           |
 | [[agent-configuration-files]] | AGENTS.md, CLAUDE.md, .cursorrules patterns and hierarchy              |
 | [[agent-best-practices]]      | Cross-platform guide: harness model, context management, anti-patterns |
@@ -31,10 +31,14 @@ Total pages: **41**
 | Page                      | Summary                                                       |
 | ------------------------- | ------------------------------------------------------------- |
 | [[claude-code-skills]]    | SKILL.md format, frontmatter, string substitutions, locations |
-| [[claude-code-hooks]]     | Lifecycle events, hook types, exit codes, matchers            |
+| [[claude-code-hooks]]     | Lifecycle events, hook types, exit codes, matchers, /goal     |
 | [[claude-code-plugins]]   | Plugin structure, manifest, distribution, namespacing         |
-| [[claude-code-memory]]    | CLAUDE.md hierarchy, path-scoped rules, imports, auto memory  |
-| [[claude-code-subagents]] | Definition format, frontmatter fields, fork mode, agent teams  |
+| [[claude-code-memory]]    | CLAUDE.md hierarchy, path-scoped rules, imports, auto memory, claudeMdExcludes + start-dir caveat |
+| [[claude-code-subagents]] | Definition format, frontmatter fields, fork mode; teams covered on [[claude-code-agent-teams]] |
+| [[claude-code-agent-teams]] | Experimental multi-session teams: file-locked shared task list, point-to-point messaging, three team hooks, plan-approval, sizing |
+| [[claude-code-workflows]] | Dynamic workflows: JS script orchestrates dozens–hundreds of subagents; plan-in-code, results in script variables off the main context |
+| [[claude-code-worktrees]] | CLI-native git-worktree isolation: --worktree flag, base-branch selection, .worktreeinclude, change-aware cleanup, non-git VCS hooks |
+| [[monorepo-large-codebase-setup]] | Scoping Claude Code in monorepos/large repos: start-dir semantics, sparsePaths, additionalDirectories, Read deny rules, claudeMdExcludes, per-directory layering |
 
 ## Cursor IDE Platform
 

--- a/wiki/knowledge/log.md
+++ b/wiki/knowledge/log.md
@@ -2,6 +2,18 @@
 
 ---
 
+## 2026-06-04 — Ingest: 5 new Claude Code vendor docs + lint fixes
+
+Summarize: Pages created (4): claude-code-agent-teams, claude-code-workflows, monorepo-large-codebase-setup, claude-code-worktrees. Source: goals.md ingested as extends only (no new page — it is a session-scoped Stop-hook wrapper). Pages extended: claude-code-subagents (Agent Teams section demoted to a stub pointing at the canonical page; corrected the stale "broadcast" claim → point-to-point, and "two team hooks" → three), agent-workflows, claude-code-hooks, claude-code-memory (fixed subdirectory-load claim for the start-from-subdir case; added claudeMdExcludes), subagents, context-engineering, claude-code-skills, skill-authoring, claude-code-plugins, agent-configuration-files. Lint fixes applied: resolved the pi-context-zone orphan (backlinks from context-engineering + harness-engineering); corrected the rpi-workflow ↔ harness-engineering dumb-zone threshold mis-attribution (40% from markus-harrer vs 60% from harness-engineering, now attributed separately); added ## Related pages to the four Compliance & Validation routing pages. Index updated 41 → 45. Sources: agent-teams.md, dynamic-workflows.md, goals.md, monorepos-and-large-repos.md, parallel-sessions-worktrees.md.
+
+**Lint pass (same run).** Mechanical checks over 41 pages (deterministic, ground truth): P0 dangling links 0, dead index entries 0, pages missing from index 0; P1 orphan 1 (pi-context-zone — fixed), format 4 (routing pages lacked `## Related pages` — fixed); P2 asymmetric backlinks ~120 (expected noise, one-way prose mentions are allowed — not acted on). Reasoning checks (8 topical clusters): 1 contradiction found and fixed (rpi-workflow ↔ harness-engineering dumb-zone threshold mis-attribution); 7 of 8 clusters clean. Post-write re-lint over all 45 pages: 0 P0, 0 orphans, 0 format violations; all 16 intended bidirectional pairs resolve both ways.
+
+**Lint findings deferred (not acted on — future work):**
+- *Citation-sparse pages (13):* agent-skills-standard, compliance-routing, context-rot, cursor-mcp, cursor-subagents, evaluating-agents-paper, multilingual-performance, persuasion-in-ai, skill-body-convention, validation-routing-claude/cursor/standalone, whitespace-and-formatting — no inline `(source:)` markers (page-level heuristic, low confidence; synthesized concept pages legitimately cite via `**Sources**:` frontmatter only). Verify or accept as-is per page.
+- *Concept-gap candidates for future ingest (no source doc yet — would be synthesis pages):* tool-calling/tool-use (recurs across 11 pages, only the schema-constrained slice is owned by structured-outputs), agent-evaluation/benchmarking (14 pages cite evals; no page owns the methodology — evaluating-agents-paper is one specific study), context-compaction (9 pages; only touched by context-engineering), permission/sandbox model (9+ pages; gating model described per-tool, never as one concept). Promotion candidates (well-homed today, split only if cluster grows): A2A (section of agent-protocols), constrained-decoding (section of structured-outputs).
+
+---
+
 ## 2026-05-21 — Update: subagent pages reflect current Claude Code facts
 
 **Pages updated (2):** `claude-code-subagents.md`, `subagents.md`

--- a/wiki/knowledge/monorepo-large-codebase-setup.md
+++ b/wiki/knowledge/monorepo-large-codebase-setup.md
@@ -1,0 +1,128 @@
+# Set up Claude Code in a monorepo or large codebase
+**Summary**: Scoping Claude Code to the part of a monorepo or large single-tree repo a task touches: start-directory semantics, worktree.sparsePaths/symlinkDirectories, additionalDirectories/--add-dir, Read deny rules, claudeMdExcludes, per-directory layering.
+**Sources**: monorepos-and-large-repos.md
+**Last updated**: 2026-06-04
+---
+
+A large codebase can be one repository with millions of lines or a monorepo with many packages. Claude Code works at any size, but as the codebase grows, defaults tuned for smaller projects can fill the context window with instructions and file reads unrelated to the task, costing tokens and degrading performance (source: monorepos-and-large-repos.md). The goal of every setting on this page is to scope Claude to the part of the tree a task actually touches. The same patterns apply to a monorepo (substitute `packages/api/`) or a large single tree (substitute a subsystem such as `src/backend/`) (source: monorepos-and-large-repos.md).
+
+Each setting is independent and they **layer rather than replace** each other, so apply whichever fit your repository (source: monorepos-and-large-repos.md). These ideas are applications of [[context-engineering]] and [[progressive-disclosure]]: keep only what the task needs in context, and load the rest on demand.
+
+## Choose where to start Claude
+
+Where you launch `claude` is the most consequential decision, because it determines which files Claude can read and edit without an extra grant, which CLAUDE.md files load at startup, and which project settings apply (source: monorepos-and-large-repos.md). Read this section first — it decides where your other settings files live.
+
+- **Start from the repository root**: Claude has file access to every file; only the root CLAUDE.md loads at launch, and each subdirectory's CLAUDE.md loads on demand when Claude reads a file there. Use this when tasks span multiple packages or subsystems (source: monorepos-and-large-repos.md).
+- **Start from a subdirectory**: file access is scoped to that subtree only until you grant more, and Claude loads **that directory's CLAUDE.md plus every ancestor's at launch**. Use this when work is scoped to one package or subsystem (source: monorepos-and-large-repos.md).
+
+The subdirectory case is the subtle one. Starting Claude *from* a subdirectory loads that directory's CLAUDE.md and every ancestor's at launch — the "subdirectory files load only on demand" rule holds only when you start from the root or an ancestor of that subdirectory (source: monorepos-and-large-repos.md). See [[claude-code-memory]] for how CLAUDE.md files load and interact in general.
+
+Project settings in `.claude/settings.json` load **only from your starting directory** and are not inherited from parent directories the way CLAUDE.md files are: a root `.claude/settings.json` applies only when you start from the root (source: monorepos-and-large-repos.md). Each subdirectory's settings file must therefore be self-contained rather than layered on a root file (source: monorepos-and-large-repos.md).
+
+## Layer CLAUDE.md files by directory
+
+A single root CLAUDE.md tends either to grow to cover every subsystem (costing context on unrelated instructions) or to stay too generic to be useful; splitting instructions across per-directory files means Claude loads repository-wide rules plus only the conventions for the code you are working in (source: monorepos-and-large-repos.md). A common split is two levels: a **root** `CLAUDE.md` for rules that apply everywhere (coding standards, commit conventions, repository layout) and a **per-subdirectory** `CLAUDE.md` for conventions specific to that area's stack — one per package in a monorepo, one per subsystem such as `src/db/` in a single tree (source: monorepos-and-large-repos.md). Commit these files so teammates inherit them; each directory's owner typically maintains its file (source: monorepos-and-large-repos.md).
+
+Keep the files current by reviewing CLAUDE.md edits in pull requests like any documentation change, by revisiting after major model releases (a rule that worked around an older model's limitation can become overhead once a newer model handles the case), and optionally by adding a `Stop` hook that proposes updates from the session transcript (source: monorepos-and-large-repos.md). See [[claude-code-hooks]] for the `Stop` hook, which receives the session-transcript path so a script can review the session and propose CLAUDE.md updates while the exposed gap is fresh (source: monorepos-and-large-repos.md).
+
+### Per-directory CLAUDE.md vs path-scoped rules
+
+Per-directory `CLAUDE.md` files and path-scoped rules under `.claude/rules/` both target instructions to part of the tree, but differ in where the file lives and when it loads (source: monorepos-and-large-repos.md). See [[agent-configuration-files]] for the broader file taxonomy.
+
+- **Per-directory `CLAUDE.md`** lives inside the directory alongside its code, loads at launch when started from that directory (or on demand when Claude reads a file there), and suits directory owners maintaining their own conventions versioned with the code (source: monorepos-and-large-repos.md).
+- **Path-scoped rule in `.claude/rules/`** lives in the central `.claude/` at the repo root and loads when Claude works with a file matching the rule's `paths:` glob; use it when you want all conventions in one place or the same rule applies to many scattered paths (source: monorepos-and-large-repos.md).
+
+### Exclude irrelevant CLAUDE.md files
+
+When you start from the repository root, each subdirectory's CLAUDE.md loads as soon as Claude reads a file there; the `claudeMdExcludes` setting skips specific files by path or glob so they never load (source: monorepos-and-large-repos.md). Use it for directories you never work in, such as other teams' packages, legacy code, or vendored subtrees. The exclusion list is **static, not a per-task switch** — to focus on a different package tomorrow, start Claude from that package's directory instead of editing exclusions (source: monorepos-and-large-repos.md).
+
+Patterns use glob syntax matched against **absolute file paths**, so start relative-style patterns with `**/` to match anywhere in the tree (source: monorepos-and-large-repos.md). Excluding a package skips every CLAUDE.md and rules file under it while the root CLAUDE.md and the packages you do work in still load normally (source: monorepos-and-large-repos.md). Managed-policy CLAUDE.md files **cannot** be excluded, so organization-wide instructions always apply, and `claudeMdExcludes` can be set at any settings scope (user, project, local, managed) with arrays merging across scopes (source: monorepos-and-large-repos.md). Put the setting in the gitignored `.claude/settings.local.json` if you only want the exclusions for yourself (source: monorepos-and-large-repos.md). See [[claude-code-memory]] for the full exclusion semantics.
+
+## Reduce what Claude reads
+
+Instructions are only part of context; file reads grow with the codebase too. Claude's content searches respect `.gitignore` by default, so paths already listed there (such as `node_modules/`, `dist/`, and `build/`) stay out of search results without extra configuration (source: monorepos-and-large-repos.md).
+
+### Block reads of generated and vendored code
+
+For paths that are checked in — a vendored SDK or committed generated code — add `Read` deny rules in `permissions.deny` to block Claude from opening those files even when a search lists them (source: monorepos-and-large-repos.md). Commit them to `.claude/settings.json` to apply for everyone, or use `.claude/settings.local.json` to keep them personal; like other project settings these files load only from the starting directory, so place them at the repository root if you start there or in each package's `.claude/` if you start from subdirectories (source: monorepos-and-large-repos.md). To enforce the same deny rules in every session regardless of starting directory, set them in managed settings, which user and project settings cannot override (source: monorepos-and-large-repos.md).
+
+Deny rules cover Claude's built-in file tools and recognized Bash file commands — including `cat`, `head`, `grep`, and `find` — when a denied path is passed as an argument. They do **not** filter denied paths out of a recursive search's output, and they do **not** cover arbitrary subprocesses that open files themselves (source: monorepos-and-large-repos.md).
+
+### Reduce file reads with code intelligence
+
+Finding where a symbol is defined or used can cost many file reads and grep calls; code-intelligence plugins connect Claude to a language server so it can jump to definitions, find references, and surface type errors directly instead of scanning the tree (source: monorepos-and-large-repos.md). The official marketplace has plugins for TypeScript, Python, Go, Rust, and other common languages — for example `/plugin install typescript-lsp@claude-plugins-official` (source: monorepos-and-large-repos.md). To enable a plugin for everyone rather than installing it yourself, add it to the `enabledPlugins` project setting (source: monorepos-and-large-repos.md). These plugins require the language's language-server binary on each developer's machine plus network access to GitHub for the official marketplace; on a restricted network, add the marketplace from an internal Git host or local path instead (source: monorepos-and-large-repos.md). This pairs well with `claudeMdExcludes` and the `Read` deny rules — those keep irrelevant content out of context while code intelligence keeps Claude from reading through what remains to locate a definition (source: monorepos-and-large-repos.md). See [[claude-code-plugins]] for plugin mechanics.
+
+## Scope worktrees and file access
+
+These settings control what is on disk in worktrees and which directories Claude can read and write beyond your starting point.
+
+### Check out only the directories you need
+
+The `--worktree` flag starts a session in a new git worktree so changes stay isolated from your main checkout; by default it checks out the entire repository, but the `worktree.sparsePaths` setting uses git sparse-checkout to write only the listed directories plus root-level files to disk, so worktrees start faster and use less space (source: monorepos-and-large-repos.md). Paths in `sparsePaths` are **relative to the repository root, regardless of which subdirectory you start Claude from** (source: monorepos-and-large-repos.md).
+
+List directories, not individual files. Root-level **files** like `package.json`, `tsconfig.base.json`, and lock files are always checked out alongside the directories you list, but root-level **directories** are not — include `.claude` explicitly if you want the repository root's `.claude/settings.json`, `.claude/rules/`, or `.claude/skills/` available inside the worktree (source: monorepos-and-large-repos.md). The lists merge across scopes, so a `.claude/settings.local.json` can add paths to a committed list but not remove them (source: monorepos-and-large-repos.md).
+
+This is particularly useful for [[claude-code-subagents]] worktree isolation: subagents are parallel Claude instances spawned for subtasks, and each one running in a worktree gets a lightweight checkout instead of the full tree. **All worktrees in a session share the same `sparsePaths`**, so if one subagent needs `packages/api/` and another needs `packages/web/`, list both (source: monorepos-and-large-repos.md).
+
+To avoid duplicating large directories like `node_modules` across worktrees, pair `sparsePaths` with `symlinkDirectories` in the same `.claude/settings.json`; this symlinks each worktree's `node_modules/` back to the main repository's copy rather than duplicating it on disk (source: monorepos-and-large-repos.md).
+
+`sparsePaths` and `symlinkDirectories` are read from your starting directory **before** the worktree is created. After creation, the session's working directory is the worktree root, not the subdirectory you launched from, so project settings inside the worktree load from the worktree root's `.claude/settings.json` (the checked-out copy of the repository root's file). Put any other settings you need inside worktrees — permission rules or hooks — in the repository root's `.claude/settings.json` (source: monorepos-and-large-repos.md).
+
+### Grant access across packages or repositories
+
+This applies when you start Claude from a subdirectory, or when a task spans multiple checkouts; if you start from the root in a single large tree, Claude already has every file and you can skip it (source: monorepos-and-large-repos.md). When you start from `packages/api/` but a task requires changes across packages — for example updating a shared type both `api` and `web` import — grant access to the sibling directory; the same mechanism reaches a separately-checked-out repository (source: monorepos-and-large-repos.md).
+
+The `additionalDirectories` setting in `.claude/settings.json` gives Claude access to directories outside the working directory, with relative paths resolving against the directory you start Claude from (source: monorepos-and-large-repos.md). You can also grant access at runtime without editing settings by passing `--add-dir` when you start Claude, e.g. `claude --add-dir ../shared` (source: monorepos-and-large-repos.md).
+
+However you add a directory, Claude can read and edit files in it — but whether the directory's CLAUDE.md, `.claude/rules/` files, and skills also load depends on how you added it (source: monorepos-and-large-repos.md):
+
+- The **`additionalDirectories` setting** grants file access only — it **never** loads CLAUDE.md, rules, or skills (source: monorepos-and-large-repos.md).
+- The **`--add-dir` flag or `/add-dir` command** always loads the directory's skills, and loads its CLAUDE.md and rules only when the `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` environment variable is set (source: monorepos-and-large-repos.md).
+
+That environment variable has **no effect** on directories listed in the `additionalDirectories` setting (source: monorepos-and-large-repos.md). Commit `additionalDirectories` to `.claude/settings.json` for sibling directories everyone needs; use `.claude/settings.local.json` or pass `--add-dir` for a personal or one-off selection (source: monorepos-and-large-repos.md).
+
+## Add per-directory skills
+
+Any subdirectory can define [[claude-code-skills]] scoped to its own stack, under `.claude/skills/` inside the directory; a skill loads on demand when Claude determines it is relevant, so API-specific tooling does not consume context during frontend work (source: monorepos-and-large-repos.md). Commit skills alongside that area's code so anyone who clones the repository gets them — one set per package in a monorepo, one per subsystem such as `src/db/.claude/skills/` in a single tree (source: monorepos-and-large-repos.md). You can also scope a skill by file pattern instead of by placement: the `paths` frontmatter field takes glob patterns, and Claude loads the skill automatically only when it works with matching files — useful for a skill in the repository root's `.claude/skills/` that applies only to certain files wherever they appear, such as a database-migration skill scoped to `**/migrations/**` (source: monorepos-and-large-repos.md).
+
+### Keep skills discoverable
+
+Which skills are in scope depends on where you start Claude (source: monorepos-and-large-repos.md):
+
+- **From a subdirectory** such as `packages/api/`: skills from that directory, every parent up to the repository root, and the user and enterprise levels (source: monorepos-and-large-repos.md).
+- **From the repository root**: skills from every subdirectory Claude touches during the session, which can accumulate into the hundreds (source: monorepos-and-large-repos.md).
+- **After adding a sibling with `--add-dir`**: that sibling's skills load too; the `additionalDirectories` setting grants file access only and does not load skills (source: monorepos-and-large-repos.md).
+
+Claude picks a skill by reading every discovered skill's name and description, and only the chosen skill's full content loads. Names always load, but **descriptions are shortened when there are many**, which can strip the keywords Claude uses to decide whether a skill applies — so keep descriptions short and lead with words a request would contain, like "writing or modifying tests in `packages/api/`" (source: monorepos-and-large-repos.md). Place skills many directories share (PR conventions, a deploy checklist) in the repository root's `.claude/skills/` so they load from any starting directory; when shared skills need their own version history or must work across repositories, package them as a plugin instead, where plugin skills use a `plugin-name:skill-name` namespace so they never collide with per-directory skills (source: monorepos-and-large-repos.md). To find unused skills, enable the OpenTelemetry logs exporter with `OTEL_LOG_TOOL_DETAILS=1` so skill names are recorded verbatim; the `skill_activated` event records every invocation and `invocation_trigger` records whether a command, Claude, or a nested skill invoked it, telling you what to consolidate or retire (source: monorepos-and-large-repos.md).
+
+## Centralize conventions when layering stops scaling
+
+Per-directory CLAUDE.md files become hard to govern as the codebase grows: conventions drift, files go stale, and no one owns the root — solving that typically falls to the team that maintains the repository's Claude Code setup rather than to each developer (source: monorepos-and-large-repos.md). Move conventions and reference content out of always-loaded CLAUDE.md and into mechanisms that load on demand — a direct application of [[context-engineering]] (source: monorepos-and-large-repos.md):
+
+- **Skills**: reference material Claude loads only when relevant to the task (source: monorepos-and-large-repos.md).
+- **Plugins**: versioned bundles of skills, hooks, and commands that a platform team owns centrally — see [[claude-code-plugins]] (source: monorepos-and-large-repos.md).
+- **MCP servers**: if your organization already runs a code search or RAG index over the repository, expose it as an MCP tool so Claude queries it instead of reading files directly (source: monorepos-and-large-repos.md).
+
+Once conventions live in plugins, a teammate starting Claude in an unfamiliar part of the tree has no signal about which plugin that area's owners maintain. A `SessionStart` hook can close that gap, since anything the hook prints to stdout is added to Claude's context before the first prompt — a script can read the launch directory from the hook input, look it up in a path-to-plugin map committed to the repository, and print the recommendation for Claude to relay (source: monorepos-and-large-repos.md). See [[claude-code-hooks]] for `SessionStart`.
+
+## Put it together
+
+Each subdirectory's `.claude/settings.json` must be self-contained, because project settings load only from the directory you start Claude in (source: monorepos-and-large-repos.md). A committed `packages/api/.claude/settings.json` can carry `worktree.sparsePaths` + `symlinkDirectories`, `permissions.additionalDirectories`, and `Read` deny rules so every developer in `packages/api/` gets the same sibling access, sparse paths, and exclusions (source: monorepos-and-large-repos.md).
+
+Because that session starts from `packages/api/`, sibling packages' CLAUDE.md files are already out of scope, so `claudeMdExcludes` is not needed there — add it to the repository root's `.claude/settings.local.json` only if you also start sessions from the root (source: monorepos-and-large-repos.md). Inside a worktree created from this session the working directory is the worktree root, so the `packages/api/` settings file does not load; the sibling packages are still reachable, but the deny rules need a second copy in the repository root's `.claude/settings.json` so worktree sessions pick them up (source: monorepos-and-large-repos.md).
+
+With this setup, starting Claude from `packages/api/` loads the root CLAUDE.md and `packages/api/CLAUDE.md` (skipping `packages/web/CLAUDE.md`), can read and edit files in `packages/api/` and `packages/shared/`, skips reads of build output under `dist/` and `build/`, has the api-testing skill available on demand, and creates worktrees containing `.claude/`, `packages/api/`, `packages/shared/`, and root-level files with the deny rules applied from the root settings file (source: monorepos-and-large-repos.md).
+
+## Scope and plan changes that span packages
+
+The configuration above controls what Claude sees; when a single change touches several packages, how you scope and sequence the task also affects the result (source: monorepos-and-large-repos.md). Two techniques help keep a cross-package change consistent: hand Claude the whole change in one session — the shared edit and its call sites together — so decisions stay consistent rather than re-derived per package; and save the plan to a markdown file in the repository before editing, because a long cross-package session compacts its context along the way and the saved plan survives where conversation history may not (source: monorepos-and-large-repos.md). Saving the plan to a durable file is the structured note-taking pattern from [[context-engineering]].
+
+## Related pages
+- [[claude-code-memory]]
+- [[claude-code-skills]]
+- [[claude-code-plugins]]
+- [[claude-code-hooks]]
+- [[claude-code-subagents]]
+- [[context-engineering]]
+- [[progressive-disclosure]]
+- [[agent-configuration-files]]

--- a/wiki/knowledge/rpi-workflow.md
+++ b/wiki/knowledge/rpi-workflow.md
@@ -104,7 +104,7 @@ Without phase structure, a single long session accumulates noise:
 3. Verbose test output and build logs
 4. The entire context window fills past 40% utilization
 
-Past that threshold, model reasoning degrades — what the [[harness-engineering]] literature calls the "dumb zone." Fresh context windows per phase are the structural prevention mechanism. (source: agentic-software-modernization-markus-harrer.md)
+Past that threshold, model reasoning starts to degrade toward what the [[harness-engineering]] literature calls the "dumb zone" — though that source pins the sharp-degradation threshold higher, at >60% utilization; the ~40% figure here comes from agentic-software-modernization-markus-harrer.md. Fresh context windows per phase are the structural prevention mechanism. (source: agentic-software-modernization-markus-harrer.md, harness-engineering.md)
 
 ## Written Artifacts as Shared Truth
 

--- a/wiki/knowledge/skill-authoring.md
+++ b/wiki/knowledge/skill-authoring.md
@@ -1,8 +1,8 @@
 # Skill Authoring
 
 **Summary**: Evidence-based practices for creating effective agent skills — covering the "start from real expertise" principle, context budgeting, progressive disclosure structure, eval-driven iteration, description optimization for trigger accuracy, and script bundling conventions.
-**Sources**: skill-authoring-best-practices.md, agentskills-best-practices.md, agentskills-evaluating-skills.md, agentskills-optimizing-descriptions.md, agentskills-using-scripts.md
-**Last updated**: 2026-04-18
+**Sources**: skill-authoring-best-practices.md, agentskills-best-practices.md, agentskills-evaluating-skills.md, agentskills-optimizing-descriptions.md, agentskills-using-scripts.md, monorepos-and-large-repos.md
+**Last updated**: 2026-06-04
 
 ---
 
@@ -191,10 +191,15 @@ The `name` + `description` fields cost ~**100 tokens** and load at startup for *
 
 Target **~50 tokens** for description — enough for precise triggering, low enough to scale across many skills.
 
+## Large-Repo Skill Hygiene
+
+When a repo accumulates many skills — e.g. a monorepo where every touched subdirectory's `.claude/skills/` accumulate "into the hundreds" — descriptions get shortened, so lead each description with the request keywords that should trigger it (source: monorepos-and-large-repos.md). Retire dead skills: use OTEL `skill_activated` telemetry and inspect the `invocation_trigger` field to find skills that are never activated and remove them (source: monorepos-and-large-repos.md). See [[monorepo-large-codebase-setup]] for per-directory skill placement and scoping by start directory.
+
 ## Related pages
 
 - [[agent-skills-standard]]
 - [[claude-code-skills]]
 - [[cursor-skills]]
+- [[monorepo-large-codebase-setup]]
 - [[persuasion-in-ai]]
 - [[progressive-disclosure]]

--- a/wiki/knowledge/subagents.md
+++ b/wiki/knowledge/subagents.md
@@ -1,8 +1,8 @@
 # Subagents
 
 **Summary**: Specialized assistants running in isolated context windows with custom system prompts and restricted tool sets — the primary mechanism for keeping main agent context clean while enabling complex parallel work across both Claude Code and Cursor platforms.
-**Sources**: creating-custom-subagents.md, subagents-guide.md, research-subagent-best-practices.md, analysis-creating-custom-subagents.md, analysis-research-subagent-best-practices.md, research-plan-implement-rpi.md, skill-issue-harness-engineering-for-coding-agents.md
-**Last updated**: 2026-05-21
+**Sources**: creating-custom-subagents.md, subagents-guide.md, research-subagent-best-practices.md, analysis-creating-custom-subagents.md, analysis-research-subagent-best-practices.md, research-plan-implement-rpi.md, skill-issue-harness-engineering-for-coding-agents.md, dynamic-workflows.md, agent-teams.md
+**Last updated**: 2026-06-04
 
 ---
 
@@ -113,6 +113,10 @@ Two concrete applications (source: skill-issue-harness-engineering-for-coding-ag
 
 The mistake is treating subagents as role-based workers ("the researcher", "the planner") when their real value is as **context windows you can throw away**. See [[harness-engineering]] for how this integrates with the full harness model.
 
+**Workflows are an orchestration layer above subagents.** Dynamic workflows are a new orchestration layer that sits *above* subagents: the workflow script spawns and coordinates many subagents (up to 16 concurrent, 1,000 total per run) and holds their intermediate results in script variables, while subagents remain the worker primitive (source: dynamic-workflows.md). This reinforces the context-firewall framing — the orchestration loop and intermediate results stay off the main context. See [[claude-code-workflows]].
+
+**Compared with agent teammates.** Subagents and agent teammates differ on one axis: communication. A subagent runs in an isolated context window and reports its result only back to the caller, never to other subagents; an agent teammate is a fully independent Claude Code session that messages other teammates directly and self-coordinates through a shared task list (source: agent-teams.md). The subagent isolation is the context firewall; teammates trade that firewall for peer-to-peer coordination. See [[claude-code-agent-teams]].
+
 ## Related pages
 
 - [[claude-code-subagents]]
@@ -123,3 +127,5 @@ The mistake is treating subagents as role-based workers ("the researcher", "the 
 - [[harness-engineering]]
 - [[rpi-workflow]]
 - [[context-engineering]]
+- [[claude-code-workflows]]
+- [[claude-code-agent-teams]]

--- a/wiki/knowledge/validation-routing-claude.md
+++ b/wiki/knowledge/validation-routing-claude.md
@@ -97,3 +97,9 @@ Read these in order when validating a Claude Code plugin artifact:
 - Loading `docs/cursor/` to check `.mdc` activation modes when auditing a Claude skill that mentions rules — Claude rules use `paths:`, not `globs:`
 - Using Cursor agent constraints (model: inherit, readonly: true) when auditing Claude agent definitions
 - Treating general-llm research (Tier 4) as sole authority instead of corroboration
+
+## Related pages
+
+- [[compliance-routing]]
+- [[validation-routing-cursor]]
+- [[validation-routing-standalone]]

--- a/wiki/knowledge/validation-routing-cursor.md
+++ b/wiki/knowledge/validation-routing-cursor.md
@@ -100,3 +100,9 @@ Read these in order when validating a Cursor IDE plugin artifact:
 - Using Claude agent constraints (`model: sonnet`, `tools:`) when auditing Cursor agent definitions
 - Loading Claude-only `.claude/rules/` files (e.g., `claude-memory.md`, `plugin-skills.md`) when validating Cursor artifacts — use Cursor-specific project rules bundled for this scope (`cursor-plugin-skills.md`, `cursor-agent-files.md`) instead, but do not apply Claude-only conventions
 - Checking `.mdc` files for `paths:` instead of `globs:` — `paths:` is a Claude leak and a contamination finding
+
+## Related pages
+
+- [[compliance-routing]]
+- [[validation-routing-claude]]
+- [[validation-routing-standalone]]

--- a/wiki/knowledge/validation-routing-standalone.md
+++ b/wiki/knowledge/validation-routing-standalone.md
@@ -127,3 +127,9 @@ Read these in order when validating a standalone skill artifact:
 - Accepting "delegate to codebase-analyzer" as valid for standalone (it is valid ONLY in Claude plugin skills)
 - Using Claude hook or subagent docs as supporting authority for standalone artifacts
 - Checking that `.claude/rules/` are referenced by standalone skill **prose or by neutral-skill templates** — they should NOT be there. (Templates of platform-targeted skills like `init-claude`/`improve-claude` MAY reference `.claude/rules/` per ADR-0005.)
+
+## Related pages
+
+- [[compliance-routing]]
+- [[validation-routing-claude]]
+- [[validation-routing-cursor]]


### PR DESCRIPTION
## What

Compiles the five new `docs/claude-code/` vendor mirrors into the `wiki/knowledge/` knowledge base (Karpathy LLM-knowledge-base method) and reconciles the lint findings surfaced in the same pass. **41 → 45 pages.**

Run via two-workflow orchestration: deterministic mechanical lint (full-corpus graph properties) → read-only analysis workflow (contradiction-by-cluster + concept-gap + per-doc ingest proposals) → consolidated approval → one-writer-per-file write workflow → integrity gate.

## New pages (4)

| Page | Source |
|---|---|
| `claude-code-agent-teams` | `agent-teams.md` |
| `claude-code-workflows` | `dynamic-workflows.md` |
| `claude-code-worktrees` | `parallel-sessions-worktrees.md` |
| `monorepo-large-codebase-setup` | `monorepos-and-large-repos.md` |

`goals.md` ingested as extends only (it is a session-scoped Stop-hook wrapper — no dedicated page). Existing pages extended with cross-links and key claims: `subagents`, `agent-workflows`, `claude-code-{subagents,hooks,memory,skills,plugins}`, `skill-authoring`, `agent-configuration-files`, `context-engineering`.

## Stale-fact corrections (the fresher dedicated docs corrected earlier compiled facts)

- **`claude-code-subagents`** — Agent Teams section demoted to a stub pointing at the new canonical page; corrected `broadcast` → point-to-point messaging, and `two team hooks` → three (adds `TaskCreated`).
- **`claude-code-memory`** — subdirectory `CLAUDE.md` load claim corrected for the start-from-subdirectory case; added `claudeMdExcludes`.

## Lint findings reconciled

- Orphan `pi-context-zone` resolved (backlinks from `context-engineering` + `harness-engineering`).
- `rpi-workflow` ↔ `harness-engineering` dumb-zone threshold mis-attribution fixed (~40% from markus-harrer vs >60% from harness-engineering, now attributed separately).
- Added `## Related pages` to the four Compliance & Validation routing pages.

Deferred findings (citation-sparse pages; concept-gap candidates: tool-calling, agent-evaluation, context-compaction, permission/sandbox model) recorded in `wiki/knowledge/log.md` for future ingest.

## Verification

- Corpus re-run: **0 dangling links, 0 dead index entries, 0 orphans, 0 format violations**; index 45/45.
- **All 16 intended bidirectional link pairs resolve both ways.**
- Changed-set audited against the per-file ownership map: no scope creep.

## Notes

- Two `chore: update gitignore` commits on this branch are IDE/environment housekeeping (`.idea/.gitignore`, plus `sandcastle-ref`/`.orchestrate` ignore entries) committed concurrently — included as-is.
