### PR TITLE
cursor-code-documentation: plugin foundation + document-as-you-code rule

### DIFF
--- a/plugins/cursor-code-documentation/.cursor-plugin/plugin.json
+++ b/plugins/cursor-code-documentation/.cursor-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "cursor-code-documentation",
+  "version": "1.0.0",
+  "description": "Deployable-behavior Cursor plugin that ships an always-apply document-as-you-code rule plus on-demand code-explain and doc-generate skills. Adds language-idiomatic inline documentation whenever the agent writes, modifies, or creates code in any language including scripts.",
+  "author": {
+    "name": "rodrigorjsf"
+  },
+  "repository": "https://github.com/rodrigorjsf/agent-engineering-toolkit",
+  "license": "MIT"
+}

--- a/plugins/cursor-code-documentation/.cursor/rules/document-as-you-code.mdc
+++ b/plugins/cursor-code-documentation/.cursor/rules/document-as-you-code.mdc
@@ -1,0 +1,25 @@
+---
+description: "Add language-idiomatic inline documentation whenever you write, modify, or create code in any language including scripts."
+alwaysApply: true
+globs: []
+---
+
+Whenever you write, modify, or create code — including scripts — add inline
+documentation in the idiomatic format for that language:
+
+- **Java** — Javadoc (`/** ... */`) on every public class, method, and field.
+- **JavaScript / TypeScript** — JSDoc (`/** ... */`) on every exported function,
+  class, and type.
+- **Python** — docstrings (`"""..."""`) on every module, class, and function.
+- **Shell scripts (bash, sh, zsh, fish, etc.)** — header comments explaining
+  the script's purpose at the top, then inline comments for non-obvious logic.
+- **Any other language** — use the idiomatic documentation format for that
+  language. Rely on your knowledge of the language's conventions; do not invent
+  a format.
+
+Scope: document what the code does and why, not how the syntax works.
+Cover: purpose, parameters, return values, exceptions/errors, and side effects
+where applicable. Omit documentation only when a symbol is private, trivial,
+and self-evident from its name alone.
+
+Apply this rule on every code write or edit, not only when asked.

--- a/plugins/cursor-code-documentation/README.md
+++ b/plugins/cursor-code-documentation/README.md
@@ -1,0 +1,100 @@
+# cursor-code-documentation
+
+A deployable-behavior Cursor plugin that ships an always-apply rule making the
+agent add language-idiomatic inline documentation whenever it writes, modifies,
+or creates code. Unlike the initializer and customizer plugins in this
+marketplace, this plugin delivers behavior on install — no artifact generation
+step required.
+
+The plugin bundles one always-apply rule and two manual-only skills:
+
+- **`document-as-you-code` rule** — active on every turn, instructs the agent
+  to add idiomatic documentation in the correct format for each language,
+  including scripts.
+- **`code-explain` skill** — deliberate, on-demand explanation of existing code
+  sections.
+- **`doc-generate` skill** — deliberate, on-demand generation of documentation
+  for a file or module.
+
+## Cost and Model Guidance
+
+The `document-as-you-code` rule is always-apply and injects a small, fixed
+prompt into every agent turn. Its token cost is negligible — roughly 30 tokens
+per turn regardless of project size.
+
+The two manual skills (`code-explain`, `doc-generate`) perform heavier analysis
+and are invoked explicitly. Their cost scales with the size of the code section
+or file being documented.
+
+**Recommended model:** any capable frontier model works well for the always-apply
+rule. For the manual skills, a frontier balanced model with high effort delivers
+good documentation quality at reasonable cost; a frontier reasoning model is
+the better choice for large or complex codebases.
+
+**Usage pattern:** install once, leave the rule active. Invoke the manual skills
+when you need comprehensive documentation for an existing file or module — not
+on every session.
+
+## Why This Plugin Exists
+
+Agents write undocumented code by default. Adding a documentation instruction
+after the fact either goes unnoticed or requires a separate prompt every
+session. An always-apply rule is the only reliable per-turn injection surface
+in Cursor (verified against official docs and Cursor forum 2026-06-21:
+`beforeSubmitPrompt` is block-only, `afterFileEdit` cannot feed the model, and
+`sessionStart` injection is currently broken).
+
+Shipping the rule as a plugin artifact means the behavior travels with the
+plugin, loads on install, and applies without any per-project configuration.
+
+## Installation
+
+### Cursor IDE (Native Plugin System)
+
+For local development and testing, load this repository through Cursor's local
+plugin directory:
+
+```bash
+# Clone the repository
+git clone https://github.com/rodrigorjsf/agent-engineering-toolkit.git ~/src/agent-engineering-toolkit
+
+# Register as a local Cursor plugin marketplace
+mkdir -p ~/.cursor/plugins/local
+ln -s ~/src/agent-engineering-toolkit ~/.cursor/plugins/local/agent-engineering-toolkit
+```
+
+Then restart Cursor (or run **Developer: Reload Window**). The repo root
+`.cursor-plugin/marketplace.json` exposes `cursor-code-documentation` alongside
+the other plugins in this marketplace.
+
+## Usage
+
+The `document-as-you-code` rule is always active after installation — no
+invocation required.
+
+The manual skills are invoked explicitly:
+
+```text
+/cursor-code-documentation:code-explain    # explain an existing code section
+/cursor-code-documentation:doc-generate    # generate documentation for a file or module
+```
+
+> **Status:** the two manual skills are delivered by upcoming slices. The rule
+> ships with this foundation release and is immediately active.
+
+## Repository Structure
+
+```text
+plugins/cursor-code-documentation/
+├── .cursor-plugin/
+│   └── plugin.json           # Plugin manifest (name, version, description)
+└── .cursor/
+    └── rules/
+        └── document-as-you-code.mdc   # Always-apply documentation rule
+```
+
+Skills land in subsequent slices under `skills/`.
+
+## License
+
+MIT


### PR DESCRIPTION
Implements #336. Foundation of the cursor-code-documentation deployable-behavior Cursor plugin: Cursor manifest (v1.0.0), the always-apply document-as-you-code rule (≤30 lines, language-idiomatic inline docs), and a README with '## Cost and Model Guidance' as its second section. First deployable-behavior plugin in this marketplace (ships behavior on install). Marketplace registration deferred to #339.