### PR TITLE
routing.json schema v2 with explicit v1 mapper and label-override merge

### DIFF
--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -21952,6 +21952,13 @@ function planWaves(input) {
 var path3 = __toESM(require("path"));
 var fs3 = __toESM(require("fs"));
 var COMPLEXITY_TIERS = ["trivial", "standard", "complex"];
+var ROLE_VARIANTS = ["standard", "deep"];
+var ROUTING_ROLES = [
+  "investigator",
+  "implementer",
+  "reviewer",
+  "conflict-resolver"
+];
 var roleConfigSchema = external_exports.object({
   model: external_exports.string().min(1).describe("Model id to spawn the role's subagent with (e.g. 'sonnet', 'opus')."),
   effort: external_exports.enum(["standard", "deep"]).describe(
@@ -22049,6 +22056,52 @@ function resolveRoutingFromConfig(input) {
     continuationBudget: config2.data.continuationBudget
   };
 }
+var roleConfigSchemaV2 = external_exports.object({
+  model: external_exports.string().min(1).describe("Model id to spawn the role's subagent with (e.g. 'sonnet', 'opus')."),
+  variant: external_exports.enum(ROLE_VARIANTS).describe(
+    "Subagent variant to spawn \u2014 selects the '-standard' or '-deep' subagent definition file. Renamed from the legacy v1 `effort` key."
+  )
+});
+var tierRoutingSchemaV2 = external_exports.object({
+  investigator: roleConfigSchemaV2.nullable(),
+  implementer: roleConfigSchemaV2,
+  reviewer: roleConfigSchemaV2,
+  "conflict-resolver": roleConfigSchemaV2
+});
+var labelFallbackSchema = external_exports.object({
+  model: external_exports.string().min(1).describe("Model id to re-spawn with when the label's primary model fails."),
+  maxRetries: external_exports.number().int().min(0).describe(
+    "How many times to re-spawn with the fallback model before giving up."
+  )
+});
+var labelSpecSchema = external_exports.object({
+  roles: external_exports.array(external_exports.enum(ROUTING_ROLES)).min(1).describe("The roles this label override patches. At least one."),
+  set: roleConfigSchemaV2.describe(
+    "The {model, variant} patch applied to every role named in `roles`."
+  ),
+  fallback: labelFallbackSchema.optional().describe("Optional model-fallback spec resolved and returned on a match.")
+});
+var labelsConfigSchema = external_exports.record(external_exports.string().min(1), labelSpecSchema).describe(
+  "Generic label-override map. Keys are routing label names (e.g. 'route:fable'); values patch named roles with a {model, variant} set and an optional fallback."
+);
+var runConfigSchema = external_exports.object({
+  intraWaveConcurrency: external_exports.enum(["parallel", "sequential"]).optional().default("parallel").describe(
+    "Run-wide policy: how to process the independent slices within one wave. 'parallel' (default) or 'sequential'. Lifted from the v1 top-level key."
+  ),
+  continuationBudget: external_exports.number().int().min(0).optional().default(2).describe(
+    "How many times the orchestrator may re-spawn the implementer in the same worktree after an 'incomplete' envelope. 0 disables continuation. Defaults to 2. Lifted from the v1 top-level key."
+  )
+});
+var routingConfigSchemaV2 = external_exports.object({
+  version: external_exports.literal(2).describe("Schema version discriminator. Always 2 for the v2 shape."),
+  tiers: external_exports.object({
+    trivial: tierRoutingSchemaV2,
+    standard: tierRoutingSchemaV2,
+    complex: tierRoutingSchemaV2
+  }).describe("Per-complexity-tier routing. All three tiers required."),
+  labels: labelsConfigSchema.optional().default({}).describe("Label-override map; empty by default."),
+  run: runConfigSchema.optional().default({}).describe("Run-wide policy block; knob defaults apply when omitted.")
+});
 
 // src/tools/render.ts
 var path5 = __toESM(require("path"));

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/routing.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/routing.ts
@@ -1,3 +1,33 @@
+/**
+ * Routing module — model/variant selection per complexity tier (ADR-0015).
+ *
+ * Two schema generations coexist here, deliberately:
+ *
+ * - The **legacy / v1** surface ({@link roleConfigSchema},
+ *   {@link tierRoutingSchema}, {@link routingConfigSchema}, {@link resolveRouting},
+ *   {@link resolveRoutingFromConfig}) keys per-role config on `effort`
+ *   (`standard`|`deep`) and carries the run-policy knobs
+ *   (`intraWaveConcurrency`, `continuationBudget`) at the top level. This is the
+ *   shape on disk in pre-v2 `.orchestrate/routing.json` files and the shape the
+ *   current `index.ts` `resolve_routing` handler and `bootstrap_config`
+ *   defaults read. It is retained UNCHANGED so those consumers stay green while
+ *   the v2 layer lands in a separate slice.
+ *
+ * - The **v2** surface ({@link routingConfigSchemaV2} and friends) introduced by
+ *   ADR-0015 renames the per-role key `effort` → `variant` (it selects which
+ *   subagent definition file is spawned — `-standard` vs `-deep` — and was never
+ *   the API effort parameter), groups the run-policy knobs under a `run` block,
+ *   and adds a generic `labels` block for the label-gated premium lane. A
+ *   `version: 2` discriminator distinguishes it from v1.
+ *
+ * v1 files upgrade to v2 in memory through an EXPLICIT field-by-field mapper
+ * ({@link upgradeV1ToV2}) rather than a naive re-parse: zod strips unknown keys,
+ * so re-parsing a v1 file under the v2 schema would silently drop
+ * `intraWaveConcurrency`/`continuationBudget` and reset them to defaults. The
+ * version-dispatch loader ({@link loadRoutingConfig}) routes by the `version`
+ * field. Label overrides merge through pure functions ({@link applyLabels}) that
+ * return structured data — they never throw.
+ */
 import * as path from "path";
 import * as fs from "fs";
 import { z } from "zod";
@@ -7,6 +37,19 @@ import { z } from "zod";
 /** Complexity tiers an issue is assessed into, low to high. */
 export const COMPLEXITY_TIERS = ["trivial", "standard", "complex"] as const;
 export type ComplexityTier = (typeof COMPLEXITY_TIERS)[number];
+
+/** The per-role subagent variants. Renamed from the legacy `effort` key in v2. */
+export const ROLE_VARIANTS = ["standard", "deep"] as const;
+export type RoleVariant = (typeof ROLE_VARIANTS)[number];
+
+/** The four pipeline roles a label override may patch. */
+export const ROUTING_ROLES = [
+  "investigator",
+  "implementer",
+  "reviewer",
+  "conflict-resolver",
+] as const;
+export type RoutingRole = (typeof ROUTING_ROLES)[number];
 
 // ─── Schemas — z.object is the single source of truth; TS types via z.infer ───
 
@@ -69,6 +112,15 @@ export const routingConfigSchema = z.object({
         "the legacy behavior). Defaults to 2."
     ),
 });
+
+/**
+ * Explicit v1 schema for upgrade. An alias of {@link routingConfigSchema} — the
+ * legacy config schema already parses the tier blocks AND the top-level
+ * run-policy keys (`intraWaveConcurrency`, `continuationBudget`), so it is the
+ * field-faithful v1 parser the upgrade path needs. Naming it `…V1` makes the
+ * version-dispatch code self-documenting; it is the SAME schema object.
+ */
+export const routingConfigSchemaV1 = routingConfigSchema;
 
 export const resolveRoutingInputSchema = z.object({
   tier: z
@@ -215,4 +267,352 @@ export function resolveRoutingFromConfig(
     routing: resolveRouting(input.tier, config.data),
     continuationBudget: config.data.continuationBudget,
   };
+}
+
+// ─── v2 schema (ADR-0015) ─────────────────────────────────────────────────────
+
+/**
+ * Per-role routing, v2 shape: which model to spawn with, and which subagent
+ * `variant` (`standard`|`deep`). `variant` REPLACES the legacy `effort` key —
+ * it selects the `-standard`/`-deep` subagent definition file and was never the
+ * API effort parameter.
+ */
+export const roleConfigSchemaV2 = z.object({
+  model: z
+    .string()
+    .min(1)
+    .describe("Model id to spawn the role's subagent with (e.g. 'sonnet', 'opus')."),
+  variant: z
+    .enum(ROLE_VARIANTS)
+    .describe(
+      "Subagent variant to spawn — selects the '-standard' or '-deep' subagent " +
+        "definition file. Renamed from the legacy v1 `effort` key."
+    ),
+});
+
+/**
+ * Routing for one complexity tier, v2 shape. `investigator` may be `null` — that
+ * tier skips the investigation pass. The other three roles always run.
+ */
+export const tierRoutingSchemaV2 = z.object({
+  investigator: roleConfigSchemaV2.nullable(),
+  implementer: roleConfigSchemaV2,
+  reviewer: roleConfigSchemaV2,
+  "conflict-resolver": roleConfigSchemaV2,
+});
+
+/** Per-label model fallback: one re-spawn as `{model}` on a spawn failure. */
+export const labelFallbackSchema = z.object({
+  model: z
+    .string()
+    .min(1)
+    .describe("Model id to re-spawn with when the label's primary model fails."),
+  maxRetries: z
+    .number()
+    .int()
+    .min(0)
+    .describe(
+      "How many times to re-spawn with the fallback model before giving up."
+    ),
+});
+
+/**
+ * One `route:*` label override. `roles` names which roles the override applies
+ * to; `set` is the `{model, variant}` patch applied to each named role; the
+ * optional `fallback` is resolved and returned alongside the patched routing.
+ */
+export const labelSpecSchema = z.object({
+  roles: z
+    .array(z.enum(ROUTING_ROLES))
+    .min(1)
+    .describe("The roles this label override patches. At least one."),
+  set: roleConfigSchemaV2.describe(
+    "The {model, variant} patch applied to every role named in `roles`."
+  ),
+  fallback: labelFallbackSchema
+    .optional()
+    .describe("Optional model-fallback spec resolved and returned on a match."),
+});
+
+/** The generic `labels` block — a record of `route:*` name → override spec. */
+export const labelsConfigSchema = z
+  .record(z.string().min(1), labelSpecSchema)
+  .describe(
+    "Generic label-override map. Keys are routing label names (e.g. " +
+      "'route:fable'); values patch named roles with a {model, variant} set " +
+      "and an optional fallback."
+  );
+
+/** The run-wide policy block — the v1 top-level knobs, grouped under `run`. */
+export const runConfigSchema = z.object({
+  intraWaveConcurrency: z
+    .enum(["parallel", "sequential"])
+    .optional()
+    .default("parallel")
+    .describe(
+      "Run-wide policy: how to process the independent slices within one wave. " +
+        "'parallel' (default) or 'sequential'. Lifted from the v1 top-level key."
+    ),
+  continuationBudget: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .default(2)
+    .describe(
+      "How many times the orchestrator may re-spawn the implementer in the " +
+        "same worktree after an 'incomplete' envelope. 0 disables continuation. " +
+        "Defaults to 2. Lifted from the v1 top-level key."
+    ),
+});
+
+/**
+ * Schema for a v2 `.orchestrate/routing.json`. Carries an explicit
+ * `version: 2` discriminator, the per-tier `tiers` block, the generic `labels`
+ * override map, and the run-policy `run` block.
+ */
+export const routingConfigSchemaV2 = z.object({
+  version: z
+    .literal(2)
+    .describe("Schema version discriminator. Always 2 for the v2 shape."),
+  tiers: z
+    .object({
+      trivial: tierRoutingSchemaV2,
+      standard: tierRoutingSchemaV2,
+      complex: tierRoutingSchemaV2,
+    })
+    .describe("Per-complexity-tier routing. All three tiers required."),
+  labels: labelsConfigSchema
+    .optional()
+    .default({})
+    .describe("Label-override map; empty by default."),
+  run: runConfigSchema
+    .optional()
+    .default({})
+    .describe("Run-wide policy block; knob defaults apply when omitted."),
+});
+
+// ─── v2 TS types ──────────────────────────────────────────────────────────────
+
+export type RoleConfigV2 = z.infer<typeof roleConfigSchemaV2>;
+export type TierRoutingV2 = z.infer<typeof tierRoutingSchemaV2>;
+export type LabelFallback = z.infer<typeof labelFallbackSchema>;
+export type LabelSpec = z.infer<typeof labelSpecSchema>;
+export type LabelsConfig = z.infer<typeof labelsConfigSchema>;
+export type RunConfig = z.infer<typeof runConfigSchema>;
+export type RoutingConfigV2 = z.infer<typeof routingConfigSchemaV2>;
+
+// ─── v1 → v2 upgrade (explicit, field-by-field) ───────────────────────────────
+
+/** Result of an in-memory v1→v2 upgrade: the config plus any deprecation notes. */
+export interface UpgradeResult {
+  config: RoutingConfigV2;
+  warnings: string[];
+}
+
+/** Maps one v1 per-role block (`effort`) to a v2 one (`variant`). */
+function upgradeRole(role: { model: string; effort: RoleVariant }): RoleConfigV2 {
+  return { model: role.model, variant: role.effort };
+}
+
+/** Maps one v1 tier block to a v2 tier block, role by role. */
+function upgradeTier(tier: TierRouting): TierRoutingV2 {
+  return {
+    investigator: tier.investigator ? upgradeRole(tier.investigator) : null,
+    implementer: upgradeRole(tier.implementer),
+    reviewer: upgradeRole(tier.reviewer),
+    "conflict-resolver": upgradeRole(tier["conflict-resolver"]),
+  };
+}
+
+/**
+ * Upgrades a parsed-and-validated v1 routing config to the v2 shape in memory,
+ * field by field. Pure. Maps each tier's `effort` → `variant`, lifts the
+ * top-level `intraWaveConcurrency`/`continuationBudget` into the `run` block
+ * VERBATIM (no re-defaulting — the v1 schema already applied its defaults), sets
+ * `version: 2`, and seeds an empty `labels` map. Returns a single deprecation
+ * warning alongside the upgraded config.
+ *
+ * This is the field-by-field mapper that a naive re-parse under
+ * {@link routingConfigSchemaV2} must NOT replace: zod strips unknown keys, so
+ * re-parsing the v1 top-level run knobs under v2 would drop them silently.
+ */
+export function upgradeV1ToV2(v1: RoutingConfig): UpgradeResult {
+  const config: RoutingConfigV2 = {
+    version: 2,
+    tiers: {
+      trivial: upgradeTier(v1.trivial),
+      standard: upgradeTier(v1.standard),
+      complex: upgradeTier(v1.complex),
+    },
+    labels: {},
+    run: {
+      intraWaveConcurrency: v1.intraWaveConcurrency,
+      continuationBudget: v1.continuationBudget,
+    },
+  };
+  return {
+    config,
+    warnings: [
+      "routing.json uses the deprecated v1 schema (no `version` field). It was " +
+        "upgraded to v2 in memory: per-role `effort` → `variant`, and the " +
+        "top-level `intraWaveConcurrency`/`continuationBudget` keys moved under " +
+        "a `run` block. Re-bootstrap or migrate the file to silence this warning.",
+    ],
+  };
+}
+
+// ─── Version-dispatch loader ──────────────────────────────────────────────────
+
+/** Outcome of loading + normalizing a routing config to the v2 shape. */
+export type LoadRoutingResult =
+  | { status: "ok"; config: RoutingConfigV2; warnings: string[] }
+  | { status: "error"; errorMessage: string };
+
+/** Maps a zod error's issues to a single `path: message; …` detail string. */
+function formatIssues(error: z.ZodError): string {
+  return error.issues
+    .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+    .join("; ");
+}
+
+/**
+ * Normalizes a parsed (JSON-decoded) routing object to the v2 shape, dispatching
+ * on its `version` field. Pure — no I/O. A missing `version` is treated as v1:
+ * the object is parsed with the EXPLICIT v1 schema and upgraded via
+ * {@link upgradeV1ToV2}, attaching a deprecation warning. `version: 2` is parsed
+ * directly with {@link routingConfigSchemaV2}. Any other `version` value, or a
+ * shape mismatch, is a structured error — never a throw.
+ */
+export function loadRoutingConfig(parsed: unknown): LoadRoutingResult {
+  const version =
+    parsed && typeof parsed === "object" && "version" in parsed
+      ? (parsed as { version: unknown }).version
+      : undefined;
+
+  if (version === undefined) {
+    // v1: parse with the explicit v1 schema, then upgrade in memory.
+    const v1 = routingConfigSchemaV1.safeParse(parsed);
+    if (!v1.success) {
+      return {
+        status: "error",
+        errorMessage: `routing.json does not match the v1 schema: ${formatIssues(
+          v1.error
+        )}`,
+      };
+    }
+    const upgraded = upgradeV1ToV2(v1.data);
+    return {
+      status: "ok",
+      config: upgraded.config,
+      warnings: upgraded.warnings,
+    };
+  }
+
+  if (version === 2) {
+    const v2 = routingConfigSchemaV2.safeParse(parsed);
+    if (!v2.success) {
+      return {
+        status: "error",
+        errorMessage: `routing.json does not match the v2 schema: ${formatIssues(
+          v2.error
+        )}`,
+      };
+    }
+    return { status: "ok", config: v2.data, warnings: [] };
+  }
+
+  return {
+    status: "error",
+    errorMessage: `routing.json has an unsupported \`version\`: ${JSON.stringify(
+      version
+    )}. Supported versions: 1 (no \`version\` field) and 2.`,
+  };
+}
+
+// ─── Label-override merge (pure) ──────────────────────────────────────────────
+
+/** The resolved fallback for a tier's routing after label application. */
+export interface ResolvedFallback {
+  role: RoutingRole;
+  label: string;
+  fallback: LabelFallback;
+}
+
+/** Structured result of applying label overrides to one tier's routing. */
+export interface ApplyLabelsResult {
+  routing: TierRoutingV2;
+  warnings: string[];
+  fallbacks: ResolvedFallback[];
+  error?: string;
+}
+
+/**
+ * Applies the configured `route:*` label overrides named in `labelNames` to a
+ * tier's routing. PURE — returns structured data, never throws.
+ *
+ * Semantics (ADR-0015 guardrails):
+ * - An override patches ONLY the roles it names; every other role is untouched.
+ * - Two configured labels patching the SAME role is a loud, structured error
+ *   (`error` set) — there is no precedence rule. The original routing is
+ *   returned unchanged in that case.
+ * - A `route:*` label present on the slice but ABSENT from the config produces a
+ *   structured warning (never a silent no-op).
+ * - Each applied label's optional `fallback` spec is resolved and returned in
+ *   `fallbacks`, tagged with the role and label it came from.
+ */
+export function applyLabels(
+  tierRouting: TierRoutingV2,
+  labelNames: string[],
+  labelsConfig: LabelsConfig
+): ApplyLabelsResult {
+  const warnings: string[] = [];
+  const fallbacks: ResolvedFallback[] = [];
+  // Clone so the input is never mutated.
+  const routing: TierRoutingV2 = {
+    investigator: tierRouting.investigator
+      ? { ...tierRouting.investigator }
+      : null,
+    implementer: { ...tierRouting.implementer },
+    reviewer: { ...tierRouting.reviewer },
+    "conflict-resolver": { ...tierRouting["conflict-resolver"] },
+  };
+
+  // Track which label first patched each role to detect same-role conflicts.
+  const patchedBy = new Map<RoutingRole, string>();
+
+  for (const labelName of labelNames) {
+    const spec = labelsConfig[labelName];
+    if (!spec) {
+      warnings.push(
+        `Label '${labelName}' is present on the slice but absent from ` +
+          `routing.json's \`labels\` block — it had no effect. Add it to the ` +
+          `config or remove the label.`
+      );
+      continue;
+    }
+
+    for (const role of spec.roles) {
+      const prior = patchedBy.get(role);
+      if (prior !== undefined) {
+        return {
+          routing: tierRouting,
+          warnings,
+          fallbacks: [],
+          error:
+            `Conflicting label overrides: both '${prior}' and '${labelName}' ` +
+            `patch the role '${role}'. There is no precedence rule — resolve ` +
+            `the conflict in routing.json (each role may be patched by at most ` +
+            `one applied label).`,
+        };
+      }
+      patchedBy.set(role, labelName);
+      routing[role] = { ...spec.set };
+      if (spec.fallback) {
+        fallbacks.push({ role, label: labelName, fallback: spec.fallback });
+      }
+    }
+  }
+
+  return { routing, warnings, fallbacks };
 }

--- a/plugins/orchestrate/orchestrate-mcp/test/routing.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/routing.test.ts
@@ -6,7 +6,15 @@ import {
   resolveRouting,
   resolveRoutingFromConfig,
   routingConfigSchema,
+  routingConfigSchemaV1,
+  routingConfigSchemaV2,
+  upgradeV1ToV2,
+  loadRoutingConfig,
+  applyLabels,
   type RoutingConfig,
+  type RoutingConfigV2,
+  type TierRoutingV2,
+  type LabelsConfig,
 } from "../src/tools/routing.js";
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
@@ -237,5 +245,307 @@ describe("routingConfigSchema continuationBudget (#234)", () => {
 
     expect(r.status).toBe("error");
     expect(r.errorCode).toBe("CONFIG_INVALID");
+  });
+});
+
+// ─── v2 schema (ADR-0015) ─────────────────────────────────────────────────────
+
+/** A well-formed v2 config used as the baseline for the v2 schema tests. */
+const VALID_CONFIG_V2: RoutingConfigV2 = {
+  version: 2,
+  tiers: {
+    trivial: {
+      investigator: null,
+      implementer: { model: "haiku", variant: "standard" },
+      reviewer: { model: "sonnet", variant: "standard" },
+      "conflict-resolver": { model: "sonnet", variant: "standard" },
+    },
+    standard: {
+      investigator: { model: "haiku", variant: "standard" },
+      implementer: { model: "sonnet", variant: "standard" },
+      reviewer: { model: "opus", variant: "standard" },
+      "conflict-resolver": { model: "opus", variant: "standard" },
+    },
+    complex: {
+      investigator: { model: "opus", variant: "deep" },
+      implementer: { model: "opus", variant: "deep" },
+      reviewer: { model: "opus", variant: "deep" },
+      "conflict-resolver": { model: "opus", variant: "deep" },
+    },
+  },
+  labels: {},
+  run: { intraWaveConcurrency: "parallel", continuationBudget: 2 },
+};
+
+describe("routingConfigSchemaV2", () => {
+  it("validates the new shape (version/tiers/labels/run)", () => {
+    expect(routingConfigSchemaV2.safeParse(VALID_CONFIG_V2).success).toBe(true);
+  });
+
+  it("accepts variant: 'standard' and variant: 'deep'", () => {
+    const parsed = routingConfigSchemaV2.parse(VALID_CONFIG_V2);
+    expect(parsed.tiers.trivial.implementer.variant).toBe("standard");
+    expect(parsed.tiers.complex.implementer.variant).toBe("deep");
+  });
+
+  it("rejects an invalid variant value", () => {
+    const bad = {
+      ...VALID_CONFIG_V2,
+      tiers: {
+        ...VALID_CONFIG_V2.tiers,
+        trivial: {
+          ...VALID_CONFIG_V2.tiers.trivial,
+          implementer: { model: "haiku", variant: "bogus" },
+        },
+      },
+    };
+    expect(routingConfigSchemaV2.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejects a v2 config whose version is not the literal 2", () => {
+    expect(
+      routingConfigSchemaV2.safeParse({ ...VALID_CONFIG_V2, version: 1 }).success
+    ).toBe(false);
+  });
+
+  it("defaults labels to {} and run knobs when omitted", () => {
+    const { labels: _l, run: _r, ...noLabelsOrRun } = VALID_CONFIG_V2;
+    const parsed = routingConfigSchemaV2.parse(noLabelsOrRun);
+    expect(parsed.labels).toEqual({});
+    expect(parsed.run.intraWaveConcurrency).toBe("parallel");
+    expect(parsed.run.continuationBudget).toBe(2);
+  });
+
+  it("validates a labels block with set + fallback", () => {
+    const withLabel = {
+      ...VALID_CONFIG_V2,
+      labels: {
+        "route:fable": {
+          roles: ["implementer"],
+          set: { model: "fable", variant: "deep" },
+          fallback: { model: "opus", maxRetries: 1 },
+        },
+      },
+    };
+    expect(routingConfigSchemaV2.safeParse(withLabel).success).toBe(true);
+  });
+
+  it("still requires all three tiers under `tiers`", () => {
+    const { complex: _c, ...missingTier } = VALID_CONFIG_V2.tiers;
+    expect(
+      routingConfigSchemaV2.safeParse({ ...VALID_CONFIG_V2, tiers: missingTier })
+        .success
+    ).toBe(false);
+  });
+});
+
+// ─── v1 → v2 upgrade (explicit mapper) ────────────────────────────────────────
+
+describe("upgradeV1ToV2 / loadRoutingConfig", () => {
+  // The canonical on-disk v1 fixture: it OMITS continuationBudget and orders
+  // intraWaveConcurrency: "sequential" first — the exact shape of the repo's
+  // own live .orchestrate/routing.json before v2.
+  const V1_ON_DISK = {
+    intraWaveConcurrency: "sequential",
+    trivial: {
+      investigator: null,
+      implementer: { model: "sonnet", effort: "standard" },
+      reviewer: { model: "sonnet", effort: "standard" },
+      "conflict-resolver": { model: "sonnet", effort: "standard" },
+    },
+    standard: {
+      investigator: null,
+      implementer: { model: "sonnet", effort: "standard" },
+      reviewer: { model: "opus", effort: "standard" },
+      "conflict-resolver": { model: "opus", effort: "standard" },
+    },
+    complex: {
+      investigator: { model: "opus", effort: "deep" },
+      implementer: { model: "opus", effort: "deep" },
+      reviewer: { model: "opus", effort: "deep" },
+      "conflict-resolver": { model: "opus", effort: "deep" },
+    },
+  };
+
+  it("maps every tier's effort → variant", () => {
+    const v1 = routingConfigSchemaV1.parse(V1_ON_DISK);
+    const { config } = upgradeV1ToV2(v1);
+
+    expect(config.version).toBe(2);
+    expect(config.tiers.trivial.implementer).toEqual({
+      model: "sonnet",
+      variant: "standard",
+    });
+    expect(config.tiers.complex.implementer).toEqual({
+      model: "opus",
+      variant: "deep",
+    });
+    // A null investigator survives the upgrade as null.
+    expect(config.tiers.trivial.investigator).toBeNull();
+    expect(config.tiers.complex.investigator).toEqual({
+      model: "opus",
+      variant: "deep",
+    });
+  });
+
+  it("preserves continuationBudget: 0 and intraWaveConcurrency: 'sequential' verbatim", () => {
+    // A v1 file that explicitly sets continuationBudget: 0 with sequential.
+    const v1raw = { ...V1_ON_DISK, continuationBudget: 0 };
+    const result = loadRoutingConfig(v1raw);
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.config.run.continuationBudget).toBe(0);
+    expect(result.config.run.intraWaveConcurrency).toBe("sequential");
+    // And the deprecation warning is present.
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain("v1");
+  });
+
+  it("lifts the v1 default continuationBudget (2) into run when the key is omitted", () => {
+    // V1_ON_DISK omits continuationBudget → v1 schema defaults it to 2.
+    const result = loadRoutingConfig(V1_ON_DISK);
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.config.run.continuationBudget).toBe(2);
+    expect(result.config.run.intraWaveConcurrency).toBe("sequential");
+  });
+
+  it("does NOT silently reset run knobs (a naive v2 re-parse would)", () => {
+    // The bug the explicit mapper guards against: re-parsing a v1 file under the
+    // v2 schema strips the top-level knobs. The loader must preserve them.
+    const naive = routingConfigSchemaV2.safeParse(V1_ON_DISK);
+    expect(naive.success).toBe(false); // v1 shape is NOT valid v2 — caught loudly.
+
+    const result = loadRoutingConfig(V1_ON_DISK);
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    // The knob survived rather than resetting to the parallel default.
+    expect(result.config.run.intraWaveConcurrency).toBe("sequential");
+  });
+
+  it("attaches a deprecation warning on v1 upgrade", () => {
+    const result = loadRoutingConfig(V1_ON_DISK);
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toContain("deprecated");
+  });
+
+  it("loads a v2 file directly with no warning", () => {
+    const result = loadRoutingConfig(VALID_CONFIG_V2);
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.warnings).toEqual([]);
+    expect(result.config.run.intraWaveConcurrency).toBe("parallel");
+  });
+
+  it("returns a structured error for an unsupported version", () => {
+    const result = loadRoutingConfig({ ...VALID_CONFIG_V2, version: 99 });
+    expect(result.status).toBe("error");
+    if (result.status !== "error") return;
+    expect(result.errorMessage).toContain("version");
+  });
+
+  it("returns a structured error for a malformed v1 shape (never throws)", () => {
+    const result = loadRoutingConfig({ trivial: {} });
+    expect(result.status).toBe("error");
+    if (result.status !== "error") return;
+    expect(result.errorMessage).toContain("v1");
+  });
+});
+
+// ─── Label-override merge (pure) ──────────────────────────────────────────────
+
+describe("applyLabels", () => {
+  const tier: TierRoutingV2 = VALID_CONFIG_V2.tiers.standard;
+
+  const labels: LabelsConfig = {
+    "route:fable": {
+      roles: ["implementer"],
+      set: { model: "fable", variant: "deep" },
+      fallback: { model: "opus", maxRetries: 1 },
+    },
+    "route:opus-review": {
+      roles: ["reviewer"],
+      set: { model: "opus", variant: "deep" },
+    },
+    // A second label that ALSO patches implementer — used for conflict tests.
+    "route:opus-impl": {
+      roles: ["implementer"],
+      set: { model: "opus", variant: "deep" },
+    },
+  };
+
+  it("applies the override to the named role only, leaving others untouched", () => {
+    const r = applyLabels(tier, ["route:fable"], labels);
+
+    expect(r.error).toBeUndefined();
+    expect(r.routing.implementer).toEqual({ model: "fable", variant: "deep" });
+    // Every other role is unchanged from the tier baseline.
+    expect(r.routing.reviewer).toEqual(tier.reviewer);
+    expect(r.routing["conflict-resolver"]).toEqual(tier["conflict-resolver"]);
+    expect(r.routing.investigator).toEqual(tier.investigator);
+  });
+
+  it("does not mutate the input tier routing", () => {
+    const before = JSON.parse(JSON.stringify(tier));
+    applyLabels(tier, ["route:fable"], labels);
+    expect(tier).toEqual(before);
+  });
+
+  it("applies two non-conflicting labels to their distinct roles", () => {
+    const r = applyLabels(tier, ["route:fable", "route:opus-review"], labels);
+
+    expect(r.error).toBeUndefined();
+    expect(r.routing.implementer).toEqual({ model: "fable", variant: "deep" });
+    expect(r.routing.reviewer).toEqual({ model: "opus", variant: "deep" });
+  });
+
+  it("returns a structured error when two labels patch the same role", () => {
+    const r = applyLabels(tier, ["route:fable", "route:opus-impl"], labels);
+
+    expect(r.error).toBeDefined();
+    expect(r.error).toContain("implementer");
+    expect(r.error).toContain("route:fable");
+    expect(r.error).toContain("route:opus-impl");
+    // On conflict the routing is returned unchanged (no partial application).
+    expect(r.routing).toEqual(tier);
+  });
+
+  it("returns a structured warning for a route:* label absent from config", () => {
+    const r = applyLabels(tier, ["route:unknown"], labels);
+
+    expect(r.error).toBeUndefined();
+    expect(r.warnings.length).toBe(1);
+    expect(r.warnings[0]).toContain("route:unknown");
+    // Never a silent no-op: routing is untouched but the warning is loud.
+    expect(r.routing).toEqual(tier);
+  });
+
+  it("resolves and returns the per-label fallback spec", () => {
+    const r = applyLabels(tier, ["route:fable"], labels);
+
+    expect(r.fallbacks).toEqual([
+      {
+        role: "implementer",
+        label: "route:fable",
+        fallback: { model: "opus", maxRetries: 1 },
+      },
+    ]);
+  });
+
+  it("returns no fallback for a label without one", () => {
+    const r = applyLabels(tier, ["route:opus-review"], labels);
+    expect(r.fallbacks).toEqual([]);
+  });
+
+  it("is a no-op (no error, no warning) when no labels are applied", () => {
+    const r = applyLabels(tier, [], labels);
+    expect(r.error).toBeUndefined();
+    expect(r.warnings).toEqual([]);
+    expect(r.fallbacks).toEqual([]);
+    expect(r.routing).toEqual(tier);
   });
 });


### PR DESCRIPTION
Implements #312. Adds the v2 routing schema (version/tiers/labels/run), an explicit v1 schema + field-by-field upgrade mapper (preserves run-policy keys, emits a deprecation warning), a version-dispatch loader, and pure label-override merge functions (named-roles-only patch, same-role conflict error, unconfigured-label warning, fallback resolution) — all additive to the existing effort-keyed API. TDD coverage in routing.test.ts; dist/ rebuilt. ADR-0015.