### PR TITLE
orchestrate: derive context window from model id via table + [Nm] suffix parser

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-engineering-toolkit",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Multi-plugin marketplace for evidence-based Claude Code artifact engineering. Provides plugins for configuration initialization (AGENTS.md, CLAUDE.md), artifact creation/optimization (skills, hooks, rules, subagents), and autonomous backlog orchestration.",
   "owner": {
     "name": "rodrigorjsf",
@@ -33,7 +33,7 @@
     {
       "name": "orchestrate",
       "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"

--- a/plugins/orchestrate/.claude-plugin/plugin.json
+++ b/plugins/orchestrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestrate",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
   "author": {
     "name": "rodrigorjsf"

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -24126,8 +24126,10 @@ var MODEL_CONTEXT_WINDOW = {
   opus: DEFAULT_CONTEXT_WINDOW_TOKENS,
   sonnet: DEFAULT_CONTEXT_WINDOW_TOKENS,
   haiku: DEFAULT_CONTEXT_WINDOW_TOKENS,
+  "claude-opus-4-8[1m]": ONE_MILLION_TOKENS,
   "claude-opus-4-7[1m]": ONE_MILLION_TOKENS,
   "claude-opus-4-1[1m]": ONE_MILLION_TOKENS,
+  "claude-sonnet-4-6[1m]": ONE_MILLION_TOKENS,
   "claude-sonnet-4-5[1m]": ONE_MILLION_TOKENS,
   "claude-sonnet-4[1m]": ONE_MILLION_TOKENS
 };
@@ -24175,8 +24177,8 @@ var bootstrapConfigOutputSchema = external_exports.object({
   contextWindowTokens: external_exports.number().optional().describe(
     "The context-window token count written into handoff.json. Always a positive integer \u2014 never NaN. Present when status='ok'."
   ),
-  contextWindowSource: external_exports.enum(["explicit", "model-table", "default"]).optional().describe(
-    "How contextWindowTokens was resolved. 'explicit' = a valid contextWindowTokens input; 'model-table' = a recognized model id; 'default' = an unknown/absent model fell back to 200000. Present when status='ok'."
+  contextWindowSource: external_exports.enum(["explicit", "model-table", "model-suffix", "default"]).optional().describe(
+    "How contextWindowTokens was resolved. 'explicit' = a valid contextWindowTokens input; 'model-table' = a recognized model id; 'model-suffix' = an unlisted id whose trailing [Nm] capacity suffix was parsed to N\xD71000000; 'default' = an unknown/absent model fell back to 200000. Present when status='ok'."
   ),
   files: external_exports.object({
     commandsJson: external_exports.enum(["written", "already-present"]),
@@ -24218,6 +24220,13 @@ function resolveContextWindow(input) {
     const fromTable = MODEL_CONTEXT_WINDOW[input.model];
     if (fromTable !== void 0) {
       return { tokens: fromTable, source: "model-table" };
+    }
+    const suffixMatch = /\[(\d+)m\]$/.exec(input.model);
+    if (suffixMatch !== void 0 && suffixMatch !== null) {
+      const n = Number.parseInt(suffixMatch[1], 10);
+      if (n > 0) {
+        return { tokens: n * ONE_MILLION_TOKENS, source: "model-suffix" };
+      }
     }
   }
   return { tokens: DEFAULT_CONTEXT_WINDOW_TOKENS, source: "default" };

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
@@ -46,8 +46,10 @@ const MODEL_CONTEXT_WINDOW: Readonly<Record<string, number>> = {
   opus: DEFAULT_CONTEXT_WINDOW_TOKENS,
   sonnet: DEFAULT_CONTEXT_WINDOW_TOKENS,
   haiku: DEFAULT_CONTEXT_WINDOW_TOKENS,
+  "claude-opus-4-8[1m]": ONE_MILLION_TOKENS,
   "claude-opus-4-7[1m]": ONE_MILLION_TOKENS,
   "claude-opus-4-1[1m]": ONE_MILLION_TOKENS,
+  "claude-sonnet-4-6[1m]": ONE_MILLION_TOKENS,
   "claude-sonnet-4-5[1m]": ONE_MILLION_TOKENS,
   "claude-sonnet-4[1m]": ONE_MILLION_TOKENS,
 };
@@ -141,13 +143,14 @@ export const bootstrapConfigOutputSchema = z.object({
         "positive integer — never NaN. Present when status='ok'."
     ),
   contextWindowSource: z
-    .enum(["explicit", "model-table", "default"])
+    .enum(["explicit", "model-table", "model-suffix", "default"])
     .optional()
     .describe(
       "How contextWindowTokens was resolved. 'explicit' = a valid " +
         "contextWindowTokens input; 'model-table' = a recognized model id; " +
-        "'default' = an unknown/absent model fell back to 200000. Present " +
-        "when status='ok'."
+        "'model-suffix' = an unlisted id whose trailing [Nm] capacity suffix " +
+        "was parsed to N×1000000; 'default' = an unknown/absent model fell " +
+        "back to 200000. Present when status='ok'."
     ),
   files: z
     .object({
@@ -227,14 +230,15 @@ function toJsonFile(value: unknown): string {
 /** How the context-window token count was resolved. */
 type ContextWindowResolution = {
   tokens: number;
-  source: "explicit" | "model-table" | "default";
+  source: "explicit" | "model-table" | "model-suffix" | "default";
 };
 
 /**
  * Resolves the context-window token count from the bootstrap input. Precedence:
  *   1. An explicit `contextWindowTokens` that is a positive integer.
  *   2. An exact model-table hit.
- *   3. The {@link DEFAULT_CONTEXT_WINDOW_TOKENS} fallback.
+ *   3. A trailing `[Nm]` capacity suffix on the model id, parsed to N×1M.
+ *   4. The {@link DEFAULT_CONTEXT_WINDOW_TOKENS} fallback.
  *
  * Always returns a positive integer — never NaN — so a malformed input can
  * never write a broken value into handoff.json.
@@ -255,6 +259,22 @@ export function resolveContextWindow(
     const fromTable = MODEL_CONTEXT_WINDOW[input.model];
     if (fromTable !== undefined) {
       return { tokens: fromTable, source: "model-table" };
+    }
+
+    // Bracket-only, post-miss fallback: parse a trailing `[Nm]` capacity token
+    // (e.g. the `[1m]` in `claude-future-x[1m]`) to N×1M. This is orthogonal to
+    // the exact-match table invariant — it never matches the table by
+    // substring and never inspects the model FAMILY; it reads only the
+    // end-anchored bracketed capacity token and runs solely after an exact
+    // table miss, so it cannot alter any exact-table outcome. The `N > 0` guard
+    // sends a pathological `[0m]` through to the default, preserving the
+    // never-zero/never-NaN contract.
+    const suffixMatch = /\[(\d+)m\]$/.exec(input.model);
+    if (suffixMatch !== undefined && suffixMatch !== null) {
+      const n = Number.parseInt(suffixMatch[1], 10);
+      if (n > 0) {
+        return { tokens: n * ONE_MILLION_TOKENS, source: "model-suffix" };
+      }
     }
   }
 

--- a/plugins/orchestrate/orchestrate-mcp/test/bootstrap-config.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/bootstrap-config.test.ts
@@ -293,6 +293,105 @@ describe("bootstrapConfig — model-derived context window", () => {
     expect(r.contextWindowTokens).toBe(200000);
     expect(r.contextWindowSource).toBe("default");
   });
+
+  it("maps a newly-listed 1M model id via the exact table", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "claude-opus-4-8[1m]",
+    });
+
+    expect(r.contextWindowTokens).toBe(1000000);
+    expect(r.contextWindowSource).toBe("model-table");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(1000000);
+  });
+
+  it("parses a trailing [1m] suffix on an unlisted id to 1000000", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "claude-future-x[1m]",
+    });
+
+    expect(r.contextWindowTokens).toBe(1000000);
+    expect(r.contextWindowSource).toBe("model-suffix");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(1000000);
+  });
+
+  it("parses a trailing [2m] suffix as N×1M (2000000)", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "claude-future-x[2m]",
+    });
+
+    expect(r.contextWindowTokens).toBe(2000000);
+    expect(r.contextWindowSource).toBe("model-suffix");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(2000000);
+  });
+
+  it("does not misclassify an unrelated family id with no bracket", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "claude-opus-4-8",
+    });
+
+    expect(r.contextWindowTokens).toBe(200000);
+    expect(r.contextWindowSource).toBe("default");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(200000);
+  });
+
+  it("sends a pathological [0m] suffix through to the default", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "claude-future-x[0m]",
+    });
+
+    expect(Number.isInteger(r.contextWindowTokens)).toBe(true);
+    expect(r.contextWindowTokens).toBe(200000);
+    expect(r.contextWindowSource).toBe("default");
+  });
+
+  it("reaches every contextWindowSource value", () => {
+    const explicit = bootstrapConfig({
+      repoPath: repo("package.json"),
+      model: "opus",
+      contextWindowTokens: 500000,
+    });
+    expect(explicit.contextWindowSource).toBe("explicit");
+
+    const table = bootstrapConfig({
+      repoPath: repo("package.json"),
+      model: "claude-sonnet-4-6[1m]",
+    });
+    expect(table.contextWindowSource).toBe("model-table");
+
+    const suffix = bootstrapConfig({
+      repoPath: repo("package.json"),
+      model: "claude-future-y[1m]",
+    });
+    expect(suffix.contextWindowSource).toBe("model-suffix");
+
+    const fallback = bootstrapConfig({
+      repoPath: repo("package.json"),
+      model: "some-future-model",
+    });
+    expect(fallback.contextWindowSource).toBe("default");
+  });
 });
 
 // ─── Config-file idempotence ──────────────────────────────────────────────────


### PR DESCRIPTION
Implements #293.

Sizes a 1M-context model at 1M instead of the 200k default. Adds `claude-opus-4-8[1m]` and `claude-sonnet-4-6[1m]` to the exact-match `MODEL_CONTEXT_WINDOW` table, plus a fallback in `resolveContextWindow` that parses a trailing `[<N>m]` suffix (`N × 1_000_000`) ONLY after an exact-table miss — bracket-token only, never the model family, so the documented exact-match invariant is preserved. A new `contextWindowSource` value `model-suffix` keeps telemetry honest; precedence is `explicit > model-table > model-suffix > default` (a `[0m]` is guarded to fall through to default). Adds 5 unit tests, rebuilds `dist/`, and carries the plugin version cascade (plugin.json 1.4.0→1.4.1; marketplace orchestrate entry →1.4.1 and top-level 1.8.0→1.8.1) as the final commit of #287.

Slice 3 of 3 under #287.