### PR TITLE
Explicit effort frontmatter across the eight subagent definitions

### DIFF
--- a/plugins/orchestrate/agents/conflict-resolver-standard.md
+++ b/plugins/orchestrate/agents/conflict-resolver-standard.md
@@ -3,6 +3,7 @@ name: conflict-resolver-standard
 description: Resolves a merge conflict between a slice branch and the umbrella branch — edits the conflicted files to a correct merged state and re-verifies. Standard-effort variant for trivial- and standard-tier issues. Spawned by the orchestrate skill; not invoked directly.
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_orchestrate_orchestrate__run_tests, mcp__plugin_orchestrate_orchestrate__run_typecheck, mcp__plugin_orchestrate_orchestrate__run_build, mcp__plugin_orchestrate_orchestrate__run_lint, mcp__plugin_orchestrate_orchestrate__run_install
 model: sonnet
+effort: medium
 maxTurns: 30
 ---
 
@@ -14,8 +15,10 @@ your job is to edit them to a correct merged state. You are spawned once per
 conflicting slice and never run directly.
 
 This is the **standard-effort variant**, spawned for trivial- and standard-tier
-issues. `maxTurns` is 30 — conflict resolution plus re-verification is a
-smaller surface than a full implementation.
+issues. `effort: medium` for standard-/trivial-tier work — reconciling
+standard-tier conflicts is bounded merge reasoning, not the deeper intent-tracing
+the `xhigh` deep variant carries. `maxTurns` is 30 — conflict resolution plus
+re-verification is a smaller surface than a full implementation.
 
 ## What you receive
 

--- a/plugins/orchestrate/agents/implementer-standard.md
+++ b/plugins/orchestrate/agents/implementer-standard.md
@@ -3,6 +3,7 @@ name: implementer-standard
 description: Implements a single tracked issue inside an isolated git worktree — edits files and verifies the work through the orchestrate capability tools. Standard-effort variant for trivial- and standard-tier issues. Spawned by the orchestrate skill; not invoked directly.
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_orchestrate_orchestrate__run_tests, mcp__plugin_orchestrate_orchestrate__run_typecheck, mcp__plugin_orchestrate_orchestrate__run_build, mcp__plugin_orchestrate_orchestrate__run_lint, mcp__plugin_orchestrate_orchestrate__run_install
 model: sonnet
+effort: medium
 maxTurns: 65
 ---
 
@@ -12,7 +13,9 @@ You implement exactly one tracked issue inside an isolated git worktree. The
 `orchestrate` skill spawns you — you never run directly.
 
 This is the **standard-effort variant**, spawned for trivial- and standard-tier
-issues. `maxTurns` is 65 because implementation is multi-file editing plus
+issues. `effort: medium` for standard-/trivial-tier work — the change is
+well-scoped editing, not the cross-cutting reasoning the `xhigh` deep variant
+carries. `maxTurns` is 65 because implementation is multi-file editing plus
 iterative capability-tool verification — exploration, edits, and re-runs after
 every fix — which needs substantially more turns than read-only analysis. The
 budget is generous enough that a standard-tier slice finishes inside it; if the

--- a/plugins/orchestrate/agents/investigator-standard.md
+++ b/plugins/orchestrate/agents/investigator-standard.md
@@ -3,6 +3,7 @@ name: investigator-standard
 description: Investigates the codebase and issue before implementation — explores relevant files, patterns, and risks, then returns a research brief for the implementer. Standard-effort variant for complex-tier issues. Spawned by the orchestrate skill before the implementer; not invoked directly.
 tools: Read, Grep, Glob, mcp__plugin_orchestrate_orchestrate__search_structural
 model: sonnet
+effort: medium
 maxTurns: 20
 ---
 
@@ -12,9 +13,11 @@ You investigate the codebase and the issue before the implementer runs. The
 `orchestrate` skill spawns you for complex-tier issues — you never run directly,
 and you never modify any file.
 
-This is the **standard-effort variant**. `maxTurns` is 20 — investigation is a
-read-only pass; 20 turns is enough to map the relevant surface before handing
-off to the implementer.
+This is the **standard-effort variant**. `effort: medium` for standard-tier
+investigation — mapping the relevant surface of a complex-tier issue is
+routine reasoning, not the deeper risk-tracing the `xhigh` deep variant carries.
+`maxTurns` is 20 — investigation is a read-only pass; 20 turns is enough to map
+the relevant surface before handing off to the implementer.
 
 ## What you receive
 

--- a/plugins/orchestrate/agents/reviewer-standard.md
+++ b/plugins/orchestrate/agents/reviewer-standard.md
@@ -3,6 +3,7 @@ name: reviewer-standard
 description: Reviews an implemented slice inside its git worktree — fixes clarity and consistency issues inline, re-runs the orchestrate capability tools, and gates the auto-merge. Standard-effort variant for trivial- and standard-tier issues. Spawned by the orchestrate skill; not invoked directly.
 tools: Read, Edit, Write, Grep, Glob, mcp__plugin_orchestrate_orchestrate__run_tests, mcp__plugin_orchestrate_orchestrate__run_typecheck, mcp__plugin_orchestrate_orchestrate__run_build, mcp__plugin_orchestrate_orchestrate__run_lint, mcp__plugin_orchestrate_orchestrate__search_structural
 model: sonnet
+effort: high
 maxTurns: 40
 ---
 
@@ -13,7 +14,10 @@ may be merged. The `orchestrate` skill spawns you after the implementer — you
 never run directly.
 
 This is the **standard-effort variant**, spawned for trivial- and standard-tier
-issues. `maxTurns` is 40 — review plus inline fixes plus re-verification.
+issues. `effort: high` because review gates the auto-merge — even at the
+standard tier the pass/fail decision is the merge-gate judgment, so it warrants
+more reasoning than the `medium` implementer and investigator it follows.
+`maxTurns` is 40 — review plus inline fixes plus re-verification.
 
 ## What you receive
 


### PR DESCRIPTION
Implements #316. Adds deterministic `effort:` frontmatter to the four `-standard` subagent definitions (medium for investigator/implementer/conflict-resolver, high for reviewer as the merge-gate role); the four `-deep` definitions already carry `effort: xhigh` (verified). Per spike #311 verdict `effort-on-haiku-targets: allowed`, the two Haiku-target standard defs receive `effort: medium` (degrades gracefully). Each touched file's prose explains its effort rationale in the existing voice. No `tools:`/`model:`/advisor-policy change (ADR-0009 parity preserved). ADR-0015.