### PR TITLE
cursor-code-documentation: quality-gate seam + marketplace registration

### DIFF
--- a/.claude/skills/cursor-code-documentation-quality-gate/SKILL.md
+++ b/.claude/skills/cursor-code-documentation-quality-gate/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: cursor-code-documentation-quality-gate
+description: "Performs a complete quality gate analysis of the cursor-code-documentation plugin. Validates its three artifacts (the always-apply rule, the two manual-only skills, the plugin manifest) against documented conventions, checks marketplace parity and the version cascade, confirms no docs drift, evaluates the red-green behavior scenarios, and generates a structured findings report compatible with /prp-core:prp-prd when issues are found."
+---
+
+# Cursor-Code-Documentation Quality Gate Analysis
+
+Perform a complete quality gate of the `cursor-code-documentation` plugin — the
+first deployable-behavior plugin in this marketplace (it *ships* a rule + skills
+consumed on install, rather than *generating* artifacts into a target project).
+This meta-skill validates every artifact against documented conventions, confirms
+marketplace parity and the version cascade, and evaluates whether the plugin's
+external behavior passes all red-green scenarios.
+
+This gate is **scaled to three artifacts** (rule + 2 skills + manifest) — it is
+deliberately NOT a six-phase clone of the generator-plugin gates, and it does NOT
+delegate phases to inspector subagents (none exist for this plugin). Run every
+check inline against the criteria reference.
+
+**Scope:** `plugins/cursor-code-documentation/` — the `.cursor/rules/document-as-you-code.mdc`
+rule, `skills/code-explain/SKILL.md`, `skills/doc-generate/SKILL.md`, and
+`.cursor-plugin/plugin.json`. Plus the repo-root `.cursor-plugin/marketplace.json`
+and root `README.md` for parity.
+
+**Convention sources:** `.claude/rules/cursor-plugin-skills.md`,
+`.claude/rules/plugin-versioning.md`, `.claude/rules/readme-files.md`,
+`docs/adr/0016-cursor-code-documentation-rule-not-hook.md`,
+`wiki/knowledge/skill-body-convention.md`.
+
+**Do NOT apply generator-skill checks.** The `references/` directory,
+`assets/templates/` directory, `validation-criteria.md` reference, delegate-to-analyzer
+phase, and intra-plugin shared-copy parity are conventions for the
+cursor-initializer / cursor-customizer *generators*. The two manual-only skills here
+have none of those by design. Importing those checks would wrongly FAIL the gate.
+
+**Report output:** `.specs/reports/cursor-code-documentation-quality-gate-[YYYY-MM-DD]-findings.md`
+(only generated when issues are found).
+
+---
+
+## Phase 1: Static Artifact Conformance
+
+Read `.claude/skills/cursor-code-documentation-quality-gate/references/quality-gate-criteria.md`
+sections "Rule Checks", "Per-Skill Checks", and "Manifest Checks". Apply each
+check inline against the live artifacts.
+
+**The rule** — `plugins/cursor-code-documentation/.cursor/rules/document-as-you-code.mdc`:
+apply checks R1–R5. Confirm `alwaysApply: true`, Cursor-native frontmatter keys
+only (`description`, `alwaysApply`, `globs` — NO Claude `paths:`), and the body
+stays within the ≤30-line budget naming the language→format mapping.
+
+**Each skill** — `plugins/cursor-code-documentation/skills/{code-explain,doc-generate}/SKILL.md`:
+apply checks S1–S7. Confirm `name` equals the folder name, `disable-model-invocation: true`
+is present, the frontmatter is valid, and the mandatory semantic tags are present
+with `id=` on every `<PHASE>` (only `<PHASE>` requires `id=`; `<PREFLIGHT>`,
+`<OUTPUT>`, and `<VALIDATION>` correctly carry none).
+
+**The manifest** — `plugins/cursor-code-documentation/.cursor-plugin/plugin.json`:
+apply checks M1–M4. Confirm `name` equals `cursor-code-documentation`, the file is
+valid JSON, and `version` + `description` are present.
+
+Record each check as PASS/FAIL with evidence (file path + quoted line). Classify
+any failure by the Severity table in the criteria reference.
+
+---
+
+## Phase 2: Marketplace Parity + Version Cascade
+
+Read the criteria reference sections "Marketplace-Parity Checks" and
+"Version-Cascade Checks". Apply each check inline.
+
+**Marketplace parity** — `.cursor-plugin/marketplace.json`:
+- The plugin is registered in the `plugins[]` array (check MP1).
+- Its entry matches the existing-sibling shape — `name` + `source` + `description`,
+  with `source` equal to the bare directory name `cursor-code-documentation`, and
+  carrying **NO per-entry `version` field** (check MP2). Assert shape parity with
+  the sibling entries, not a hardcoded key count.
+
+**Version cascade**:
+- `.cursor-plugin/marketplace.json` `metadata.version` is bumped to `1.2.0` —
+  MINOR, mirroring a new `plugins[]` entry (check VC1).
+- `plugins/cursor-code-documentation/.cursor-plugin/plugin.json` `version` STAYS
+  at `1.0.0` — this slice touches no file under `plugins/cursor-code-documentation/**`,
+  so the plugin manifest does NOT bump (check VC2).
+- Do NOT check `.claude-plugin/marketplace.json` — cascade rule (2) is
+  Claude-Code-only; this Cursor plugin is not in the Claude registry.
+
+**Root README parity** — root `README.md`:
+- A Distributions-table row for `cursor-code-documentation` exists (check MP3).
+- An install one-liner block linking to the plugin README exists (check MP4).
+
+Record each check as PASS/FAIL with evidence.
+
+---
+
+## Phase 3: Docs-Drift — Documented N/A
+
+This plugin has **NO `references/` directory** and **NO `docs/cursor` reference
+mirrors** to drift against — it ships live behavior, not generated artifacts
+derived from a documentation corpus. There is no `docs-drift-checker` subagent for
+this plugin; do NOT attempt to delegate to one.
+
+Record this phase as **CLEAN (N/A by design)** — a documented no-op, not a skipped
+check. If a future revision adds a `references/` directory or a `docs/cursor`
+mirror, this phase must be upgraded to a real drift check.
+
+---
+
+## Phase 4: Red-Green Scenario Evaluation
+
+Read the criteria reference section "Red-Green Scenario Table". Evaluate each of
+the four behavior scenarios inline against the shipped artifacts. Each is
+GREEN-expected for the implemented plugin.
+
+| # | Scenario | GREEN assertion |
+|---|----------|-----------------|
+| G1 | Edit/create a code symbol | The always-apply rule fires every turn and maps the language to its idiomatic doc format (Java→Javadoc, JS/TS→JSDoc, Python→docstring, shell→header comment). |
+| G2 | `/code-explain` invoked | The `code-explain` skill produces the three-section structured explanation (Overview, Key Concepts, Step-by-Step Breakdown). |
+| G3 | `/doc-generate` invoked | The `doc-generate` skill produces the requested documentation artifact (API docs, README section, or inline doc-strings). |
+| G4 | Mid-edit, no explicit `/command` | Neither manual skill auto-fires — `disable-model-invocation: true` is present on both skills, so the model does not auto-invoke them. |
+
+For each scenario, confirm the relevant artifact contains the guidance/frontmatter
+that makes the assertion hold, and record PASS/FAIL with evidence (the rule body
+for G1, each skill's `<PROCESS>`/`<OUTPUT>` for G2/G3, the `disable-model-invocation`
+frontmatter for G4).
+
+---
+
+## Phase 5: Findings Synthesis
+
+Aggregate all results from Phases 1, 2, 3, and 4.
+
+Compute and display the **Quality Gate Dashboard**:
+
+```
+Quality Gate Dashboard — cursor-code-documentation [DATE]
+═══════════════════════════════════════════════════════════
+Category                          Checks  Passed  Failed  Status
+──────────────────────────────────────────────────────────
+Static Artifact Conformance         [N]     [N]     [N]   [PASS/FAIL]
+Marketplace Parity + Version        [N]     [N]     [N]   [PASS/FAIL]
+Docs-Drift (N/A by design)            1       1       0    PASS
+Red-Green Scenario Evaluation         4     [N]     [N]   [PASS/FAIL]
+──────────────────────────────────────────────────────────
+OVERALL                             [N]     [N]     [N]   [PASS/FAIL]
+═══════════════════════════════════════════════════════════
+```
+
+**If all checks pass:**
+> ✅ Quality Gate PASSED — All [N] checks passed. All three artifacts comply with
+> documented cursor-code-documentation conventions, the marketplace registration
+> and version cascade are correct, and all four red-green scenarios evaluate as GREEN.
+
+**Stop here. Do NOT write any report file to `.specs/reports/`.**
+
+**If any checks fail:** generate `.specs/reports/cursor-code-documentation-quality-gate-[YYYY-MM-DD]-findings.md`.
+
+Read the criteria reference section "## Report Template" for the exact document
+structure to follow. For each finding, assign a Finding ID (F001, F002, …) and
+document: the artifact path, the rule violated, the rule source, the current state
+(quote evidence), the expected state, the impact, and the proposed fix. Group
+related findings into Improvement Areas, and close the report with a PRD Brief
+section pre-formatted as input for `/prp-core:prp-prd`.
+
+After writing the file, report:
+> ⚠️ Quality Gate FAILED — [N] finding(s) across [N] category(ies).
+> Findings report: `.specs/reports/cursor-code-documentation-quality-gate-[date]-findings.md`
+> Next step: Run `/prp-core:prp-prd` with this findings file to create a remediation PRD.
+
+---
+
+## Regression Checkpoint
+
+Before declaring the gate complete, confirm:
+
+- [ ] No generator-skill check (`references/` dir, `assets/templates/` dir,
+      `validation-criteria.md`, delegate-to-analyzer, intra-plugin shared-copy parity)
+      was applied to the manual-only skills — those conventions govern the
+      cursor-initializer / cursor-customizer generators, not this deployable-behavior plugin.
+- [ ] The `id=` check was scoped to `<PHASE>` only — `<PREFLIGHT>`, `<OUTPUT>`, and
+      `<VALIDATION>` correctly carry no `id=` and were not flagged.
+- [ ] No Claude-specific field (`paths:`) was required of, or found in, any Cursor artifact.
+- [ ] The version-cascade check asserted `metadata.version` → 1.2.0 AND
+      `plugin.json` staying at 1.0.0 — it did NOT demand a plugin.json bump.
+- [ ] The marketplace-parity check asserted sibling-shape parity with NO per-entry
+      version field — not a hardcoded key count.

--- a/.claude/skills/cursor-code-documentation-quality-gate/references/quality-gate-criteria.md
+++ b/.claude/skills/cursor-code-documentation-quality-gate/references/quality-gate-criteria.md
@@ -1,0 +1,194 @@
+# Quality Gate Criteria — Cursor-Code-Documentation
+
+Complete check tables, severity classification, and findings report template for
+the cursor-code-documentation quality gate meta-skill. All tables below encode the
+GREEN-expected state for the shipped plugin.
+
+Source: `.claude/rules/cursor-plugin-skills.md`, `.claude/rules/plugin-versioning.md`,
+`.claude/rules/readme-files.md`, `docs/adr/0016-cursor-code-documentation-rule-not-hook.md`,
+`wiki/knowledge/skill-body-convention.md`
+
+## Contents
+
+1. [Rule Checks](#rule-checks)
+2. [Per-Skill Checks](#per-skill-checks)
+3. [Manifest Checks](#manifest-checks)
+4. [Marketplace-Parity Checks](#marketplace-parity-checks)
+5. [Version-Cascade Checks](#version-cascade-checks)
+6. [Red-Green Scenario Table](#red-green-scenario-table)
+7. [Severity Classification](#severity-classification)
+8. [Report Template](#report-template)
+
+---
+
+## Rule Checks
+
+Target: `plugins/cursor-code-documentation/.cursor/rules/document-as-you-code.mdc`
+
+| # | Check | Threshold | Severity if Violated |
+|---|-------|-----------|---------------------|
+| R1 | YAML frontmatter present with `description` | Required | CRITICAL |
+| R2 | `alwaysApply` equals `true` | Required (always-on per-turn injection) | CRITICAL |
+| R3 | Frontmatter uses ONLY Cursor-native keys (`description`, `alwaysApply`, `globs`) | Cursor constraint | CRITICAL |
+| R4 | NO Claude-specific `paths:` field present | Prohibited (Claude field) | CRITICAL |
+| R5 | Body ≤ 30 lines and names the language→format mapping (Java→Javadoc, JS/TS→JSDoc, Python→docstring, shell→header comment) | Hard limit + content | MAJOR |
+
+---
+
+## Per-Skill Checks
+
+Targets: `plugins/cursor-code-documentation/skills/code-explain/SKILL.md`,
+`plugins/cursor-code-documentation/skills/doc-generate/SKILL.md`
+
+| # | Check | Threshold | Severity if Violated |
+|---|-------|-----------|---------------------|
+| S1 | YAML frontmatter present with `name` and `description` | Required | CRITICAL |
+| S2 | `name` equals the containing folder name (`code-explain` / `doc-generate`) | Exact | CRITICAL |
+| S3 | `disable-model-invocation: true` present (manual-only invocation) | Required | CRITICAL |
+| S4 | `description` ≤ 1024 chars, non-empty, no XML tags | Exact | MAJOR |
+| S5 | Mandatory semantic tags present: `<TRIGGER>`, `<BEHAVIOUR>`, `<HARD_RULES>`, `<PROCESS>` containing ≥1 `<PHASE>` | Required | CRITICAL |
+| S6 | Every `<PHASE>` carries an `id=` attribute (ONLY `<PHASE>` requires `id=`; `<PREFLIGHT>`/`<OUTPUT>`/`<VALIDATION>` correctly carry none) | Required | CRITICAL |
+| S7 | All opened tags balanced; all attribute values quoted | Well-formed | CRITICAL |
+
+> **Do NOT apply generator checks** to these skills: no `references/` dir, no
+> `assets/templates/` dir, no `validation-criteria.md` reference, no
+> delegate-to-analyzer phase, no intra-plugin shared-copy parity. Those govern the
+> cursor-initializer / cursor-customizer generators. These are manual-only,
+> deployable-behavior skills with none of those surfaces by design.
+
+---
+
+## Manifest Checks
+
+Target: `plugins/cursor-code-documentation/.cursor-plugin/plugin.json`
+
+| # | Check | Threshold | Severity if Violated |
+|---|-------|-----------|---------------------|
+| M1 | Valid JSON (parses without error) | Required | CRITICAL |
+| M2 | `name` equals `cursor-code-documentation` | Exact | CRITICAL |
+| M3 | `version` present and valid SemVer (`1.0.0`) | Required | CRITICAL |
+| M4 | `description` present and non-empty | Required | MAJOR |
+
+---
+
+## Marketplace-Parity Checks
+
+Target: repo-root `.cursor-plugin/marketplace.json` and root `README.md`
+
+| # | Check | Threshold | Severity if Violated |
+|---|-------|-----------|---------------------|
+| MP1 | `cursor-code-documentation` registered in the `plugins[]` array | Required | CRITICAL |
+| MP2 | Entry matches existing-sibling shape (`name` + `source` + `description`), `source` equals bare dir name `cursor-code-documentation`, and carries NO per-entry `version` field | Shape parity | CRITICAL |
+| MP3 | Root `README.md` Distributions table has a `cursor-code-documentation` row | Required | MAJOR |
+| MP4 | Root `README.md` Installation section has a `cursor-code-documentation` install one-liner block linking to the plugin README | Required | MAJOR |
+
+> MP2 asserts parity with the sibling entries' shape, NOT a hardcoded key count.
+> Acceptance criterion #4 forbids only a per-entry `version` field; a `description`
+> matching the two siblings is required for shape consistency.
+
+---
+
+## Version-Cascade Checks
+
+Source: `.claude/rules/plugin-versioning.md`
+
+| # | Check | Threshold | Severity if Violated |
+|---|-------|-----------|---------------------|
+| VC1 | `.cursor-plugin/marketplace.json` `metadata.version` bumped to `1.2.0` (MINOR — new `plugins[]` entry) | Exact | CRITICAL |
+| VC2 | `plugins/cursor-code-documentation/.cursor-plugin/plugin.json` `version` STAYS `1.0.0` (this slice touches no file under `plugins/cursor-code-documentation/**`) | Exact | MAJOR |
+
+> Do NOT check `.claude-plugin/marketplace.json` — cascade rule (2) is
+> Claude-Code-only; this Cursor plugin is not in the Claude registry. The two
+> marketplaces are independent.
+
+---
+
+## Red-Green Scenario Table
+
+All four scenarios are GREEN-expected for the shipped plugin.
+
+| # | Scenario | RED baseline (absent behavior) | GREEN assertion (evidence in artifact) |
+|---|----------|--------------------------------|----------------------------------------|
+| G1 | Edit/create a code symbol | No automatic documentation added | The always-apply rule (`alwaysApply: true`) maps each language to its idiomatic doc format and instructs documenting on every code write/edit |
+| G2 | `/code-explain` invoked | No structured explanation | `code-explain` `<PROCESS>` produces the three-section format (Overview, Key Concepts, Step-by-Step Breakdown) |
+| G3 | `/doc-generate` invoked | No documentation artifact | `doc-generate` `<PROCESS>` produces the requested form (API docs, README section, or inline doc-strings) |
+| G4 | Mid-edit, no explicit `/command` | A manual skill auto-fires spuriously | Both skills carry `disable-model-invocation: true`, so neither auto-invokes |
+
+---
+
+## Severity Classification
+
+| Severity | Meaning | Must Fix Before Release? |
+|----------|---------|--------------------------|
+| CRITICAL | Hard limit violated; feature broken or convention fundamentally wrong | Yes — blocking |
+| MAJOR | Structural convention violated; output quality or parity at risk | Yes — before next release |
+| MINOR | Quality or documentation convention missed; no runtime impact | Recommended — track in backlog |
+
+---
+
+## Report Template
+
+Use this structure for `.specs/reports/cursor-code-documentation-quality-gate-[YYYY-MM-DD]-findings.md`:
+
+```markdown
+# Cursor-Code-Documentation Quality Gate Findings — [YYYY-MM-DD]
+
+**Status:** FAIL — [N] findings ([N] CRITICAL, [N] MAJOR, [N] MINOR)
+
+## Quality Gate Dashboard
+
+| Category | Checks | Passed | Failed | Status |
+|----------|--------|--------|--------|--------|
+| Static Artifact Conformance | [N] | [N] | [N] | PASS/FAIL |
+| Marketplace Parity + Version | [N] | [N] | [N] | PASS/FAIL |
+| Docs-Drift (N/A by design) | 1 | 1 | 0 | PASS |
+| Red-Green Scenario Evaluation | 4 | [N] | [N] | PASS/FAIL |
+| **OVERALL** | [N] | [N] | [N] | **FAIL** |
+
+---
+
+## Findings
+
+### F001 — [Short Title] [CRITICAL/MAJOR/MINOR]
+
+- **Category**: Static | Marketplace/Version | Red-Green
+- **Artifact**: `[file path]`
+- **Rule Violated**: "[exact rule text]"
+- **Rule Source**: `[rule file]` — [section]
+- **Current State**: [what the artifact contains — quote evidence]
+- **Expected State**: [what it should contain per documentation]
+- **Impact**: [what degrades or breaks without fixing]
+- **Proposed Fix**: [specific action — what to add/change/remove]
+
+[Repeat for each finding...]
+
+---
+
+## Improvement Areas
+
+### Area 1: [Name]
+**Findings covered:** F001, F002
+**Summary:** [Why these findings belong together]
+**Estimated scope:** [number of files, nature of change]
+
+---
+
+## PRD Brief
+
+> This section is structured as input for `/prp-core:prp-prd`.
+
+**Problem Statement:**
+[Summary of what's wrong with the current state, grounded in the findings above]
+
+**Evidence:**
+[Key evidence points — file paths, rule citations, measurements]
+
+**Proposed Solution:**
+[What changes resolve all findings — at improvement-area level]
+
+**Success Metrics:**
+[Specific checks that would now pass]
+
+**Out of Scope:**
+[What this remediation does NOT address]
+```

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "email": "rodrigo_rjsf@hotmail.com"
   },
   "metadata": {
-    "description": "Multi-plugin marketplace for evidence-based Cursor artifact engineering. Ships the rules-first Cursor distribution as an Initializer/Customizer pair: cursor-initializer bootstraps minimal, scoped .cursor/rules/*.mdc hierarchies; cursor-customizer creates and improves individual Cursor artifacts (rules, hooks, skills, subagents) inside an already-initialized project.",
-    "version": "1.1.0",
+    "description": "Multi-plugin marketplace for evidence-based Cursor artifact engineering. Ships the rules-first Cursor distribution as an Initializer/Customizer pair: cursor-initializer bootstraps minimal, scoped .cursor/rules/*.mdc hierarchies; cursor-customizer creates and improves individual Cursor artifacts (rules, hooks, skills, subagents) inside an already-initialized project. Adds cursor-code-documentation, a deployable-behavior plugin that ships an always-apply document-as-you-code rule plus on-demand code-explain and doc-generate skills.",
+    "version": "1.2.0",
     "pluginRoot": "plugins"
   },
   "plugins": [
@@ -19,6 +19,11 @@
       "name": "cursor-customizer",
       "source": "cursor-customizer",
       "description": "Rules-first, product-strict customizer for the Cursor distribution: creates and improves individual Cursor artifacts (rules, hooks, skills, subagents) inside an already-initialized project. Sibling of cursor-initializer."
+    },
+    {
+      "name": "cursor-code-documentation",
+      "source": "cursor-code-documentation",
+      "description": "Deployable-behavior Cursor plugin that ships an always-apply document-as-you-code rule plus on-demand code-explain and doc-generate skills. Adds language-idiomatic inline documentation whenever the agent writes, modifies, or creates code in any language including scripts."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ the generated files are in place. Treat the first execution as a one-time invest
 | `orchestrate` | Claude Code | Native plugin system | [plugins/orchestrate/README.md](plugins/orchestrate/README.md) |
 | `cursor-initializer` | Cursor IDE | Native plugin system | [plugins/cursor-initializer/README.md](plugins/cursor-initializer/README.md) |
 | `cursor-customizer` | Cursor IDE | Native plugin system | [plugins/cursor-customizer/README.md](plugins/cursor-customizer/README.md) |
+| `cursor-code-documentation` | Cursor IDE | Native plugin system | [plugins/cursor-code-documentation/README.md](plugins/cursor-code-documentation/README.md) |
 | Standalone | Any AI tool | `npx skills add` / manual | [skills/README.md](skills/README.md) |
 
 ## Research Foundation
@@ -94,6 +95,16 @@ ln -s ~/src/agent-engineering-toolkit ~/.cursor/plugins/local/agent-engineering-
 ```
 
 → See [plugins/cursor-customizer/README.md](plugins/cursor-customizer/README.md) for full setup instructions.
+
+### Cursor IDE — cursor-code-documentation
+
+```bash
+git clone https://github.com/rodrigorjsf/agent-engineering-toolkit.git ~/src/agent-engineering-toolkit
+mkdir -p ~/.cursor/plugins/local
+ln -s ~/src/agent-engineering-toolkit ~/.cursor/plugins/local/agent-engineering-toolkit
+```
+
+→ See [plugins/cursor-code-documentation/README.md](plugins/cursor-code-documentation/README.md) for full setup instructions.
 
 ### npx skills add — Standalone
 


### PR DESCRIPTION
Implements #339. Completion slice for the cursor-code-documentation plugin: (1) a single scaled quality-gate skill (.claude/skills/cursor-code-documentation-quality-gate/) validating the 3 artifacts + marketplace parity + version cascade + docs-drift (N/A) + red-green scenarios; (2) registers the plugin in the root Cursor marketplace (.cursor-plugin/marketplace.json) and bumps metadata.version 1.1.0 -> 1.2.0; (3) root README distributions row + Cursor install one-liner. plugin.json stays 1.0.0; the Claude Code marketplace is untouched (independent registry).