### PR TITLE
Skill wiring: label-once resolution, variant spawns, model-fallback step, resume matrix row

### DIFF
--- a/plugins/orchestrate/skills/orchestrate/SKILL.md
+++ b/plugins/orchestrate/skills/orchestrate/SKILL.md
@@ -40,17 +40,32 @@ back over the cap; do **not** generalize that exception to any other skill.)
   conflicts with the umbrella branch, it edits the conflicted files to a
   correct merged state. It is spawned once per conflicting slice.
 
-Every role except the orchestrator exists in two effort variants — `-standard`
+Every role except the orchestrator exists in two variants — `-standard`
 and `-deep`. The `resolve_routing` tool picks the variant and model per role
-from the issue's complexity tier (section 3, step 2). Each role is spawned by
-its **namespaced** subagent type — `orchestrate:investigator-<effort>`,
-`orchestrate:implementer-<effort>`, `orchestrate:reviewer-<effort>`, and
-`orchestrate:conflict-resolver-<effort>`, where `<effort>` is `standard` or
+from the issue's complexity tier **and its routing labels** (section 3, step 2).
+Each role is spawned by
+its **namespaced** subagent type — `orchestrate:investigator-<variant>`,
+`orchestrate:implementer-<variant>`, `orchestrate:reviewer-<variant>`, and
+`orchestrate:conflict-resolver-<variant>`, where `<variant>` is `standard` or
 `deep`. The `orchestrate:` prefix is required: the plugin registers its bundled
 subagents under that namespace, so a bare, un-namespaced name fails to resolve.
 All four subagents have **no Bash and no git access** — they are sandboxed to
 one worktree (the investigator is read-only). Only the orchestrator touches
 branches, remotes, and the tracker.
+
+**Routing labels — read once, frozen, suggested never applied.** A slice issue
+may carry a `route:*` label that patches its routing (e.g. `route:fable`, the
+label-gated implementer-only premium lane). `resolve_routing` reads those labels
+**exactly once**, at slice creation (section 3, step 2): the orchestrator passes
+the issue's labels to the tool and **freezes** the returned `{model, variant,
+optional fallback}` into the slice's `resolvedRouting` checkpoint field. A
+resumed run routes from that frozen checkpoint, **never** from live GitHub
+labels — relabelling an issue mid-run changes nothing. The orchestrator may
+**suggest** a `route:*` label for a slice in its report but **never applies one
+itself** — the same self-promotion guard that forbids it from re-tiering a slice
+upward by writing a label (it routes; it does not relabel). The label semantics,
+the configured-vs-unconfigured outcomes, and the Fable lane's security exclusion
+are in `references/prerequisites.md`, co-located with the `routing.json` schema.
 
 IDE or language-server diagnostics about files under a worktree path —
 unresolved imports, missing-module errors, or stale type errors from a checkout
@@ -179,6 +194,19 @@ always preserved and the changed-file set always reconstructed via
 | `pushed` | implementer, reviewer | `git ls-remote --heads origin orchestrate/slice-<N>` confirms the branch | step 7 (open PR) |
 | `pr-open` | implementer, reviewer | `gh pr view` confirms the PR; `git ls-remote` confirms the branch | step 8 (merge) |
 | `merged` | all subagents | — (merge already landed in umbrella) | step 9 only (label transition + `remove_worktree`) |
+
+**Resume routing is frozen, not re-derived (the fallback-aware dimension).**
+Orthogonal to the `subState` row above: when a resumed in-progress slice
+**re-spawns** any subagent (the rows that do not skip the implementer/reviewer),
+it routes **only** from the slice's frozen `resolvedRouting` checkpoint — its
+recorded `model`, `variant`, and `fallback` — never from live GitHub labels and
+never by re-calling `resolve_routing`. A slice whose `resolvedRouting.fallbackTaken`
+is `true` (a premium-spawned implementer that already failed over to the fallback
+model in the prior session, section 3) resumes on that **frozen fallback model**
+— the premium lane is **not** re-applied and the one-time fallback is **not**
+re-armed. This keeps routing deterministic across a handoff: the label was read
+once at slice creation, and the checkpoint — not the issue's current labels — is
+the source of truth for every re-spawn.
 
 On resume the implementer's *declared* `filesChanged` is gone, so the
 reconstructed `recover_changed_files` set feeds the reviewer prompt and the
@@ -329,6 +357,26 @@ staged changeset is empty, or a merge conflict the `conflict-resolver` cannot
 fix. The orchestrator decides FAILURE **only** from the validated envelope and
 tool results — never from a subagent's prose. An invalid or missing envelope is
 always a FAILED slice; it is never treated as success.
+
+**Model fallback — one premium-spawn interception before FAILED.** A
+**premium-spawned** implementer (one whose `resolvedRouting` carried a `fallback`
+because a `route:*` label patched it — e.g. `route:fable`) gets **one** rescue
+before the slice is declared FAILED. When such an implementer fails in a way the
+fallback covers — a model **refusal**, a retention/safety **400**, or an
+**invalid/missing envelope** — and the slice's `resolvedRouting.fallbackTaken` is
+not yet set, the orchestrator **re-spawns it exactly once on the fallback model**
+(`resolvedRouting.fallback.model`, e.g. `opus`) in the **same** worktree, sets
+`resolvedRouting.fallbackTaken: true`, and narrates the swap in the final report
+("fable declined → served by opus"). This swap is a **model exchange**, distinct
+from the same-model continue-in-place loop: it does **not** consume or increment
+`continuationBudget`, and `fallbackTaken` is a **persisted slice-level** once-only
+guard (set in the checkpoint, surviving a handoff) — so the fallback fires at most
+once across the initial spawn and every continuation. A fallback that is absent
+(no premium label), already spent (`fallbackTaken` already `true`), or that does
+not apply (a *valid* `blocked` envelope is a genuine obstacle the fallback model
+would not fix) leaves the ordinary FAILED taxonomy above unchanged. The mechanics
+— where the re-spawn runs and how the checkpoint is written — are in
+`references/slice-pipeline.md` (the model-fallback step adjacent to step 4).
 
 The implementer envelope's `incomplete` status is the implementer's graceful
 turn-budget self-report — partial, resumable work, carrying a `remainingWork`

--- a/plugins/orchestrate/skills/orchestrate/references/prerequisites.md
+++ b/plugins/orchestrate/skills/orchestrate/references/prerequisites.md
@@ -40,6 +40,37 @@ subagent has no shell to regenerate the lockfile. Without `routing.json` the
 `resolve_routing` tool errors
 and the run falls back to the `-standard` variant of every role with no model
 override.
+
+### Routing labels and the Fable premium lane
+
+`routing.json` (v2) carries an optional `labels` block — a map of `route:*`
+label names to a routing override. When a slice issue carries one of those
+labels, `resolve_routing` patches the named roles with the label's `{model,
+variant}` and resolves its optional model `fallback`. The orchestrator passes
+the issue's labels to `resolve_routing` **once, at slice creation**, and freezes
+the result into the slice's `resolvedRouting` checkpoint; every later spawn and
+every resume routes from that frozen checkpoint, never from live labels (the
+mechanics are in `references/slice-pipeline.md` step 2, the judgment in the
+spine). The orchestrator may **suggest** a `route:*` label in its report but
+**never applies one itself**.
+
+- **`route:fable`** — the canonical premium lane: a **label-gated,
+  implementer-only** override that spawns the implementer on a premium model
+  with an `opus` fallback. It is **not** a complexity tier — it is orthogonal to
+  `trivial`/`standard`/`complex` and is triggered solely by the label.
+- **Unconfigured `route:*` label** — a `route:*` label on the slice that the
+  `labels` block does not define produces a loud **WARNING** in the run report
+  (`resolve_routing`'s `warnings[]`): the label had no effect; fix `routing.json`
+  or drop the label.
+- **Same-role conflict** — two applied labels that patch the **same** role is a
+  loud **ERROR** (`resolve_routing` `LABEL_CONFLICT`); there is no precedence
+  rule and the slice FAILS until the operator resolves it in `routing.json`.
+- **Security exclusion** — the Fable lane is **excluded for security/cyber
+  slices**: Fable's safety classifiers refuse benign security work, so such a
+  slice would only burn the spawn and fall through to the `opus` fallback. Do
+  **not** apply (or suggest) `route:fable` on a security/cyber slice; route it
+  through the ordinary complexity tiers instead.
+
 An optional `.orchestrate/handoff.json` tunes the context-watchdog threshold
 and the successor launcher; without it, built-in defaults apply (see
 `references/context-handoff.md`). Installing the `ast-grep` CLI is optional —

--- a/plugins/orchestrate/skills/orchestrate/references/slice-pipeline.md
+++ b/plugins/orchestrate/skills/orchestrate/references/slice-pipeline.md
@@ -22,17 +22,36 @@ narration in the spine describes.
    `install` command in the new worktree before returning, so the capability
    tools have the dependencies they need. On `status: "error"` — including an
    `install` that failed — the slice has **FAILED** (see *Failure handling*).
-2. **Resolve routing.** Call the `resolve_routing` MCP tool with the slice's
-   `tier` and the repository root as `repoPath`. It returns, per role, the
-   `model` and effort variant to spawn:
-   - `status: "ok"` — use the returned `routing`.
+2. **Resolve routing — read the labels once, freeze the result.** Call the
+   `resolve_routing` MCP tool with the slice's `tier`, the repository root as
+   `repoPath`, and the **issue's GitHub labels** (the labels already parsed in
+   `references/run-lifecycle.md` step 3) as `labels` — this is the **only** place
+   the labels drive routing. It returns, per role, the `model` and `variant` to
+   spawn, plus any label-resolved `fallbacks` and `warnings`:
+   - `status: "ok"` — use the returned `routing`. **Freeze it into the slice's
+     `resolvedRouting` checkpoint field** in `run-state.json` at slice creation:
+     the per-role `{model, variant}` blocks, and — because the Fable lane is
+     implementer-only — the implementer's entry from the returned `fallbacks`
+     array mapped into the single `resolvedRouting.fallback` `{model, maxRetries}`
+     (with `fallbackTaken: false`). Every later spawn and every resume routes
+     from this frozen checkpoint, never by re-reading labels (the resume-routing
+     principle in the spine's resume matrix).
+   - **`warnings[]`** (present on `ok`) — surface each in the run report. An
+     unconfigured `route:*` label present on the slice (in the config's `labels`
+     block) yields a loud **WARNING** here: the label had no effect, so the
+     operator can fix `routing.json` or drop the label.
+   - `errorCode: "LABEL_CONFLICT"` — **two applied labels patch the same role**
+     (there is no precedence rule). This is a loud **ERROR**: the slice has
+     **FAILED**; report the conflicting labels so the operator resolves it in
+     `routing.json`.
    - `errorCode: "CONFIG_NOT_FOUND"` — no routing is configured; fall back to
      the `-standard` variant of every role with no `model` override (each
-     subagent's frontmatter model applies), and skip the investigator.
+     subagent's frontmatter model applies), skip the investigator, and freeze
+     no `fallback` (an unrouted slice has no premium lane).
    - `errorCode: "CONFIG_INVALID"` — the routing config is broken; the slice
      has **FAILED**.
 3. **Run the investigator (higher tiers only).** If `routing.investigator` is
-   non-null, spawn the `orchestrate:investigator-<effort>` subagent — `<effort>`
+   non-null, spawn the `orchestrate:investigator-<variant>` subagent — `<variant>`
    and the Agent `model` override both come from `routing.investigator`. Its
    prompt must carry the issue number/title/body **and the slice's acceptance
    criteria explicitly named as the hard scope boundary** — the canonical per-
@@ -50,8 +69,8 @@ narration in the spine describes.
    An `invalid` or `missing` envelope is a failed investigation pass — the
    slice has **FAILED** (the investigator is read-only, so no worktree fallback
    applies). If `routing.investigator` is null, skip this step.
-4. **Run the implementer.** Spawn the `orchestrate:implementer-<effort>`
-   subagent — `<effort>` and the `model` override from `routing.implementer`. Its
+4. **Run the implementer.** Spawn the `orchestrate:implementer-<variant>`
+   subagent — `<variant>` and the `model` override from `routing.implementer`. Its
    prompt must carry the issue number/title/body, the worktree path (every
    change goes there), the investigator's brief if one was produced, an
    instruction to verify with the capability tools using the worktree path as
@@ -85,8 +104,8 @@ narration in the spine describes.
      `git -C <worktreePath> ls-files --others --exclude-standard`. A filename-set
      comparison is insufficient — the same file may be rewritten with real
      progress or returned byte-identical.
-   - While `continuationsUsed < budget`: re-spawn `orchestrate:implementer-<effort>`
-     in the **same** worktree (same routing/model/effort) with a continuation
+   - While `continuationsUsed < budget`: re-spawn `orchestrate:implementer-<variant>`
+     in the **same** worktree (same routing/model/variant) with a continuation
      prompt = the issue, the worktree path, the PRIOR envelope's `remainingWork`,
      the standard verify/no-git reminders, and an explicit "partial work is
      already in the worktree — continue it, do not restart." Validate the
@@ -112,6 +131,44 @@ narration in the spine describes.
    An `invalid` or `missing` envelope also means the slice has **FAILED** — a
    hard turn-limit cutoff that truncates the envelope mid-emission lands here as
    `invalid`, distinct from the graceful `incomplete` self-report above.
+
+   **Model fallback (premium spawns only — runs BEFORE the FAILED verdict).**
+   This interception is **separate from** the continue-in-place loop above: the
+   loop re-spawns the *same* model on `incomplete` and counts against
+   `continuationBudget`; this step **swaps** the model exactly once on a *model
+   failure* and does **not** touch `continuationBudget`. It applies only to a
+   **premium-spawned** implementer — one whose frozen `resolvedRouting.fallback`
+   is set because a `route:*` label (e.g. `route:fable`) patched the implementer
+   in step 2. Before declaring such a slice FAILED from a step-4 or loop failure,
+   check whether the failure is one the fallback covers and whether the rescue is
+   still available:
+   - **Trigger set** — the implementer **refused**, returned a retention/safety
+     **400**, or emitted an **invalid/missing envelope**. A *valid* `blocked`
+     envelope is **excluded**: it is a genuine obstacle (e.g. a missing
+     dependency) the fallback model would not fix — keep it on the immediate
+     FAILED path.
+   - **Guard** — proceed only when `resolvedRouting.fallback` is set **and**
+     `resolvedRouting.fallbackTaken` is still `false`. If there is no fallback
+     (an ordinary, non-premium spawn) or it is already spent
+     (`fallbackTaken: true`), skip this step and apply the ordinary FAILED
+     taxonomy.
+   - **Re-spawn** — spawn `orchestrate:implementer-<variant>` **once** in the
+     **same** worktree, overriding the Agent `model` to
+     `resolvedRouting.fallback.model` (e.g. `opus`), with the standard prompt
+     (issue, worktree path, the investigator brief if any, verify/no-git
+     reminders; carry the prior `remainingWork` if the failure came from the
+     continuation loop). Set `resolvedRouting.fallbackTaken: true` in the slice
+     checkpoint and write `run-state.json` **before** the re-spawn, so the
+     once-only guard survives a mid-spawn handoff — `fallbackTaken` is a
+     **persisted slice-level** flag, not a loop-local counter, and the fallback
+     fires at most once across the initial spawn and every continuation.
+   - **Classify the fallback envelope** with `validate_envelope` (role
+     `implementer`) exactly as the initial spawn: `completed` → step 4a;
+     `incomplete` → re-enter the continue-in-place loop (the fallback model now
+     drives it, still bounded by `continuationBudget`); `blocked`, or an
+     `invalid`/`missing` envelope → the slice has **FAILED** (the one rescue is
+     spent). Record the swap for the final-report narration ("fable declined →
+     served by opus"; see `references/wave-loop.md`).
 4a. **Verify the changeset against the worktree.** After a `completed`
    implementer envelope — and before trusting it — call the `verify_changeset`
    MCP tool with the slice's `worktreePath` and the implementer envelope's
@@ -140,8 +197,8 @@ narration in the spine describes.
    spawning the reviewer. (These two adjacent checkpoints differ only in
    resume granularity — the resume matrix in section 1 re-runs the capability
    gate for both.)
-5. **Run the reviewer.** Spawn the `orchestrate:reviewer-<effort>` subagent —
-   `<effort>` and the `model` override from `routing.reviewer` — in the same
+5. **Run the reviewer.** Spawn the `orchestrate:reviewer-<variant>` subagent —
+   `<variant>` and the `model` override from `routing.reviewer` — in the same
    worktree. Its prompt must carry the issue, the worktree path, the
    changed-file set agreed on by step 4a — the implementer envelope's
    `filesChanged` when `verify_changeset` matched, the union of declared and
@@ -309,7 +366,7 @@ narration in the spine describes.
       - `verdict: "error"` — a git or input failure (`errorCode`,
         `errorMessage`); the slice has **FAILED**, wired like every other
         MCP-tool error in this section.
-   2. Spawn the `orchestrate:conflict-resolver-<effort>` subagent — `<effort>`
+   2. Spawn the `orchestrate:conflict-resolver-<variant>` subagent — `<variant>`
       and the `model` override from `routing.conflict-resolver`. Its prompt
       must carry the issue, the worktree path, and the list of conflicted
       files (the `conflictedFiles` from step 1).

--- a/plugins/orchestrate/skills/orchestrate/references/wave-loop.md
+++ b/plugins/orchestrate/skills/orchestrate/references/wave-loop.md
@@ -216,3 +216,13 @@ summary of the run. If `parentIssue` is set, post a final summary comment on
 it. Report to the user: the umbrella branch, the final pull request URL, the
 paths of the three rendered artifacts, and — per slice — its final state and
 pull request.
+
+**Narrate the routing notes in the per-slice summary.** For each slice whose
+`resolvedRouting.fallbackTaken` is `true`, note the **model-fallback swap** in
+its summary line — e.g. "slice #N: fable declined → served by opus" — so the
+premium-lane fallover is visible in the report (the swap itself runs in
+`references/slice-pipeline.md` step 4). Surface any routing-label
+**WARNING** (an unconfigured `route:*` label) or **ERROR** (a same-role
+`LABEL_CONFLICT`) from `resolve_routing` in the same summary, and — where the
+orchestrator judges a slice would have benefited from a premium lane — it may
+**suggest** a `route:fable` label, but it **never applies one itself**.


### PR DESCRIPTION
Implements #317. Wires routing v2 into the orchestrator skill prose: spawn types renamed `<role>-<effort>`→`<role>-<variant>` (zero stale spawn-suffix); labels read once at slice creation and frozen into resolvedRouting (resume routes from checkpoint, never live labels); model-fallback step (one re-spawn on the fallback model in the same worktree, fallbackTaken persisted, outside continuationBudget, narrated in the report); fallback-aware resume-matrix row; route:fable label semantics + warning/conflict + Fable security exclusion. ADR-0013/0009/0014 invariants held; README deferred to #318. ADR-0015.