### PR TITLE
orchestrate: loud-on-empty warning when bootstrap writes an empty commands.json

### DIFF
--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -24181,6 +24181,9 @@ var bootstrapConfigOutputSchema = external_exports.object({
   ),
   errorMessage: external_exports.string().optional().describe(
     "Cleaned, human-readable failure description. Present when status='error'."
+  ),
+  warnings: external_exports.array(external_exports.string()).optional().describe(
+    "Advisory warnings about the bootstrapped configuration. Non-empty only when status='ok' and the freshly-written commands.json is empty ({}) \u2014 meaning no recognized project type was detected and the capability gates (run_tests, run_build, etc.) will report 'not-configured', allowing a slice to merge green with no verification. Empty array when the written commands map is non-empty. Present when status='ok'."
   )
 });
 function firstLine7(message) {
@@ -24372,6 +24375,10 @@ function bootstrapConfig(input) {
       errorMessage: `Failed to update .gitignore: ${gitignoreResult.message}`
     };
   }
+  const commandsMapEmpty = Object.keys(validatedCommands.data).length === 0;
+  const warnings = commandsResult.kind === "written" && commandsMapEmpty ? [
+    "commands.json was written empty ({}): no recognized project type detected. The capability gates run_tests and run_build will report 'not-configured' \u2014 a slice can merge green with no verification. Edit .orchestrate/commands.json to add your project's test and build commands."
+  ] : [];
   return {
     status: "ok",
     projectType,
@@ -24383,7 +24390,8 @@ function bootstrapConfig(input) {
       handoffJson: handoffResult.kind
     },
     runsDir: runsDirExisted ? "already-present" : "created",
-    gitignore: gitignoreResult.kind
+    gitignore: gitignoreResult.kind,
+    warnings
   };
 }
 
@@ -26026,6 +26034,9 @@ var handleBootstrapConfig = async (input) => {
     ].filter((n) => n !== null);
     const filesNote = written.length > 0 ? `wrote ${written.join(", ")}` : "all config files already present";
     text = `Bootstrapped .orchestrate/ config for a ${result.projectType} project (${filesNote}; context window ${result.contextWindowTokens} tokens, source: ${result.contextWindowSource}; runs dir ${result.runsDir}; .gitignore ${result.gitignore}).`;
+    if (result.warnings && result.warnings.length > 0) {
+      text += ` WARNING: ${result.warnings.join(" ")}`;
+    }
   } else {
     text = `Bootstrap failed [${result.errorCode}]: ${result.errorMessage}`;
   }

--- a/plugins/orchestrate/orchestrate-mcp/src/index.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/index.ts
@@ -934,6 +934,9 @@ const handleBootstrapConfig: ToolHandler<
       `(${filesNote}; context window ${result.contextWindowTokens} tokens, ` +
       `source: ${result.contextWindowSource}; runs dir ${result.runsDir}; ` +
       `.gitignore ${result.gitignore}).`;
+    if (result.warnings && result.warnings.length > 0) {
+      text += ` WARNING: ${result.warnings.join(" ")}`;
+    }
   } else {
     text = `Bootstrap failed [${result.errorCode}]: ${result.errorMessage}`;
   }

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
@@ -190,6 +190,17 @@ export const bootstrapConfigOutputSchema = z.object({
     .describe(
       "Cleaned, human-readable failure description. Present when status='error'."
     ),
+  warnings: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Advisory warnings about the bootstrapped configuration. Non-empty only " +
+        "when status='ok' and the freshly-written commands.json is empty ({}) — " +
+        "meaning no recognized project type was detected and the capability gates " +
+        "(run_tests, run_build, etc.) will report 'not-configured', allowing a " +
+        "slice to merge green with no verification. Empty array when the written " +
+        "commands map is non-empty. Present when status='ok'."
+    ),
 });
 
 // ─── TS types — derived from the schemas (single source of truth) ─────────────
@@ -503,6 +514,23 @@ export function bootstrapConfig(
     };
   }
 
+  // Emit a loud warning when the bootstrapper just wrote an empty commands.json
+  // ({}). This happens for unrecognized project types ('none') where no manifest
+  // is detected. An empty map means all capability gates (run_tests, run_build,
+  // etc.) will report 'not-configured' — a slice can merge green with no
+  // verification, which is a common source of false-green merges.
+  const commandsMapEmpty =
+    Object.keys(validatedCommands.data).length === 0;
+  const warnings: string[] =
+    commandsResult.kind === "written" && commandsMapEmpty
+      ? [
+          "commands.json was written empty ({}): no recognized project type detected. " +
+            "The capability gates run_tests and run_build will report 'not-configured' — " +
+            "a slice can merge green with no verification. " +
+            "Edit .orchestrate/commands.json to add your project's test and build commands.",
+        ]
+      : [];
+
   return {
     status: "ok",
     projectType,
@@ -515,5 +543,6 @@ export function bootstrapConfig(
     },
     runsDir: runsDirExisted ? "already-present" : "created",
     gitignore: gitignoreResult.kind,
+    warnings,
   };
 }

--- a/plugins/orchestrate/orchestrate-mcp/test/bootstrap-config.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/bootstrap-config.test.ts
@@ -175,6 +175,46 @@ describe("bootstrapConfig — commands.json per project type", () => {
   });
 });
 
+// ─── Empty-config warning ─────────────────────────────────────────────────────
+
+describe("bootstrapConfig — empty-config warnings", () => {
+  it("warns when the freshly-written commands.json is empty (no manifest detected)", () => {
+    const dir = repo(); // no manifest → 'none' project type → empty commands map
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.status).toBe("ok");
+    expect(r.warnings).toBeDefined();
+    expect(r.warnings!.length).toBeGreaterThan(0);
+    // The warning must name the no-op gates
+    expect(r.warnings![0]).toContain("run_tests");
+    expect(r.warnings![0]).toContain("run_build");
+    // Must name the consequence (false-green merge risk)
+    expect(r.warnings![0]).toContain("not-configured");
+  });
+
+  it("emits no warnings when commands.json is written non-empty (recognized project type)", () => {
+    const dir = repo("package.json"); // npm project → non-empty commands map
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.status).toBe("ok");
+    expect(r.warnings).toBeDefined();
+    expect(r.warnings).toEqual([]);
+  });
+
+  it("emits no warnings when commands.json already existed (not freshly written)", () => {
+    // Pre-write an empty commands.json — the bootstrapper skips writing it.
+    const dir = repo(); // no manifest → 'none' project type
+    fs.mkdirSync(path.join(dir, ".orchestrate"));
+    fs.writeFileSync(path.join(dir, ".orchestrate", "commands.json"), "{}\n");
+
+    const r = bootstrapConfig({ repoPath: dir });
+
+    // File was already-present, not freshly written → no warning.
+    expect(r.files!.commandsJson).toBe("already-present");
+    expect(r.warnings).toEqual([]);
+  });
+});
+
 // ─── Model-derived context window ─────────────────────────────────────────────
 
 describe("bootstrapConfig — model-derived context window", () => {

--- a/plugins/orchestrate/skills/orchestrate/references/prerequisites.md
+++ b/plugins/orchestrate/skills/orchestrate/references/prerequisites.md
@@ -14,7 +14,13 @@ The target project's `.orchestrate/` configuration — `commands.json`,
 first run** by the `bootstrap_config` MCP tool (section 1, Fresh run, step 1),
 or committed ahead of time from the plugin's `templates/`. Without
 `commands.json` the capability tools return `not-configured`, which is
-tolerated. When the project's capability commands need installed dependencies,
+tolerated. **When the bootstrapper writes an empty `commands.json` (`{}`)** —
+because no recognized project type was detected — it emits a `warnings[]` field
+in its result and surfaces the warning in its human-readable output. This means
+`run_tests` and `run_build` will report `not-configured`, and a slice can merge
+green with no verification. If you see this warning, edit
+`.orchestrate/commands.json` to add your project's test and build commands
+before starting the run. When the project's capability commands need installed dependencies,
 `commands.json` must also set an `install` command — `create_worktree` runs it
 in every fresh worktree, which checks out only tracked files and so has no
 dependency directory of its own, and the implementer/conflict-resolver


### PR DESCRIPTION
Implements #291.

Adds a structured `warnings: string[]` field to the `bootstrap_config` result, populated **iff** the written `commands.json` is empty (`{}`). Surfaced in the `index.ts` human-readable output and documented in `references/prerequisites.md`, so the operator learns the per-slice capability gates (`run_tests`/`run_build`) will silently no-op before a false-green merge. Warning, not error — bootstrap still returns `status: "ok"`. Adds 3 unit tests (empty→warns / non-empty→silent / already-present→silent) and rebuilds `dist/`.

Slice 1 of 3 under #287.