### PR TITLE
Persist resolved slice routing in run-state checkpoint

### DIFF
--- a/plugins/orchestrate/orchestrate-mcp/dist/index.js
+++ b/plugins/orchestrate/orchestrate-mcp/dist/index.js
@@ -22311,6 +22311,14 @@ var subStateEnum = external_exports.enum([
   "pr-open",
   "merged"
 ]);
+var resolvedRoutingSchema = external_exports.object({
+  investigator: roleConfigSchemaV2.nullable(),
+  implementer: roleConfigSchemaV2,
+  reviewer: roleConfigSchemaV2,
+  "conflict-resolver": roleConfigSchemaV2,
+  fallback: labelFallbackSchema.optional(),
+  fallbackTaken: external_exports.boolean().default(false)
+});
 var sliceSchema = external_exports.object({
   issue: external_exports.number().int(),
   title: external_exports.string(),
@@ -22323,7 +22331,8 @@ var sliceSchema = external_exports.object({
   worktreePath: external_exports.string().nullable(),
   pullRequest: external_exports.string().nullable(),
   failureReason: external_exports.string().nullable(),
-  updatedAt: external_exports.string()
+  updatedAt: external_exports.string(),
+  resolvedRouting: resolvedRoutingSchema.optional()
 });
 var runStateSchema = external_exports.object({
   runId: external_exports.string(),

--- a/plugins/orchestrate/orchestrate-mcp/src/tools/render.ts
+++ b/plugins/orchestrate/orchestrate-mcp/src/tools/render.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { z } from "zod";
 import { resolveRunDir, type RunPaths } from "../run-dir.js";
+import { roleConfigSchemaV2, labelFallbackSchema } from "./routing.js";
 
 // ─── Schemas — z.object is the single source of truth; TS types via z.infer ───
 
@@ -20,6 +21,19 @@ const subStateEnum = z.enum([
   "merged",
 ]);
 
+// Resolved routing frozen at slice creation — captures per-role model+variant,
+// an optional label fallback spec, and whether the fallback was already used.
+// The entire field is OPTIONAL on the slice so pre-existing checkpoints (written
+// before this field was added) continue to validate (backward-compat, criterion 3).
+const resolvedRoutingSchema = z.object({
+  investigator: roleConfigSchemaV2.nullable(),
+  implementer: roleConfigSchemaV2,
+  reviewer: roleConfigSchemaV2,
+  "conflict-resolver": roleConfigSchemaV2,
+  fallback: labelFallbackSchema.optional(),
+  fallbackTaken: z.boolean().default(false),
+});
+
 const sliceSchema = z.object({
   issue: z.number().int(),
   title: z.string(),
@@ -33,6 +47,7 @@ const sliceSchema = z.object({
   pullRequest: z.string().nullable(),
   failureReason: z.string().nullable(),
   updatedAt: z.string(),
+  resolvedRouting: resolvedRoutingSchema.optional(),
 });
 
 export const runStateSchema = z.object({

--- a/plugins/orchestrate/orchestrate-mcp/test/validate-run-state.test.ts
+++ b/plugins/orchestrate/orchestrate-mcp/test/validate-run-state.test.ts
@@ -23,6 +23,15 @@ const SLICE = {
   updatedAt: "2026-05-21T01:30:00Z",
 };
 
+/** A valid resolvedRouting object for use in slice fixtures. */
+const RESOLVED_ROUTING = {
+  investigator: null,
+  implementer: { model: "claude-sonnet-4-5", variant: "standard" },
+  reviewer: { model: "claude-sonnet-4-5", variant: "standard" },
+  "conflict-resolver": { model: "claude-sonnet-4-5", variant: "standard" },
+  fallbackTaken: false,
+};
+
 /** A full run-state with `slices` as the canonical MAP keyed by issue-id string. */
 function validMapState(): Record<string, unknown> {
   return {
@@ -112,5 +121,70 @@ describe("validateRunState", () => {
     const result = await validateRunState({ runId: "../escape", repoPath });
     expect(result.status).toBe("invalid");
     expect(result.errorCode).toBe("RUN_ID_INVALID");
+  });
+
+  // ─── resolvedRouting field tests (criterion 1 / 2 / 3) ───────────────────────
+
+  it("slice WITH valid resolvedRouting returns status: valid", async () => {
+    const state = validMapState();
+    (state.slices as Record<string, unknown>)["157"] = {
+      ...SLICE,
+      resolvedRouting: RESOLVED_ROUTING,
+    };
+    const repoPath = project(state);
+    const result = await validateRunState({ runId: RUN_ID, repoPath });
+    expect(result).toEqual({ status: "valid" });
+  });
+
+  it("slice WITH resolvedRouting carrying a fallback spec returns status: valid", async () => {
+    const state = validMapState();
+    (state.slices as Record<string, unknown>)["157"] = {
+      ...SLICE,
+      resolvedRouting: {
+        ...RESOLVED_ROUTING,
+        fallback: { model: "claude-opus-4-5", maxRetries: 1 },
+        fallbackTaken: true,
+      },
+    };
+    const repoPath = project(state);
+    const result = await validateRunState({ runId: RUN_ID, repoPath });
+    expect(result).toEqual({ status: "valid" });
+  });
+
+  it("LEGACY slice WITHOUT resolvedRouting still returns status: valid (backward-compat)", async () => {
+    // SLICE has no resolvedRouting — simulates a pre-existing checkpoint.
+    const repoPath = project(validMapState());
+    const result = await validateRunState({ runId: RUN_ID, repoPath });
+    expect(result).toEqual({ status: "valid" });
+  });
+
+  it("malformed resolvedRouting (bad variant enum) returns RUN_STATE_INVALID with field-path error", async () => {
+    const state = validMapState();
+    (state.slices as Record<string, unknown>)["157"] = {
+      ...SLICE,
+      resolvedRouting: {
+        ...RESOLVED_ROUTING,
+        implementer: { model: "claude-sonnet-4-5", variant: "ultra" }, // "ultra" is not in the enum
+      },
+    };
+    const repoPath = project(state);
+    const result = await validateRunState({ runId: RUN_ID, repoPath });
+    expect(result.status).toBe("invalid");
+    expect(result.errorCode).toBe("RUN_STATE_INVALID");
+    expect(result.errorMessage).toContain("resolvedRouting");
+  });
+
+  it("malformed resolvedRouting (missing required role) returns RUN_STATE_INVALID", async () => {
+    const state = validMapState();
+    const { implementer: _omit, ...noImplementer } = RESOLVED_ROUTING;
+    (state.slices as Record<string, unknown>)["157"] = {
+      ...SLICE,
+      resolvedRouting: noImplementer,
+    };
+    const repoPath = project(state);
+    const result = await validateRunState({ runId: RUN_ID, repoPath });
+    expect(result.status).toBe("invalid");
+    expect(result.errorCode).toBe("RUN_STATE_INVALID");
+    expect(result.errorMessage).toContain("resolvedRouting");
   });
 });

--- a/plugins/orchestrate/skills/orchestrate/references/run-state.md
+++ b/plugins/orchestrate/skills/orchestrate/references/run-state.md
@@ -68,7 +68,15 @@ metadata, not source — the target project should gitignore
       "worktreePath": "/abs/path/.orchestrate-worktrees/prd153-20260521-015143/slice-157",
       "pullRequest": "https://github.com/owner/repo/pull/200",
       "failureReason": null,
-      "updatedAt": "2026-05-21T02:05:00Z"
+      "updatedAt": "2026-05-21T02:05:00Z",
+      "resolvedRouting": {
+        "investigator": null,
+        "implementer": { "model": "claude-sonnet-4-5", "variant": "standard" },
+        "reviewer": { "model": "claude-sonnet-4-5", "variant": "standard" },
+        "conflict-resolver": { "model": "claude-sonnet-4-5", "variant": "standard" },
+        "fallback": { "model": "claude-opus-4-5", "maxRetries": 1 },
+        "fallbackTaken": false
+      }
     }
   }
 }
@@ -128,6 +136,20 @@ metadata, not source — the target project should gitignore
 - `pullRequest` — the slice pull request URL, or `null` before it is opened.
 - `failureReason` — a short explanation when `state` is `failed`/`skipped`; else `null`.
 - `updatedAt` — when this slice last changed state.
+- `resolvedRouting` — **optional**; absent on checkpoints written before this
+  field was introduced (backward-compatible). When present, it captures the
+  routing that was frozen at slice creation so a resumed run routes the slice
+  from the checkpoint rather than from live GitHub labels. Shape:
+  - `investigator` — `{model, variant}` for the investigator role, or `null`
+    when this tier skips the investigation pass.
+  - `implementer` — `{model, variant}` for the implementer role.
+  - `reviewer` — `{model, variant}` for the reviewer role.
+  - `conflict-resolver` — `{model, variant}` for the conflict-resolver role.
+  - `fallback` — **optional** `{model, maxRetries}` spec; present when a
+    label override (e.g. `route:fable`) carried a fallback, absent otherwise.
+  - `fallbackTaken` — boolean; `true` when the fallback was already used on a
+    previous spawn attempt in this run, preventing the fallback from being
+    applied again on resume. Defaults to `false`.
 
 ## Slice states
 


### PR DESCRIPTION
Implements #315. Adds an optional `resolvedRouting` field to the run-state slice schema (per-role {model, variant}, optional fallback {model, maxRetries}, fallbackTaken marker) so a resumed run routes from the checkpoint, never from live labels, and a model fallback is never repeated/lost across handoff. `validate_run_state` accepts the new fields and rejects malformed ones with field-path errors; legacy checkpoints without the field still validate (additive/optional). +5 TDD tests; run-state.md updated; dist/ rebuilt. ADR-0015.