### PR TITLE
chore(release): orchestrate 1.4.1 → 1.5.0 (/orchestrate preflight mode)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agent-engineering-toolkit",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Multi-plugin marketplace for evidence-based Claude Code artifact engineering. Provides plugins for configuration initialization (AGENTS.md, CLAUDE.md), artifact creation/optimization (skills, hooks, rules, subagents), and autonomous backlog orchestration.",
   "owner": {
     "name": "rodrigorjsf",
@@ -33,7 +33,7 @@
     {
       "name": "orchestrate",
       "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "author": {
         "name": "rodrigorjsf",
         "email": "rodrigo_rjsf@hotmail.com"

--- a/plugins/orchestrate/.claude-plugin/plugin.json
+++ b/plugins/orchestrate/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestrate",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Autonomously orchestrate a backlog of ready-for-agent GitHub issues — dependency-ordered waves, implementer and reviewer subagents in isolated git worktrees, checkpointed and resumable.",
   "author": {
     "name": "rodrigorjsf"


### PR DESCRIPTION
Version bump companion to #307 (PRD #286 — the `/orchestrate preflight <PRD#>` mode).

The new user-facing mode is an additive, backward-compatible feature → **MINOR** bump. Cascade per `.claude/rules/plugin-versioning.md`:

| Manifest | Field | Was | Now |
|---|---|---|---|
| `plugins/orchestrate/.claude-plugin/plugin.json` | `version` | 1.4.1 | **1.5.0** |
| `.claude-plugin/marketplace.json` | orchestrate `plugins[].version` (mirrors plugin) | 1.4.1 | **1.5.0** |
| `.claude-plugin/marketplace.json` | top-level `version` (mirrors minor magnitude) | 1.8.1 | **1.9.0** |

Cursor marketplace untouched (orchestrate is not a Cursor plugin; registries are independent).

**Merge alongside #307** so the new mode and its version bump land together — #307 carries the feature, this carries the version.