### PR TITLE
orchestrate run prd287-20260605-023800 — PRD #287 false-green hardening (F1+F2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-engineering-toolkit",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Multi-plugin marketplace for evidence-based Claude Code artifact engineering. Provides plugins for configuration initialization (AGENTS.md, CLAUDE.md), artifact creation/optimization (skills, hooks, rules, subagents), and autonomous backlog orchestration.",
   "owner": {
     "name": "rodrigorjsf",
@@ -33,7 +33,7 @@
     {
       "name": "orchestrate",
       "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -170,7 +170,7 @@ The exported function in `backlog-partitioner.ts` that narrows the full backlog 
 _Avoid_: backlog filter, PRD filter (too generic)
 
 **Capability detector** (`detect-project` module):
-A pure module in `orchestrate-mcp/src/tools/detect-project.ts` that inspects a repository root's top-level manifest files and returns the **Capability command map** for the detected project type. Input: a repository root path. Output: a command map or empty object. No side effects. Detection precedence: npm (`package.json`) > Cargo (`Cargo.toml`) > Python (`pyproject.toml`) > Make (`Makefile`) > none. A repository with no recognized manifest yields an empty map — never a fallback npm map.
+A pure module in `orchestrate-mcp/src/tools/detect-project.ts` that inspects a repository root's top-level manifest files and returns the **Capability command map** for the detected project type. Input: a repository root path. Output: a command map or empty object. No side effects. Detection precedence: npm (`package.json`) > Cargo (`Cargo.toml`) > Python (`pyproject.toml`) > Maven (`pom.xml`) > Gradle (`build.gradle` / `build.gradle.kts`) > Make (`Makefile`) > none. A repository with no recognized manifest yields an empty map — never a fallback npm map.
 _Avoid_: project sniffer, auto-configurator, manifest scanner
 
 **Capability command map**:

--- a/plugins/orchestrate/.claude-plugin/plugin.json
+++ b/plugins/orchestrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestrate",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
   "author": {
     "name": "rodrigorjsf"

--- a/plugins/orchestrate/README.md
+++ b/plugins/orchestrate/README.md
@@ -81,6 +81,8 @@ The `detect-project` module (`orchestrate-mcp/src/tools/detect-project.ts`) auto
 | `package.json` | npm | `npm test`, `npm run typecheck`, `npm run build`, `npm run lint` |
 | `Cargo.toml` | Cargo | `cargo test`, `cargo check`, `cargo build`, `cargo clippy` |
 | `pyproject.toml` | Python | `pytest`, `mypy .`, `python -m build`, `ruff check .` |
+| `pom.xml` | Maven | `mvn -B test`, `mvn -B -DskipTests compile`, `mvn -B -DskipTests package` |
+| `build.gradle` / `build.gradle.kts` | Gradle | `./gradlew test`, `./gradlew classes`, `./gradlew assemble` |
 | `Makefile` | Make | `make test`, `make typecheck`, `make build`, `make lint` |
 | _(none found)_ | none | empty map — no capability tool is wired to a failing command |
 
@@ -107,7 +109,7 @@ A manifest-less repository yields `{}` — never an npm fallback — so no capab
 
 The `bootstrap_config` MCP tool makes a first-ever run set up its own `.orchestrate/` configuration with no manual steps. On a fresh run — when the repository has no `.orchestrate/` directory — the orchestrator calls it before planning the backlog. It:
 
-- Composes the **capability detector** above and writes a project-appropriate `.orchestrate/commands.json`. The shipped `templates/commands.json` is an empty `{}` safe default — the bootstrapper is the canonical source of a project-aware config. For an npm project it also sets `install: ["npm", "ci"]`; for cargo, Python, Make, or an unrecognized project it omits `install` (a wrong install command is worse than none).
+- Composes the **capability detector** above and writes a project-appropriate `.orchestrate/commands.json`. The shipped `templates/commands.json` is an empty `{}` safe default — the bootstrapper is the canonical source of a project-aware config. For an npm project it also sets `install: ["npm", "install"]`; for cargo, Python, Maven, Gradle, Make, or an unrecognized project it omits `install` (a wrong install command is worse than none).
 - Writes `.orchestrate/handoff.json` with a context-window size **derived from the running model**, not a static 200k constant. The model id (or an explicit token count) is passed as a tool input — the MCP process cannot see the calling LLM's model. A small explicit table maps the model to its window; an unknown or absent model falls back to `200000`.
 - Writes `.orchestrate/routing.json` from the shipped defaults.
 - Creates `.orchestrate/runs/` and idempotently appends `.orchestrate/runs/` to the repository's `.gitignore` — exactly once, even across repeated bootstraps.
@@ -244,11 +246,11 @@ Maps each capability verb to the **argv array** that runs it. The argv form is e
   "typecheck": ["npm", "run", "typecheck"],
   "build": ["npm", "run", "build"],
   "lint": ["npm", "run", "lint"],
-  "install": ["npm", "ci"]
+  "install": ["npm", "install"]
 }
 ```
 
-The optional `install` verb runs once in each fresh worktree before the capability commands. `bootstrap_config` sets it to `["npm", "ci"]` for an npm project and omits it for every other project type — a wrong install command is worse than none.
+The optional `install` verb runs once in each fresh worktree before the capability commands. `bootstrap_config` sets it to `["npm", "install"]` for an npm project and omits it for every other project type — a wrong install command is worse than none.
 
 ### `.orchestrate/routing.json`
 

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -24034,6 +24034,9 @@ var DETECTION_RULES = [
   { manifest: "package.json", type: "npm" },
   { manifest: "Cargo.toml", type: "cargo" },
   { manifest: "pyproject.toml", type: "python" },
+  { manifest: "pom.xml", type: "maven" },
+  { manifest: "build.gradle", type: "gradle" },
+  { manifest: "build.gradle.kts", type: "gradle" },
   { manifest: "Makefile", type: "make" }
 ];
 var COMMAND_MAPS = {
@@ -24050,6 +24053,18 @@ var COMMAND_MAPS = {
     build: ["python", "-m", "build"],
     lint: ["ruff", "check", "."],
     install: ["pip", "install", "-e", "."]
+  },
+  maven: {
+    tests: ["mvn", "-B", "test"],
+    typecheck: ["mvn", "-B", "-DskipTests", "compile"],
+    build: ["mvn", "-B", "-DskipTests", "package"]
+    // install and lint intentionally absent — see doc comment above
+  },
+  gradle: {
+    tests: ["./gradlew", "test"],
+    typecheck: ["./gradlew", "classes"],
+    build: ["./gradlew", "assemble"]
+    // install and lint intentionally absent — see doc comment above
   },
   make: {
     tests: ["make", "test"],
@@ -24154,7 +24169,7 @@ var bootstrapConfigOutputSchema = external_exports.object({
   status: external_exports.enum(["ok", "error"]).describe(
     "Outcome discriminant. 'ok' = the bootstrap completed (every file either written or already present); 'error' = a filesystem write failed and the configuration is incomplete."
   ),
-  projectType: external_exports.enum(["npm", "cargo", "python", "make", "none"]).optional().describe(
+  projectType: external_exports.enum(["npm", "cargo", "python", "maven", "gradle", "make", "none"]).optional().describe(
     "The detected project type. 'none' means no recognized manifest \u2014 commands.json is written empty. Present when status='ok'."
   ),
   contextWindowTokens: external_exports.number().optional().describe(

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -24126,8 +24126,10 @@ var MODEL_CONTEXT_WINDOW = {
   opus: DEFAULT_CONTEXT_WINDOW_TOKENS,
   sonnet: DEFAULT_CONTEXT_WINDOW_TOKENS,
   haiku: DEFAULT_CONTEXT_WINDOW_TOKENS,
+  "claude-opus-4-8[1m]": ONE_MILLION_TOKENS,
   "claude-opus-4-7[1m]": ONE_MILLION_TOKENS,
   "claude-opus-4-1[1m]": ONE_MILLION_TOKENS,
+  "claude-sonnet-4-6[1m]": ONE_MILLION_TOKENS,
   "claude-sonnet-4-5[1m]": ONE_MILLION_TOKENS,
   "claude-sonnet-4[1m]": ONE_MILLION_TOKENS
 };
@@ -24175,8 +24177,8 @@ var bootstrapConfigOutputSchema = external_exports.object({
   contextWindowTokens: external_exports.number().optional().describe(
     "The context-window token count written into handoff.json. Always a positive integer \u2014 never NaN. Present when status='ok'."
   ),
-  contextWindowSource: external_exports.enum(["explicit", "model-table", "default"]).optional().describe(
-    "How contextWindowTokens was resolved. 'explicit' = a valid contextWindowTokens input; 'model-table' = a recognized model id; 'default' = an unknown/absent model fell back to 200000. Present when status='ok'."
+  contextWindowSource: external_exports.enum(["explicit", "model-table", "model-suffix", "default"]).optional().describe(
+    "How contextWindowTokens was resolved. 'explicit' = a valid contextWindowTokens input; 'model-table' = a recognized model id; 'model-suffix' = an unlisted id whose trailing [Nm] capacity suffix was parsed to N\xD71000000; 'default' = an unknown/absent model fell back to 200000. Present when status='ok'."
   ),
   files: external_exports.object({
     commandsJson: external_exports.enum(["written", "already-present"]),
@@ -24218,6 +24220,13 @@ function resolveContextWindow(input) {
     const fromTable = MODEL_CONTEXT_WINDOW[input.model];
     if (fromTable !== void 0) {
       return { tokens: fromTable, source: "model-table" };
+    }
+    const suffixMatch = /\[(\d+)m\]$/.exec(input.model);
+    if (suffixMatch !== void 0 && suffixMatch !== null) {
+      const n = Number.parseInt(suffixMatch[1], 10);
+      if (n > 0) {
+        return { tokens: n * ONE_MILLION_TOKENS, source: "model-suffix" };
+      }
     }
   }
   return { tokens: DEFAULT_CONTEXT_WINDOW_TOKENS, source: "default" };

--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -24181,6 +24181,9 @@ var bootstrapConfigOutputSchema = external_exports.object({
   ),
   errorMessage: external_exports.string().optional().describe(
     "Cleaned, human-readable failure description. Present when status='error'."
+  ),
+  warnings: external_exports.array(external_exports.string()).optional().describe(
+    "Advisory warnings about the bootstrapped configuration. Non-empty only when status='ok' and the freshly-written commands.json is empty ({}) \u2014 meaning no recognized project type was detected and the capability gates (run_tests, run_build, etc.) will report 'not-configured', allowing a slice to merge green with no verification. Empty array when the written commands map is non-empty. Present when status='ok'."
   )
 });
 function firstLine7(message) {
@@ -24372,6 +24375,10 @@ function bootstrapConfig(input) {
       errorMessage: `Failed to update .gitignore: ${gitignoreResult.message}`
     };
   }
+  const commandsMapEmpty = Object.keys(validatedCommands.data).length === 0;
+  const warnings = commandsResult.kind === "written" && commandsMapEmpty ? [
+    "commands.json was written empty ({}): no recognized project type detected. The capability gates run_tests and run_build will report 'not-configured' \u2014 a slice can merge green with no verification. Edit .orchestrate/commands.json to add your project's test and build commands."
+  ] : [];
   return {
     status: "ok",
     projectType,
@@ -24383,7 +24390,8 @@ function bootstrapConfig(input) {
       handoffJson: handoffResult.kind
     },
     runsDir: runsDirExisted ? "already-present" : "created",
-    gitignore: gitignoreResult.kind
+    gitignore: gitignoreResult.kind,
+    warnings
   };
 }
 
@@ -26026,6 +26034,9 @@ var handleBootstrapConfig = async (input) => {
     ].filter((n) => n !== null);
     const filesNote = written.length > 0 ? `wrote ${written.join(", ")}` : "all config files already present";
     text = `Bootstrapped .orchestrate/ config for a ${result.projectType} project (${filesNote}; context window ${result.contextWindowTokens} tokens, source: ${result.contextWindowSource}; runs dir ${result.runsDir}; .gitignore ${result.gitignore}).`;
+    if (result.warnings && result.warnings.length > 0) {
+      text += ` WARNING: ${result.warnings.join(" ")}`;
+    }
   } else {
     text = `Bootstrap failed [${result.errorCode}]: ${result.errorMessage}`;
   }

--- a/plugins/orchestrate/orchestrate-mcp/src/index.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/index.ts
@@ -934,6 +934,9 @@ const handleBootstrapConfig: ToolHandler<
       `(${filesNote}; context window ${result.contextWindowTokens} tokens, ` +
       `source: ${result.contextWindowSource}; runs dir ${result.runsDir}; ` +
       `.gitignore ${result.gitignore}).`;
+    if (result.warnings && result.warnings.length > 0) {
+      text += ` WARNING: ${result.warnings.join(" ")}`;
+    }
   } else {
     text = `Bootstrap failed [${result.errorCode}]: ${result.errorMessage}`;
   }

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
@@ -46,8 +46,10 @@ const MODEL_CONTEXT_WINDOW: Readonly<Record<string, number>> = {
   opus: DEFAULT_CONTEXT_WINDOW_TOKENS,
   sonnet: DEFAULT_CONTEXT_WINDOW_TOKENS,
   haiku: DEFAULT_CONTEXT_WINDOW_TOKENS,
+  "claude-opus-4-8[1m]": ONE_MILLION_TOKENS,
   "claude-opus-4-7[1m]": ONE_MILLION_TOKENS,
   "claude-opus-4-1[1m]": ONE_MILLION_TOKENS,
+  "claude-sonnet-4-6[1m]": ONE_MILLION_TOKENS,
   "claude-sonnet-4-5[1m]": ONE_MILLION_TOKENS,
   "claude-sonnet-4[1m]": ONE_MILLION_TOKENS,
 };
@@ -141,13 +143,14 @@ export const bootstrapConfigOutputSchema = z.object({
         "positive integer — never NaN. Present when status='ok'."
     ),
   contextWindowSource: z
-    .enum(["explicit", "model-table", "default"])
+    .enum(["explicit", "model-table", "model-suffix", "default"])
     .optional()
     .describe(
       "How contextWindowTokens was resolved. 'explicit' = a valid " +
         "contextWindowTokens input; 'model-table' = a recognized model id; " +
-        "'default' = an unknown/absent model fell back to 200000. Present " +
-        "when status='ok'."
+        "'model-suffix' = an unlisted id whose trailing [Nm] capacity suffix " +
+        "was parsed to N×1000000; 'default' = an unknown/absent model fell " +
+        "back to 200000. Present when status='ok'."
     ),
   files: z
     .object({
@@ -227,14 +230,15 @@ function toJsonFile(value: unknown): string {
 /** How the context-window token count was resolved. */
 type ContextWindowResolution = {
   tokens: number;
-  source: "explicit" | "model-table" | "default";
+  source: "explicit" | "model-table" | "model-suffix" | "default";
 };
 
 /**
  * Resolves the context-window token count from the bootstrap input. Precedence:
  *   1. An explicit `contextWindowTokens` that is a positive integer.
  *   2. An exact model-table hit.
- *   3. The {@link DEFAULT_CONTEXT_WINDOW_TOKENS} fallback.
+ *   3. A trailing `[Nm]` capacity suffix on the model id, parsed to N×1M.
+ *   4. The {@link DEFAULT_CONTEXT_WINDOW_TOKENS} fallback.
  *
  * Always returns a positive integer — never NaN — so a malformed input can
  * never write a broken value into handoff.json.
@@ -255,6 +259,22 @@ export function resolveContextWindow(
     const fromTable = MODEL_CONTEXT_WINDOW[input.model];
     if (fromTable !== undefined) {
       return { tokens: fromTable, source: "model-table" };
+    }
+
+    // Bracket-only, post-miss fallback: parse a trailing `[Nm]` capacity token
+    // (e.g. the `[1m]` in `claude-future-x[1m]`) to N×1M. This is orthogonal to
+    // the exact-match table invariant — it never matches the table by
+    // substring and never inspects the model FAMILY; it reads only the
+    // end-anchored bracketed capacity token and runs solely after an exact
+    // table miss, so it cannot alter any exact-table outcome. The `N > 0` guard
+    // sends a pathological `[0m]` through to the default, preserving the
+    // never-zero/never-NaN contract.
+    const suffixMatch = /\[(\d+)m\]$/.exec(input.model);
+    if (suffixMatch !== undefined && suffixMatch !== null) {
+      const n = Number.parseInt(suffixMatch[1], 10);
+      if (n > 0) {
+        return { tokens: n * ONE_MILLION_TOKENS, source: "model-suffix" };
+      }
     }
   }
 

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
@@ -127,7 +127,7 @@ export const bootstrapConfigOutputSchema = z.object({
         "failed and the configuration is incomplete."
     ),
   projectType: z
-    .enum(["npm", "cargo", "python", "make", "none"])
+    .enum(["npm", "cargo", "python", "maven", "gradle", "make", "none"])
     .optional()
     .describe(
       "The detected project type. 'none' means no recognized manifest — " +

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/bootstrap-config.ts
@@ -190,6 +190,17 @@ export const bootstrapConfigOutputSchema = z.object({
     .describe(
       "Cleaned, human-readable failure description. Present when status='error'."
     ),
+  warnings: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Advisory warnings about the bootstrapped configuration. Non-empty only " +
+        "when status='ok' and the freshly-written commands.json is empty ({}) — " +
+        "meaning no recognized project type was detected and the capability gates " +
+        "(run_tests, run_build, etc.) will report 'not-configured', allowing a " +
+        "slice to merge green with no verification. Empty array when the written " +
+        "commands map is non-empty. Present when status='ok'."
+    ),
 });
 
 // ─── TS types — derived from the schemas (single source of truth) ─────────────
@@ -503,6 +514,23 @@ export function bootstrapConfig(
     };
   }
 
+  // Emit a loud warning when the bootstrapper just wrote an empty commands.json
+  // ({}). This happens for unrecognized project types ('none') where no manifest
+  // is detected. An empty map means all capability gates (run_tests, run_build,
+  // etc.) will report 'not-configured' — a slice can merge green with no
+  // verification, which is a common source of false-green merges.
+  const commandsMapEmpty =
+    Object.keys(validatedCommands.data).length === 0;
+  const warnings: string[] =
+    commandsResult.kind === "written" && commandsMapEmpty
+      ? [
+          "commands.json was written empty ({}): no recognized project type detected. " +
+            "The capability gates run_tests and run_build will report 'not-configured' — " +
+            "a slice can merge green with no verification. " +
+            "Edit .orchestrate/commands.json to add your project's test and build commands.",
+        ]
+      : [];
+
   return {
     status: "ok",
     projectType,
@@ -515,5 +543,6 @@ export function bootstrapConfig(
     },
     runsDir: runsDirExisted ? "already-present" : "created",
     gitignore: gitignoreResult.kind,
+    warnings,
   };
 }

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/detect-project.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/detect-project.ts
@@ -6,12 +6,24 @@ import * as fs from "fs";
  * A recognized project type, or 'none' when no manifest is detected.
  *
  * Detection precedence (manifest-first, then Make):
- *   npm (package.json) > cargo (Cargo.toml) > python (pyproject.toml) > make (Makefile) > none
+ *   npm (package.json) > cargo (Cargo.toml) > python (pyproject.toml) >
+ *   maven (pom.xml) > gradle (build.gradle / build.gradle.kts) > make (Makefile) > none
  *
  * Python detection uses `pyproject.toml` only (the modern standard as of PEP 517/518).
  * `setup.py` is legacy and intentionally excluded.
+ *
+ * Maven/Gradle: both omit `install` and `lint` by design — JVM build tools resolve
+ * dependencies on demand; an `install` verb would fail in the pom-less worktree of a
+ * skeleton-creating first slice; neither ecosystem has a canonical linter.
  */
-export type ProjectType = "npm" | "cargo" | "python" | "make" | "none";
+export type ProjectType =
+  | "npm"
+  | "cargo"
+  | "python"
+  | "maven"
+  | "gradle"
+  | "make"
+  | "none";
 
 /**
  * A capability command map — the four fixed capability verbs the orchestrate
@@ -80,12 +92,20 @@ export function detectJsPackageManager(
  * Ordered detection rules. The first match wins — earlier entries have higher
  * priority. `Makefile` is last because it often wraps another toolchain;
  * language-specific manifests take precedence over a thin Make wrapper.
+ *
+ * JVM manifests (`pom.xml`, `build.gradle`, `build.gradle.kts`) rank after
+ * Python and before Makefile — language manifests take precedence over a Make
+ * wrapper. Two gradle entries cover both the Groovy (`.gradle`) and Kotlin
+ * (`.gradle.kts`) DSL variants.
  */
 const DETECTION_RULES: ReadonlyArray<{ manifest: string; type: ProjectType }> =
   [
     { manifest: "package.json", type: "npm" },
     { manifest: "Cargo.toml", type: "cargo" },
     { manifest: "pyproject.toml", type: "python" },
+    { manifest: "pom.xml", type: "maven" },
+    { manifest: "build.gradle", type: "gradle" },
+    { manifest: "build.gradle.kts", type: "gradle" },
     { manifest: "Makefile", type: "make" },
   ];
 
@@ -100,7 +120,11 @@ const DETECTION_RULES: ReadonlyArray<{ manifest: string; type: ProjectType }> =
  *
  * The map type is `CapabilityCommandMap` (install OPTIONAL) — `cargo` and
  * `python` carry an `install` (the mutating dependency-resolve step), but
- * `make` omits it: the ledger specifies no install verb for a thin Make wrapper.
+ * `make`, `maven`, and `gradle` omit it:
+ *   - `make`: the ledger specifies no install verb for a thin Make wrapper.
+ *   - `maven`/`gradle`: JVM tools resolve dependencies on demand; an `install`
+ *     verb would fail in the pom-less worktree of a skeleton-creating first
+ *     slice. Neither ecosystem has a canonical linter, so `lint` is also absent.
  *
  * Python commands assume the standard modern toolchain:
  *   - `pytest`   for tests (de-facto standard)
@@ -108,6 +132,11 @@ const DETECTION_RULES: ReadonlyArray<{ manifest: string; type: ProjectType }> =
  *   - `python -m build` for building
  *   - `ruff check .` for linting (modern replacement for flake8)
  *   - `pip install -e .` for install (editable install of the local package)
+ *
+ * Maven commands use `-B` (batch/non-interactive) for CI compatibility.
+ * Gradle commands use the wrapper (`./gradlew`) so the project-local version is
+ * used; `assemble` avoids re-running the test suite; `classes` compiles the
+ * whole main source set (covers Kotlin `.kts` repos, unlike `compileJava`).
  */
 const COMMAND_MAPS: Record<
   Exclude<ProjectType, "none" | "npm">,
@@ -126,6 +155,18 @@ const COMMAND_MAPS: Record<
     build: ["python", "-m", "build"],
     lint: ["ruff", "check", "."],
     install: ["pip", "install", "-e", "."],
+  },
+  maven: {
+    tests: ["mvn", "-B", "test"],
+    typecheck: ["mvn", "-B", "-DskipTests", "compile"],
+    build: ["mvn", "-B", "-DskipTests", "package"],
+    // install and lint intentionally absent — see doc comment above
+  },
+  gradle: {
+    tests: ["./gradlew", "test"],
+    typecheck: ["./gradlew", "classes"],
+    build: ["./gradlew", "assemble"],
+    // install and lint intentionally absent — see doc comment above
   },
   make: {
     tests: ["make", "test"],
@@ -167,8 +208,8 @@ export function buildJsCommandMap(
  * repository root. Pure — no I/O; the caller supplies the manifest list.
  *
  * Returns the first match from {@link DETECTION_RULES}, applying
- * manifest-first priority (npm > cargo > python > make). Returns 'none' when
- * no recognized manifest is present.
+ * manifest-first priority (npm > cargo > python > maven > gradle > make).
+ * Returns 'none' when no recognized manifest is present.
  */
 export function detectProjectType(manifestsPresent: string[]): ProjectType {
   const present = new Set(manifestsPresent);
@@ -184,10 +225,11 @@ export function detectProjectType(manifestsPresent: string[]): ProjectType {
  * Returns the command map for a given project type. Pure — no I/O.
  *
  * For 'none', returns an empty object (`{}`). For a recognized type, returns
- * the four capability verbs plus the `install` setup verb where one exists:
- * npm/cargo/python carry `install`; `make` does not. For an `npm` project the
- * whole verb set is keyed on `jsPackageManager` (lockfile-resolved by the
- * caller, defaulting to pnpm when none is supplied).
+ * the capability verbs plus the `install` setup verb where one exists:
+ * npm/cargo/python carry `install`; `make`, `maven`, and `gradle` do not.
+ * `maven` and `gradle` also omit `lint`. For an `npm` project the whole verb
+ * set is keyed on `jsPackageManager` (lockfile-resolved by the caller,
+ * defaulting to pnpm when none is supplied).
  */
 export function buildCommandMap(
   type: ProjectType,

--- a/plugins/orchestrate/orchestrate-mcp/test/bootstrap-config.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/bootstrap-config.test.ts
@@ -175,6 +175,46 @@ describe("bootstrapConfig — commands.json per project type", () => {
   });
 });
 
+// ─── Empty-config warning ─────────────────────────────────────────────────────
+
+describe("bootstrapConfig — empty-config warnings", () => {
+  it("warns when the freshly-written commands.json is empty (no manifest detected)", () => {
+    const dir = repo(); // no manifest → 'none' project type → empty commands map
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.status).toBe("ok");
+    expect(r.warnings).toBeDefined();
+    expect(r.warnings!.length).toBeGreaterThan(0);
+    // The warning must name the no-op gates
+    expect(r.warnings![0]).toContain("run_tests");
+    expect(r.warnings![0]).toContain("run_build");
+    // Must name the consequence (false-green merge risk)
+    expect(r.warnings![0]).toContain("not-configured");
+  });
+
+  it("emits no warnings when commands.json is written non-empty (recognized project type)", () => {
+    const dir = repo("package.json"); // npm project → non-empty commands map
+    const r = bootstrapConfig({ repoPath: dir });
+
+    expect(r.status).toBe("ok");
+    expect(r.warnings).toBeDefined();
+    expect(r.warnings).toEqual([]);
+  });
+
+  it("emits no warnings when commands.json already existed (not freshly written)", () => {
+    // Pre-write an empty commands.json — the bootstrapper skips writing it.
+    const dir = repo(); // no manifest → 'none' project type
+    fs.mkdirSync(path.join(dir, ".orchestrate"));
+    fs.writeFileSync(path.join(dir, ".orchestrate", "commands.json"), "{}\n");
+
+    const r = bootstrapConfig({ repoPath: dir });
+
+    // File was already-present, not freshly written → no warning.
+    expect(r.files!.commandsJson).toBe("already-present");
+    expect(r.warnings).toEqual([]);
+  });
+});
+
 // ─── Model-derived context window ─────────────────────────────────────────────
 
 describe("bootstrapConfig — model-derived context window", () => {

--- a/plugins/orchestrate/orchestrate-mcp/test/bootstrap-config.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/bootstrap-config.test.ts
@@ -293,6 +293,105 @@ describe("bootstrapConfig — model-derived context window", () => {
     expect(r.contextWindowTokens).toBe(200000);
     expect(r.contextWindowSource).toBe("default");
   });
+
+  it("maps a newly-listed 1M model id via the exact table", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "claude-opus-4-8[1m]",
+    });
+
+    expect(r.contextWindowTokens).toBe(1000000);
+    expect(r.contextWindowSource).toBe("model-table");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(1000000);
+  });
+
+  it("parses a trailing [1m] suffix on an unlisted id to 1000000", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "claude-future-x[1m]",
+    });
+
+    expect(r.contextWindowTokens).toBe(1000000);
+    expect(r.contextWindowSource).toBe("model-suffix");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(1000000);
+  });
+
+  it("parses a trailing [2m] suffix as N×1M (2000000)", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "claude-future-x[2m]",
+    });
+
+    expect(r.contextWindowTokens).toBe(2000000);
+    expect(r.contextWindowSource).toBe("model-suffix");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(2000000);
+  });
+
+  it("does not misclassify an unrelated family id with no bracket", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "claude-opus-4-8",
+    });
+
+    expect(r.contextWindowTokens).toBe(200000);
+    expect(r.contextWindowSource).toBe("default");
+    const handoff = readConfig(dir, "handoff.json") as {
+      watchdog: { contextWindowTokens: number };
+    };
+    expect(handoff.watchdog.contextWindowTokens).toBe(200000);
+  });
+
+  it("sends a pathological [0m] suffix through to the default", () => {
+    const dir = repo("package.json");
+    const r = bootstrapConfig({
+      repoPath: dir,
+      model: "claude-future-x[0m]",
+    });
+
+    expect(Number.isInteger(r.contextWindowTokens)).toBe(true);
+    expect(r.contextWindowTokens).toBe(200000);
+    expect(r.contextWindowSource).toBe("default");
+  });
+
+  it("reaches every contextWindowSource value", () => {
+    const explicit = bootstrapConfig({
+      repoPath: repo("package.json"),
+      model: "opus",
+      contextWindowTokens: 500000,
+    });
+    expect(explicit.contextWindowSource).toBe("explicit");
+
+    const table = bootstrapConfig({
+      repoPath: repo("package.json"),
+      model: "claude-sonnet-4-6[1m]",
+    });
+    expect(table.contextWindowSource).toBe("model-table");
+
+    const suffix = bootstrapConfig({
+      repoPath: repo("package.json"),
+      model: "claude-future-y[1m]",
+    });
+    expect(suffix.contextWindowSource).toBe("model-suffix");
+
+    const fallback = bootstrapConfig({
+      repoPath: repo("package.json"),
+      model: "some-future-model",
+    });
+    expect(fallback.contextWindowSource).toBe("default");
+  });
 });
 
 // ─── Config-file idempotence ──────────────────────────────────────────────────

--- a/plugins/orchestrate/orchestrate-mcp/test/detect-project.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/detect-project.test.ts
@@ -58,6 +58,18 @@ describe("detectProjectType (pure)", () => {
     expect(detectProjectType(["pyproject.toml"])).toBe("python");
   });
 
+  it("returns 'maven' when pom.xml is present", () => {
+    expect(detectProjectType(["pom.xml"])).toBe("maven");
+  });
+
+  it("returns 'gradle' when build.gradle is present", () => {
+    expect(detectProjectType(["build.gradle"])).toBe("gradle");
+  });
+
+  it("returns 'gradle' when build.gradle.kts is present (Kotlin DSL repo)", () => {
+    expect(detectProjectType(["build.gradle.kts"])).toBe("gradle");
+  });
+
   it("returns 'make' when Makefile is present", () => {
     expect(detectProjectType(["Makefile"])).toBe("make");
   });
@@ -77,6 +89,22 @@ describe("detectProjectType (pure)", () => {
 
   it("prefers python over Makefile when both are present", () => {
     expect(detectProjectType(["Makefile", "pyproject.toml"])).toBe("python");
+  });
+
+  it("prefers maven over Makefile when both are present", () => {
+    expect(detectProjectType(["Makefile", "pom.xml"])).toBe("maven");
+  });
+
+  it("prefers gradle over Makefile when both are present", () => {
+    expect(detectProjectType(["Makefile", "build.gradle"])).toBe("gradle");
+  });
+
+  it("prefers gradle (kts) over Makefile when both are present", () => {
+    expect(detectProjectType(["Makefile", "build.gradle.kts"])).toBe("gradle");
+  });
+
+  it("prefers python over maven when both are present", () => {
+    expect(detectProjectType(["pom.xml", "pyproject.toml"])).toBe("python");
   });
 
   it("prefers npm over python when both are present", () => {
@@ -130,6 +158,28 @@ describe("buildCommandMap (pure)", () => {
     expect(map.build).toEqual(["python", "-m", "build"]);
     expect(map.lint).toEqual(["ruff", "check", "."]);
     expect(map.install).toEqual(["pip", "install", "-e", "."]);
+  });
+
+  it("returns the maven command map for 'maven', WITHOUT install or lint", () => {
+    const map = buildCommandMap("maven");
+    expect(map.tests).toEqual(["mvn", "-B", "test"]);
+    expect(map.typecheck).toEqual(["mvn", "-B", "-DskipTests", "compile"]);
+    expect(map.build).toEqual(["mvn", "-B", "-DskipTests", "package"]);
+    // maven has no install verb — resolves deps on demand
+    expect("install" in map).toBe(false);
+    // maven has no lint verb — no canonical linter
+    expect("lint" in map).toBe(false);
+  });
+
+  it("returns the gradle command map for 'gradle', WITHOUT install or lint", () => {
+    const map = buildCommandMap("gradle");
+    expect(map.tests).toEqual(["./gradlew", "test"]);
+    expect(map.typecheck).toEqual(["./gradlew", "classes"]);
+    expect(map.build).toEqual(["./gradlew", "assemble"]);
+    // gradle has no install verb — resolves deps on demand
+    expect("install" in map).toBe(false);
+    // gradle has no lint verb — no canonical linter
+    expect("lint" in map).toBe(false);
   });
 
   it("returns the make command map for 'make', WITHOUT an install verb", () => {
@@ -273,6 +323,36 @@ describe("detectCommandMap", () => {
     expect(map.tests).toEqual(["pytest"]);
     expect(map.typecheck).toEqual(["mypy", "."]);
     expect(map.install).toEqual(["pip", "install", "-e", "."]);
+  });
+
+  it("detects maven from pom.xml, without install or lint", () => {
+    const dir = repo({ "pom.xml": "<project/>" });
+    const map = detectCommandMap(dir);
+    expect(map.tests).toEqual(["mvn", "-B", "test"]);
+    expect(map.typecheck).toEqual(["mvn", "-B", "-DskipTests", "compile"]);
+    expect(map.build).toEqual(["mvn", "-B", "-DskipTests", "package"]);
+    expect("install" in map).toBe(false);
+    expect("lint" in map).toBe(false);
+  });
+
+  it("detects gradle from build.gradle, without install or lint", () => {
+    const dir = repo({ "build.gradle": "plugins { id 'java' }" });
+    const map = detectCommandMap(dir);
+    expect(map.tests).toEqual(["./gradlew", "test"]);
+    expect(map.typecheck).toEqual(["./gradlew", "classes"]);
+    expect(map.build).toEqual(["./gradlew", "assemble"]);
+    expect("install" in map).toBe(false);
+    expect("lint" in map).toBe(false);
+  });
+
+  it("detects gradle from build.gradle.kts (Kotlin DSL-only repo), without install or lint", () => {
+    const dir = repo({ "build.gradle.kts": "plugins { java }" });
+    const map = detectCommandMap(dir);
+    expect(map.tests).toEqual(["./gradlew", "test"]);
+    expect(map.typecheck).toEqual(["./gradlew", "classes"]);
+    expect(map.build).toEqual(["./gradlew", "assemble"]);
+    expect("install" in map).toBe(false);
+    expect("lint" in map).toBe(false);
   });
 
   it("detects make from Makefile", () => {

--- a/plugins/orchestrate/skills/orchestrate/references/prerequisites.md
+++ b/plugins/orchestrate/skills/orchestrate/references/prerequisites.md
@@ -14,7 +14,13 @@ The target project's `.orchestrate/` configuration — `commands.json`,
 first run** by the `bootstrap_config` MCP tool (section 1, Fresh run, step 1),
 or committed ahead of time from the plugin's `templates/`. Without
 `commands.json` the capability tools return `not-configured`, which is
-tolerated. When the project's capability commands need installed dependencies,
+tolerated. **When the bootstrapper writes an empty `commands.json` (`{}`)** —
+because no recognized project type was detected — it emits a `warnings[]` field
+in its result and surfaces the warning in its human-readable output. This means
+`run_tests` and `run_build` will report `not-configured`, and a slice can merge
+green with no verification. If you see this warning, edit
+`.orchestrate/commands.json` to add your project's test and build commands
+before starting the run. When the project's capability commands need installed dependencies,
 `commands.json` must also set an `install` command — `create_worktree` runs it
 in every fresh worktree, which checks out only tracked files and so has no
 dependency directory of its own, and the implementer/conflict-resolver

--- a/plugins/orchestrate/skills/orchestrate/references/prerequisites.md
+++ b/plugins/orchestrate/skills/orchestrate/references/prerequisites.md
@@ -30,7 +30,11 @@ npm/cargo/python projects — for the JS ecosystem the package manager is keyed
 on the lockfile (`pnpm-lock.yaml`→pnpm, `yarn.lock`→yarn,
 `package-lock.json`→npm, defaulting to **pnpm** with no lock), and the install
 is the mutating/resolving form (`pnpm install` / `npm install`, never
-`npm ci`). A project that overrides `install` with a strict reproducible form
+`npm ci`). Maven and Gradle projects are also detected (test, build, and
+typecheck commands are set), but receive **no `install` verb** — JVM build
+tools resolve dependencies on demand and an install step would fail in a
+pom-less worktree; neither ecosystem has a canonical linter, so `lint` is also
+omitted. A project that overrides `install` with a strict reproducible form
 (`npm ci`, `--frozen-lockfile`) forfeits in-slice new-dependency support — a
 subagent has no shell to regenerate the lockfile. Without `routing.json` the
 `resolve_routing` tool errors


### PR DESCRIPTION
Autonomous orchestrate run of **PRD #287** (empty `commands.json` false-green + stale model-table context-window mis-sizing). Three `ready-for-agent` child slices, ordered into 2 dependency waves, each implemented + reviewed in an isolated worktree and squash-merged into the umbrella. Left unmerged for human review.

## Slices (all `passed`)
- **#291** (Wave 0, standard) — loud-on-empty `warnings: string[]` when bootstrap writes an empty `commands.json`; surfaced in `index.ts` + `prerequisites.md`. The durable, ecosystem-agnostic spine (slice PR #294).
- **#292** (Wave 1, standard) — Maven/Gradle detection in `DETECTION_RULES` + capability command maps (both omit `install`/`lint`); precedence after `pyproject.toml`, before `Makefile`; README/CONTEXT/prerequisites docs + `npm ci`→`npm install` drift reconcile (slice PR #296).
- **#293** (Wave 1, complex) — context-window exact-match table entries (`claude-opus-4-8[1m]`, `claude-sonnet-4-6[1m]`) + a post-table-miss `[Nm]` suffix parser (`model-suffix` source) that preserves the documented exact-match invariant; plugin version cascade plugin.json 1.4.0→1.4.1, marketplace entry →1.4.1, top-level 1.8.0→1.8.1 (slice PR #297).

## Verification
Every slice passed an independent pre-merge gate (`run_build` + `run_tests`). Test count grew 503 → **524 passing**; the sole remaining failure is a pre-existing, unrelated baseline (`resolve-merge-conflict.test.ts` RE-ENTRANCY), tracked separately. `dist/` rebuilt in every slice that touched `src/`.

## Run note
A git-identity friction in the orchestrate `finalize_slice` tool surfaced mid-run and is filed as #295 (does not affect this diff).

Closes #291
Closes #292
Closes #293