### PR TITLE
orchestrate: detect Maven and Gradle projects and bootstrap their capability command maps

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -170,7 +170,7 @@ The exported function in `backlog-partitioner.ts` that narrows the full backlog 
 _Avoid_: backlog filter, PRD filter (too generic)
 
 **Capability detector** (`detect-project` module):
-A pure module in `orchestrate-mcp/src/tools/detect-project.ts` that inspects a repository root's top-level manifest files and returns the **Capability command map** for the detected project type. Input: a repository root path. Output: a command map or empty object. No side effects. Detection precedence: npm (`package.json`) > Cargo (`Cargo.toml`) > Python (`pyproject.toml`) > Make (`Makefile`) > none. A repository with no recognized manifest yields an empty map — never a fallback npm map.
+A pure module in `orchestrate-mcp/src/tools/detect-project.ts` that inspects a repository root's top-level manifest files and returns the **Capability command map** for the detected project type. Input: a repository root path. Output: a command map or empty object. No side effects. Detection precedence: npm (`package.json`) > Cargo (`Cargo.toml`) > Python (`pyproject.toml`) > Maven (`pom.xml`) > Gradle (`build.gradle` / `build.gradle.kts`) > Make (`Makefile`) > none. A repository with no recognized manifest yields an empty map — never a fallback npm map.
 _Avoid_: project sniffer, auto-configurator, manifest scanner
 
 **Capability command map**:

--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -81,6 +81,8 @@ The `detect-project` module (`orchestrate-mcp/src/tools/detect-project.ts`) auto
 | `package.json` | npm | `npm test`, `npm run typecheck`, `npm run build`, `npm run lint` |
 | `Cargo.toml` | Cargo | `cargo test`, `cargo check`, `cargo build`, `cargo clippy` |
 | `pyproject.toml` | Python | `pytest`, `mypy .`, `python -m build`, `ruff check .` |
+| `pom.xml` | Maven | `mvn -B test`, `mvn -B -DskipTests compile`, `mvn -B -DskipTests package` |
+| `build.gradle` / `build.gradle.kts` | Gradle | `./gradlew test`, `./gradlew classes`, `./gradlew assemble` |
 | `Makefile` | Make | `make test`, `make typecheck`, `make build`, `make lint` |
 | _(none found)_ | none | empty map — no capability tool is wired to a failing command |
 
@@ -107,7 +109,7 @@ A manifest-less repository yields `{}` — never an npm fallback — so no capab
 
 The `bootstrap_config` MCP tool makes a first-ever run set up its own `.orchestrate/` configuration with no manual steps. On a fresh run — when the repository has no `.orchestrate/` directory — the orchestrator calls it before planning the backlog. It:
 
-- Composes the **capability detector** above and writes a project-appropriate `.orchestrate/commands.json`. The shipped `templates/commands.json` is an empty `{}` safe default — the bootstrapper is the canonical source of a project-aware config. For an npm project it also sets `install: ["npm", "ci"]`; for cargo, Python, Make, or an unrecognized project it omits `install` (a wrong install command is worse than none).
+- Composes the **capability detector** above and writes a project-appropriate `.orchestrate/commands.json`. The shipped `templates/commands.json` is an empty `{}` safe default — the bootstrapper is the canonical source of a project-aware config. For an npm project it also sets `install: ["npm", "install"]`; for cargo, Python, Maven, Gradle, Make, or an unrecognized project it omits `install` (a wrong install command is worse than none).
 - Writes `.orchestrate/handoff.json` with a context-window size **derived from the running model**, not a static 200k constant. The model id (or an explicit token count) is passed as a tool input — the MCP process cannot see the calling LLM's model. A small explicit table maps the model to its window; an unknown or absent model falls back to `200000`.
 - Writes `.orchestrate/routing.json` from the shipped defaults.
 - Creates `.orchestrate/runs/` and idempotently appends `.orchestrate/runs/` to the repository's `.gitignore` — exactly once, even across repeated bootstraps.
@@ -244,11 +246,11 @@ Maps each capability verb to the **argv array** that runs it. The argv form is e
   "typecheck": ["npm", "run", "typecheck"],
   "build": ["npm", "run", "build"],
   "lint": ["npm", "run", "lint"],
-  "install": ["npm", "ci"]
+  "install": ["npm", "install"]
 }
 ```
 
-The optional `install` verb runs once in each fresh worktree before the capability commands. `bootstrap_config` sets it to `["npm", "ci"]` for an npm project and omits it for every other project type — a wrong install command is worse than none.
+The optional `install` verb runs once in each fresh worktree before the capability commands. `bootstrap_config` sets it to `["npm", "install"]` for an npm project and omits it for every other project type — a wrong install command is worse than none.
 
 ### `.orchestrate/routing.json`
 

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -24034,6 +24034,9 @@ var DETECTION_RULES = [
   { manifest: "package.json", type: "npm" },
   { manifest: "Cargo.toml", type: "cargo" },
   { manifest: "pyproject.toml", type: "python" },
+  { manifest: "pom.xml", type: "maven" },
+  { manifest: "build.gradle", type: "gradle" },
+  { manifest: "build.gradle.kts", type: "gradle" },
   { manifest: "Makefile", type: "make" }
 ];
 var COMMAND_MAPS = {
@@ -24050,6 +24053,18 @@ var COMMAND_MAPS = {
     build: ["python", "-m", "build"],
     lint: ["ruff", "check", "."],
     install: ["pip", "install", "-e", "."]
+  },
+  maven: {
+    tests: ["mvn", "-B", "test"],
+    typecheck: ["mvn", "-B", "-DskipTests", "compile"],
+    build: ["mvn", "-B", "-DskipTests", "package"]
+    // install and lint intentionally absent — see doc comment above
+  },
+  gradle: {
+    tests: ["./gradlew", "test"],
+    typecheck: ["./gradlew", "classes"],
+    build: ["./gradlew", "assemble"]
+    // install and lint intentionally absent — see doc comment above
   },
   make: {
     tests: ["make", "test"],
@@ -24154,7 +24169,7 @@ var bootstrapConfigOutputSchema = external_exports.object({
   status: external_exports.enum(["ok", "error"]).describe(
     "Outcome discriminant. 'ok' = the bootstrap completed (every file either written or already present); 'error' = a filesystem write failed and the configuration is incomplete."
   ),
-  projectType: external_exports.enum(["npm", "cargo", "python", "make", "none"]).optional().describe(
+  projectType: external_exports.enum(["npm", "cargo", "python", "maven", "gradle", "make", "none"]).optional().describe(
     "The detected project type. 'none' means no recognized manifest \u2014 commands.json is written empty. Present when status='ok'."
   ),
   contextWindowTokens: external_exports.number().optional().describe(

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
@@ -127,7 +127,7 @@ export const bootstrapConfigOutputSchema = z.object({
         "failed and the configuration is incomplete."
     ),
   projectType: z
-    .enum(["npm", "cargo", "python", "make", "none"])
+    .enum(["npm", "cargo", "python", "maven", "gradle", "make", "none"])
     .optional()
     .describe(
       "The detected project type. 'none' means no recognized manifest — " +

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/detect-project.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/detect-project.ts
@@ -6,12 +6,24 @@ import * as fs from "fs";
  * A recognized project type, or 'none' when no manifest is detected.
  *
  * Detection precedence (manifest-first, then Make):
- *   npm (package.json) > cargo (Cargo.toml) > python (pyproject.toml) > make (Makefile) > none
+ *   npm (package.json) > cargo (Cargo.toml) > python (pyproject.toml) >
+ *   maven (pom.xml) > gradle (build.gradle / build.gradle.kts) > make (Makefile) > none
  *
  * Python detection uses `pyproject.toml` only (the modern standard as of PEP 517/518).
  * `setup.py` is legacy and intentionally excluded.
+ *
+ * Maven/Gradle: both omit `install` and `lint` by design — JVM build tools resolve
+ * dependencies on demand; an `install` verb would fail in the pom-less worktree of a
+ * skeleton-creating first slice; neither ecosystem has a canonical linter.
  */
-export type ProjectType = "npm" | "cargo" | "python" | "make" | "none";
+export type ProjectType =
+  | "npm"
+  | "cargo"
+  | "python"
+  | "maven"
+  | "gradle"
+  | "make"
+  | "none";
 
 /**
  * A capability command map — the four fixed capability verbs the orchestrate
@@ -80,12 +92,20 @@ export function detectJsPackageManager(
  * Ordered detection rules. The first match wins — earlier entries have higher
  * priority. `Makefile` is last because it often wraps another toolchain;
  * language-specific manifests take precedence over a thin Make wrapper.
+ *
+ * JVM manifests (`pom.xml`, `build.gradle`, `build.gradle.kts`) rank after
+ * Python and before Makefile — language manifests take precedence over a Make
+ * wrapper. Two gradle entries cover both the Groovy (`.gradle`) and Kotlin
+ * (`.gradle.kts`) DSL variants.
  */
 const DETECTION_RULES: ReadonlyArray<{ manifest: string; type: ProjectType }> =
   [
     { manifest: "package.json", type: "npm" },
     { manifest: "Cargo.toml", type: "cargo" },
     { manifest: "pyproject.toml", type: "python" },
+    { manifest: "pom.xml", type: "maven" },
+    { manifest: "build.gradle", type: "gradle" },
+    { manifest: "build.gradle.kts", type: "gradle" },
     { manifest: "Makefile", type: "make" },
   ];
 
@@ -100,7 +120,11 @@ const DETECTION_RULES: ReadonlyArray<{ manifest: string; type: ProjectType }> =
  *
  * The map type is `CapabilityCommandMap` (install OPTIONAL) — `cargo` and
  * `python` carry an `install` (the mutating dependency-resolve step), but
- * `make` omits it: the ledger specifies no install verb for a thin Make wrapper.
+ * `make`, `maven`, and `gradle` omit it:
+ *   - `make`: the ledger specifies no install verb for a thin Make wrapper.
+ *   - `maven`/`gradle`: JVM tools resolve dependencies on demand; an `install`
+ *     verb would fail in the pom-less worktree of a skeleton-creating first
+ *     slice. Neither ecosystem has a canonical linter, so `lint` is also absent.
  *
  * Python commands assume the standard modern toolchain:
  *   - `pytest`   for tests (de-facto standard)
@@ -108,6 +132,11 @@ const DETECTION_RULES: ReadonlyArray<{ manifest: string; type: ProjectType }> =
  *   - `python -m build` for building
  *   - `ruff check .` for linting (modern replacement for flake8)
  *   - `pip install -e .` for install (editable install of the local package)
+ *
+ * Maven commands use `-B` (batch/non-interactive) for CI compatibility.
+ * Gradle commands use the wrapper (`./gradlew`) so the project-local version is
+ * used; `assemble` avoids re-running the test suite; `classes` compiles the
+ * whole main source set (covers Kotlin `.kts` repos, unlike `compileJava`).
  */
 const COMMAND_MAPS: Record<
   Exclude<ProjectType, "none" | "npm">,
@@ -126,6 +155,18 @@ const COMMAND_MAPS: Record<
     build: ["python", "-m", "build"],
     lint: ["ruff", "check", "."],
     install: ["pip", "install", "-e", "."],
+  },
+  maven: {
+    tests: ["mvn", "-B", "test"],
+    typecheck: ["mvn", "-B", "-DskipTests", "compile"],
+    build: ["mvn", "-B", "-DskipTests", "package"],
+    // install and lint intentionally absent — see doc comment above
+  },
+  gradle: {
+    tests: ["./gradlew", "test"],
+    typecheck: ["./gradlew", "classes"],
+    build: ["./gradlew", "assemble"],
+    // install and lint intentionally absent — see doc comment above
   },
   make: {
     tests: ["make", "test"],
@@ -167,8 +208,8 @@ export function buildJsCommandMap(
  * repository root. Pure — no I/O; the caller supplies the manifest list.
  *
  * Returns the first match from {@link DETECTION_RULES}, applying
- * manifest-first priority (npm > cargo > python > make). Returns 'none' when
- * no recognized manifest is present.
+ * manifest-first priority (npm > cargo > python > maven > gradle > make).
+ * Returns 'none' when no recognized manifest is present.
  */
 export function detectProjectType(manifestsPresent: string[]): ProjectType {
   const present = new Set(manifestsPresent);
@@ -184,10 +225,11 @@ export function detectProjectType(manifestsPresent: string[]): ProjectType {
  * Returns the command map for a given project type. Pure — no I/O.
  *
  * For 'none', returns an empty object (`{}`). For a recognized type, returns
- * the four capability verbs plus the `install` setup verb where one exists:
- * npm/cargo/python carry `install`; `make` does not. For an `npm` project the
- * whole verb set is keyed on `jsPackageManager` (lockfile-resolved by the
- * caller, defaulting to pnpm when none is supplied).
+ * the capability verbs plus the `install` setup verb where one exists:
+ * npm/cargo/python carry `install`; `make`, `maven`, and `gradle` do not.
+ * `maven` and `gradle` also omit `lint`. For an `npm` project the whole verb
+ * set is keyed on `jsPackageManager` (lockfile-resolved by the caller,
+ * defaulting to pnpm when none is supplied).
  */
 export function buildCommandMap(
   type: ProjectType,

--- a/plugins/orchestrate/orchestrate-mcp/test/detect-project.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/detect-project.test.ts
@@ -58,6 +58,18 @@ describe("detectProjectType (pure)", () => {
     expect(detectProjectType(["pyproject.toml"])).toBe("python");
   });
 
+  it("returns 'maven' when pom.xml is present", () => {
+    expect(detectProjectType(["pom.xml"])).toBe("maven");
+  });
+
+  it("returns 'gradle' when build.gradle is present", () => {
+    expect(detectProjectType(["build.gradle"])).toBe("gradle");
+  });
+
+  it("returns 'gradle' when build.gradle.kts is present (Kotlin DSL repo)", () => {
+    expect(detectProjectType(["build.gradle.kts"])).toBe("gradle");
+  });
+
   it("returns 'make' when Makefile is present", () => {
     expect(detectProjectType(["Makefile"])).toBe("make");
   });
@@ -77,6 +89,22 @@ describe("detectProjectType (pure)", () => {
 
   it("prefers python over Makefile when both are present", () => {
     expect(detectProjectType(["Makefile", "pyproject.toml"])).toBe("python");
+  });
+
+  it("prefers maven over Makefile when both are present", () => {
+    expect(detectProjectType(["Makefile", "pom.xml"])).toBe("maven");
+  });
+
+  it("prefers gradle over Makefile when both are present", () => {
+    expect(detectProjectType(["Makefile", "build.gradle"])).toBe("gradle");
+  });
+
+  it("prefers gradle (kts) over Makefile when both are present", () => {
+    expect(detectProjectType(["Makefile", "build.gradle.kts"])).toBe("gradle");
+  });
+
+  it("prefers python over maven when both are present", () => {
+    expect(detectProjectType(["pom.xml", "pyproject.toml"])).toBe("python");
   });
 
   it("prefers npm over python when both are present", () => {
@@ -130,6 +158,28 @@ describe("buildCommandMap (pure)", () => {
     expect(map.build).toEqual(["python", "-m", "build"]);
     expect(map.lint).toEqual(["ruff", "check", "."]);
     expect(map.install).toEqual(["pip", "install", "-e", "."]);
+  });
+
+  it("returns the maven command map for 'maven', WITHOUT install or lint", () => {
+    const map = buildCommandMap("maven");
+    expect(map.tests).toEqual(["mvn", "-B", "test"]);
+    expect(map.typecheck).toEqual(["mvn", "-B", "-DskipTests", "compile"]);
+    expect(map.build).toEqual(["mvn", "-B", "-DskipTests", "package"]);
+    // maven has no install verb — resolves deps on demand
+    expect("install" in map).toBe(false);
+    // maven has no lint verb — no canonical linter
+    expect("lint" in map).toBe(false);
+  });
+
+  it("returns the gradle command map for 'gradle', WITHOUT install or lint", () => {
+    const map = buildCommandMap("gradle");
+    expect(map.tests).toEqual(["./gradlew", "test"]);
+    expect(map.typecheck).toEqual(["./gradlew", "classes"]);
+    expect(map.build).toEqual(["./gradlew", "assemble"]);
+    // gradle has no install verb — resolves deps on demand
+    expect("install" in map).toBe(false);
+    // gradle has no lint verb — no canonical linter
+    expect("lint" in map).toBe(false);
   });
 
   it("returns the make command map for 'make', WITHOUT an install verb", () => {
@@ -273,6 +323,36 @@ describe("detectCommandMap", () => {
     expect(map.tests).toEqual(["pytest"]);
     expect(map.typecheck).toEqual(["mypy", "."]);
     expect(map.install).toEqual(["pip", "install", "-e", "."]);
+  });
+
+  it("detects maven from pom.xml, without install or lint", () => {
+    const dir = repo({ "pom.xml": "<project/>" });
+    const map = detectCommandMap(dir);
+    expect(map.tests).toEqual(["mvn", "-B", "test"]);
+    expect(map.typecheck).toEqual(["mvn", "-B", "-DskipTests", "compile"]);
+    expect(map.build).toEqual(["mvn", "-B", "-DskipTests", "package"]);
+    expect("install" in map).toBe(false);
+    expect("lint" in map).toBe(false);
+  });
+
+  it("detects gradle from build.gradle, without install or lint", () => {
+    const dir = repo({ "build.gradle": "plugins { id 'java' }" });
+    const map = detectCommandMap(dir);
+    expect(map.tests).toEqual(["./gradlew", "test"]);
+    expect(map.typecheck).toEqual(["./gradlew", "classes"]);
+    expect(map.build).toEqual(["./gradlew", "assemble"]);
+    expect("install" in map).toBe(false);
+    expect("lint" in map).toBe(false);
+  });
+
+  it("detects gradle from build.gradle.kts (Kotlin DSL-only repo), without install or lint", () => {
+    const dir = repo({ "build.gradle.kts": "plugins { java }" });
+    const map = detectCommandMap(dir);
+    expect(map.tests).toEqual(["./gradlew", "test"]);
+    expect(map.typecheck).toEqual(["./gradlew", "classes"]);
+    expect(map.build).toEqual(["./gradlew", "assemble"]);
+    expect("install" in map).toBe(false);
+    expect("lint" in map).toBe(false);
   });
 
   it("detects make from Makefile", () => {

--- a/plugins/orchestrate/skills/orchestrate/references/prerequisites.md
+++ b/plugins/orchestrate/skills/orchestrate/references/prerequisites.md
@@ -30,7 +30,11 @@ npm/cargo/python projects — for the JS ecosystem the package manager is keyed
 on the lockfile (`pnpm-lock.yaml`→pnpm, `yarn.lock`→yarn,
 `package-lock.json`→npm, defaulting to **pnpm** with no lock), and the install
 is the mutating/resolving form (`pnpm install` / `npm install`, never
-`npm ci`). A project that overrides `install` with a strict reproducible form
+`npm ci`). Maven and Gradle projects are also detected (test, build, and
+typecheck commands are set), but receive **no `install` verb** — JVM build
+tools resolve dependencies on demand and an install step would fail in a
+pom-less worktree; neither ecosystem has a canonical linter, so `lint` is also
+omitted. A project that overrides `install` with a strict reproducible form
 (`npm ci`, `--frozen-lockfile`) forfeits in-slice new-dependency support — a
 subagent has no shell to regenerate the lockfile. Without `routing.json` the
 `resolve_routing` tool errors


### PR DESCRIPTION
Implements #292.

Adds `pom.xml` → maven and `build.gradle[.kts]` → gradle to `DETECTION_RULES` with canonical capability command maps (maven: `mvn -B test` / `mvn -B -DskipTests package` / `mvn -B -DskipTests compile`; gradle: `./gradlew test` / `assemble` / `classes`). Both omit `install` and `lint` by design. Precedence is after `pyproject.toml` and before the `Makefile` wrapper, so a repo with both a JVM manifest and a Makefile detects the JVM ecosystem. Updates the `ProjectType` union + Zod enum, adds unit tests (maven, gradle, `.kts`-only), updates README/CONTEXT.md/prerequisites.md, reconciles the `npm ci`→`npm install` doc drift, and rebuilds `dist/`.

Slice 2 of 3 under #287.